### PR TITLE
.Net: fixing KernelProcessEventData toObject

### DIFF
--- a/dotnet/src/Experimental/Process.Abstractions/KernelProcessEventData.cs
+++ b/dotnet/src/Experimental/Process.Abstractions/KernelProcessEventData.cs
@@ -2,6 +2,7 @@
 using System;
 using System.Runtime.Serialization;
 using System.Text.Json;
+using Microsoft.SemanticKernel.Connectors.OpenAI;
 
 namespace Microsoft.SemanticKernel;
 
@@ -37,11 +38,22 @@ public sealed record KernelProcessEventData
         {
             try
             {
+                if (type == typeof(OpenAIChatMessageContent))
+                {
+                    // Special case for OpenAIChatMessageContent, which only has constructors with parameters
+                    // Instead using base class ChatMessageContent
+                    return JsonSerializer.Deserialize<ChatMessageContent>(this.Content);
+                }
+
                 return JsonSerializer.Deserialize(this.Content, type);
             }
             catch (JsonException)
             {
                 throw new KernelException($"Cannot deserialize object {this.Content}");
+            }
+            catch (NotSupportedException e)
+            {
+                throw new KernelException($"Cannot deserialize object {this.Content}, type {type.FullName} has no parameterless constructor", e);
             }
         }
 

--- a/dotnet/src/Experimental/Process.Abstractions/Process.Abstractions.csproj
+++ b/dotnet/src/Experimental/Process.Abstractions/Process.Abstractions.csproj
@@ -20,6 +20,7 @@
   </PropertyGroup>
 
   <ItemGroup>
+    <ProjectReference Include="..\..\Connectors\Connectors.OpenAI\Connectors.OpenAI.csproj" />
     <ProjectReference Include="..\..\SemanticKernel.Core\SemanticKernel.Core.csproj" />
   </ItemGroup>
 


### PR DESCRIPTION
### Motivation and Context

Processes Samples Step 04 doesn't work after latest serialization update in KernelProcessEventData

Fixes #11694


### Contribution Checklist

<!-- Before submitting this PR, please make sure: -->

- [x] The code builds clean without any errors or warnings
- [x] The PR follows the [SK Contribution Guidelines](https://github.com/microsoft/semantic-kernel/blob/main/CONTRIBUTING.md) and the [pre-submission formatting script](https://github.com/microsoft/semantic-kernel/blob/main/CONTRIBUTING.md#development-scripts) raises no violations
- [x] All unit tests pass, and I have added new tests where possible
- [x] I didn't break anyone :smile:
