### PR TITLE
.Net: Use ChatHistoryAgentThread with OpenAIResponseAgent

### DIFF
--- a/dotnet/samples/GettingStartedWithAgents/OpenAIResponse/Step02_ConversationState.cs
+++ b/dotnet/samples/GettingStartedWithAgents/OpenAIResponse/Step02_ConversationState.cs
@@ -98,7 +98,6 @@ public class Step02_ConversationState(ITestOutputHelper output) : BaseResponsesA
             await foreach (AgentResponseItem<ChatMessageContent> responseItem in responseItems)
             {
                 agentThread = responseItem.Thread;
-                this.Output.WriteLine(agentThread.Id);
                 WriteAgentChatMessage(responseItem.Message);
             }
         }

--- a/dotnet/src/Agents/OpenAI/Agents.OpenAI.csproj
+++ b/dotnet/src/Agents/OpenAI/Agents.OpenAI.csproj
@@ -35,6 +35,7 @@
   <ItemGroup>
     <ProjectReference Include="..\..\Connectors\Connectors.OpenAI\Connectors.OpenAI.csproj" />
     <ProjectReference Include="..\Abstractions\Agents.Abstractions.csproj" />
+    <ProjectReference Include="..\Core\Agents.Core.csproj" />
   </ItemGroup>
 
   <ItemGroup>

--- a/dotnet/src/Agents/OpenAI/OpenAIResponseAgentThread.cs
+++ b/dotnet/src/Agents/OpenAI/OpenAIResponseAgentThread.cs
@@ -34,14 +34,14 @@ public sealed class OpenAIResponseAgentThread : AgentThread
     /// Initializes a new instance of the <see cref="OpenAIResponseAgentThread"/> class that resumes an existing response.
     /// </summary>
     /// <param name="client">The agents client to use for interacting with responses.</param>
-    /// <param name="id">The ID of an existing response to resume.</param>
-    public OpenAIResponseAgentThread(OpenAIResponseClient client, string id)
+    /// <param name="responseId">The ID of an existing response to resume.</param>
+    public OpenAIResponseAgentThread(OpenAIResponseClient client, string responseId)
     {
         Verify.NotNull(client);
-        Verify.NotNull(id);
+        Verify.NotNull(responseId);
 
         this._client = client;
-        this.ResponseId = id;
+        this.ResponseId = responseId;
     }
 
     /// <summary>

--- a/dotnet/src/Agents/OpenAI/OpenAIResponseAgentThread.cs
+++ b/dotnet/src/Agents/OpenAI/OpenAIResponseAgentThread.cs
@@ -6,32 +6,28 @@ using System.Diagnostics.CodeAnalysis;
 using System.Runtime.CompilerServices;
 using System.Threading;
 using System.Threading.Tasks;
-using Microsoft.SemanticKernel.ChatCompletion;
 using OpenAI.Responses;
 
 namespace Microsoft.SemanticKernel.Agents.OpenAI;
 
 /// <summary>
-/// Represents a conversation thread for an OpenAI responses-based agent.
+/// Represents a conversation thread for an OpenAI Response API based agent when store is enabled.
 /// </summary>
 [ExcludeFromCodeCoverage]
 public sealed class OpenAIResponseAgentThread : AgentThread
 {
     private readonly OpenAIResponseClient _client;
-    private readonly ChatHistory _chatHistory = new();
     private bool _isDeleted = false;
 
     /// <summary>
     /// Initializes a new instance of the <see cref="OpenAIResponseAgentThread"/> class.
     /// </summary>
     /// <param name="client">The agents client to use for interacting with responses.</param>
-    /// <param name="enableStore">Enable storing messages on the server.</param>
-    public OpenAIResponseAgentThread(OpenAIResponseClient client, bool enableStore = false)
+    public OpenAIResponseAgentThread(OpenAIResponseClient client)
     {
         Verify.NotNull(client);
 
         this._client = client;
-        this.StoreEnabled = enableStore;
     }
 
     /// <summary>
@@ -39,31 +35,19 @@ public sealed class OpenAIResponseAgentThread : AgentThread
     /// </summary>
     /// <param name="client">The agents client to use for interacting with responses.</param>
     /// <param name="id">The ID of an existing response to resume.</param>
-    /// <param name="enableStore">Enable storing messages on the server.</param>
-    public OpenAIResponseAgentThread(OpenAIResponseClient client, string id, bool enableStore = false)
+    public OpenAIResponseAgentThread(OpenAIResponseClient client, string id)
     {
         Verify.NotNull(client);
         Verify.NotNull(id);
 
         this._client = client;
         this.ResponseId = id;
-        this.StoreEnabled = enableStore;
     }
-
-    /// <summary>
-    /// Storing of messages is enabled.
-    /// </summary>
-    public bool StoreEnabled { get; private set; } = false;
 
     /// <summary>
     /// The current response id.
     /// </summary>
     internal string? ResponseId { get; set; }
-
-    /// <summary>
-    /// The current chat history.
-    /// </summary>
-    internal ChatHistory ChatHistory => this._chatHistory;
 
     /// <inheritdoc />
     public override string? Id => this.ResponseId;
@@ -93,7 +77,6 @@ public sealed class OpenAIResponseAgentThread : AgentThread
             throw new InvalidOperationException("This thread cannot be deleted, since it has not been created.");
         }
 
-        this._chatHistory.Clear();
         this._isDeleted = true;
 
         return Task.CompletedTask;
@@ -107,12 +90,6 @@ public sealed class OpenAIResponseAgentThread : AgentThread
             throw new InvalidOperationException("This thread has been deleted and cannot be used anymore.");
         }
 
-        // Keep track of locally
-        if (string.IsNullOrEmpty(this.ResponseId))
-        {
-            this._chatHistory.Add(newMessage);
-        }
-
         return Task.CompletedTask;
     }
 
@@ -124,7 +101,7 @@ public sealed class OpenAIResponseAgentThread : AgentThread
             throw new InvalidOperationException("This thread has been deleted and cannot be used anymore.");
         }
 
-        if (this.StoreEnabled && !string.IsNullOrEmpty(this.ResponseId))
+        if (!string.IsNullOrEmpty(this.ResponseId))
         {
             var options = new ResponseItemCollectionOptions();
             var collectionResult = this._client.GetResponseInputItemsAsync(this.ResponseId, options, cancellationToken).ConfigureAwait(false);
@@ -133,12 +110,7 @@ public sealed class OpenAIResponseAgentThread : AgentThread
                 yield return responseItem.ToChatMessageContent();
             }
         }
-        else
-        {
-            foreach (var message in this._chatHistory)
-            {
-                yield return message;
-            }
-        }
+
+        yield break;
     }
 }

--- a/dotnet/src/Agents/UnitTests/OpenAI/OpenAIResponseAgentThreadTests.cs
+++ b/dotnet/src/Agents/UnitTests/OpenAI/OpenAIResponseAgentThreadTests.cs
@@ -23,7 +23,7 @@ public sealed class OpenAIResponseAgentThreadTests : BaseOpenAIResponseClientTes
         // Arrange & Act & Assert
         Assert.Throws<ArgumentNullException>(() => new OpenAIResponseAgentThread(null!));
         Assert.Throws<ArgumentNullException>(() => new OpenAIResponseAgentThread(null!, "threadId"));
-        Assert.Throws<ArgumentNullException>(() => new OpenAIResponseAgentThread(this.Client, id: null!));
+        Assert.Throws<ArgumentNullException>(() => new OpenAIResponseAgentThread(this.Client, responseId: null!));
 
         var agentThread = new OpenAIResponseAgentThread(this.Client);
         Assert.NotNull(agentThread);
@@ -72,7 +72,7 @@ public sealed class OpenAIResponseAgentThreadTests : BaseOpenAIResponseClientTes
              new HttpResponseMessage(System.Net.HttpStatusCode.OK) { Content = new StringContent(MessagesResponse) }
          );
         var responseId = "resp_67e8ff743ea08191b085bea42b4d83e809a3a922c4f4221b";
-        var thread = new OpenAIResponseAgentThread(this.Client, id: responseId);
+        var thread = new OpenAIResponseAgentThread(this.Client, responseId: responseId);
 
         // Act
         var messages = thread.GetMessagesAsync();

--- a/dotnet/src/Agents/UnitTests/OpenAI/OpenAIResponseAgentThreadTests.cs
+++ b/dotnet/src/Agents/UnitTests/OpenAI/OpenAIResponseAgentThreadTests.cs
@@ -47,7 +47,7 @@ public sealed class OpenAIResponseAgentThreadTests : BaseOpenAIResponseClientTes
     /// Verify <see cref="OpenAIResponseAgentThread.GetMessagesAsync(System.Threading.CancellationToken)"/> returned when store is disabled.
     /// </summary>
     [Fact]
-    public async Task VerifyGetMessagesWhenStoreDisabledAsync()
+    public async Task VerifyGetMessagesWhenThreadIsUnusedAsync()
     {
         // Arrange
         var thread = new OpenAIResponseAgentThread(this.Client);
@@ -72,7 +72,7 @@ public sealed class OpenAIResponseAgentThreadTests : BaseOpenAIResponseClientTes
              new HttpResponseMessage(System.Net.HttpStatusCode.OK) { Content = new StringContent(MessagesResponse) }
          );
         var responseId = "resp_67e8ff743ea08191b085bea42b4d83e809a3a922c4f4221b";
-        var thread = new OpenAIResponseAgentThread(this.Client, id: responseId, enableStore: true);
+        var thread = new OpenAIResponseAgentThread(this.Client, id: responseId);
 
         // Act
         var messages = thread.GetMessagesAsync();


### PR DESCRIPTION
### Motivation and Context

Response to this suggestion:
_Instead of having a StoreEnabled on the agentThread, consider supporting two thread types, e.g. ChatHistoryAgentThread and OpenAIResponseAgentThread._ 

### Description

<!-- Describe your changes, the overall approach, the underlying design.
     These notes will help understanding how your code works. Thanks! -->

### Contribution Checklist

<!-- Before submitting this PR, please make sure: -->

- [ ] The code builds clean without any errors or warnings
- [ ] The PR follows the [SK Contribution Guidelines](https://github.com/microsoft/semantic-kernel/blob/main/CONTRIBUTING.md) and the [pre-submission formatting script](https://github.com/microsoft/semantic-kernel/blob/main/CONTRIBUTING.md#development-scripts) raises no violations
- [ ] All unit tests pass, and I have added new tests where possible
- [ ] I didn't break anyone :smile:
