### PR TITLE
.Net: [MEVD] Updated VectorStoreException. Made implementations sealed

### DIFF
--- a/dotnet/samples/Concepts/Memory/VectorStoreLangchainInterop/QdrantFactory.cs
+++ b/dotnet/samples/Concepts/Memory/VectorStoreLangchainInterop/QdrantFactory.cs
@@ -37,14 +37,17 @@ public static class QdrantFactory
     /// <param name="qdrantClient">Qdrant client that can be used to manage the collections and points in a Qdrant store.</param>
     /// <returns>The <see cref="IVectorStore"/>.</returns>
     public static IVectorStore CreateQdrantLangchainInteropVectorStore(QdrantClient qdrantClient)
-        => new QdrantLangchainInteropVectorStore(qdrantClient);
+        => new QdrantLangchainInteropVectorStore(new QdrantVectorStore(qdrantClient), qdrantClient);
 
-    private sealed class QdrantLangchainInteropVectorStore(QdrantClient qdrantClient)
-        : QdrantVectorStore(qdrantClient)
+    private sealed class QdrantLangchainInteropVectorStore(
+        IVectorStore innerStore,
+        QdrantClient qdrantClient)
+        : IVectorStore
     {
         private readonly QdrantClient _qdrantClient = qdrantClient;
 
-        public override IVectorStoreRecordCollection<TKey, TRecord> GetCollection<TKey, TRecord>(string name, VectorStoreRecordDefinition? vectorStoreRecordDefinition = null)
+        public IVectorStoreRecordCollection<TKey, TRecord> GetCollection<TKey, TRecord>(string name, VectorStoreRecordDefinition? vectorStoreRecordDefinition = null)
+            where TKey : notnull
         {
             // Create a Qdrant collection. To be compatible with Langchain
             // we need to use a custom record definition that matches the
@@ -90,6 +93,10 @@ public static class QdrantFactory
 
             throw new NotSupportedException("This VectorStore is only usable with Guid keys and LangchainDocument<Guid> record types or string keys and LangchainDocument<string> record types");
         }
+
+        public object? GetService(Type serviceType, object? serviceKey = null) => innerStore.GetService(serviceType, serviceKey);
+
+        public IAsyncEnumerable<string> ListCollectionNamesAsync(CancellationToken cancellationToken = default) => innerStore.ListCollectionNamesAsync(cancellationToken);
     }
 
     /// <summary>

--- a/dotnet/samples/Concepts/Memory/VectorStore_DataIngestion_CustomMapper.cs
+++ b/dotnet/samples/Concepts/Memory/VectorStore_DataIngestion_CustomMapper.cs
@@ -66,7 +66,9 @@ public class VectorStore_DataIngestion_CustomMapper(ITestOutputHelper output, Ve
         // Initiate the docker container and construct the vector store using the custom factory for creating collections.
         await redisFixture.ManualInitializeAsync();
         ConnectionMultiplexer redis = ConnectionMultiplexer.Connect("localhost:6379");
-        var vectorStore = new CustomRedisVectorStore(redis.GetDatabase());
+
+        var database = redis.GetDatabase();
+        var vectorStore = new CustomRedisVectorStore(new RedisVectorStore(database), database);
 
         // Get and create collection if it doesn't exist, using the record definition containing the storage model.
         var collection = vectorStore.GetCollection<string, GenericDataModel>("skglossary", s_glossaryDefinition);
@@ -131,12 +133,15 @@ public class VectorStore_DataIngestion_CustomMapper(ITestOutputHelper output, Ve
         }
     }
 
-    private sealed class CustomRedisVectorStore(IDatabase database, RedisVectorStoreOptions? options = default)
-        : RedisVectorStore(database, options)
+    private sealed class CustomRedisVectorStore(
+        IVectorStore innerStore,
+        IDatabase database)
+        : IVectorStore
     {
         private readonly IDatabase _database = database;
 
-        public override IVectorStoreRecordCollection<TKey, TRecord> GetCollection<TKey, TRecord>(string name, VectorStoreRecordDefinition? vectorStoreRecordDefinition = null)
+        public IVectorStoreRecordCollection<TKey, TRecord> GetCollection<TKey, TRecord>(string name, VectorStoreRecordDefinition? vectorStoreRecordDefinition = null)
+            where TKey : notnull
         {
             // If the record definition is the glossary definition and the record type is the generic data model, inject the custom mapper into the collection options.
             if (vectorStoreRecordDefinition == s_glossaryDefinition && typeof(TRecord) == typeof(GenericDataModel))
@@ -149,6 +154,10 @@ public class VectorStore_DataIngestion_CustomMapper(ITestOutputHelper output, Ve
             var collection = new RedisJsonVectorStoreRecordCollection<TRecord>(_database, name, new() { VectorStoreRecordDefinition = vectorStoreRecordDefinition }) as IVectorStoreRecordCollection<TKey, TRecord>;
             return collection!;
         }
+
+        public object? GetService(Type serviceType, object? serviceKey = null) => innerStore.GetService(serviceType, serviceKey);
+
+        public IAsyncEnumerable<string> ListCollectionNamesAsync(CancellationToken cancellationToken = default) => innerStore.ListCollectionNamesAsync(cancellationToken);
     }
 
     /// <summary>

--- a/dotnet/src/Connectors/Connectors.Memory.AzureAISearch/AzureAISearchVectorStoreRecordCollection.cs
+++ b/dotnet/src/Connectors/Connectors.Memory.AzureAISearch/AzureAISearchVectorStoreRecordCollection.cs
@@ -24,7 +24,7 @@ namespace Microsoft.SemanticKernel.Connectors.AzureAISearch;
 /// </summary>
 /// <typeparam name="TRecord">The data model to use for adding, updating and retrieving data from storage.</typeparam>
 #pragma warning disable CA1711 // Identifiers should not have incorrect suffix
-public class AzureAISearchVectorStoreRecordCollection<TRecord> :
+public sealed class AzureAISearchVectorStoreRecordCollection<TRecord> :
     IVectorStoreRecordCollection<string, TRecord>,
     IVectorizableTextSearch<TRecord>,
     IKeywordHybridSearch<TRecord>
@@ -108,7 +108,7 @@ public class AzureAISearchVectorStoreRecordCollection<TRecord> :
     public string CollectionName => this._collectionName;
 
     /// <inheritdoc />
-    public virtual async Task<bool> CollectionExistsAsync(CancellationToken cancellationToken = default)
+    public async Task<bool> CollectionExistsAsync(CancellationToken cancellationToken = default)
     {
         try
         {
@@ -123,7 +123,8 @@ public class AzureAISearchVectorStoreRecordCollection<TRecord> :
         {
             throw new VectorStoreOperationException("Call to vector store failed.", ex)
             {
-                VectorStoreType = AzureAISearchConstants.VectorStoreSystemName,
+                VectorStoreSystemName = AzureAISearchConstants.VectorStoreSystemName,
+                VectorStoreName = this._collectionMetadata.VectorStoreName,
                 CollectionName = this._collectionName,
                 OperationName = "GetIndex"
             };
@@ -131,7 +132,7 @@ public class AzureAISearchVectorStoreRecordCollection<TRecord> :
     }
 
     /// <inheritdoc />
-    public virtual Task CreateCollectionAsync(CancellationToken cancellationToken = default)
+    public Task CreateCollectionAsync(CancellationToken cancellationToken = default)
     {
         var vectorSearchConfig = new VectorSearch();
         var searchFields = new List<SearchField>();
@@ -173,7 +174,7 @@ public class AzureAISearchVectorStoreRecordCollection<TRecord> :
     }
 
     /// <inheritdoc />
-    public virtual async Task CreateCollectionIfNotExistsAsync(CancellationToken cancellationToken = default)
+    public async Task CreateCollectionIfNotExistsAsync(CancellationToken cancellationToken = default)
     {
         if (!await this.CollectionExistsAsync(cancellationToken).ConfigureAwait(false))
         {
@@ -182,7 +183,7 @@ public class AzureAISearchVectorStoreRecordCollection<TRecord> :
     }
 
     /// <inheritdoc />
-    public virtual Task DeleteCollectionAsync(CancellationToken cancellationToken = default)
+    public Task DeleteCollectionAsync(CancellationToken cancellationToken = default)
     {
         return this.RunOperationAsync<Response>(
             "DeleteIndex",
@@ -200,7 +201,7 @@ public class AzureAISearchVectorStoreRecordCollection<TRecord> :
     }
 
     /// <inheritdoc />
-    public virtual Task<TRecord?> GetAsync(string key, GetRecordOptions? options = default, CancellationToken cancellationToken = default)
+    public Task<TRecord?> GetAsync(string key, GetRecordOptions? options = default, CancellationToken cancellationToken = default)
     {
         Verify.NotNullOrWhiteSpace(key);
 
@@ -213,7 +214,7 @@ public class AzureAISearchVectorStoreRecordCollection<TRecord> :
     }
 
     /// <inheritdoc />
-    public virtual async IAsyncEnumerable<TRecord> GetAsync(IEnumerable<string> keys, GetRecordOptions? options = default, [EnumeratorCancellation] CancellationToken cancellationToken = default)
+    public async IAsyncEnumerable<TRecord> GetAsync(IEnumerable<string> keys, GetRecordOptions? options = default, [EnumeratorCancellation] CancellationToken cancellationToken = default)
     {
         Verify.NotNull(keys);
 
@@ -234,7 +235,7 @@ public class AzureAISearchVectorStoreRecordCollection<TRecord> :
     }
 
     /// <inheritdoc />
-    public virtual Task DeleteAsync(string key, CancellationToken cancellationToken = default)
+    public Task DeleteAsync(string key, CancellationToken cancellationToken = default)
     {
         Verify.NotNullOrWhiteSpace(key);
 
@@ -245,7 +246,7 @@ public class AzureAISearchVectorStoreRecordCollection<TRecord> :
     }
 
     /// <inheritdoc />
-    public virtual Task DeleteAsync(IEnumerable<string> keys, CancellationToken cancellationToken = default)
+    public Task DeleteAsync(IEnumerable<string> keys, CancellationToken cancellationToken = default)
     {
         Verify.NotNull(keys);
         if (!keys.Any())
@@ -260,7 +261,7 @@ public class AzureAISearchVectorStoreRecordCollection<TRecord> :
     }
 
     /// <inheritdoc />
-    public virtual async Task<string> UpsertAsync(TRecord record, CancellationToken cancellationToken = default)
+    public async Task<string> UpsertAsync(TRecord record, CancellationToken cancellationToken = default)
     {
         Verify.NotNull(record);
 
@@ -273,7 +274,7 @@ public class AzureAISearchVectorStoreRecordCollection<TRecord> :
     }
 
     /// <inheritdoc />
-    public virtual async IAsyncEnumerable<string> UpsertAsync(IEnumerable<TRecord> records, [EnumeratorCancellation] CancellationToken cancellationToken = default)
+    public async IAsyncEnumerable<string> UpsertAsync(IEnumerable<TRecord> records, [EnumeratorCancellation] CancellationToken cancellationToken = default)
     {
         Verify.NotNull(records);
         if (!records.Any())
@@ -293,7 +294,7 @@ public class AzureAISearchVectorStoreRecordCollection<TRecord> :
     }
 
     /// <inheritdoc />
-    public virtual Task<VectorSearchResults<TRecord>> VectorizedSearchAsync<TVector>(TVector vector, int top, VectorSearchOptions<TRecord>? options = null, CancellationToken cancellationToken = default)
+    public Task<VectorSearchResults<TRecord>> VectorizedSearchAsync<TVector>(TVector vector, int top, VectorSearchOptions<TRecord>? options = null, CancellationToken cancellationToken = default)
     {
         var floatVector = VerifyVectorParam(vector);
         Verify.NotLessThan(top, 1);
@@ -350,7 +351,7 @@ public class AzureAISearchVectorStoreRecordCollection<TRecord> :
     }
 
     /// <inheritdoc />
-    public virtual Task<VectorSearchResults<TRecord>> VectorizableTextSearchAsync(string searchText, int top, VectorSearchOptions<TRecord>? options = null, CancellationToken cancellationToken = default)
+    public Task<VectorSearchResults<TRecord>> VectorizableTextSearchAsync(string searchText, int top, VectorSearchOptions<TRecord>? options = null, CancellationToken cancellationToken = default)
     {
         Verify.NotNull(searchText);
         Verify.NotLessThan(top, 1);
@@ -512,6 +513,7 @@ public class AzureAISearchVectorStoreRecordCollection<TRecord> :
 
             return VectorStoreErrorHandler.RunModelConversion(
                 AzureAISearchConstants.VectorStoreSystemName,
+                this._collectionMetadata.VectorStoreName,
                 this._collectionName,
                 OperationName,
                 () => this._mapper!.MapFromStorageToDataModel(jsonObject, new() { IncludeVectors = includeVectors }));
@@ -574,7 +576,8 @@ public class AzureAISearchVectorStoreRecordCollection<TRecord> :
         if (this._mapper is not null)
         {
             var jsonObjects = VectorStoreErrorHandler.RunModelConversion(
-                AzureAISearchConstants.VectorStoreSystemName!,
+                AzureAISearchConstants.VectorStoreSystemName,
+                this._collectionMetadata.VectorStoreName,
                 this._collectionName,
                 OperationName,
                 () => records.Select(this._mapper!.MapFromDataToStorageModel));
@@ -603,6 +606,7 @@ public class AzureAISearchVectorStoreRecordCollection<TRecord> :
         {
             var document = VectorStoreErrorHandler.RunModelConversion(
                 AzureAISearchConstants.VectorStoreSystemName,
+                this._collectionMetadata.VectorStoreName,
                 this._collectionName,
                 operationName,
                 () => this._mapper!.MapFromStorageToDataModel(result.Document, new() { IncludeVectors = includeVectors }));
@@ -686,7 +690,8 @@ public class AzureAISearchVectorStoreRecordCollection<TRecord> :
         {
             throw new VectorStoreOperationException("Call to vector store failed.", ex)
             {
-                VectorStoreType = AzureAISearchConstants.VectorStoreSystemName,
+                VectorStoreSystemName = AzureAISearchConstants.VectorStoreSystemName,
+                VectorStoreName = this._collectionMetadata.VectorStoreName,
                 CollectionName = this._collectionName,
                 OperationName = operationName
             };
@@ -695,7 +700,8 @@ public class AzureAISearchVectorStoreRecordCollection<TRecord> :
         {
             throw new VectorStoreOperationException("Call to vector store failed.", ex)
             {
-                VectorStoreType = AzureAISearchConstants.VectorStoreSystemName,
+                VectorStoreSystemName = AzureAISearchConstants.VectorStoreSystemName,
+                VectorStoreName = this._collectionMetadata.VectorStoreName,
                 CollectionName = this._collectionName,
                 OperationName = operationName
             };

--- a/dotnet/src/Connectors/Connectors.Memory.AzureCosmosDBMongoDB/AzureCosmosDBMongoDBVectorStore.cs
+++ b/dotnet/src/Connectors/Connectors.Memory.AzureCosmosDBMongoDB/AzureCosmosDBMongoDBVectorStore.cs
@@ -15,7 +15,7 @@ namespace Microsoft.SemanticKernel.Connectors.AzureCosmosDBMongoDB;
 /// <remarks>
 /// This class can be used with collections of any schema type, but requires you to provide schema information when getting a collection.
 /// </remarks>
-public class AzureCosmosDBMongoDBVectorStore : IVectorStore
+public sealed class AzureCosmosDBMongoDBVectorStore : IVectorStore
 {
     /// <summary>Metadata about vector store.</summary>
     private readonly VectorStoreMetadata _metadata;
@@ -46,7 +46,7 @@ public class AzureCosmosDBMongoDBVectorStore : IVectorStore
     }
 
     /// <inheritdoc />
-    public virtual IVectorStoreRecordCollection<TKey, TRecord> GetCollection<TKey, TRecord>(string name, VectorStoreRecordDefinition? vectorStoreRecordDefinition = null)
+    public IVectorStoreRecordCollection<TKey, TRecord> GetCollection<TKey, TRecord>(string name, VectorStoreRecordDefinition? vectorStoreRecordDefinition = null)
         where TKey : notnull
     {
 #pragma warning disable CS0618 // IAzureCosmosDBMongoDBVectorStoreRecordCollectionFactory is obsolete
@@ -70,7 +70,7 @@ public class AzureCosmosDBMongoDBVectorStore : IVectorStore
     }
 
     /// <inheritdoc />
-    public virtual async IAsyncEnumerable<string> ListCollectionNamesAsync([EnumeratorCancellation] CancellationToken cancellationToken = default)
+    public async IAsyncEnumerable<string> ListCollectionNamesAsync([EnumeratorCancellation] CancellationToken cancellationToken = default)
     {
         using var cursor = await this._mongoDatabase
             .ListCollectionNamesAsync(cancellationToken: cancellationToken)

--- a/dotnet/src/Connectors/Connectors.Memory.AzureCosmosDBNoSQL/AzureCosmosDBNoSQLVectorStore.cs
+++ b/dotnet/src/Connectors/Connectors.Memory.AzureCosmosDBNoSQL/AzureCosmosDBNoSQLVectorStore.cs
@@ -15,7 +15,7 @@ namespace Microsoft.SemanticKernel.Connectors.AzureCosmosDBNoSQL;
 /// <remarks>
 /// This class can be used with collections of any schema type, but requires you to provide schema information when getting a collection.
 /// </remarks>
-public class AzureCosmosDBNoSQLVectorStore : IVectorStore
+public sealed class AzureCosmosDBNoSQLVectorStore : IVectorStore
 {
     /// <summary>Metadata about vector store.</summary>
     private readonly VectorStoreMetadata _metadata;
@@ -46,7 +46,7 @@ public class AzureCosmosDBNoSQLVectorStore : IVectorStore
     }
 
     /// <inheritdoc />
-    public virtual IVectorStoreRecordCollection<TKey, TRecord> GetCollection<TKey, TRecord>(string name, VectorStoreRecordDefinition? vectorStoreRecordDefinition = null)
+    public IVectorStoreRecordCollection<TKey, TRecord> GetCollection<TKey, TRecord>(string name, VectorStoreRecordDefinition? vectorStoreRecordDefinition = null)
         where TKey : notnull
     {
 #pragma warning disable CS0618 // IAzureCosmosDBNoSQLVectorStoreRecordCollectionFactory is obsolete
@@ -77,7 +77,7 @@ public class AzureCosmosDBNoSQLVectorStore : IVectorStore
     }
 
     /// <inheritdoc />
-    public virtual async IAsyncEnumerable<string> ListCollectionNamesAsync([EnumeratorCancellation] CancellationToken cancellationToken = default)
+    public async IAsyncEnumerable<string> ListCollectionNamesAsync([EnumeratorCancellation] CancellationToken cancellationToken = default)
     {
         const string Query = "SELECT VALUE(c.id) FROM c";
 

--- a/dotnet/src/Connectors/Connectors.Memory.AzureCosmosDBNoSQL/AzureCosmosDBNoSQLVectorStoreRecordCollection.cs
+++ b/dotnet/src/Connectors/Connectors.Memory.AzureCosmosDBNoSQL/AzureCosmosDBNoSQLVectorStoreRecordCollection.cs
@@ -23,7 +23,7 @@ namespace Microsoft.SemanticKernel.Connectors.AzureCosmosDBNoSQL;
 /// </summary>
 /// <typeparam name="TRecord">The data model to use for adding, updating and retrieving data from storage.</typeparam>
 #pragma warning disable CA1711 // Identifiers should not have incorrect suffix
-public class AzureCosmosDBNoSQLVectorStoreRecordCollection<TRecord> :
+public sealed class AzureCosmosDBNoSQLVectorStoreRecordCollection<TRecord> :
     IVectorStoreRecordCollection<string, TRecord>,
     IVectorStoreRecordCollection<AzureCosmosDBNoSQLCompositeKey, TRecord>,
     IKeywordHybridSearch<TRecord>
@@ -115,7 +115,7 @@ public class AzureCosmosDBNoSQLVectorStoreRecordCollection<TRecord> :
     }
 
     /// <inheritdoc />
-    public virtual Task<bool> CollectionExistsAsync(CancellationToken cancellationToken = default)
+    public Task<bool> CollectionExistsAsync(CancellationToken cancellationToken = default)
     {
         return this.RunOperationAsync("GetContainerQueryIterator", async () =>
         {
@@ -140,14 +140,14 @@ public class AzureCosmosDBNoSQLVectorStoreRecordCollection<TRecord> :
     }
 
     /// <inheritdoc />
-    public virtual Task CreateCollectionAsync(CancellationToken cancellationToken = default)
+    public Task CreateCollectionAsync(CancellationToken cancellationToken = default)
     {
         return this.RunOperationAsync("CreateContainer", () =>
             this._database.CreateContainerAsync(this.GetContainerProperties(), cancellationToken: cancellationToken));
     }
 
     /// <inheritdoc />
-    public virtual async Task CreateCollectionIfNotExistsAsync(CancellationToken cancellationToken = default)
+    public async Task CreateCollectionIfNotExistsAsync(CancellationToken cancellationToken = default)
     {
         if (!await this.CollectionExistsAsync(cancellationToken).ConfigureAwait(false))
         {
@@ -156,7 +156,7 @@ public class AzureCosmosDBNoSQLVectorStoreRecordCollection<TRecord> :
     }
 
     /// <inheritdoc />
-    public virtual Task DeleteCollectionAsync(CancellationToken cancellationToken = default)
+    public Task DeleteCollectionAsync(CancellationToken cancellationToken = default)
     {
         return this.RunOperationAsync("DeleteContainer", () =>
             this._database
@@ -167,7 +167,7 @@ public class AzureCosmosDBNoSQLVectorStoreRecordCollection<TRecord> :
     #region Implementation of IVectorStoreRecordCollection<string, TRecord>
 
     /// <inheritdoc />
-    public virtual Task DeleteAsync(string key, CancellationToken cancellationToken = default)
+    public Task DeleteAsync(string key, CancellationToken cancellationToken = default)
     {
         // Use record key as partition key
         var compositeKey = new AzureCosmosDBNoSQLCompositeKey(recordKey: key, partitionKey: key);
@@ -176,7 +176,7 @@ public class AzureCosmosDBNoSQLVectorStoreRecordCollection<TRecord> :
     }
 
     /// <inheritdoc />
-    public virtual Task DeleteAsync(IEnumerable<string> keys, CancellationToken cancellationToken = default)
+    public Task DeleteAsync(IEnumerable<string> keys, CancellationToken cancellationToken = default)
     {
         // Use record keys as partition keys
         var compositeKeys = keys.Select(key => new AzureCosmosDBNoSQLCompositeKey(recordKey: key, partitionKey: key));
@@ -185,7 +185,7 @@ public class AzureCosmosDBNoSQLVectorStoreRecordCollection<TRecord> :
     }
 
     /// <inheritdoc />
-    public virtual async Task<TRecord?> GetAsync(string key, GetRecordOptions? options = null, CancellationToken cancellationToken = default)
+    public async Task<TRecord?> GetAsync(string key, GetRecordOptions? options = null, CancellationToken cancellationToken = default)
     {
         // Use record key as partition key
         var compositeKey = new AzureCosmosDBNoSQLCompositeKey(recordKey: key, partitionKey: key);
@@ -196,7 +196,7 @@ public class AzureCosmosDBNoSQLVectorStoreRecordCollection<TRecord> :
     }
 
     /// <inheritdoc />
-    public virtual async IAsyncEnumerable<TRecord> GetAsync(
+    public async IAsyncEnumerable<TRecord> GetAsync(
         IEnumerable<string> keys,
         GetRecordOptions? options = null,
         [EnumeratorCancellation] CancellationToken cancellationToken = default)
@@ -214,7 +214,7 @@ public class AzureCosmosDBNoSQLVectorStoreRecordCollection<TRecord> :
     }
 
     /// <inheritdoc />
-    public virtual async Task<string> UpsertAsync(TRecord record, CancellationToken cancellationToken = default)
+    public async Task<string> UpsertAsync(TRecord record, CancellationToken cancellationToken = default)
     {
         var key = await this.InternalUpsertAsync(record, cancellationToken).ConfigureAwait(false);
 
@@ -222,7 +222,7 @@ public class AzureCosmosDBNoSQLVectorStoreRecordCollection<TRecord> :
     }
 
     /// <inheritdoc />
-    public virtual async IAsyncEnumerable<string> UpsertAsync(IEnumerable<TRecord> records, [EnumeratorCancellation] CancellationToken cancellationToken = default)
+    public async IAsyncEnumerable<string> UpsertAsync(IEnumerable<TRecord> records, [EnumeratorCancellation] CancellationToken cancellationToken = default)
     {
         Verify.NotNull(records);
 
@@ -244,7 +244,7 @@ public class AzureCosmosDBNoSQLVectorStoreRecordCollection<TRecord> :
     #region Implementation of IVectorStoreRecordCollection<AzureCosmosDBNoSQLCompositeKey, TRecord>
 
     /// <inheritdoc />
-    public virtual async Task<TRecord?> GetAsync(AzureCosmosDBNoSQLCompositeKey key, GetRecordOptions? options = null, CancellationToken cancellationToken = default)
+    public async Task<TRecord?> GetAsync(AzureCosmosDBNoSQLCompositeKey key, GetRecordOptions? options = null, CancellationToken cancellationToken = default)
     {
         return await this.InternalGetAsync([key], options, cancellationToken)
             .FirstOrDefaultAsync(cancellationToken)
@@ -252,7 +252,7 @@ public class AzureCosmosDBNoSQLVectorStoreRecordCollection<TRecord> :
     }
 
     /// <inheritdoc />
-    public virtual async IAsyncEnumerable<TRecord> GetAsync(
+    public async IAsyncEnumerable<TRecord> GetAsync(
         IEnumerable<AzureCosmosDBNoSQLCompositeKey> keys,
         GetRecordOptions? options = null,
         [EnumeratorCancellation] CancellationToken cancellationToken = default)
@@ -267,13 +267,13 @@ public class AzureCosmosDBNoSQLVectorStoreRecordCollection<TRecord> :
     }
 
     /// <inheritdoc />
-    public virtual Task DeleteAsync(AzureCosmosDBNoSQLCompositeKey key, CancellationToken cancellationToken = default)
+    public Task DeleteAsync(AzureCosmosDBNoSQLCompositeKey key, CancellationToken cancellationToken = default)
     {
         return this.InternalDeleteAsync([key], cancellationToken);
     }
 
     /// <inheritdoc />
-    public virtual Task DeleteAsync(IEnumerable<AzureCosmosDBNoSQLCompositeKey> keys, CancellationToken cancellationToken = default)
+    public Task DeleteAsync(IEnumerable<AzureCosmosDBNoSQLCompositeKey> keys, CancellationToken cancellationToken = default)
     {
         return this.InternalDeleteAsync(keys, cancellationToken);
     }
@@ -305,7 +305,7 @@ public class AzureCosmosDBNoSQLVectorStoreRecordCollection<TRecord> :
     }
 
     /// <inheritdoc />
-    public virtual Task<VectorSearchResults<TRecord>> VectorizedSearchAsync<TVector>(
+    public Task<VectorSearchResults<TRecord>> VectorizedSearchAsync<TVector>(
         TVector vector,
         int top,
         VectorSearchOptions<TRecord>? options = null,
@@ -424,7 +424,8 @@ public class AzureCosmosDBNoSQLVectorStoreRecordCollection<TRecord> :
         {
             throw new VectorStoreOperationException("Call to vector store failed.", ex)
             {
-                VectorStoreType = AzureCosmosDBNoSQLConstants.VectorStoreSystemName,
+                VectorStoreSystemName = AzureCosmosDBNoSQLConstants.VectorStoreSystemName,
+                VectorStoreName = this._collectionMetadata.VectorStoreName,
                 CollectionName = this.CollectionName,
                 OperationName = operationName
             };
@@ -585,6 +586,7 @@ public class AzureCosmosDBNoSQLVectorStoreRecordCollection<TRecord> :
         {
             yield return VectorStoreErrorHandler.RunModelConversion(
                 AzureCosmosDBNoSQLConstants.VectorStoreSystemName,
+                this._collectionMetadata.VectorStoreName,
                 this.CollectionName,
                 OperationName,
                 () => this._mapper.MapFromStorageToDataModel(jsonObject, new() { IncludeVectors = includeVectors }));
@@ -601,6 +603,7 @@ public class AzureCosmosDBNoSQLVectorStoreRecordCollection<TRecord> :
 
         var jsonObject = VectorStoreErrorHandler.RunModelConversion(
                 AzureCosmosDBNoSQLConstants.VectorStoreSystemName,
+                this._collectionMetadata.VectorStoreName,
                 this.CollectionName,
                 OperationName,
                 () => this._mapper.MapFromDataToStorageModel(record));
@@ -681,6 +684,7 @@ public class AzureCosmosDBNoSQLVectorStoreRecordCollection<TRecord> :
 
             var record = VectorStoreErrorHandler.RunModelConversion(
                 AzureCosmosDBNoSQLConstants.VectorStoreSystemName,
+                this._collectionMetadata.VectorStoreName,
                 this.CollectionName,
                 operationName,
                 () => this._mapper.MapFromStorageToDataModel(jsonObject, new() { IncludeVectors = includeVectors }));

--- a/dotnet/src/Connectors/Connectors.Memory.InMemory/InMemoryVectorStoreRecordCollection.cs
+++ b/dotnet/src/Connectors/Connectors.Memory.InMemory/InMemoryVectorStoreRecordCollection.cs
@@ -153,7 +153,7 @@ public sealed class InMemoryVectorStoreRecordCollection<TKey, TRecord> : IVector
 
         return Task.FromException(new VectorStoreOperationException("Collection already exists.")
         {
-            VectorStoreType = InMemoryConstants.VectorStoreSystemName,
+            VectorStoreSystemName = InMemoryConstants.VectorStoreSystemName,
             CollectionName = this.CollectionName,
             OperationName = "CreateCollection"
         });

--- a/dotnet/src/Connectors/Connectors.Memory.MongoDB/MongoDBVectorStore.cs
+++ b/dotnet/src/Connectors/Connectors.Memory.MongoDB/MongoDBVectorStore.cs
@@ -15,7 +15,7 @@ namespace Microsoft.SemanticKernel.Connectors.MongoDB;
 /// <remarks>
 /// This class can be used with collections of any schema type, but requires you to provide schema information when getting a collection.
 /// </remarks>
-public class MongoDBVectorStore : IVectorStore
+public sealed class MongoDBVectorStore : IVectorStore
 {
     /// <summary>Metadata about vector store.</summary>
     private readonly VectorStoreMetadata _metadata;
@@ -46,7 +46,7 @@ public class MongoDBVectorStore : IVectorStore
     }
 
     /// <inheritdoc />
-    public virtual IVectorStoreRecordCollection<TKey, TRecord> GetCollection<TKey, TRecord>(string name, VectorStoreRecordDefinition? vectorStoreRecordDefinition = null)
+    public IVectorStoreRecordCollection<TKey, TRecord> GetCollection<TKey, TRecord>(string name, VectorStoreRecordDefinition? vectorStoreRecordDefinition = null)
         where TKey : notnull
     {
 #pragma warning disable CS0618 // IMongoDBVectorStoreRecordCollectionFactoryß is obsolete
@@ -70,7 +70,7 @@ public class MongoDBVectorStore : IVectorStore
     }
 
     /// <inheritdoc />
-    public virtual async IAsyncEnumerable<string> ListCollectionNamesAsync([EnumeratorCancellation] CancellationToken cancellationToken = default)
+    public async IAsyncEnumerable<string> ListCollectionNamesAsync([EnumeratorCancellation] CancellationToken cancellationToken = default)
     {
         using var cursor = await this._mongoDatabase
             .ListCollectionNamesAsync(cancellationToken: cancellationToken)

--- a/dotnet/src/Connectors/Connectors.Memory.MongoDB/MongoDBVectorStoreRecordCollection.cs
+++ b/dotnet/src/Connectors/Connectors.Memory.MongoDB/MongoDBVectorStoreRecordCollection.cs
@@ -20,7 +20,7 @@ namespace Microsoft.SemanticKernel.Connectors.MongoDB;
 /// </summary>
 /// <typeparam name="TRecord">The data model to use for adding, updating and retrieving data from storage.</typeparam>
 #pragma warning disable CA1711 // Identifiers should not have incorrect suffix
-public class MongoDBVectorStoreRecordCollection<TRecord> : IVectorStoreRecordCollection<string, TRecord>, IKeywordHybridSearch<TRecord>
+public sealed class MongoDBVectorStoreRecordCollection<TRecord> : IVectorStoreRecordCollection<string, TRecord>, IKeywordHybridSearch<TRecord>
 #pragma warning restore CA1711 // Identifiers should not have incorrect suffix
 {
     /// <summary>Metadata about vector store record collection.</summary>
@@ -90,11 +90,11 @@ public class MongoDBVectorStoreRecordCollection<TRecord> : IVectorStoreRecordCol
     }
 
     /// <inheritdoc />
-    public virtual Task<bool> CollectionExistsAsync(CancellationToken cancellationToken = default)
+    public Task<bool> CollectionExistsAsync(CancellationToken cancellationToken = default)
         => this.RunOperationAsync("ListCollectionNames", () => this.InternalCollectionExistsAsync(cancellationToken));
 
     /// <inheritdoc />
-    public virtual async Task CreateCollectionAsync(CancellationToken cancellationToken = default)
+    public async Task CreateCollectionAsync(CancellationToken cancellationToken = default)
     {
         // The IMongoDatabase.CreateCollectionAsync "Creates a new collection if not already available".
         // To make sure that all the connectors are consistent, we throw when the collection exists.
@@ -102,7 +102,8 @@ public class MongoDBVectorStoreRecordCollection<TRecord> : IVectorStoreRecordCol
         {
             throw new VectorStoreOperationException("Collection already exists.")
             {
-                VectorStoreType = MongoDBConstants.VectorStoreSystemName,
+                VectorStoreSystemName = MongoDBConstants.VectorStoreSystemName,
+                VectorStoreName = this._collectionMetadata.VectorStoreName,
                 CollectionName = this.CollectionName,
                 OperationName = "CreateCollection"
             };
@@ -112,7 +113,7 @@ public class MongoDBVectorStoreRecordCollection<TRecord> : IVectorStoreRecordCol
     }
 
     /// <inheritdoc />
-    public virtual async Task CreateCollectionIfNotExistsAsync(CancellationToken cancellationToken = default)
+    public async Task CreateCollectionIfNotExistsAsync(CancellationToken cancellationToken = default)
     {
         // The IMongoDatabase.CreateCollectionAsync "Creates a new collection if not already available".
         // So for CreateCollectionIfNotExistsAsync, we don't perform an additional check.
@@ -128,7 +129,7 @@ public class MongoDBVectorStoreRecordCollection<TRecord> : IVectorStoreRecordCol
     }
 
     /// <inheritdoc />
-    public virtual async Task DeleteAsync(string key, CancellationToken cancellationToken = default)
+    public async Task DeleteAsync(string key, CancellationToken cancellationToken = default)
     {
         Verify.NotNullOrWhiteSpace(key);
 
@@ -137,7 +138,7 @@ public class MongoDBVectorStoreRecordCollection<TRecord> : IVectorStoreRecordCol
     }
 
     /// <inheritdoc />
-    public virtual async Task DeleteAsync(IEnumerable<string> keys, CancellationToken cancellationToken = default)
+    public async Task DeleteAsync(IEnumerable<string> keys, CancellationToken cancellationToken = default)
     {
         Verify.NotNull(keys);
 
@@ -146,11 +147,11 @@ public class MongoDBVectorStoreRecordCollection<TRecord> : IVectorStoreRecordCol
     }
 
     /// <inheritdoc />
-    public virtual Task DeleteCollectionAsync(CancellationToken cancellationToken = default)
+    public Task DeleteCollectionAsync(CancellationToken cancellationToken = default)
         => this.RunOperationAsync("DropCollection", () => this._mongoDatabase.DropCollectionAsync(this.CollectionName, cancellationToken));
 
     /// <inheritdoc />
-    public virtual async Task<TRecord?> GetAsync(string key, GetRecordOptions? options = null, CancellationToken cancellationToken = default)
+    public async Task<TRecord?> GetAsync(string key, GetRecordOptions? options = null, CancellationToken cancellationToken = default)
     {
         Verify.NotNullOrWhiteSpace(key);
 
@@ -174,13 +175,14 @@ public class MongoDBVectorStoreRecordCollection<TRecord> : IVectorStoreRecordCol
 
         return VectorStoreErrorHandler.RunModelConversion(
             MongoDBConstants.VectorStoreSystemName,
+            this._collectionMetadata.VectorStoreName,
             this.CollectionName,
             OperationName,
             () => this._mapper.MapFromStorageToDataModel(record, new() { IncludeVectors = includeVectors }));
     }
 
     /// <inheritdoc />
-    public virtual async IAsyncEnumerable<TRecord> GetAsync(
+    public async IAsyncEnumerable<TRecord> GetAsync(
         IEnumerable<string> keys,
         GetRecordOptions? options = null,
         [EnumeratorCancellation] CancellationToken cancellationToken = default)
@@ -201,6 +203,7 @@ public class MongoDBVectorStoreRecordCollection<TRecord> : IVectorStoreRecordCol
                 {
                     yield return VectorStoreErrorHandler.RunModelConversion(
                         MongoDBConstants.VectorStoreSystemName,
+                        this._collectionMetadata.VectorStoreName,
                         this.CollectionName,
                         OperationName,
                         () => this._mapper.MapFromStorageToDataModel(record, new()));
@@ -210,7 +213,7 @@ public class MongoDBVectorStoreRecordCollection<TRecord> : IVectorStoreRecordCol
     }
 
     /// <inheritdoc />
-    public virtual Task<string> UpsertAsync(TRecord record, CancellationToken cancellationToken = default)
+    public Task<string> UpsertAsync(TRecord record, CancellationToken cancellationToken = default)
     {
         Verify.NotNull(record);
 
@@ -219,6 +222,7 @@ public class MongoDBVectorStoreRecordCollection<TRecord> : IVectorStoreRecordCol
         var replaceOptions = new ReplaceOptions { IsUpsert = true };
         var storageModel = VectorStoreErrorHandler.RunModelConversion(
             MongoDBConstants.VectorStoreSystemName,
+            this._collectionMetadata.VectorStoreName,
             this.CollectionName,
             OperationName,
             () => this._mapper.MapFromDataToStorageModel(record));
@@ -236,7 +240,7 @@ public class MongoDBVectorStoreRecordCollection<TRecord> : IVectorStoreRecordCol
     }
 
     /// <inheritdoc />
-    public virtual async IAsyncEnumerable<string> UpsertAsync(IEnumerable<TRecord> records, [EnumeratorCancellation] CancellationToken cancellationToken = default)
+    public async IAsyncEnumerable<string> UpsertAsync(IEnumerable<TRecord> records, [EnumeratorCancellation] CancellationToken cancellationToken = default)
     {
         Verify.NotNull(records);
 
@@ -253,7 +257,7 @@ public class MongoDBVectorStoreRecordCollection<TRecord> : IVectorStoreRecordCol
     }
 
     /// <inheritdoc />
-    public virtual async Task<VectorSearchResults<TRecord>> VectorizedSearchAsync<TVector>(
+    public async Task<VectorSearchResults<TRecord>> VectorizedSearchAsync<TVector>(
         TVector vector,
         int top,
         MEVD.VectorSearchOptions<TRecord>? options = null,
@@ -490,6 +494,7 @@ public class MongoDBVectorStoreRecordCollection<TRecord> : IVectorStoreRecordCol
                     var score = response[ScorePropertyName].AsDouble;
                     var record = VectorStoreErrorHandler.RunModelConversion(
                         MongoDBConstants.VectorStoreSystemName,
+                        this._collectionMetadata.VectorStoreName,
                         this.CollectionName,
                         OperationName,
                         () => this._mapper.MapFromStorageToDataModel(response[DocumentPropertyName].AsBsonDocument, new() { IncludeVectors = includeVectors }));
@@ -528,7 +533,8 @@ public class MongoDBVectorStoreRecordCollection<TRecord> : IVectorStoreRecordCol
         {
             throw new VectorStoreOperationException("Call to vector store failed.", ex)
             {
-                VectorStoreType = MongoDBConstants.VectorStoreSystemName,
+                VectorStoreSystemName = MongoDBConstants.VectorStoreSystemName,
+                VectorStoreName = this._collectionMetadata.VectorStoreName,
                 CollectionName = this.CollectionName,
                 OperationName = operationName
             };
@@ -545,7 +551,8 @@ public class MongoDBVectorStoreRecordCollection<TRecord> : IVectorStoreRecordCol
         {
             throw new VectorStoreOperationException("Call to vector store failed.", ex)
             {
-                VectorStoreType = MongoDBConstants.VectorStoreSystemName,
+                VectorStoreSystemName = MongoDBConstants.VectorStoreSystemName,
+                VectorStoreName = this._collectionMetadata.VectorStoreName,
                 CollectionName = this.CollectionName,
                 OperationName = operationName
             };
@@ -576,7 +583,8 @@ public class MongoDBVectorStoreRecordCollection<TRecord> : IVectorStoreRecordCol
                 {
                     throw new VectorStoreOperationException("Call to vector store failed.", ex)
                     {
-                        VectorStoreType = MongoDBConstants.VectorStoreSystemName,
+                        VectorStoreSystemName = MongoDBConstants.VectorStoreSystemName,
+                        VectorStoreName = this._collectionMetadata.VectorStoreName,
                         CollectionName = this.CollectionName,
                         OperationName = operationName
                     };
@@ -610,7 +618,8 @@ public class MongoDBVectorStoreRecordCollection<TRecord> : IVectorStoreRecordCol
                 {
                     throw new VectorStoreOperationException("Call to vector store failed.", ex)
                     {
-                        VectorStoreType = MongoDBConstants.VectorStoreSystemName,
+                        VectorStoreSystemName = MongoDBConstants.VectorStoreSystemName,
+                        VectorStoreName = this._collectionMetadata.VectorStoreName,
                         CollectionName = this.CollectionName,
                         OperationName = operationName
                     };

--- a/dotnet/src/Connectors/Connectors.Memory.Pinecone/PineconeVectorStore.cs
+++ b/dotnet/src/Connectors/Connectors.Memory.Pinecone/PineconeVectorStore.cs
@@ -16,7 +16,7 @@ namespace Microsoft.SemanticKernel.Connectors.Pinecone;
 /// <remarks>
 /// This class can be used with collections of any schema type, but requires you to provide schema information when getting a collection.
 /// </remarks>
-public class PineconeVectorStore : IVectorStore
+public sealed class PineconeVectorStore : IVectorStore
 {
     private readonly Sdk.PineconeClient _pineconeClient;
     private readonly PineconeVectorStoreOptions _options;
@@ -43,7 +43,7 @@ public class PineconeVectorStore : IVectorStore
     }
 
     /// <inheritdoc />
-    public virtual IVectorStoreRecordCollection<TKey, TRecord> GetCollection<TKey, TRecord>(string name, VectorStoreRecordDefinition? vectorStoreRecordDefinition = null)
+    public IVectorStoreRecordCollection<TKey, TRecord> GetCollection<TKey, TRecord>(string name, VectorStoreRecordDefinition? vectorStoreRecordDefinition = null)
         where TKey : notnull
     {
 #pragma warning disable CS0618 // IPineconeVectorStoreRecordCollectionFactory is obsolete
@@ -65,7 +65,7 @@ public class PineconeVectorStore : IVectorStore
     }
 
     /// <inheritdoc />
-    public virtual async IAsyncEnumerable<string> ListCollectionNamesAsync([EnumeratorCancellation] CancellationToken cancellationToken = default)
+    public async IAsyncEnumerable<string> ListCollectionNamesAsync([EnumeratorCancellation] CancellationToken cancellationToken = default)
     {
         IndexList indexList;
 
@@ -77,7 +77,8 @@ public class PineconeVectorStore : IVectorStore
         {
             throw new VectorStoreOperationException("Call to vector store failed.", ex)
             {
-                VectorStoreType = PineconeConstants.VectorStoreSystemName,
+                VectorStoreSystemName = PineconeConstants.VectorStoreSystemName,
+                VectorStoreName = this._metadata.VectorStoreName,
                 OperationName = "ListCollections"
             };
         }

--- a/dotnet/src/Connectors/Connectors.Memory.Pinecone/PineconeVectorStoreRecordCollection.cs
+++ b/dotnet/src/Connectors/Connectors.Memory.Pinecone/PineconeVectorStoreRecordCollection.cs
@@ -19,7 +19,7 @@ namespace Microsoft.SemanticKernel.Connectors.Pinecone;
 /// </summary>
 /// <typeparam name="TRecord">The data model to use for adding, updating and retrieving data from storage.</typeparam>
 #pragma warning disable CA1711 // Identifiers should not have incorrect suffix
-public class PineconeVectorStoreRecordCollection<TRecord> : IVectorStoreRecordCollection<string, TRecord>
+public sealed class PineconeVectorStoreRecordCollection<TRecord> : IVectorStoreRecordCollection<string, TRecord>
 #pragma warning restore CA1711 // Identifiers should not have incorrect suffix
 {
     private static readonly VectorSearchOptions<TRecord> s_defaultVectorSearchOptions = new();
@@ -69,7 +69,7 @@ public class PineconeVectorStoreRecordCollection<TRecord> : IVectorStoreRecordCo
     }
 
     /// <inheritdoc />
-    public virtual Task<bool> CollectionExistsAsync(CancellationToken cancellationToken = default)
+    public Task<bool> CollectionExistsAsync(CancellationToken cancellationToken = default)
         => this.RunCollectionOperationAsync(
             "CollectionExists",
             async () =>
@@ -80,7 +80,7 @@ public class PineconeVectorStoreRecordCollection<TRecord> : IVectorStoreRecordCo
             });
 
     /// <inheritdoc />
-    public virtual Task CreateCollectionAsync(CancellationToken cancellationToken = default)
+    public Task CreateCollectionAsync(CancellationToken cancellationToken = default)
     {
         // we already run through record property validation, so a single VectorStoreRecordVectorProperty is guaranteed.
         var vectorProperty = this._model.VectorProperty!;
@@ -111,7 +111,7 @@ public class PineconeVectorStoreRecordCollection<TRecord> : IVectorStoreRecordCo
     }
 
     /// <inheritdoc />
-    public virtual async Task CreateCollectionIfNotExistsAsync(CancellationToken cancellationToken = default)
+    public async Task CreateCollectionIfNotExistsAsync(CancellationToken cancellationToken = default)
     {
         if (!await this.CollectionExistsAsync(cancellationToken).ConfigureAwait(false))
         {
@@ -127,7 +127,7 @@ public class PineconeVectorStoreRecordCollection<TRecord> : IVectorStoreRecordCo
     }
 
     /// <inheritdoc />
-    public virtual async Task DeleteCollectionAsync(CancellationToken cancellationToken = default)
+    public async Task DeleteCollectionAsync(CancellationToken cancellationToken = default)
     {
         try
         {
@@ -141,7 +141,8 @@ public class PineconeVectorStoreRecordCollection<TRecord> : IVectorStoreRecordCo
         {
             throw new VectorStoreOperationException("Call to vector store failed.", other)
             {
-                VectorStoreType = PineconeConstants.VectorStoreSystemName,
+                VectorStoreSystemName = PineconeConstants.VectorStoreSystemName,
+                VectorStoreName = this._collectionMetadata.VectorStoreName,
                 CollectionName = this.CollectionName,
                 OperationName = "DeleteCollection"
             };
@@ -149,7 +150,7 @@ public class PineconeVectorStoreRecordCollection<TRecord> : IVectorStoreRecordCo
     }
 
     /// <inheritdoc />
-    public virtual async Task<TRecord?> GetAsync(string key, GetRecordOptions? options = null, CancellationToken cancellationToken = default)
+    public async Task<TRecord?> GetAsync(string key, GetRecordOptions? options = null, CancellationToken cancellationToken = default)
     {
         Verify.NotNull(key);
 
@@ -172,13 +173,14 @@ public class PineconeVectorStoreRecordCollection<TRecord> : IVectorStoreRecordCo
         StorageToDataModelMapperOptions mapperOptions = new() { IncludeVectors = options?.IncludeVectors is true };
         return VectorStoreErrorHandler.RunModelConversion(
             PineconeConstants.VectorStoreSystemName,
+            this._collectionMetadata.VectorStoreName,
             this.CollectionName,
             "Get",
             () => this._mapper.MapFromStorageToDataModel(result, mapperOptions));
     }
 
     /// <inheritdoc />
-    public virtual async IAsyncEnumerable<TRecord> GetAsync(
+    public async IAsyncEnumerable<TRecord> GetAsync(
         IEnumerable<string> keys,
         GetRecordOptions? options = default,
         [EnumeratorCancellation] CancellationToken cancellationToken = default)
@@ -208,6 +210,7 @@ public class PineconeVectorStoreRecordCollection<TRecord> : IVectorStoreRecordCo
         StorageToDataModelMapperOptions mapperOptions = new() { IncludeVectors = options?.IncludeVectors is true };
         var records = VectorStoreErrorHandler.RunModelConversion(
             PineconeConstants.VectorStoreSystemName,
+            this._collectionMetadata.VectorStoreName,
             this.CollectionName,
             "GetBatch",
             () => response.Vectors.Values.Select(x => this._mapper.MapFromStorageToDataModel(x, mapperOptions)));
@@ -219,7 +222,7 @@ public class PineconeVectorStoreRecordCollection<TRecord> : IVectorStoreRecordCo
     }
 
     /// <inheritdoc />
-    public virtual Task DeleteAsync(string key, CancellationToken cancellationToken = default)
+    public Task DeleteAsync(string key, CancellationToken cancellationToken = default)
     {
         Verify.NotNullOrWhiteSpace(key);
 
@@ -235,7 +238,7 @@ public class PineconeVectorStoreRecordCollection<TRecord> : IVectorStoreRecordCo
     }
 
     /// <inheritdoc />
-    public virtual Task DeleteAsync(IEnumerable<string> keys, CancellationToken cancellationToken = default)
+    public Task DeleteAsync(IEnumerable<string> keys, CancellationToken cancellationToken = default)
     {
         Verify.NotNull(keys);
 
@@ -257,12 +260,13 @@ public class PineconeVectorStoreRecordCollection<TRecord> : IVectorStoreRecordCo
     }
 
     /// <inheritdoc />
-    public virtual async Task<string> UpsertAsync(TRecord record, CancellationToken cancellationToken = default)
+    public async Task<string> UpsertAsync(TRecord record, CancellationToken cancellationToken = default)
     {
         Verify.NotNull(record);
 
         var vector = VectorStoreErrorHandler.RunModelConversion(
             PineconeConstants.VectorStoreSystemName,
+            this._collectionMetadata.VectorStoreName,
             this.CollectionName,
             "Upsert",
             () => this._mapper.MapFromDataToStorageModel(record));
@@ -281,12 +285,13 @@ public class PineconeVectorStoreRecordCollection<TRecord> : IVectorStoreRecordCo
     }
 
     /// <inheritdoc />
-    public virtual async IAsyncEnumerable<string> UpsertAsync(IEnumerable<TRecord> records, [EnumeratorCancellation] CancellationToken cancellationToken = default)
+    public async IAsyncEnumerable<string> UpsertAsync(IEnumerable<TRecord> records, [EnumeratorCancellation] CancellationToken cancellationToken = default)
     {
         Verify.NotNull(records);
 
         var vectors = VectorStoreErrorHandler.RunModelConversion(
             PineconeConstants.VectorStoreSystemName,
+            this._collectionMetadata.VectorStoreName,
             this.CollectionName,
             "UpsertBatch",
             () => records.Select(this._mapper.MapFromDataToStorageModel).ToList());
@@ -313,7 +318,7 @@ public class PineconeVectorStoreRecordCollection<TRecord> : IVectorStoreRecordCo
     }
 
     /// <inheritdoc />
-    public virtual async Task<VectorSearchResults<TRecord>> VectorizedSearchAsync<TVector>(TVector vector, int top, VectorSearchOptions<TRecord>? options = null, CancellationToken cancellationToken = default)
+    public async Task<VectorSearchResults<TRecord>> VectorizedSearchAsync<TVector>(TVector vector, int top, VectorSearchOptions<TRecord>? options = null, CancellationToken cancellationToken = default)
     {
         Verify.NotNull(vector);
         Verify.NotLessThan(top, 1);
@@ -362,6 +367,7 @@ public class PineconeVectorStoreRecordCollection<TRecord> : IVectorStoreRecordCo
         StorageToDataModelMapperOptions mapperOptions = new() { IncludeVectors = options.IncludeVectors is true };
         var records = VectorStoreErrorHandler.RunModelConversion(
             PineconeConstants.VectorStoreSystemName,
+            this._collectionMetadata.VectorStoreName,
             this.CollectionName,
             "Query",
             () => skippedResults.Select(x => new VectorSearchResult<TRecord>(this._mapper.MapFromStorageToDataModel(new Sdk.Vector()
@@ -407,7 +413,8 @@ public class PineconeVectorStoreRecordCollection<TRecord> : IVectorStoreRecordCo
         {
             throw new VectorStoreOperationException("Call to vector store failed.", ex)
             {
-                VectorStoreType = PineconeConstants.VectorStoreSystemName,
+                VectorStoreSystemName = PineconeConstants.VectorStoreSystemName,
+                VectorStoreName = this._collectionMetadata.VectorStoreName,
                 CollectionName = this.CollectionName,
                 OperationName = operationName
             };
@@ -424,7 +431,8 @@ public class PineconeVectorStoreRecordCollection<TRecord> : IVectorStoreRecordCo
         {
             throw new VectorStoreOperationException("Call to vector store failed.", ex)
             {
-                VectorStoreType = PineconeConstants.VectorStoreSystemName,
+                VectorStoreSystemName = PineconeConstants.VectorStoreSystemName,
+                VectorStoreName = this._collectionMetadata.VectorStoreName,
                 CollectionName = this.CollectionName,
                 OperationName = operationName
             };

--- a/dotnet/src/Connectors/Connectors.Memory.Postgres/PostgresVectorStore.cs
+++ b/dotnet/src/Connectors/Connectors.Memory.Postgres/PostgresVectorStore.cs
@@ -11,7 +11,7 @@ namespace Microsoft.SemanticKernel.Connectors.Postgres;
 /// <summary>
 /// Represents a vector store implementation using PostgreSQL.
 /// </summary>
-public class PostgresVectorStore : IVectorStore
+public sealed class PostgresVectorStore : IVectorStore
 {
     private readonly IPostgresVectorStoreDbClient _postgresClient;
     private readonly NpgsqlDataSource? _dataSource;
@@ -56,16 +56,17 @@ public class PostgresVectorStore : IVectorStore
     }
 
     /// <inheritdoc />
-    public virtual IAsyncEnumerable<string> ListCollectionNamesAsync(CancellationToken cancellationToken = default)
+    public IAsyncEnumerable<string> ListCollectionNamesAsync(CancellationToken cancellationToken = default)
     {
         return PostgresVectorStoreUtils.WrapAsyncEnumerableAsync(
             this._postgresClient.GetTablesAsync(cancellationToken),
-            "ListCollectionNames"
+            "ListCollectionNames",
+            this._metadata.VectorStoreName
         );
     }
 
     /// <inheritdoc />
-    public virtual IVectorStoreRecordCollection<TKey, TRecord> GetCollection<TKey, TRecord>(string name, VectorStoreRecordDefinition? vectorStoreRecordDefinition = null)
+    public IVectorStoreRecordCollection<TKey, TRecord> GetCollection<TKey, TRecord>(string name, VectorStoreRecordDefinition? vectorStoreRecordDefinition = null)
         where TKey : notnull
     {
 #pragma warning disable CS0618 // IPostgresVectorStoreRecordCollectionFactory is obsolete

--- a/dotnet/src/Connectors/Connectors.Memory.Postgres/PostgresVectorStoreUtils.cs
+++ b/dotnet/src/Connectors/Connectors.Memory.Postgres/PostgresVectorStoreUtils.cs
@@ -17,20 +17,22 @@ internal static class PostgresVectorStoreUtils
     /// <typeparam name="T">The type of the items in the async enumerable.</typeparam>
     /// <param name="asyncEnumerable">The async enumerable to wrap.</param>
     /// <param name="operationName">The name of the operation being performed.</param>
+    /// <param name="vectorStoreName">The name of the vector store.</param>
     /// <param name="collectionName">The name of the collection being operated on.</param>
     /// <returns>An async enumerable that will throw a <see cref="VectorStoreOperationException"/> if an exception is thrown while iterating over the original enumerator.</returns>
     public static async IAsyncEnumerable<T> WrapAsyncEnumerableAsync<T>(
         IAsyncEnumerable<T> asyncEnumerable,
         string operationName,
+        string? vectorStoreName = null,
         string? collectionName = null)
     {
         var enumerator = asyncEnumerable.ConfigureAwait(false).GetAsyncEnumerator();
 
-        var nextResult = await GetNextAsync<T>(enumerator, operationName, collectionName).ConfigureAwait(false);
+        var nextResult = await GetNextAsync<T>(enumerator, operationName, vectorStoreName, collectionName).ConfigureAwait(false);
         while (nextResult.more)
         {
             yield return nextResult.item;
-            nextResult = await GetNextAsync(enumerator, operationName, collectionName).ConfigureAwait(false);
+            nextResult = await GetNextAsync(enumerator, operationName, vectorStoreName, collectionName).ConfigureAwait(false);
         }
     }
 
@@ -40,11 +42,13 @@ internal static class PostgresVectorStoreUtils
     /// </summary>
     /// <param name="enumerator">The enumerator to get the next result from.</param>
     /// <param name="operationName">The name of the operation being performed.</param>
+    /// <param name="vectorStoreName">The name of the vector store.</param>
     /// <param name="collectionName">The name of the collection being operated on.</param>
     /// <returns>A value indicating whether there are more results and the current string if true.</returns>
     public static async Task<(T item, bool more)> GetNextAsync<T>(
         ConfiguredCancelableAsyncEnumerable<T>.Enumerator enumerator,
         string operationName,
+        string? vectorStoreName = null,
         string? collectionName = null)
     {
         try
@@ -56,7 +60,8 @@ internal static class PostgresVectorStoreUtils
         {
             throw new VectorStoreOperationException("Call to vector store failed.", ex)
             {
-                VectorStoreType = PostgresConstants.VectorStoreSystemName,
+                VectorStoreSystemName = PostgresConstants.VectorStoreSystemName,
+                VectorStoreName = vectorStoreName,
                 CollectionName = collectionName,
                 OperationName = operationName
             };

--- a/dotnet/src/Connectors/Connectors.Memory.Qdrant/QdrantVectorStore.cs
+++ b/dotnet/src/Connectors/Connectors.Memory.Qdrant/QdrantVectorStore.cs
@@ -16,7 +16,7 @@ namespace Microsoft.SemanticKernel.Connectors.Qdrant;
 /// <remarks>
 /// This class can be used with collections of any schema type, but requires you to provide schema information when getting a collection.
 /// </remarks>
-public class QdrantVectorStore : IVectorStore
+public sealed class QdrantVectorStore : IVectorStore
 {
     /// <summary>Metadata about vector store.</summary>
     private readonly VectorStoreMetadata _metadata;
@@ -56,7 +56,7 @@ public class QdrantVectorStore : IVectorStore
     }
 
     /// <inheritdoc />
-    public virtual IVectorStoreRecordCollection<TKey, TRecord> GetCollection<TKey, TRecord>(string name, VectorStoreRecordDefinition? vectorStoreRecordDefinition = null)
+    public IVectorStoreRecordCollection<TKey, TRecord> GetCollection<TKey, TRecord>(string name, VectorStoreRecordDefinition? vectorStoreRecordDefinition = null)
         where TKey : notnull
     {
 #pragma warning disable CS0618 // IQdrantVectorStoreRecordCollectionFactory is obsolete
@@ -81,7 +81,7 @@ public class QdrantVectorStore : IVectorStore
     }
 
     /// <inheritdoc />
-    public virtual async IAsyncEnumerable<string> ListCollectionNamesAsync([EnumeratorCancellation] CancellationToken cancellationToken = default)
+    public async IAsyncEnumerable<string> ListCollectionNamesAsync([EnumeratorCancellation] CancellationToken cancellationToken = default)
     {
         IReadOnlyList<string> collections;
 
@@ -93,7 +93,8 @@ public class QdrantVectorStore : IVectorStore
         {
             throw new VectorStoreOperationException("Call to vector store failed.", ex)
             {
-                VectorStoreType = QdrantConstants.VectorStoreSystemName,
+                VectorStoreSystemName = QdrantConstants.VectorStoreSystemName,
+                VectorStoreName = this._metadata.VectorStoreName,
                 OperationName = "ListCollections"
             };
         }

--- a/dotnet/src/Connectors/Connectors.Memory.Qdrant/QdrantVectorStoreCollectionSearchMapping.cs
+++ b/dotnet/src/Connectors/Connectors.Memory.Qdrant/QdrantVectorStoreCollectionSearchMapping.cs
@@ -94,12 +94,20 @@ internal static class QdrantVectorStoreCollectionSearchMapping
     /// <param name="point">The point to map to a <see cref="VectorSearchResult{TRecord}"/>.</param>
     /// <param name="mapper">The mapper to perform the main mapping operation with.</param>
     /// <param name="includeVectors">A value indicating whether to include vectors in the mapped result.</param>
-    /// <param name="databaseSystemName">The name of the database system the operation is being run on.</param>
+    /// <param name="vectorStoreSystemName">The name of the vector store system the operation is being run on.</param>
+    /// <param name="vectorStoreName">The name of the vector store the operation is being run on.</param>
     /// <param name="collectionName">The name of the collection the operation is being run on.</param>
     /// <param name="operationName">The type of database operation being run.</param>
     /// <returns>The mapped <see cref="VectorSearchResult{TRecord}"/>.</returns>
 #pragma warning disable CS0618 // IVectorStoreRecordMapper is obsolete
-    public static VectorSearchResult<TRecord> MapScoredPointToVectorSearchResult<TRecord>(ScoredPoint point, IVectorStoreRecordMapper<TRecord, PointStruct> mapper, bool includeVectors, string databaseSystemName, string collectionName, string operationName)
+    public static VectorSearchResult<TRecord> MapScoredPointToVectorSearchResult<TRecord>(
+        ScoredPoint point,
+        IVectorStoreRecordMapper<TRecord, PointStruct> mapper,
+        bool includeVectors,
+        string vectorStoreSystemName,
+        string? vectorStoreName,
+        string collectionName,
+        string operationName)
 #pragma warning restore CS0618
     {
         // Since the mapper doesn't know about scored points, we need to convert the scored point to a point struct first.
@@ -118,7 +126,8 @@ internal static class QdrantVectorStoreCollectionSearchMapping
         // Do the mapping with error handling.
         return new VectorSearchResult<TRecord>(
             VectorStoreErrorHandler.RunModelConversion(
-                databaseSystemName,
+                vectorStoreSystemName,
+                vectorStoreName,
                 collectionName,
                 operationName,
                 () => mapper.MapFromStorageToDataModel(pointStruct, new() { IncludeVectors = includeVectors })),

--- a/dotnet/src/Connectors/Connectors.Memory.Qdrant/QdrantVectorStoreRecordCollection.cs
+++ b/dotnet/src/Connectors/Connectors.Memory.Qdrant/QdrantVectorStoreRecordCollection.cs
@@ -20,7 +20,7 @@ namespace Microsoft.SemanticKernel.Connectors.Qdrant;
 /// </summary>
 /// <typeparam name="TRecord">The data model to use for adding, updating and retrieving data from storage.</typeparam>
 #pragma warning disable CA1711 // Identifiers should not have incorrect suffix
-public class QdrantVectorStoreRecordCollection<TRecord> :
+public sealed class QdrantVectorStoreRecordCollection<TRecord> :
     IVectorStoreRecordCollection<ulong, TRecord>,
     IVectorStoreRecordCollection<Guid, TRecord>,
     IKeywordHybridSearch<TRecord>
@@ -108,7 +108,7 @@ public class QdrantVectorStoreRecordCollection<TRecord> :
     public string CollectionName => this._collectionName;
 
     /// <inheritdoc />
-    public virtual Task<bool> CollectionExistsAsync(CancellationToken cancellationToken = default)
+    public Task<bool> CollectionExistsAsync(CancellationToken cancellationToken = default)
     {
         return this.RunOperationAsync(
             "CollectionExists",
@@ -116,7 +116,7 @@ public class QdrantVectorStoreRecordCollection<TRecord> :
     }
 
     /// <inheritdoc />
-    public virtual async Task CreateCollectionAsync(CancellationToken cancellationToken = default)
+    public async Task CreateCollectionAsync(CancellationToken cancellationToken = default)
     {
         if (!this._options.HasNamedVectors)
         {
@@ -200,7 +200,7 @@ public class QdrantVectorStoreRecordCollection<TRecord> :
     }
 
     /// <inheritdoc />
-    public virtual async Task CreateCollectionIfNotExistsAsync(CancellationToken cancellationToken = default)
+    public async Task CreateCollectionIfNotExistsAsync(CancellationToken cancellationToken = default)
     {
         if (!await this.CollectionExistsAsync(cancellationToken).ConfigureAwait(false))
         {
@@ -209,7 +209,7 @@ public class QdrantVectorStoreRecordCollection<TRecord> :
     }
 
     /// <inheritdoc />
-    public virtual Task DeleteCollectionAsync(CancellationToken cancellationToken = default)
+    public Task DeleteCollectionAsync(CancellationToken cancellationToken = default)
         => this.RunOperationAsync("DeleteCollection",
             async () =>
             {
@@ -232,7 +232,7 @@ public class QdrantVectorStoreRecordCollection<TRecord> :
             });
 
     /// <inheritdoc />
-    public virtual async Task<TRecord?> GetAsync(ulong key, GetRecordOptions? options = null, CancellationToken cancellationToken = default)
+    public async Task<TRecord?> GetAsync(ulong key, GetRecordOptions? options = null, CancellationToken cancellationToken = default)
     {
         Verify.NotNull(key);
 
@@ -241,7 +241,7 @@ public class QdrantVectorStoreRecordCollection<TRecord> :
     }
 
     /// <inheritdoc />
-    public virtual async Task<TRecord?> GetAsync(Guid key, GetRecordOptions? options = null, CancellationToken cancellationToken = default)
+    public async Task<TRecord?> GetAsync(Guid key, GetRecordOptions? options = null, CancellationToken cancellationToken = default)
     {
         Verify.NotNull(key);
 
@@ -250,19 +250,19 @@ public class QdrantVectorStoreRecordCollection<TRecord> :
     }
 
     /// <inheritdoc />
-    public virtual IAsyncEnumerable<TRecord> GetAsync(IEnumerable<ulong> keys, GetRecordOptions? options = default, CancellationToken cancellationToken = default)
+    public IAsyncEnumerable<TRecord> GetAsync(IEnumerable<ulong> keys, GetRecordOptions? options = default, CancellationToken cancellationToken = default)
     {
         return this.GetBatchByPointIdAsync(keys, key => new PointId { Num = key }, options, cancellationToken);
     }
 
     /// <inheritdoc />
-    public virtual IAsyncEnumerable<TRecord> GetAsync(IEnumerable<Guid> keys, GetRecordOptions? options = default, CancellationToken cancellationToken = default)
+    public IAsyncEnumerable<TRecord> GetAsync(IEnumerable<Guid> keys, GetRecordOptions? options = default, CancellationToken cancellationToken = default)
     {
         return this.GetBatchByPointIdAsync(keys, key => new PointId { Uuid = key.ToString("D") }, options, cancellationToken);
     }
 
     /// <inheritdoc />
-    public virtual Task DeleteAsync(ulong key, CancellationToken cancellationToken = default)
+    public Task DeleteAsync(ulong key, CancellationToken cancellationToken = default)
     {
         Verify.NotNull(key);
 
@@ -276,7 +276,7 @@ public class QdrantVectorStoreRecordCollection<TRecord> :
     }
 
     /// <inheritdoc />
-    public virtual Task DeleteAsync(Guid key, CancellationToken cancellationToken = default)
+    public Task DeleteAsync(Guid key, CancellationToken cancellationToken = default)
     {
         Verify.NotNull(key);
 
@@ -290,7 +290,7 @@ public class QdrantVectorStoreRecordCollection<TRecord> :
     }
 
     /// <inheritdoc />
-    public virtual Task DeleteAsync(IEnumerable<ulong> keys, CancellationToken cancellationToken = default)
+    public Task DeleteAsync(IEnumerable<ulong> keys, CancellationToken cancellationToken = default)
     {
         Verify.NotNull(keys);
 
@@ -304,7 +304,7 @@ public class QdrantVectorStoreRecordCollection<TRecord> :
     }
 
     /// <inheritdoc />
-    public virtual Task DeleteAsync(IEnumerable<Guid> keys, CancellationToken cancellationToken = default)
+    public Task DeleteAsync(IEnumerable<Guid> keys, CancellationToken cancellationToken = default)
     {
         Verify.NotNull(keys);
 
@@ -318,13 +318,14 @@ public class QdrantVectorStoreRecordCollection<TRecord> :
     }
 
     /// <inheritdoc />
-    public virtual async Task<ulong> UpsertAsync(TRecord record, CancellationToken cancellationToken = default)
+    public async Task<ulong> UpsertAsync(TRecord record, CancellationToken cancellationToken = default)
     {
         Verify.NotNull(record);
 
         // Create point from record.
         var pointStruct = VectorStoreErrorHandler.RunModelConversion(
             QdrantConstants.VectorStoreSystemName,
+            this._collectionMetadata.VectorStoreName,
             this._collectionName,
             UpsertName,
             () => this._mapper.MapFromDataToStorageModel(record));
@@ -344,6 +345,7 @@ public class QdrantVectorStoreRecordCollection<TRecord> :
         // Create point from record.
         var pointStruct = VectorStoreErrorHandler.RunModelConversion(
             QdrantConstants.VectorStoreSystemName,
+            this._collectionMetadata.VectorStoreName,
             this._collectionName,
             UpsertName,
             () => this._mapper.MapFromDataToStorageModel(record));
@@ -356,13 +358,14 @@ public class QdrantVectorStoreRecordCollection<TRecord> :
     }
 
     /// <inheritdoc />
-    public virtual async IAsyncEnumerable<ulong> UpsertAsync(IEnumerable<TRecord> records, [EnumeratorCancellation] CancellationToken cancellationToken = default)
+    public async IAsyncEnumerable<ulong> UpsertAsync(IEnumerable<TRecord> records, [EnumeratorCancellation] CancellationToken cancellationToken = default)
     {
         Verify.NotNull(records);
 
         // Create points from records.
         var pointStructs = VectorStoreErrorHandler.RunModelConversion(
             QdrantConstants.VectorStoreSystemName,
+            this._collectionMetadata.VectorStoreName,
             this._collectionName,
             UpsertName,
             () => records.Select(this._mapper.MapFromDataToStorageModel).ToList());
@@ -386,6 +389,7 @@ public class QdrantVectorStoreRecordCollection<TRecord> :
         // Create points from records.
         var pointStructs = VectorStoreErrorHandler.RunModelConversion(
             QdrantConstants.VectorStoreSystemName,
+            this._collectionMetadata.VectorStoreName,
             this._collectionName,
             UpsertName,
             () => records.Select(this._mapper.MapFromDataToStorageModel).ToList());
@@ -444,6 +448,7 @@ public class QdrantVectorStoreRecordCollection<TRecord> :
 
             yield return VectorStoreErrorHandler.RunModelConversion(
                 QdrantConstants.VectorStoreSystemName,
+                this._collectionMetadata.VectorStoreName,
                 this._collectionName,
                 OperationName,
                 () => this._mapper.MapFromStorageToDataModel(pointStruct, new() { IncludeVectors = includeVectors }));
@@ -451,7 +456,7 @@ public class QdrantVectorStoreRecordCollection<TRecord> :
     }
 
     /// <inheritdoc />
-    public virtual async Task<VectorSearchResults<TRecord>> VectorizedSearchAsync<TVector>(TVector vector, int top, VectorSearchOptions<TRecord>? options = null, CancellationToken cancellationToken = default)
+    public async Task<VectorSearchResults<TRecord>> VectorizedSearchAsync<TVector>(TVector vector, int top, VectorSearchOptions<TRecord>? options = null, CancellationToken cancellationToken = default)
     {
         var floatVector = VerifyVectorParam(vector);
         Verify.NotLessThan(top, 1);
@@ -499,6 +504,7 @@ public class QdrantVectorStoreRecordCollection<TRecord> :
                 this._mapper,
                 internalOptions.IncludeVectors,
                 QdrantConstants.VectorStoreSystemName,
+                this._collectionMetadata.VectorStoreName,
                 this._collectionName,
                 "Query"));
 
@@ -584,6 +590,7 @@ public class QdrantVectorStoreRecordCollection<TRecord> :
                 this._mapper,
                 internalOptions.IncludeVectors,
                 QdrantConstants.VectorStoreSystemName,
+                this._collectionMetadata.VectorStoreName,
                 this._collectionName,
                 "Query"));
 
@@ -619,7 +626,8 @@ public class QdrantVectorStoreRecordCollection<TRecord> :
         {
             throw new VectorStoreOperationException("Call to vector store failed.", ex)
             {
-                VectorStoreType = QdrantConstants.VectorStoreSystemName,
+                VectorStoreSystemName = QdrantConstants.VectorStoreSystemName,
+                VectorStoreName = this._collectionMetadata.VectorStoreName,
                 CollectionName = this._collectionName,
                 OperationName = operationName
             };
@@ -643,7 +651,8 @@ public class QdrantVectorStoreRecordCollection<TRecord> :
         {
             throw new VectorStoreOperationException("Call to vector store failed.", ex)
             {
-                VectorStoreType = QdrantConstants.VectorStoreSystemName,
+                VectorStoreSystemName = QdrantConstants.VectorStoreSystemName,
+                VectorStoreName = this._collectionMetadata.VectorStoreName,
                 CollectionName = this._collectionName,
                 OperationName = operationName
             };

--- a/dotnet/src/Connectors/Connectors.Memory.Redis/RedisVectorStore.cs
+++ b/dotnet/src/Connectors/Connectors.Memory.Redis/RedisVectorStore.cs
@@ -16,7 +16,7 @@ namespace Microsoft.SemanticKernel.Connectors.Redis;
 /// <remarks>
 /// This class can be used with collections of any schema type, but requires you to provide schema information when getting a collection.
 /// </remarks>
-public class RedisVectorStore : IVectorStore
+public sealed class RedisVectorStore : IVectorStore
 {
     /// <summary>Metadata about vector store.</summary>
     private readonly VectorStoreMetadata _metadata;
@@ -47,7 +47,7 @@ public class RedisVectorStore : IVectorStore
     }
 
     /// <inheritdoc />
-    public virtual IVectorStoreRecordCollection<TKey, TRecord> GetCollection<TKey, TRecord>(string name, VectorStoreRecordDefinition? vectorStoreRecordDefinition = null)
+    public IVectorStoreRecordCollection<TKey, TRecord> GetCollection<TKey, TRecord>(string name, VectorStoreRecordDefinition? vectorStoreRecordDefinition = null)
         where TKey : notnull
     {
 #pragma warning disable CS0618 // IRedisVectorStoreRecordCollectionFactory is obsolete
@@ -75,7 +75,7 @@ public class RedisVectorStore : IVectorStore
     }
 
     /// <inheritdoc />
-    public virtual async IAsyncEnumerable<string> ListCollectionNamesAsync([EnumeratorCancellation] CancellationToken cancellationToken = default)
+    public async IAsyncEnumerable<string> ListCollectionNamesAsync([EnumeratorCancellation] CancellationToken cancellationToken = default)
     {
         const string OperationName = "";
         RedisResult[] listResult;
@@ -88,7 +88,8 @@ public class RedisVectorStore : IVectorStore
         {
             throw new VectorStoreOperationException("Call to vector store failed.", ex)
             {
-                VectorStoreType = RedisConstants.VectorStoreSystemName,
+                VectorStoreSystemName = RedisConstants.VectorStoreSystemName,
+                VectorStoreName = this._metadata.VectorStoreName,
                 OperationName = OperationName
             };
         }

--- a/dotnet/src/Connectors/Connectors.Memory.SqlServer/ExceptionWrapper.cs
+++ b/dotnet/src/Connectors/Connectors.Memory.SqlServer/ExceptionWrapper.cs
@@ -16,9 +16,10 @@ internal static class ExceptionWrapper
         SqlConnection connection,
         SqlCommand command,
         Func<SqlCommand, CancellationToken, Task<T>> func,
-        CancellationToken cancellationToken,
         string operationName,
-        string? collectionName = null)
+        string? vectorStoreName = null,
+        string? collectionName = null,
+        CancellationToken cancellationToken = default)
     {
         if (connection.State != System.Data.ConnectionState.Open)
         {
@@ -39,18 +40,20 @@ internal static class ExceptionWrapper
 
             throw new VectorStoreOperationException(ex.Message, ex)
             {
-                OperationName = operationName,
-                VectorStoreType = SqlServerConstants.VectorStoreSystemName,
-                CollectionName = collectionName
+                VectorStoreSystemName = SqlServerConstants.VectorStoreSystemName,
+                VectorStoreName = vectorStoreName,
+                CollectionName = collectionName,
+                OperationName = operationName
             };
         }
     }
 
     internal static async Task<bool> WrapReadAsync(
         SqlDataReader reader,
-        CancellationToken cancellationToken,
         string operationName,
-        string? collectionName = null)
+        string? vectorStoreName = null,
+        string? collectionName = null,
+        CancellationToken cancellationToken = default)
     {
         try
         {
@@ -60,9 +63,10 @@ internal static class ExceptionWrapper
         {
             throw new VectorStoreOperationException(ex.Message, ex)
             {
-                OperationName = operationName,
-                VectorStoreType = SqlServerConstants.VectorStoreSystemName,
-                CollectionName = collectionName
+                VectorStoreSystemName = SqlServerConstants.VectorStoreSystemName,
+                VectorStoreName = vectorStoreName,
+                CollectionName = collectionName,
+                OperationName = operationName
             };
         }
     }

--- a/dotnet/src/Connectors/Connectors.Memory.SqlServer/SqlServerVectorStore.cs
+++ b/dotnet/src/Connectors/Connectors.Memory.SqlServer/SqlServerVectorStore.cs
@@ -66,11 +66,19 @@ public sealed class SqlServerVectorStore : IVectorStore
         using SqlConnection connection = new(this._connectionString);
         using SqlCommand command = SqlServerCommandBuilder.SelectTableNames(connection, this._options.Schema);
 
-        using SqlDataReader reader = await ExceptionWrapper.WrapAsync(connection, command,
+        using SqlDataReader reader = await ExceptionWrapper.WrapAsync(
+            connection,
+            command,
             static (cmd, ct) => cmd.ExecuteReaderAsync(ct),
-            cancellationToken, "ListCollection").ConfigureAwait(false);
+            operationName: "ListCollectionNames",
+            vectorStoreName: this._metadata.VectorStoreName,
+            cancellationToken: cancellationToken).ConfigureAwait(false);
 
-        while (await ExceptionWrapper.WrapReadAsync(reader, cancellationToken, "ListCollection").ConfigureAwait(false))
+        while (await ExceptionWrapper.WrapReadAsync(
+            reader,
+            operationName: "ListCollectionNames",
+            vectorStoreName: this._metadata.VectorStoreName,
+            cancellationToken: cancellationToken).ConfigureAwait(false))
         {
             yield return reader.GetString(reader.GetOrdinal("table_name"));
         }

--- a/dotnet/src/Connectors/Connectors.Memory.SqlServer/SqlServerVectorStoreRecordCollection.cs
+++ b/dotnet/src/Connectors/Connectors.Memory.SqlServer/SqlServerVectorStoreRecordCollection.cs
@@ -91,7 +91,11 @@ public sealed class SqlServerVectorStoreRecordCollection<TKey, TRecord>
             {
                 using SqlDataReader reader = await cmd.ExecuteReaderAsync(ct).ConfigureAwait(false);
                 return await reader.ReadAsync(ct).ConfigureAwait(false);
-            }, cancellationToken, "CollectionExists", this.CollectionName).ConfigureAwait(false);
+            },
+            "CollectionExists",
+            this._collectionMetadata.VectorStoreName,
+            this.CollectionName,
+            cancellationToken).ConfigureAwait(false);
     }
 
     /// <inheritdoc/>
@@ -122,7 +126,10 @@ public sealed class SqlServerVectorStoreRecordCollection<TKey, TRecord>
 
         await ExceptionWrapper.WrapAsync(connection, command,
             static (cmd, ct) => cmd.ExecuteNonQueryAsync(ct),
-            cancellationToken, "CreateCollection", this.CollectionName).ConfigureAwait(false);
+            "CreateCollection",
+            this._collectionMetadata.VectorStoreName,
+            this.CollectionName,
+            cancellationToken).ConfigureAwait(false);
     }
 
     /// <inheritdoc/>
@@ -134,7 +141,10 @@ public sealed class SqlServerVectorStoreRecordCollection<TKey, TRecord>
 
         await ExceptionWrapper.WrapAsync(connection, command,
             static (cmd, ct) => cmd.ExecuteNonQueryAsync(ct),
-            cancellationToken, "DeleteCollection", this.CollectionName).ConfigureAwait(false);
+            "DeleteCollection",
+            this._collectionMetadata.VectorStoreName,
+            this.CollectionName,
+            cancellationToken).ConfigureAwait(false);
     }
 
     /// <inheritdoc/>
@@ -152,7 +162,10 @@ public sealed class SqlServerVectorStoreRecordCollection<TKey, TRecord>
 
         await ExceptionWrapper.WrapAsync(connection, command,
             static (cmd, ct) => cmd.ExecuteNonQueryAsync(ct),
-            cancellationToken, "Delete", this.CollectionName).ConfigureAwait(false);
+            "Delete",
+            this._collectionMetadata.VectorStoreName,
+            this.CollectionName,
+            cancellationToken).ConfigureAwait(false);
     }
 
     /// <inheritdoc/>
@@ -215,9 +228,10 @@ public sealed class SqlServerVectorStoreRecordCollection<TKey, TRecord>
 
             throw new VectorStoreOperationException(ex.Message, ex)
             {
-                OperationName = "DeleteBatch",
-                VectorStoreType = SqlServerConstants.VectorStoreSystemName,
-                CollectionName = this.CollectionName
+                VectorStoreSystemName = SqlServerConstants.VectorStoreSystemName,
+                VectorStoreName = this._collectionMetadata.VectorStoreName,
+                CollectionName = this.CollectionName,
+                OperationName = "DeleteBatch"
             };
         }
     }
@@ -244,7 +258,11 @@ public sealed class SqlServerVectorStoreRecordCollection<TKey, TRecord>
                 SqlDataReader reader = await cmd.ExecuteReaderAsync(ct).ConfigureAwait(false);
                 await reader.ReadAsync(ct).ConfigureAwait(false);
                 return reader;
-            }, cancellationToken, "Get", this.CollectionName).ConfigureAwait(false);
+            },
+            "Get",
+            this._collectionMetadata.VectorStoreName,
+            this.CollectionName,
+            cancellationToken).ConfigureAwait(false);
 
         return reader.HasRows
             ? this._mapper.MapFromStorageToDataModel(
@@ -290,9 +308,17 @@ public sealed class SqlServerVectorStoreRecordCollection<TKey, TRecord>
 
             using SqlDataReader reader = await ExceptionWrapper.WrapAsync(connection, command,
                 static (cmd, ct) => cmd.ExecuteReaderAsync(ct),
-                cancellationToken, "GetBatch", this.CollectionName).ConfigureAwait(false);
+                "GetBatch",
+                this._collectionMetadata.VectorStoreName,
+                this.CollectionName,
+                cancellationToken).ConfigureAwait(false);
 
-            while (await ExceptionWrapper.WrapReadAsync(reader, cancellationToken, "GetBatch", this.CollectionName).ConfigureAwait(false))
+            while (await ExceptionWrapper.WrapReadAsync(
+                reader,
+                "GetBatch",
+                this._collectionMetadata.VectorStoreName,
+                this.CollectionName,
+                cancellationToken).ConfigureAwait(false))
             {
                 yield return this._mapper.MapFromStorageToDataModel(
                     new SqlDataReaderDictionary(reader, this._model.VectorProperties),
@@ -320,7 +346,11 @@ public sealed class SqlServerVectorStoreRecordCollection<TKey, TRecord>
                 using SqlDataReader reader = await cmd.ExecuteReaderAsync(ct).ConfigureAwait(false);
                 await reader.ReadAsync(ct).ConfigureAwait(false);
                 return reader.GetFieldValue<TKey>(0);
-            }, cancellationToken, "Upsert", this.CollectionName).ConfigureAwait(false);
+            },
+            "Upsert",
+            this._collectionMetadata.VectorStoreName,
+            this.CollectionName,
+            cancellationToken).ConfigureAwait(false);
     }
 
     /// <inheritdoc/>
@@ -387,9 +417,10 @@ public sealed class SqlServerVectorStoreRecordCollection<TKey, TRecord>
 
             throw new VectorStoreOperationException(ex.Message, ex)
             {
-                OperationName = "UpsertBatch",
-                VectorStoreType = SqlServerConstants.VectorStoreSystemName,
-                CollectionName = this.CollectionName
+                VectorStoreSystemName = SqlServerConstants.VectorStoreSystemName,
+                VectorStoreName = this._collectionMetadata.VectorStoreName,
+                CollectionName = this.CollectionName,
+                OperationName = "UpsertBatch"
             };
         }
 
@@ -452,7 +483,11 @@ public sealed class SqlServerVectorStoreRecordCollection<TKey, TRecord>
             {
                 var results = this.ReadVectorSearchResultsAsync(connection, cmd, searchOptions.IncludeVectors, ct);
                 return Task.FromResult(new VectorSearchResults<TRecord>(results));
-            }, cancellationToken, "VectorizedSearch", this.CollectionName).ConfigureAwait(false);
+            },
+            "VectorizedSearch",
+            this._collectionMetadata.VectorStoreName,
+            this.CollectionName,
+            cancellationToken).ConfigureAwait(false);
     }
 
     /// <inheritdoc />

--- a/dotnet/src/Connectors/Connectors.Memory.Sqlite/SqliteVectorStore.cs
+++ b/dotnet/src/Connectors/Connectors.Memory.Sqlite/SqliteVectorStore.cs
@@ -16,7 +16,7 @@ namespace Microsoft.SemanticKernel.Connectors.Sqlite;
 /// <remarks>
 /// This class can be used with collections of any schema type, but requires you to provide schema information when getting a collection.
 /// </remarks>
-public class SqliteVectorStore : IVectorStore
+public sealed class SqliteVectorStore : IVectorStore
 {
     /// <summary>Metadata about vector store.</summary>
     private readonly VectorStoreMetadata _metadata;
@@ -60,7 +60,7 @@ public class SqliteVectorStore : IVectorStore
         => throw new InvalidOperationException("Use the constructor that accepts a connection string instead.");
 
     /// <inheritdoc />
-    public virtual IVectorStoreRecordCollection<TKey, TRecord> GetCollection<TKey, TRecord>(string name, VectorStoreRecordDefinition? vectorStoreRecordDefinition = null)
+    public IVectorStoreRecordCollection<TKey, TRecord> GetCollection<TKey, TRecord>(string name, VectorStoreRecordDefinition? vectorStoreRecordDefinition = null)
         where TKey : notnull
     {
 #pragma warning disable CS0618 // ISqliteVectorStoreRecordCollectionFactory is obsolete
@@ -92,7 +92,7 @@ public class SqliteVectorStore : IVectorStore
     }
 
     /// <inheritdoc />
-    public virtual async IAsyncEnumerable<string> ListCollectionNamesAsync([EnumeratorCancellation] CancellationToken cancellationToken = default)
+    public async IAsyncEnumerable<string> ListCollectionNamesAsync([EnumeratorCancellation] CancellationToken cancellationToken = default)
     {
         const string TablePropertyName = "name";
         const string Query = $"SELECT {TablePropertyName} FROM sqlite_master WHERE type='table' AND name NOT LIKE 'sqlite_%';";

--- a/dotnet/src/Connectors/Connectors.Memory.Weaviate/WeaviateVectorStore.cs
+++ b/dotnet/src/Connectors/Connectors.Memory.Weaviate/WeaviateVectorStore.cs
@@ -16,7 +16,7 @@ namespace Microsoft.SemanticKernel.Connectors.Weaviate;
 /// <remarks>
 /// This class can be used with collections of any schema type, but requires you to provide schema information when getting a collection.
 /// </remarks>
-public class WeaviateVectorStore : IVectorStore
+public sealed class WeaviateVectorStore : IVectorStore
 {
     /// <summary>Metadata about vector store.</summary>
     private readonly VectorStoreMetadata _metadata;
@@ -51,7 +51,7 @@ public class WeaviateVectorStore : IVectorStore
 
     /// <inheritdoc />
     /// <remarks>The collection name must start with a capital letter and contain only ASCII letters and digits.</remarks>
-    public virtual IVectorStoreRecordCollection<TKey, TRecord> GetCollection<TKey, TRecord>(string name, VectorStoreRecordDefinition? vectorStoreRecordDefinition = null)
+    public IVectorStoreRecordCollection<TKey, TRecord> GetCollection<TKey, TRecord>(string name, VectorStoreRecordDefinition? vectorStoreRecordDefinition = null)
         where TKey : notnull
     {
 #pragma warning disable CS0618 // IWeaviateVectorStoreRecordCollectionFactory is obsolete
@@ -83,7 +83,7 @@ public class WeaviateVectorStore : IVectorStore
     }
 
     /// <inheritdoc />
-    public virtual async IAsyncEnumerable<string> ListCollectionNamesAsync([EnumeratorCancellation] CancellationToken cancellationToken = default)
+    public async IAsyncEnumerable<string> ListCollectionNamesAsync([EnumeratorCancellation] CancellationToken cancellationToken = default)
     {
         using var request = new WeaviateGetCollectionsRequest().Build();
         WeaviateGetCollectionsResponse collectionsResponse;
@@ -99,7 +99,8 @@ public class WeaviateVectorStore : IVectorStore
         {
             throw new VectorStoreOperationException("Call to vector store failed.", e)
             {
-                VectorStoreType = WeaviateConstants.VectorStoreSystemName,
+                VectorStoreSystemName = WeaviateConstants.VectorStoreSystemName,
+                VectorStoreName = this._metadata.VectorStoreName,
                 OperationName = "ListCollectionNames"
             };
         }

--- a/dotnet/src/Connectors/Connectors.Memory.Weaviate/WeaviateVectorStoreRecordCollection.cs
+++ b/dotnet/src/Connectors/Connectors.Memory.Weaviate/WeaviateVectorStoreRecordCollection.cs
@@ -21,7 +21,7 @@ namespace Microsoft.SemanticKernel.Connectors.Weaviate;
 /// </summary>
 /// <typeparam name="TRecord">The data model to use for adding, updating and retrieving data from storage.</typeparam>
 #pragma warning disable CA1711 // Identifiers should not have incorrect suffix
-public class WeaviateVectorStoreRecordCollection<TRecord> : IVectorStoreRecordCollection<Guid, TRecord>, IKeywordHybridSearch<TRecord>
+public sealed class WeaviateVectorStoreRecordCollection<TRecord> : IVectorStoreRecordCollection<Guid, TRecord>, IKeywordHybridSearch<TRecord>
 #pragma warning restore CA1711 // Identifiers should not have incorrect suffix
 {
     /// <summary>Metadata about vector store record collection.</summary>
@@ -108,7 +108,7 @@ public class WeaviateVectorStoreRecordCollection<TRecord> : IVectorStoreRecordCo
     }
 
     /// <inheritdoc />
-    public virtual Task<bool> CollectionExistsAsync(CancellationToken cancellationToken = default)
+    public Task<bool> CollectionExistsAsync(CancellationToken cancellationToken = default)
     {
         const string OperationName = "GetCollectionSchema";
 
@@ -125,7 +125,7 @@ public class WeaviateVectorStoreRecordCollection<TRecord> : IVectorStoreRecordCo
     }
 
     /// <inheritdoc />
-    public virtual Task CreateCollectionAsync(CancellationToken cancellationToken = default)
+    public Task CreateCollectionAsync(CancellationToken cancellationToken = default)
     {
         const string OperationName = "CreateCollectionSchema";
 
@@ -140,7 +140,7 @@ public class WeaviateVectorStoreRecordCollection<TRecord> : IVectorStoreRecordCo
     }
 
     /// <inheritdoc />
-    public virtual async Task CreateCollectionIfNotExistsAsync(CancellationToken cancellationToken = default)
+    public async Task CreateCollectionIfNotExistsAsync(CancellationToken cancellationToken = default)
     {
         if (!await this.CollectionExistsAsync(cancellationToken).ConfigureAwait(false))
         {
@@ -149,7 +149,7 @@ public class WeaviateVectorStoreRecordCollection<TRecord> : IVectorStoreRecordCo
     }
 
     /// <inheritdoc />
-    public virtual Task DeleteCollectionAsync(CancellationToken cancellationToken = default)
+    public Task DeleteCollectionAsync(CancellationToken cancellationToken = default)
     {
         const string OperationName = "DeleteCollectionSchema";
 
@@ -162,7 +162,7 @@ public class WeaviateVectorStoreRecordCollection<TRecord> : IVectorStoreRecordCo
     }
 
     /// <inheritdoc />
-    public virtual Task DeleteAsync(Guid key, CancellationToken cancellationToken = default)
+    public Task DeleteAsync(Guid key, CancellationToken cancellationToken = default)
     {
         const string OperationName = "DeleteObject";
 
@@ -175,7 +175,7 @@ public class WeaviateVectorStoreRecordCollection<TRecord> : IVectorStoreRecordCo
     }
 
     /// <inheritdoc />
-    public virtual Task DeleteAsync(IEnumerable<Guid> keys, CancellationToken cancellationToken = default)
+    public Task DeleteAsync(IEnumerable<Guid> keys, CancellationToken cancellationToken = default)
     {
         const string OperationName = "DeleteObjectBatch";
         const string ContainsAnyOperator = "ContainsAny";
@@ -200,7 +200,7 @@ public class WeaviateVectorStoreRecordCollection<TRecord> : IVectorStoreRecordCo
     }
 
     /// <inheritdoc />
-    public virtual Task<TRecord?> GetAsync(Guid key, GetRecordOptions? options = null, CancellationToken cancellationToken = default)
+    public Task<TRecord?> GetAsync(Guid key, GetRecordOptions? options = null, CancellationToken cancellationToken = default)
     {
         const string OperationName = "GetCollectionObject";
 
@@ -218,6 +218,7 @@ public class WeaviateVectorStoreRecordCollection<TRecord> : IVectorStoreRecordCo
 
             return VectorStoreErrorHandler.RunModelConversion(
                 WeaviateConstants.VectorStoreSystemName,
+                this._collectionMetadata.VectorStoreName,
                 this.CollectionName,
                 OperationName,
                 () => this._mapper.MapFromStorageToDataModel(jsonObject!, new() { IncludeVectors = includeVectors }));
@@ -225,7 +226,7 @@ public class WeaviateVectorStoreRecordCollection<TRecord> : IVectorStoreRecordCo
     }
 
     /// <inheritdoc />
-    public virtual async IAsyncEnumerable<TRecord> GetAsync(
+    public async IAsyncEnumerable<TRecord> GetAsync(
         IEnumerable<Guid> keys,
         GetRecordOptions? options = null,
         [EnumeratorCancellation] CancellationToken cancellationToken = default)
@@ -244,7 +245,7 @@ public class WeaviateVectorStoreRecordCollection<TRecord> : IVectorStoreRecordCo
     }
 
     /// <inheritdoc />
-    public virtual async Task<Guid> UpsertAsync(TRecord record, CancellationToken cancellationToken = default)
+    public async Task<Guid> UpsertAsync(TRecord record, CancellationToken cancellationToken = default)
     {
         return await this.UpsertAsync([record], cancellationToken)
             .FirstOrDefaultAsync(cancellationToken)
@@ -252,7 +253,7 @@ public class WeaviateVectorStoreRecordCollection<TRecord> : IVectorStoreRecordCo
     }
 
     /// <inheritdoc />
-    public virtual async IAsyncEnumerable<Guid> UpsertAsync(IEnumerable<TRecord> records, [EnumeratorCancellation] CancellationToken cancellationToken = default)
+    public async IAsyncEnumerable<Guid> UpsertAsync(IEnumerable<TRecord> records, [EnumeratorCancellation] CancellationToken cancellationToken = default)
     {
         const string OperationName = "UpsertCollectionObject";
 
@@ -260,6 +261,7 @@ public class WeaviateVectorStoreRecordCollection<TRecord> : IVectorStoreRecordCo
         {
             var jsonObjects = records.Select(record => VectorStoreErrorHandler.RunModelConversion(
                 WeaviateConstants.VectorStoreSystemName,
+                this._collectionMetadata.VectorStoreName,
                 this.CollectionName,
                 OperationName,
                 () => this._mapper.MapFromDataToStorageModel(record))).ToList();
@@ -282,7 +284,7 @@ public class WeaviateVectorStoreRecordCollection<TRecord> : IVectorStoreRecordCo
     }
 
     /// <inheritdoc />
-    public virtual async Task<VectorSearchResults<TRecord>> VectorizedSearchAsync<TVector>(
+    public async Task<VectorSearchResults<TRecord>> VectorizedSearchAsync<TVector>(
         TVector vector,
         int top,
         VectorSearchOptions<TRecord>? options = null,
@@ -361,7 +363,8 @@ public class WeaviateVectorStoreRecordCollection<TRecord> : IVectorStoreRecordCo
         {
             throw new VectorStoreOperationException($"Error occurred during vector search. Response: {content}")
             {
-                VectorStoreType = WeaviateConstants.VectorStoreSystemName,
+                VectorStoreSystemName = WeaviateConstants.VectorStoreSystemName,
+                VectorStoreName = this._collectionMetadata.VectorStoreName,
                 CollectionName = this.CollectionName,
                 OperationName = operationName
             };
@@ -373,6 +376,7 @@ public class WeaviateVectorStoreRecordCollection<TRecord> : IVectorStoreRecordCo
 
             var record = VectorStoreErrorHandler.RunModelConversion(
                 WeaviateConstants.VectorStoreSystemName,
+                this._collectionMetadata.VectorStoreName,
                 this.CollectionName,
                 operationName,
                 () => this._mapper.MapFromStorageToDataModel(storageModel, new() { IncludeVectors = includeVectors }));
@@ -437,7 +441,8 @@ public class WeaviateVectorStoreRecordCollection<TRecord> : IVectorStoreRecordCo
         {
             throw new VectorStoreOperationException("Call to vector store failed.", ex)
             {
-                VectorStoreType = WeaviateConstants.VectorStoreSystemName,
+                VectorStoreSystemName = WeaviateConstants.VectorStoreSystemName,
+                VectorStoreName = this._collectionMetadata.VectorStoreName,
                 CollectionName = this.CollectionName,
                 OperationName = operationName
             };

--- a/dotnet/src/Connectors/Connectors.Qdrant.UnitTests/QdrantVectorStoreCollectionSearchMappingTests.cs
+++ b/dotnet/src/Connectors/Connectors.Qdrant.UnitTests/QdrantVectorStoreCollectionSearchMappingTests.cs
@@ -119,7 +119,7 @@ public class QdrantVectorStoreCollectionSearchMappingTests
         mapperMock.Setup(x => x.MapFromStorageToDataModel(It.IsAny<PointStruct>(), It.IsAny<StorageToDataModelMapperOptions>())).Returns(new DataModel { Id = 1, DataField = "data 1", Embedding = new float[] { 1, 2, 3 } });
 
         // Act.
-        var actual = QdrantVectorStoreCollectionSearchMapping.MapScoredPointToVectorSearchResult<DataModel>(scoredPoint, mapperMock.Object, true, "Qdrant", "mycollection", "query");
+        var actual = QdrantVectorStoreCollectionSearchMapping.MapScoredPointToVectorSearchResult<DataModel>(scoredPoint, mapperMock.Object, true, "Qdrant", "myvectorstore", "mycollection", "query");
 
         // Assert.
         Assert.Equal(1ul, actual.Record.Id);

--- a/dotnet/src/Connectors/VectorData.Abstractions/CompatibilitySuppressions.xml
+++ b/dotnet/src/Connectors/VectorData.Abstractions/CompatibilitySuppressions.xml
@@ -73,6 +73,20 @@
   </Suppression>
   <Suppression>
     <DiagnosticId>CP0002</DiagnosticId>
+    <Target>M:Microsoft.Extensions.VectorData.VectorStoreException.get_VectorStoreType</Target>
+    <Left>lib/net462/Microsoft.Extensions.VectorData.Abstractions.dll</Left>
+    <Right>lib/net462/Microsoft.Extensions.VectorData.Abstractions.dll</Right>
+    <IsBaselineSuppression>true</IsBaselineSuppression>
+  </Suppression>
+  <Suppression>
+    <DiagnosticId>CP0002</DiagnosticId>
+    <Target>M:Microsoft.Extensions.VectorData.VectorStoreException.set_VectorStoreType(System.String)</Target>
+    <Left>lib/net462/Microsoft.Extensions.VectorData.Abstractions.dll</Left>
+    <Right>lib/net462/Microsoft.Extensions.VectorData.Abstractions.dll</Right>
+    <IsBaselineSuppression>true</IsBaselineSuppression>
+  </Suppression>
+  <Suppression>
+    <DiagnosticId>CP0002</DiagnosticId>
     <Target>M:Microsoft.Extensions.VectorData.HybridSearchOptions`1.get_Top</Target>
     <Left>lib/net8.0/Microsoft.Extensions.VectorData.Abstractions.dll</Left>
     <Right>lib/net8.0/Microsoft.Extensions.VectorData.Abstractions.dll</Right>
@@ -143,6 +157,20 @@
   </Suppression>
   <Suppression>
     <DiagnosticId>CP0002</DiagnosticId>
+    <Target>M:Microsoft.Extensions.VectorData.VectorStoreException.get_VectorStoreType</Target>
+    <Left>lib/net8.0/Microsoft.Extensions.VectorData.Abstractions.dll</Left>
+    <Right>lib/net8.0/Microsoft.Extensions.VectorData.Abstractions.dll</Right>
+    <IsBaselineSuppression>true</IsBaselineSuppression>
+  </Suppression>
+  <Suppression>
+    <DiagnosticId>CP0002</DiagnosticId>
+    <Target>M:Microsoft.Extensions.VectorData.VectorStoreException.set_VectorStoreType(System.String)</Target>
+    <Left>lib/net8.0/Microsoft.Extensions.VectorData.Abstractions.dll</Left>
+    <Right>lib/net8.0/Microsoft.Extensions.VectorData.Abstractions.dll</Right>
+    <IsBaselineSuppression>true</IsBaselineSuppression>
+  </Suppression>
+  <Suppression>
+    <DiagnosticId>CP0002</DiagnosticId>
     <Target>M:Microsoft.Extensions.VectorData.HybridSearchOptions`1.get_Top</Target>
     <Left>lib/netstandard2.0/Microsoft.Extensions.VectorData.Abstractions.dll</Left>
     <Right>lib/netstandard2.0/Microsoft.Extensions.VectorData.Abstractions.dll</Right>
@@ -207,6 +235,20 @@
   <Suppression>
     <DiagnosticId>CP0002</DiagnosticId>
     <Target>M:Microsoft.Extensions.VectorData.VectorSearchOptions`1.set_Top(System.Int32)</Target>
+    <Left>lib/netstandard2.0/Microsoft.Extensions.VectorData.Abstractions.dll</Left>
+    <Right>lib/netstandard2.0/Microsoft.Extensions.VectorData.Abstractions.dll</Right>
+    <IsBaselineSuppression>true</IsBaselineSuppression>
+  </Suppression>
+  <Suppression>
+    <DiagnosticId>CP0002</DiagnosticId>
+    <Target>M:Microsoft.Extensions.VectorData.VectorStoreException.get_VectorStoreType</Target>
+    <Left>lib/netstandard2.0/Microsoft.Extensions.VectorData.Abstractions.dll</Left>
+    <Right>lib/netstandard2.0/Microsoft.Extensions.VectorData.Abstractions.dll</Right>
+    <IsBaselineSuppression>true</IsBaselineSuppression>
+  </Suppression>
+  <Suppression>
+    <DiagnosticId>CP0002</DiagnosticId>
+    <Target>M:Microsoft.Extensions.VectorData.VectorStoreException.set_VectorStoreType(System.String)</Target>
     <Left>lib/netstandard2.0/Microsoft.Extensions.VectorData.Abstractions.dll</Left>
     <Right>lib/netstandard2.0/Microsoft.Extensions.VectorData.Abstractions.dll</Right>
     <IsBaselineSuppression>true</IsBaselineSuppression>

--- a/dotnet/src/Connectors/VectorData.Abstractions/VectorStorage/VectorStoreException.cs
+++ b/dotnet/src/Connectors/VectorData.Abstractions/VectorStorage/VectorStoreException.cs
@@ -33,10 +33,18 @@ public abstract class VectorStoreException : Exception
     {
     }
 
+    /// <summary>The name of the vector store system.</summary>
+    /// <remarks>
+    /// Where possible, this maps to the "db.system.name" attribute defined in the
+    /// OpenTelemetry Semantic Conventions for database calls and systems, see <see href="https://opentelemetry.io/docs/specs/semconv/database/"/>.
+    /// Example: redis, sqlite, mysql.
+    /// </remarks>
+    public string? VectorStoreSystemName { get; init; }
+
     /// <summary>
-    /// Gets or sets the type of vector store that the failing operation was performed on.
+    /// The name of the vector store (database).
     /// </summary>
-    public string? VectorStoreType { get; init; }
+    public string? VectorStoreName { get; init; }
 
     /// <summary>
     /// Gets or sets the name of the vector store collection that the failing operation was performed on.

--- a/dotnet/src/InternalUtilities/src/Data/VectorStoreErrorHandler.cs
+++ b/dotnet/src/InternalUtilities/src/Data/VectorStoreErrorHandler.cs
@@ -16,13 +16,19 @@ internal static class VectorStoreErrorHandler
     /// Run the given model conversion and wrap any exceptions with <see cref="VectorStoreRecordMappingException"/>.
     /// </summary>
     /// <typeparam name="T">The response type of the operation.</typeparam>
-    /// <param name="databaseSystemName">The name of the database system the operation is being run on.</param>
+    /// <param name="vectorStoreSystemName">The name of the vector store system the operation is being run on.</param>
+    /// <param name="vectorStoreName">The name of the vector store the operation is being run on.</param>
     /// <param name="collectionName">The name of the collection the operation is being run on.</param>
     /// <param name="operationName">The type of database operation being run.</param>
     /// <param name="operation">The operation to run.</param>
     /// <returns>The result of the operation.</returns>
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
-    public static T RunModelConversion<T>(string databaseSystemName, string collectionName, string operationName, Func<T> operation)
+    public static T RunModelConversion<T>(
+        string vectorStoreSystemName,
+        string? vectorStoreName,
+        string collectionName,
+        string operationName,
+        Func<T> operation)
     {
         try
         {
@@ -32,7 +38,8 @@ internal static class VectorStoreErrorHandler
         {
             throw new VectorStoreRecordMappingException("Failed to convert vector store record.", ex)
             {
-                VectorStoreType = databaseSystemName,
+                VectorStoreSystemName = vectorStoreSystemName,
+                VectorStoreName = vectorStoreName,
                 CollectionName = collectionName,
                 OperationName = operationName
             };


### PR DESCRIPTION
### Motivation and Context

<!-- Thank you for your contribution to the semantic-kernel repo!
Please help reviewers and future users, providing the following information:
  1. Why is this change required?
  2. What problem does it solve?
  3. What scenario does it contribute to?
  4. If it fixes an open issue, please link to the issue here.
-->

Resolves: https://github.com/microsoft/semantic-kernel/issues/11384
Resolves: https://github.com/microsoft/semantic-kernel/issues/11385

- Made vector store implementations `sealed`. 
- Updated `VectorStoreException` with new `VectorStoreName` property and renamed `VectorStoreType` to `VectorStoreSystemName`.

### Contribution Checklist

<!-- Before submitting this PR, please make sure: -->

- [x] The code builds clean without any errors or warnings
- [x] The PR follows the [SK Contribution Guidelines](https://github.com/microsoft/semantic-kernel/blob/main/CONTRIBUTING.md) and the [pre-submission formatting script](https://github.com/microsoft/semantic-kernel/blob/main/CONTRIBUTING.md#development-scripts) raises no violations
- [x] All unit tests pass, and I have added new tests where possible
- [x] I didn't break anyone :smile:
