### PR TITLE
.Net: Fix Google Gemini Enums Schema definition

### DIFF
--- a/dotnet/samples/Concepts/ChatCompletion/Google_GeminiStructuredOutputs.cs
+++ b/dotnet/samples/Concepts/ChatCompletion/Google_GeminiStructuredOutputs.cs
@@ -191,7 +191,24 @@ public class Google_GeminiStructuredOutputs(ITestOutputHelper output) : BaseTest
 
         public bool IsAvailableOnStreaming { get; set; }
 
+        public MovieGenre? Genre { get; set; }
+
         public List<string> Tags { get; set; }
+    }
+
+    private enum MovieGenre
+    {
+        Action,
+        Adventure,
+        Comedy,
+        Drama,
+        Fantasy,
+        Horror,
+        Mystery,
+        Romance,
+        SciFi,
+        Thriller,
+        Western
     }
 
     private sealed class EmailResult
@@ -256,6 +273,7 @@ public class Google_GeminiStructuredOutputs(ITestOutputHelper output) : BaseTest
                       Director: {movie.Director}
                       Release year: {movie.ReleaseYear}
                       Rating: {movie.Rating}
+                      Genre: {movie.Genre}
                       Is available on streaming: {movie.IsAvailableOnStreaming}
                       Tags: {string.Join(",", movie.Tags ?? [])}
                 """);

--- a/dotnet/src/Connectors/Connectors.Google.UnitTests/Core/Gemini/GeminiRequestTests.cs
+++ b/dotnet/src/Connectors/Connectors.Google.UnitTests/Core/Gemini/GeminiRequestTests.cs
@@ -584,6 +584,49 @@ public sealed class GeminiRequestTests
         Assert.True(ageProperty.GetProperty("nullable").GetBoolean());
     }
 
+    [Fact]
+    public void ResponseSchemaAddsTypeToEnumProperties()
+    {
+        // Arrange
+        var prompt = "prompt-example";
+        var schemaWithEnum = """
+            {
+                "type": "object",
+                "properties": {
+                    "status": {
+                        "enum": ["active", "inactive", null],
+                        "description": "user status"
+                    },
+                    "role": {
+                        "enum": ["admin", "user"],
+                        "description": "user role"
+                    }
+                }
+            }
+            """;
+
+        var executionSettings = new GeminiPromptExecutionSettings
+        {
+            ResponseMimeType = "application/json",
+            ResponseSchema = JsonSerializer.Deserialize<JsonElement>(schemaWithEnum)
+        };
+
+        // Act
+        var request = GeminiRequest.FromPromptAndExecutionSettings(prompt, executionSettings);
+
+        // Assert
+        Assert.NotNull(request.Configuration?.ResponseSchema);
+        var properties = request.Configuration.ResponseSchema.Value.GetProperty("properties");
+
+        var statusProperty = properties.GetProperty("status");
+        Assert.Equal("string", statusProperty.GetProperty("type").GetString());
+        Assert.Equal(3, statusProperty.GetProperty("enum").GetArrayLength());
+
+        var roleProperty = properties.GetProperty("role");
+        Assert.Equal("string", roleProperty.GetProperty("type").GetString());
+        Assert.Equal(2, roleProperty.GetProperty("enum").GetArrayLength());
+    }
+
     private sealed class DummyContent(object? innerContent, string? modelId = null, IReadOnlyDictionary<string, object?>? metadata = null) :
         KernelContent(innerContent, modelId, metadata);
 

--- a/dotnet/src/Connectors/Connectors.Google.UnitTests/Core/Gemini/GeminiRequestTests.cs
+++ b/dotnet/src/Connectors/Connectors.Google.UnitTests/Core/Gemini/GeminiRequestTests.cs
@@ -591,15 +591,22 @@ public sealed class GeminiRequestTests
         var prompt = "prompt-example";
         var schemaWithEnum = """
             {
-                "type": "object",
-                "properties": {
-                    "status": {
-                        "enum": ["active", "inactive", null],
-                        "description": "user status"
-                    },
-                    "role": {
-                        "enum": ["admin", "user"],
-                        "description": "user role"
+                "properties" : {
+                    "Movies": {
+                        "type" : "array",
+                        "items" : {
+                            "type" : "object",
+                            "properties" : {
+                                "status": {
+                                    "enum": ["active", "inactive", null],
+                                    "description": "user status"
+                                },
+                                "role": {
+                                    "enum": ["admin", "user"],
+                                    "description": "user role"
+                                }
+                            }
+                        }
                     }
                 }
             }
@@ -616,7 +623,11 @@ public sealed class GeminiRequestTests
 
         // Assert
         Assert.NotNull(request.Configuration?.ResponseSchema);
-        var properties = request.Configuration.ResponseSchema.Value.GetProperty("properties");
+        var properties = request.Configuration.ResponseSchema.Value
+            .GetProperty("properties")
+            .GetProperty("Movies")
+            .GetProperty("items")
+            .GetProperty("properties");
 
         var statusProperty = properties.GetProperty("status");
         Assert.Equal("string", statusProperty.GetProperty("type").GetString());

--- a/dotnet/src/Connectors/Connectors.Google/Core/Gemini/Models/GeminiRequest.cs
+++ b/dotnet/src/Connectors/Connectors.Google/Core/Gemini/Models/GeminiRequest.cs
@@ -361,7 +361,7 @@ internal sealed class GeminiRequest
                 {
                     if (property.Value is JsonObject propertyObj)
                     {
-                        // Handle enum properties - add "type": "enum" if missing
+                        // Handle enum properties - add "type": "string" if missing
                         if (propertyObj.TryGetPropertyValue("enum", out JsonNode? enumNode) && !propertyObj.ContainsKey("type"))
                         {
                             propertyObj["type"] = JsonValue.Create("string");

--- a/dotnet/src/Connectors/Connectors.Google/Core/Gemini/Models/GeminiRequest.cs
+++ b/dotnet/src/Connectors/Connectors.Google/Core/Gemini/Models/GeminiRequest.cs
@@ -326,7 +326,7 @@ internal sealed class GeminiRequest
             _ => CreateSchema(responseSchemaSettings.GetType(), GetDefaultOptions())
         };
 
-        jsonElement = AdjustOpenApi3Nullables(jsonElement);
+        jsonElement = TransformToOpenApi3Schema(jsonElement);
         return jsonElement;
     }
 
@@ -343,17 +343,17 @@ internal sealed class GeminiRequest
     /// - Replaces the type array with a single type value
     /// - Adds "nullable": true as a property
     /// </remarks>
-    private static JsonElement AdjustOpenApi3Nullables(JsonElement jsonElement)
+    private static JsonElement TransformToOpenApi3Schema(JsonElement jsonElement)
     {
         JsonNode? node = JsonNode.Parse(jsonElement.GetRawText());
         if (node is JsonObject rootObject)
         {
-            AdjustOpenApi3Object(rootObject);
+            TransformOpenApi3Object(rootObject);
         }
 
         return JsonSerializer.SerializeToElement(node, GetDefaultOptions());
 
-        static void AdjustOpenApi3Object(JsonObject obj)
+        static void TransformOpenApi3Object(JsonObject obj)
         {
             if (obj.TryGetPropertyValue("properties", out JsonNode? propsNode) && propsNode is JsonObject properties)
             {
@@ -382,13 +382,13 @@ internal sealed class GeminiRequest
                             {
                                 if (propertyObj.TryGetPropertyValue("items", out JsonNode? itemsNode) && itemsNode is JsonObject itemsObj)
                                 {
-                                    AdjustOpenApi3Object(itemsObj);
+                                    TransformOpenApi3Object(itemsObj);
                                 }
                             }
                         }
 
                         // Recursively process nested objects
-                        AdjustOpenApi3Object(propertyObj);
+                        TransformOpenApi3Object(propertyObj);
                     }
                 }
             }


### PR DESCRIPTION
### Motivation and Context

- Fix #11395 

AIJsonUtilities Schema generation does not generate the `type` for `enum` properties, this workaround became necessary to allow enums to be used with VertexAI/GoogleAI API's.

FYI @eiriktsarpalis 