### PR TITLE
.Net: [MEVD] Improved Cosmos NoSQL initialization logic

### DIFF
--- a/dotnet/src/Connectors/Connectors.AzureCosmosDBNoSQL.UnitTests/AzureCosmosDBNoSQLKernelBuilderExtensionsTests.cs
+++ b/dotnet/src/Connectors/Connectors.AzureCosmosDBNoSQL.UnitTests/AzureCosmosDBNoSQLKernelBuilderExtensionsTests.cs
@@ -1,6 +1,7 @@
 ﻿// Copyright (c) Microsoft. All rights reserved.
 
 using System.Reflection;
+using System.Text.Json;
 using Microsoft.Azure.Cosmos;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.VectorData;
@@ -18,12 +19,24 @@ namespace SemanticKernel.Connectors.AzureCosmosDBNoSQL.UnitTests;
 public sealed class AzureCosmosDBNoSQLKernelBuilderExtensionsTests
 {
     private readonly IKernelBuilder _kernelBuilder = Kernel.CreateBuilder();
+    private readonly Mock<Database> _mockDatabase = new();
+
+    public AzureCosmosDBNoSQLKernelBuilderExtensionsTests()
+    {
+        var mockClient = new Mock<CosmosClient>();
+
+        mockClient.Setup(l => l.ClientOptions).Returns(new CosmosClientOptions() { UseSystemTextJsonSerializerWithOptions = JsonSerializerOptions.Default });
+
+        this._mockDatabase
+            .Setup(l => l.Client)
+            .Returns(mockClient.Object);
+    }
 
     [Fact]
     public void AddVectorStoreRegistersClass()
     {
         // Arrange
-        this._kernelBuilder.Services.AddSingleton<Database>(Mock.Of<Database>());
+        this._kernelBuilder.Services.AddSingleton<Database>(this._mockDatabase.Object);
 
         // Act
         this._kernelBuilder.AddAzureCosmosDBNoSQLVectorStore();
@@ -55,7 +68,7 @@ public sealed class AzureCosmosDBNoSQLKernelBuilderExtensionsTests
     public void AddVectorStoreRecordCollectionRegistersClass()
     {
         // Arrange
-        this._kernelBuilder.Services.AddSingleton<Database>(Mock.Of<Database>());
+        this._kernelBuilder.Services.AddSingleton<Database>(this._mockDatabase.Object);
 
         // Act
         this._kernelBuilder.AddAzureCosmosDBNoSQLVectorStoreRecordCollection<TestRecord>("testcollection");

--- a/dotnet/src/Connectors/Connectors.AzureCosmosDBNoSQL.UnitTests/AzureCosmosDBNoSQLServiceCollectionExtensionsTests.cs
+++ b/dotnet/src/Connectors/Connectors.AzureCosmosDBNoSQL.UnitTests/AzureCosmosDBNoSQLServiceCollectionExtensionsTests.cs
@@ -1,6 +1,7 @@
 ﻿// Copyright (c) Microsoft. All rights reserved.
 
 using System.Reflection;
+using System.Text.Json;
 using Microsoft.Azure.Cosmos;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.VectorData;
@@ -18,12 +19,24 @@ namespace SemanticKernel.Connectors.AzureCosmosDBNoSQL.UnitTests;
 public sealed class AzureCosmosDBNoSQLServiceCollectionExtensionsTests
 {
     private readonly IServiceCollection _serviceCollection = new ServiceCollection();
+    private readonly Mock<Database> _mockDatabase = new();
+
+    public AzureCosmosDBNoSQLServiceCollectionExtensionsTests()
+    {
+        var mockClient = new Mock<CosmosClient>();
+
+        mockClient.Setup(l => l.ClientOptions).Returns(new CosmosClientOptions() { UseSystemTextJsonSerializerWithOptions = JsonSerializerOptions.Default });
+
+        this._mockDatabase
+            .Setup(l => l.Client)
+            .Returns(mockClient.Object);
+    }
 
     [Fact]
     public void AddVectorStoreRegistersClass()
     {
         // Arrange
-        this._serviceCollection.AddSingleton<Database>(Mock.Of<Database>());
+        this._serviceCollection.AddSingleton<Database>(this._mockDatabase.Object);
 
         // Act
         this._serviceCollection.AddAzureCosmosDBNoSQLVectorStore();
@@ -56,7 +69,7 @@ public sealed class AzureCosmosDBNoSQLServiceCollectionExtensionsTests
     public void AddVectorStoreRecordCollectionRegistersClass()
     {
         // Arrange
-        this._serviceCollection.AddSingleton<Database>(Mock.Of<Database>());
+        this._serviceCollection.AddSingleton<Database>(this._mockDatabase.Object);
 
         // Act
         this._serviceCollection.AddAzureCosmosDBNoSQLVectorStoreRecordCollection<TestRecord>("testcollection");

--- a/dotnet/src/Connectors/Connectors.AzureCosmosDBNoSQL.UnitTests/AzureCosmosDBNoSQLVectorStoreTests.cs
+++ b/dotnet/src/Connectors/Connectors.AzureCosmosDBNoSQL.UnitTests/AzureCosmosDBNoSQLVectorStoreTests.cs
@@ -3,6 +3,7 @@
 using System;
 using System.Collections.Generic;
 using System.Linq;
+using System.Text.Json;
 using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.Azure.Cosmos;
@@ -19,6 +20,17 @@ namespace SemanticKernel.Connectors.AzureCosmosDBNoSQL.UnitTests;
 public sealed class AzureCosmosDBNoSQLVectorStoreTests
 {
     private readonly Mock<Database> _mockDatabase = new();
+
+    public AzureCosmosDBNoSQLVectorStoreTests()
+    {
+        var mockClient = new Mock<CosmosClient>();
+
+        mockClient.Setup(l => l.ClientOptions).Returns(new CosmosClientOptions() { UseSystemTextJsonSerializerWithOptions = JsonSerializerOptions.Default });
+
+        this._mockDatabase
+            .Setup(l => l.Client)
+            .Returns(mockClient.Object);
+    }
 
     [Fact]
     public void GetCollectionWithNotSupportedKeyThrowsException()

--- a/dotnet/src/Connectors/Connectors.Memory.AzureCosmosDBNoSQL/AzureCosmosDBNoSQLVectorStoreRecordCollection.cs
+++ b/dotnet/src/Connectors/Connectors.Memory.AzureCosmosDBNoSQL/AzureCosmosDBNoSQLVectorStoreRecordCollection.cs
@@ -74,6 +74,13 @@ public sealed class AzureCosmosDBNoSQLVectorStoreRecordCollection<TRecord> :
         Verify.NotNull(database);
         Verify.NotNullOrWhiteSpace(collectionName);
 
+        if (database.Client?.ClientOptions?.UseSystemTextJsonSerializerWithOptions is null)
+        {
+            throw new ArgumentException(
+                $"Property {nameof(CosmosClientOptions.UseSystemTextJsonSerializerWithOptions)} in CosmosClient.ClientOptions " +
+                $"is required to be configured for {nameof(AzureCosmosDBNoSQLVectorStoreRecordCollection<TRecord>)}.");
+        }
+
         // Assign.
         this._database = database;
         this.CollectionName = collectionName;


### PR DESCRIPTION
### Motivation and Context

<!-- Thank you for your contribution to the semantic-kernel repo!
Please help reviewers and future users, providing the following information:
  1. Why is this change required?
  2. What problem does it solve?
  3. What scenario does it contribute to?
  4. If it fixes an open issue, please link to the issue here.
-->

Resolves: https://github.com/microsoft/semantic-kernel/issues/10351

Updated Cosmos NoSQL initialization logic with exception message about using `CosmosClientOptions.UseSystemTextJsonSerializerWithOptions` property.

### Contribution Checklist

<!-- Before submitting this PR, please make sure: -->

- [x] The code builds clean without any errors or warnings
- [x] The PR follows the [SK Contribution Guidelines](https://github.com/microsoft/semantic-kernel/blob/main/CONTRIBUTING.md) and the [pre-submission formatting script](https://github.com/microsoft/semantic-kernel/blob/main/CONTRIBUTING.md#development-scripts) raises no violations
- [x] All unit tests pass, and I have added new tests where possible
- [x] I didn't break anyone :smile:
