### PR TITLE
.Net: Bug: Function calling fails when Gemini returns function call as non-first part #11651

### DIFF
--- a/dotnet/src/Connectors/Connectors.Google/Core/Gemini/Clients/GeminiChatCompletionClient.cs
+++ b/dotnet/src/Connectors/Connectors.Google/Core/Gemini/Clients/GeminiChatCompletionClient.cs
@@ -604,13 +604,13 @@ internal sealed class GeminiChatCompletionClient : ClientBase
 
     private GeminiChatMessageContent GetChatMessageContentFromCandidate(GeminiResponse geminiResponse, GeminiResponseCandidate candidate)
     {
-        GeminiPart? part = candidate.Content?.Parts?[0];
-        GeminiPart.FunctionCallPart[]? toolCalls = part?.FunctionCall is { } function ? [function] : null;
+        string? text = candidate?.Content?.Parts?.Select(p => p.Text).FirstOrDefault(t => t != null);
+        GeminiPart.FunctionCallPart? functionCall = candidate?.Content?.Parts?.Select(p => p.FunctionCall).FirstOrDefault(fc => fc != null);
         return new GeminiChatMessageContent(
             role: candidate.Content?.Role ?? AuthorRole.Assistant,
-            content: part?.Text ?? string.Empty,
+            content: text ?? string.Empty,
             modelId: this._modelId,
-            functionsToolCalls: toolCalls,
+            functionsToolCalls: functionCall is { } function ? [function] : null,
             metadata: GetResponseMetadata(geminiResponse, candidate));
     }
 


### PR DESCRIPTION
### Motivation and Context

FunctionToolCall via Gemini is broken at the moment and I need this feature.
I need this working as soon as possible so I decided to propose the fix in the hopes this would get sorted out quickly.

**Currently Open Bug:** [.Net: Bug: Function calling fails when Gemini returns function call as non-first part #11651"](https://github.com/microsoft/semantic-kernel/issues/11651)

### Description

Linq was already available so I just used that to select the first part that has Text and the first part that has a FunctionCall and then used these instead of just selecting the first part (what's being done today). This ensures both are found if they exist at all in the response.

### Contribution Checklist

<!-- Before submitting this PR, please make sure: -->

- [ ] The code builds clean without any errors or warnings
- [ ] The PR follows the [SK Contribution Guidelines](https://github.com/microsoft/semantic-kernel/blob/main/CONTRIBUTING.md) and the [pre-submission formatting script](https://github.com/microsoft/semantic-kernel/blob/main/CONTRIBUTING.md#development-scripts) raises no violations
- [ ] All unit tests pass, and I have added new tests where possible
- [ ] I didn't break anyone :smile:
