### PR TITLE
.Net: add 'RetainArgumentTypes' to agent arguments for ModelContextProtocolPlugin demo

### DIFF
--- a/dotnet/samples/Demos/ModelContextProtocolPlugin/Program.cs
+++ b/dotnet/samples/Demos/ModelContextProtocolPlugin/Program.cs
@@ -78,7 +78,7 @@ ChatCompletionAgent agent = new()
     Instructions = "Answer questions about GitHub repositories.",
     Name = "GitHubAgent",
     Kernel = kernel,
-    Arguments = new KernelArguments(new PromptExecutionSettings() { FunctionChoiceBehavior = FunctionChoiceBehavior.Auto() }),
+    Arguments = new KernelArguments(executionSettings),
 };
 
 // Respond to user input, invoking functions where appropriate.


### PR DESCRIPTION
### Motivation and Context

Extremely high token consumption when running this demo: [https://github.com/microsoft/semantic-kernel/tree/main/dotnet/samples/Demos/ModelContextProtocolPlugin](https://github.com/microsoft/semantic-kernel/tree/main/dotnet/samples/Demos/ModelContextProtocolPlugin)

When calling the ChatCompletionAgent with the default 'false' value for RetainArgumentTypes, all arguments are converted to string values which causes some of the tool calls to fail. The agent then iterates through other tools, searching for a successful response. This results in 80-85k tokens being consumed where only 11-12k should be consumed.

### Description

This PR will update the ModelContextProtocolPlugin demo to re-use the configured PromptExecutionSettings object that includes the correct value for `RetainArgumentTypes`.

