### PR TITLE
.Net: Fix sk function arguments serialization

### DIFF
--- a/dotnet/src/SemanticKernel.Abstractions/AbstractionsJsonContext.cs
+++ b/dotnet/src/SemanticKernel.Abstractions/AbstractionsJsonContext.cs
@@ -18,6 +18,7 @@ namespace Microsoft.SemanticKernel;
 [JsonSerializable(typeof(JsonElement))]
 [JsonSerializable(typeof(KernelFunctionSchemaModel))]
 [JsonSerializable(typeof(PromptExecutionSettings))]
+[JsonSerializable(typeof(KernelArguments))]
 // types commonly used as values in settings dictionaries
 [JsonSerializable(typeof(string))]
 [JsonSerializable(typeof(int))]


### PR DESCRIPTION
### Motivation and Context

Fixes the issue of function arguments serialization of SK functions created from functions of `M.E.AI.AIFunction` type.

Fixes: https://github.com/microsoft/semantic-kernel/issues/11600
