### PR TITLE
Python: Add ChatCompletionAgent integration tests

### DIFF
--- a/python/semantic_kernel/agents/chat_completion/chat_completion_agent.py
+++ b/python/semantic_kernel/agents/chat_completion/chat_completion_agent.py
@@ -418,7 +418,10 @@ class ChatCompletionAgent(Agent):
                 role = response.role
                 response.name = self.name
                 response_builder.append(response.content)
-                yield AgentResponseItem(message=response, thread=thread)
+                if role == AuthorRole.ASSISTANT:
+                    # Do not yield non-assistant messages
+                    # Those can be yielded by using the on_intermediate_message callback
+                    yield AgentResponseItem(message=response, thread=thread)
 
         await self._capture_mutated_messages(
             agent_chat_history,

--- a/python/semantic_kernel/agents/open_ai/openai_responses_agent.py
+++ b/python/semantic_kernel/agents/open_ai/openai_responses_agent.py
@@ -333,7 +333,7 @@ class OpenAIResponsesAgent(Agent):
         """
         try:
             openai_settings = OpenAISettings.create(
-                response_model_id=ai_model_id,
+                responses_model_id=ai_model_id,
                 api_key=api_key,
                 org_id=org_id,
                 env_file_path=env_file_path,

--- a/python/tests/integration/agents/azureai_agent/test_azureai_agent_integration.py
+++ b/python/tests/integration/agents/azureai_agent/test_azureai_agent_integration.py
@@ -8,10 +8,8 @@ from azure.ai.projects.models import CodeInterpreterTool, FileSearchTool
 from azure.identity.aio import DefaultAzureCredential
 
 from semantic_kernel.agents import AzureAIAgent, AzureAIAgentSettings
-from semantic_kernel.contents.chat_message_content import ChatMessageContent
-from semantic_kernel.contents.streaming_chat_message_content import StreamingChatMessageContent
-from semantic_kernel.contents.utils.author_role import AuthorRole
-from semantic_kernel.functions.kernel_function_decorator import kernel_function
+from semantic_kernel.contents import AuthorRole, ChatMessageContent, StreamingChatMessageContent
+from semantic_kernel.functions import kernel_function
 
 
 class WeatherPlugin:

--- a/python/tests/integration/agents/chat_completion_agent/test_chat_completion_agent_integration.py
+++ b/python/tests/integration/agents/chat_completion_agent/test_chat_completion_agent_integration.py
@@ -1,0 +1,178 @@
+# Copyright (c) Microsoft. All rights reserved.
+
+from typing import Annotated
+
+import pytest
+
+from semantic_kernel.agents import ChatCompletionAgent
+from semantic_kernel.connectors.ai.open_ai import AzureChatCompletion, OpenAIChatCompletion
+from semantic_kernel.contents import AuthorRole, ChatMessageContent, StreamingChatMessageContent
+from semantic_kernel.functions import kernel_function
+
+
+class WeatherPlugin:
+    """A sample Mock weather plugin."""
+
+    @kernel_function(description="Get real-time weather information.")
+    def current_weather(self, location: Annotated[str, "The location to get the weather"]) -> str:
+        """Returns the current weather."""
+        return f"The weather in {location} is sunny."
+
+
+class TestChatCompletionAgentIntegration:
+    @pytest.fixture(params=["azure", "openai"])
+    async def chat_completion_agent(self, request):
+        raw_param = request.param
+
+        if isinstance(raw_param, str):
+            agent_service, params = raw_param, {}
+        elif isinstance(raw_param, tuple) and len(raw_param) == 2:
+            agent_service, params = raw_param
+        else:
+            raise ValueError(f"Unsupported param format: {raw_param}")
+
+        plugins = []
+
+        service = AzureChatCompletion() if agent_service == "azure" else OpenAIChatCompletion()
+
+        if params.get("enable_kernel_function"):
+            plugins.append(WeatherPlugin())
+
+        agent = ChatCompletionAgent(
+            service=service,
+            name="SKPythonIntegrationTestChatCompletionAgent",
+            instructions="You are a helpful assistant that help users with their questions.",
+            plugins=plugins,
+        )
+
+        yield agent  # yield agent for test method to use
+
+    # region Simple 'Hello' messages tests
+
+    @pytest.mark.parametrize("chat_completion_agent", ["azure", "openai"], indirect=True, ids=["azure", "openai"])
+    async def test_get_response(self, chat_completion_agent: ChatCompletionAgent):
+        """Test get response of the agent."""
+        response = await chat_completion_agent.get_response(messages="Hello")
+        assert isinstance(response.message, ChatMessageContent)
+        assert response.message.role == AuthorRole.ASSISTANT
+        assert response.message.content is not None
+
+    @pytest.mark.parametrize("chat_completion_agent", ["azure", "openai"], indirect=True, ids=["azure", "openai"])
+    async def test_get_response_with_thread(self, chat_completion_agent: ChatCompletionAgent):
+        """Test get response of the agent with a thread."""
+        thread = None
+        user_messages = ["Hello, I am John Doe.", "What is my name?"]
+        for user_message in user_messages:
+            response = await chat_completion_agent.get_response(messages=user_message, thread=thread)
+            thread = response.thread
+            assert thread is not None
+            assert isinstance(response.message, ChatMessageContent)
+            assert response.message.role == AuthorRole.ASSISTANT
+            assert response.message.content is not None
+        await thread.delete() if thread else None
+
+    @pytest.mark.parametrize("chat_completion_agent", ["azure", "openai"], indirect=True, ids=["azure", "openai"])
+    async def test_invoke(self, chat_completion_agent: ChatCompletionAgent):
+        """Test invoke of the agent."""
+        async for response in chat_completion_agent.invoke(messages="Hello"):
+            assert isinstance(response.message, ChatMessageContent)
+            assert response.message.role == AuthorRole.ASSISTANT
+            assert response.message.content is not None
+
+    @pytest.mark.parametrize("chat_completion_agent", ["azure", "openai"], indirect=True, ids=["azure", "openai"])
+    async def test_invoke_with_thread(self, chat_completion_agent: ChatCompletionAgent):
+        """Test invoke of the agent with a thread."""
+        thread = None
+        user_messages = ["Hello, I am John Doe.", "What is my name?"]
+        for user_message in user_messages:
+            async for response in chat_completion_agent.invoke(messages=user_message, thread=thread):
+                thread = response.thread
+                assert thread is not None
+                assert isinstance(response.message, ChatMessageContent)
+                assert response.message.role == AuthorRole.ASSISTANT
+                assert response.message.content is not None
+        await thread.delete() if thread else None
+
+    @pytest.mark.parametrize("chat_completion_agent", ["azure", "openai"], indirect=True, ids=["azure", "openai"])
+    async def test_invoke_stream(self, chat_completion_agent: ChatCompletionAgent):
+        """Test invoke stream of the agent."""
+        async for response in chat_completion_agent.invoke_stream(messages="Hello"):
+            assert isinstance(response.message, StreamingChatMessageContent)
+            assert response.message.role == AuthorRole.ASSISTANT
+            assert response.message.content is not None
+
+    @pytest.mark.parametrize("chat_completion_agent", ["azure", "openai"], indirect=True, ids=["azure", "openai"])
+    async def test_invoke_stream_with_thread(self, chat_completion_agent: ChatCompletionAgent):
+        """Test invoke stream of the agent with a thread."""
+        thread = None
+        user_messages = ["Hello, I am John Doe.", "What is my name?"]
+        for user_message in user_messages:
+            async for response in chat_completion_agent.invoke_stream(messages=user_message, thread=thread):
+                thread = response.thread
+                assert thread is not None
+                assert isinstance(response.message, StreamingChatMessageContent)
+                assert response.message.role == AuthorRole.ASSISTANT
+                assert response.message.content is not None
+        await thread.delete() if thread else None
+
+    # endregion
+
+    # region Function calling tests
+
+    @pytest.mark.parametrize(
+        "chat_completion_agent",
+        [
+            ("azure", {"enable_kernel_function": True}),
+            ("openai", {"enable_kernel_function": True}),
+        ],
+        indirect=["chat_completion_agent"],
+        ids=["azure-function-calling", "openai-function-calling"],
+    )
+    async def test_function_calling_get_response(self, chat_completion_agent: ChatCompletionAgent):
+        """Test function calling."""
+        response = await chat_completion_agent.get_response(
+            messages="What is the weather in Seattle?",
+        )
+        assert isinstance(response.message, ChatMessageContent)
+        assert response.message.role == AuthorRole.ASSISTANT
+        assert "sunny" in response.message.content
+
+    @pytest.mark.parametrize(
+        "chat_completion_agent",
+        [
+            ("azure", {"enable_kernel_function": True}),
+            ("openai", {"enable_kernel_function": True}),
+        ],
+        indirect=["chat_completion_agent"],
+        ids=["azure-function-calling", "openai-function-calling"],
+    )
+    async def test_function_calling_invoke(self, chat_completion_agent: ChatCompletionAgent):
+        """Test function calling."""
+        async for response in chat_completion_agent.invoke(
+            messages="What is the weather in Seattle?",
+        ):
+            assert isinstance(response.message, ChatMessageContent)
+            assert response.message.role == AuthorRole.ASSISTANT
+            assert "sunny" in response.message.content
+
+    @pytest.mark.parametrize(
+        "chat_completion_agent",
+        [
+            ("azure", {"enable_kernel_function": True}),
+            ("openai", {"enable_kernel_function": True}),
+        ],
+        indirect=["chat_completion_agent"],
+        ids=["azure-function-calling", "openai-function-calling"],
+    )
+    async def test_function_calling_stream(self, chat_completion_agent: ChatCompletionAgent):
+        """Test function calling streaming."""
+        full_message: str = ""
+        async for response in chat_completion_agent.invoke_stream(
+            messages="What is the weather in Seattle?",
+        ):
+            assert isinstance(response.message, StreamingChatMessageContent)
+            assert response.message.role == AuthorRole.ASSISTANT
+            full_message += response.message.content
+        assert "sunny" in full_message
+
+    # endregion

--- a/python/tests/integration/agents/openai_assistant_agent/test_openai_assistant_agent_integration.py
+++ b/python/tests/integration/agents/openai_assistant_agent/test_openai_assistant_agent_integration.py
@@ -6,10 +6,8 @@ from typing import Annotated
 import pytest
 
 from semantic_kernel.agents import AzureAssistantAgent, OpenAIAssistantAgent
-from semantic_kernel.contents.chat_message_content import ChatMessageContent
-from semantic_kernel.contents.streaming_chat_message_content import StreamingChatMessageContent
-from semantic_kernel.contents.utils.author_role import AuthorRole
-from semantic_kernel.functions.kernel_function_decorator import kernel_function
+from semantic_kernel.contents import AuthorRole, ChatMessageContent, StreamingChatMessageContent
+from semantic_kernel.functions import kernel_function
 
 
 class WeatherPlugin:

--- a/python/tests/integration/agents/openai_responses_agent/test_openai_responses_agent_integration.py
+++ b/python/tests/integration/agents/openai_responses_agent/test_openai_responses_agent_integration.py
@@ -7,10 +7,8 @@ import pytest
 from pydantic import BaseModel
 
 from semantic_kernel.agents import AzureResponsesAgent, OpenAIResponsesAgent
-from semantic_kernel.contents.chat_message_content import ChatMessageContent
-from semantic_kernel.contents.streaming_chat_message_content import StreamingChatMessageContent
-from semantic_kernel.contents.utils.author_role import AuthorRole
-from semantic_kernel.functions.kernel_function_decorator import kernel_function
+from semantic_kernel.contents import AuthorRole, ChatMessageContent, StreamingChatMessageContent
+from semantic_kernel.functions import kernel_function
 
 
 class WeatherPlugin:


### PR DESCRIPTION
### Motivation and Context

Add ChatCompletionAgent integration tests. The last set of agent integration tests that aren't available right now. Additionally, as part of creating the tests, it was discovered that we're yielding FunctionCallContent and FunctionResultContent, when we shouldn't be. To handle those content types, one needs to use the `on_intermediate_message` callback. 

<!-- Thank you for your contribution to the semantic-kernel repo!
Please help reviewers and future users, providing the following information:
  1. Why is this change required?
  2. What problem does it solve?
  3. What scenario does it contribute to?
  4. If it fixes an open issue, please link to the issue here.
-->

### Description

Adds ChatCompletionAgent integration tests. 
- Fix Responses Agent thread get_messages method to properly return input messages from the API.

<!-- Describe your changes, the overall approach, the underlying design.
     These notes will help understanding how your code works. Thanks! -->

### Contribution Checklist

<!-- Before submitting this PR, please make sure: -->

- [X] The code builds clean without any errors or warnings
- [X] The PR follows the [SK Contribution Guidelines](https://github.com/microsoft/semantic-kernel/blob/main/CONTRIBUTING.md) and the [pre-submission formatting script](https://github.com/microsoft/semantic-kernel/blob/main/CONTRIBUTING.md#development-scripts) raises no violations
- [X] All unit tests pass, and I have added new tests where possible
- [X] I didn't break anyone :smile:
