### PR TITLE
.Net MEVD: fix two bugs

### DIFF
--- a/dotnet/src/Connectors/Connectors.Memory.AzureAISearch/AzureAISearchVectorStoreRecordCollection.cs
+++ b/dotnet/src/Connectors/Connectors.Memory.AzureAISearch/AzureAISearchVectorStoreRecordCollection.cs
@@ -602,6 +602,8 @@ public sealed class AzureAISearchVectorStoreRecordCollection<TKey, TRecord> :
             {
                 yield return result;
             }
+
+            yield break;
         }
 
         // Execute search and map using the built in Azure AI Search mapper.

--- a/dotnet/src/VectorDataIntegrationTests/VectorDataIntegrationTests/Filter/BasicQueryTests.cs
+++ b/dotnet/src/VectorDataIntegrationTests/VectorDataIntegrationTests/Filter/BasicQueryTests.cs
@@ -1,10 +1,18 @@
 ﻿// Copyright (c) Microsoft. All rights reserved.
 
+using System.Linq.Expressions;
+
 namespace VectorDataSpecificationTests.Filter;
 
 public abstract class BasicQueryTests<TKey>(BasicQueryTests<TKey>.QueryFixture fixture)
     : BasicFilterTests<TKey>(fixture) where TKey : notnull
 {
+    protected override async Task<List<FilterRecord>> GetRecords(Expression<Func<FilterRecord, bool>> filter, int top, ReadOnlyMemory<float> vector)
+        => (await fixture.Collection.GetAsync(filter, top).ToListAsync()).OrderBy(r => r.Key).ToList();
+
+    protected override async Task<List<Dictionary<string, object?>>> GetDynamicRecords(Expression<Func<Dictionary<string, object?>, bool>> dynamicFilter, int top, ReadOnlyMemory<float> vector)
+        => (await fixture.DynamicCollection.GetAsync(dynamicFilter, top).ToListAsync()).OrderBy(r => r[nameof(FilterRecord.Key)]!).ToList();
+
     [Obsolete("Not used by derived types")]
     public sealed override Task Legacy_And() => Task.CompletedTask;
 


### PR DESCRIPTION
When I introduced `BasicQueryTests` in #11112, the idea was that this class derives from `BasicFilterTests` and overrides method that gets the resuls to call `GetAsync` rather than `VectorizedSearchAsync`:

![{1B2F7D58-0CCF-48F2-A007-F29597F27A89}](https://github.com/user-attachments/assets/d01496a1-2919-472d-8522-8712caefacff)

When @roji was working on `BasicFilterTests` in #11392 to extend them with the capability to use dynamic model for filtering, he wanted to remove the ordering that was introduced in `BasicQueryTests` https://github.com/microsoft/semantic-kernel/pull/11392#discussion_r2037066364

but it seems that by mistake @roji has also removed the call to `GetAsync`. So `BasicQueryTests` was testing exactly the same thing 
`BasicFilterTests` did:

![{49FF7B67-FBDB-4350-91FE-5809E56B7B10}](https://github.com/user-attachments/assets/de9beb68-150d-4299-89d9-1d4478ef69b1)
