### PR TITLE
.Net: Update MCP prompt sample

### DIFF
--- a/dotnet/samples/Demos/ModelContextProtocolClientServer/MCPClient/Extensions/PromptResultExtensions.cs
+++ b/dotnet/samples/Demos/ModelContextProtocolClientServer/MCPClient/Extensions/PromptResultExtensions.cs
@@ -1,6 +1,7 @@
 ﻿// Copyright (c) Microsoft. All rights reserved.
 
 using System;
+using System.Collections.Generic;
 using Microsoft.SemanticKernel;
 using Microsoft.SemanticKernel.ChatCompletion;
 using ModelContextProtocol.Protocol.Types;
@@ -13,13 +14,13 @@ namespace MCPClient;
 internal static class PromptResultExtensions
 {
     /// <summary>
-    /// Converts a <see cref="GetPromptResult"/> to a <see cref="ChatHistory"/>.
+    /// Converts a <see cref="GetPromptResult"/> to chat message contents.
     /// </summary>
     /// <param name="result">The prompt result to convert.</param>
     /// <returns>The corresponding <see cref="ChatHistory"/>.</returns>
-    public static ChatHistory ToChatHistory(this GetPromptResult result)
+    public static IList<ChatMessageContent> ToChatMessageContents(this GetPromptResult result)
     {
-        ChatHistory chatHistory = [];
+        List<ChatMessageContent> contents = [];
 
         foreach (PromptMessage message in result.Messages)
         {
@@ -33,13 +34,16 @@ internal static class PromptResultExtensions
                 case "image":
                     items.Add(new ImageContent(Convert.FromBase64String(message.Content.Data!), message.Content.MimeType));
                     break;
+                case "audio":
+                    items.Add(new AudioContent(Convert.FromBase64String(message.Content.Data!), message.Content.MimeType));
+                    break;
                 default:
                     throw new InvalidOperationException($"Unexpected message content type '{message.Content.Type}'");
             }
 
-            chatHistory.Add(new ChatMessageContent(message.Role.ToAuthorRole(), items));
+            contents.Add(new ChatMessageContent(message.Role.ToAuthorRole(), items));
         }
 
-        return chatHistory;
+        return contents;
     }
 }

--- a/dotnet/samples/Demos/ModelContextProtocolClientServer/MCPClient/Program.cs
+++ b/dotnet/samples/Demos/ModelContextProtocolClientServer/MCPClient/Program.cs
@@ -22,7 +22,7 @@ internal sealed class Program
     {
         await UseMCPToolsAsync();
 
-        await UseMCPToolsAndPromptAsync();
+        await UseMCPPromptAsync();
 
         await UseMCPResourcesAsync();
 
@@ -175,59 +175,50 @@ internal sealed class Program
     }
 
     /// <summary>
-    /// Demonstrates how to use the MCP tools and MCP prompt with the Semantic Kernel.
+    /// Demonstrates how to use the MCP prompt with the Semantic Kernel.
     /// The code in this method:
     /// 1. Creates an MCP client.
-    /// 2. Retrieves the list of tools provided by the MCP server.
-    /// 3. Retrieves the list of prompts provided by the MCP server.
-    /// 4. Creates a kernel and registers the MCP tools as Kernel functions.
-    /// 5. Requests the `GetCurrentWeatherForCity` prompt from the MCP server.
-    /// 6. The MCP server renders the prompt using the `Boston` as value for the `city` parameter and the result of the `DateTimeUtils-GetCurrentDateTimeInUtc` server-side invocation added to the prompt as part of prompt rendering.
-    /// 7. Converts the MCP server prompt: list of messages where each message is represented by content and role to a chat history.
-    /// 8. Sends the chat history to the AI model together with the MCP tools represented as Kernel functions.
-    /// 9. The AI model calls WeatherUtils-GetWeatherForCity function with the current date time and the `Boston` arguments extracted from the prompt to get the weather information.
-    /// 10. Having received the weather information from the function call, the AI model returns the answer to the prompt.
+    /// 2. Retrieves the list of prompts provided by the MCP server.
+    /// 3. Gets the current weather for Boston and Sydney using the `GetCurrentWeatherForCity` prompt.
+    /// 4. Adds the MCP server prompts to the chat history and prompts the AI model to compare the weather in the two cities and suggest the best place to go for a walk.
+    /// 5. After receiving and processing the weather data for both cities and the prompt, the AI model returns an answer.
     /// </summary>
-    private static async Task UseMCPToolsAndPromptAsync()
+    private static async Task UseMCPPromptAsync()
     {
-        Console.WriteLine($"Running the {nameof(UseMCPToolsAndPromptAsync)} sample.");
+        Console.WriteLine($"Running the {nameof(UseMCPPromptAsync)} sample.");
 
         // Create an MCP client
         await using IMcpClient mcpClient = await CreateMcpClientAsync();
-
-        // Retrieve and display the list provided by the MCP server
-        IList<McpClientTool> tools = await mcpClient.ListToolsAsync();
-        DisplayTools(tools);
 
         // Retrieve and display the list of prompts provided by the MCP server
         IList<McpClientPrompt> prompts = await mcpClient.ListPromptsAsync();
         DisplayPrompts(prompts);
 
-        // Create a kernel and register the MCP tools
+        // Create a kernel
         Kernel kernel = CreateKernelWithChatCompletionService();
-        kernel.Plugins.AddFromFunctions("Tools", tools.Select(aiFunction => aiFunction.AsKernelFunction()));
 
-        // Enable automatic function calling
-        OpenAIPromptExecutionSettings executionSettings = new()
-        {
-            Temperature = 0,
-            FunctionChoiceBehavior = FunctionChoiceBehavior.Auto(options: new() { RetainArgumentTypes = true })
-        };
+        // Get weather for Boston using the `GetCurrentWeatherForCity` prompt from the MCP server
+        GetPromptResult bostonWeatherPrompt = await mcpClient.GetPromptAsync("GetCurrentWeatherForCity", new Dictionary<string, object?>() { ["city"] = "Boston", ["time"] = DateTime.UtcNow.ToString() });
 
-        // Retrieve the `GetCurrentWeatherForCity` prompt from the MCP server and convert it to a chat history
-        GetPromptResult promptResult = await mcpClient.GetPromptAsync("GetCurrentWeatherForCity", new Dictionary<string, object?>() { ["city"] = "Boston" });
+        // Get weather for Sydney using the `GetCurrentWeatherForCity` prompt from the MCP server
+        GetPromptResult sydneyWeatherPrompt = await mcpClient.GetPromptAsync("GetCurrentWeatherForCity", new Dictionary<string, object?>() { ["city"] = "Sydney", ["time"] = DateTime.UtcNow.ToString() });
 
-        ChatHistory chatHistory = promptResult.ToChatHistory();
+        // Add the prompts to the chat history
+        ChatHistory chatHistory = [];
+        chatHistory.AddRange(bostonWeatherPrompt.ToChatMessageContents());
+        chatHistory.AddRange(sydneyWeatherPrompt.ToChatMessageContents());
+        chatHistory.AddUserMessage("Compare the weather in the two cities and suggest the best place to go for a walk.");
 
         // Execute a prompt using the MCP tools and prompt
         IChatCompletionService chatCompletion = kernel.GetRequiredService<IChatCompletionService>();
 
-        ChatMessageContent result = await chatCompletion.GetChatMessageContentAsync(chatHistory, executionSettings, kernel);
+        ChatMessageContent result = await chatCompletion.GetChatMessageContentAsync(chatHistory, kernel: kernel);
 
         Console.WriteLine(result);
         Console.WriteLine();
 
-        // The expected output is: The weather in Boston as of 2025-04-02 16:39:40 is 61°F and rainy.
+        // The expected output is: Given these conditions, Sydney would be the better choice for a pleasant walk, as the sunny and warm weather is ideal for outdoor activities.
+        // The rain in Boston could make walking less enjoyable and potentially inconvenient.
     }
 
     /// <summary>

--- a/dotnet/samples/Demos/ModelContextProtocolClientServer/MCPServer/Extensions/McpServerBuilderExtensions.cs
+++ b/dotnet/samples/Demos/ModelContextProtocolClientServer/MCPServer/Extensions/McpServerBuilderExtensions.cs
@@ -1,5 +1,6 @@
 ﻿// Copyright (c) Microsoft. All rights reserved.
 
+using MCPServer.Prompts;
 using MCPServer.Resources;
 using Microsoft.SemanticKernel;
 using ModelContextProtocol.Protocol.Types;
@@ -27,6 +28,22 @@ public static class McpServerBuilderExtensions
                 builder.Services.AddSingleton(services => McpServerTool.Create(function.AsAIFunction()));
             }
         }
+
+        return builder;
+    }
+
+    /// <summary>
+    /// Adds a resource template to the server.
+    /// </summary>
+    /// <param name="builder">The MCP server builder.</param>
+    /// <param name="templateDefinition">The resource template definition.</param>
+    /// <returns>The builder instance.</returns>
+    public static IMcpServerBuilder WithPrompt(this IMcpServerBuilder builder, PromptDefinition templateDefinition)
+    {
+        PromptRegistry.RegisterPrompt(templateDefinition);
+
+        builder.WithListPromptsHandler(PromptRegistry.HandlerListPromptRequestsAsync);
+        builder.WithGetPromptHandler(PromptRegistry.HandlerGetPromptRequestsAsync);
 
         return builder;
     }

--- a/dotnet/samples/Demos/ModelContextProtocolClientServer/MCPServer/Program.cs
+++ b/dotnet/samples/Demos/ModelContextProtocolClientServer/MCPServer/Program.cs
@@ -18,9 +18,6 @@ Kernel kernel = CreateKernel();
 kernel.Plugins.AddFromType<DateTimeUtils>();
 kernel.Plugins.AddFromType<WeatherUtils>();
 
-// Register prompts
-PromptRegistry.RegisterPrompt(PromptDefinition.Create(EmbeddedResource.ReadAsString("Prompts.getCurrentWeatherForCity.json"), kernel));
-
 var builder = Host.CreateEmptyApplicationBuilder(settings: null);
 builder.Services
     .AddMcpServer()
@@ -28,6 +25,9 @@ builder.Services
 
     // Add all functions from the kernel plugins to the MCP server as tools
     .WithTools(kernel.Plugins)
+
+    // Register the `getCurrentWeatherForCity` prompt
+    .WithPrompt(PromptDefinition.Create(EmbeddedResource.ReadAsString("Prompts.getCurrentWeatherForCity.json"), kernel))
 
     // Register vector search as MCP resource template
     .WithResourceTemplate(CreateVectorStoreSearchResourceTemplate(kernel))
@@ -38,11 +38,7 @@ builder.Services
         uri: "image://cat.jpg",
         name: "cat-image",
         content: EmbeddedResource.ReadAsBytes("Resources.cat.jpg"),
-        mimeType: "image/jpeg"))
-
-    // Register prompt handlers
-    .WithListPromptsHandler(PromptRegistry.HandlerListPromptRequestsAsync)
-    .WithGetPromptHandler(PromptRegistry.HandlerGetPromptRequestsAsync);
+        mimeType: "image/jpeg"));
 
 await builder.Build().RunAsync();
 

--- a/dotnet/samples/Demos/ModelContextProtocolClientServer/MCPServer/Prompts/PromptDefinition.cs
+++ b/dotnet/samples/Demos/ModelContextProtocolClientServer/MCPServer/Prompts/PromptDefinition.cs
@@ -10,7 +10,7 @@ namespace MCPServer.Prompts;
 /// <summary>
 /// Represents a prompt definition.
 /// </summary>
-internal sealed class PromptDefinition
+public sealed class PromptDefinition
 {
     /// <summary>
     /// Gets or sets the prompt.
@@ -32,13 +32,13 @@ internal sealed class PromptDefinition
     {
         PromptTemplateConfig promptTemplateConfig = PromptTemplateConfig.FromJson(jsonPrompt);
 
+        IPromptTemplate promptTemplate = new HandlebarsPromptTemplateFactory().Create(promptTemplateConfig);
+
         return new PromptDefinition()
         {
             Prompt = GetPrompt(promptTemplateConfig),
             Handler = (context, cancellationToken) =>
             {
-                IPromptTemplate promptTemplate = new HandlebarsPromptTemplateFactory().Create(promptTemplateConfig);
-
                 return GetPromptHandlerAsync(context, promptTemplateConfig, promptTemplate, kernel, cancellationToken);
             }
         };
@@ -103,7 +103,7 @@ internal sealed class PromptDefinition
                         Type = "text",
                         Text = renderedPrompt
                     },
-                    Role = Role.User
+                    Role = Role.Assistant
                 }
             ]
         };

--- a/dotnet/samples/Demos/ModelContextProtocolClientServer/MCPServer/Prompts/getCurrentWeatherForCity.json
+++ b/dotnet/samples/Demos/ModelContextProtocolClientServer/MCPServer/Prompts/getCurrentWeatherForCity.json
@@ -2,11 +2,16 @@
   "name": "GetCurrentWeatherForCity",
   "description": "Provides current weather information for a specified city.",
   "template_format": "handlebars",
-  "template": "What is the weather in {{city}} as of {{DateTimeUtils-GetCurrentDateTimeInUtc}}?",
+  "template": "It's {{WeatherUtils-GetWeatherForCity city time}} in {{city}} as of {{time}}",
   "input_variables": [
     {
       "name": "city",
       "description": "The city for which to get the weather.",
+      "is_required": true
+    },
+    {
+      "name": "time",
+      "description": "The UTC time for which to get the weather.",
       "is_required": true
     }
   ]


### PR DESCRIPTION
### Motivation,  Context and Description

This PR changes the MCP prompt to be a little more useful so that it can be reused on the client side. Additionally, the prompt registration API is simplified and aligned with the resource and resource template registration APIs - `With*` extension methods. Lastly, it maps prompt messages to a list of chat message content that can be easily added to the chat history on the client side by a hosting app.

Contributes to: https://github.com/microsoft/semantic-kernel/issues/11199