### PR TITLE
Python: Fix `TypeError` when required is missing in MCP tool’s inputSchema

### DIFF
--- a/python/semantic_kernel/connectors/mcp.py
+++ b/python/semantic_kernel/connectors/mcp.py
@@ -102,7 +102,7 @@ def get_parameter_from_mcp_prompt(prompt: Prompt) -> list[dict[str, Any]]:
 def get_parameters_from_mcp_tool(tool: Tool) -> list[dict[str, Any]]:
     """Creates an MCPFunction instance from a tool."""
     properties = tool.inputSchema.get("properties", None)
-    required = tool.inputSchema.get("required", list())
+    required = tool.inputSchema.get("required", [])
     # Check if 'properties' is missing or not a dictionary
     if not properties:
         return []

--- a/python/semantic_kernel/connectors/mcp.py
+++ b/python/semantic_kernel/connectors/mcp.py
@@ -102,7 +102,7 @@ def get_parameter_from_mcp_prompt(prompt: Prompt) -> list[dict[str, Any]]:
 def get_parameters_from_mcp_tool(tool: Tool) -> list[dict[str, Any]]:
     """Creates an MCPFunction instance from a tool."""
     properties = tool.inputSchema.get("properties", None)
-    required = tool.inputSchema.get("required", None)
+    required = tool.inputSchema.get("required", list())
     # Check if 'properties' is missing or not a dictionary
     if not properties:
         return []


### PR DESCRIPTION
### Motivation and Context

Resolves #11457

### Description

Fixed an issue where a `TypeError` would occur when the inputSchema of a tool listed from the MCP server did not include any required parameters.

### Contribution Checklist

<!-- Before submitting this PR, please make sure: -->

- [ ] The code builds clean without any errors or warnings
- [x] The PR follows the [SK Contribution Guidelines](https://github.com/microsoft/semantic-kernel/blob/main/CONTRIBUTING.md) and the [pre-submission formatting script](https://github.com/microsoft/semantic-kernel/blob/main/CONTRIBUTING.md#development-scripts) raises no violations
- [ ] All unit tests pass, and I have added new tests where possible
- [x] I didn't break anyone :smile:
