### PR TITLE
.Net: Introduce a LINQ filter preprocessor in MEVD

### DIFF
--- a/dotnet/src/Connectors/Connectors.Memory.AzureCosmosDBNoSQL/AzureCosmosDBNoSqlFilterTranslator.cs
+++ b/dotnet/src/Connectors/Connectors.Memory.AzureCosmosDBNoSQL/AzureCosmosDBNoSqlFilterTranslator.cs
@@ -10,6 +10,7 @@ using System.Reflection;
 using System.Runtime.CompilerServices;
 using System.Text;
 using Microsoft.Extensions.VectorData.ConnectorSupport;
+using Microsoft.Extensions.VectorData.ConnectorSupport.Filter;
 
 namespace Microsoft.SemanticKernel.Connectors.AzureCosmosDBNoSQL;
 
@@ -30,7 +31,11 @@ internal class AzureCosmosDBNoSqlFilterTranslator
         Debug.Assert(lambdaExpression.Parameters.Count == 1);
         this._recordParameter = lambdaExpression.Parameters[0];
 
+        var preprocessor = new FilterTranslationPreprocessor { InlineCapturedVariables = false };
+        var preprocessedExpression = preprocessor.Visit(lambdaExpression);
+
         this.Translate(lambdaExpression.Body);
+
         return (this._sql.ToString(), this._parameters);
     }
 

--- a/dotnet/src/Connectors/Connectors.Memory.MongoDB/MongoDBFilterTranslator.cs
+++ b/dotnet/src/Connectors/Connectors.Memory.MongoDB/MongoDBFilterTranslator.cs
@@ -7,9 +7,8 @@ using System.Diagnostics;
 using System.Diagnostics.CodeAnalysis;
 using System.Linq;
 using System.Linq.Expressions;
-using System.Reflection;
-using System.Runtime.CompilerServices;
 using Microsoft.Extensions.VectorData.ConnectorSupport;
+using Microsoft.Extensions.VectorData.ConnectorSupport.Filter;
 using MongoDB.Bson;
 
 namespace Microsoft.SemanticKernel.Connectors.MongoDB;
@@ -28,7 +27,10 @@ internal class MongoDBFilterTranslator
         Debug.Assert(lambdaExpression.Parameters.Count == 1);
         this._recordParameter = lambdaExpression.Parameters[0];
 
-        return this.Translate(lambdaExpression.Body);
+        var preprocessor = new FilterTranslationPreprocessor { InlineCapturedVariables = true };
+        var preprocessedExpression = preprocessor.Visit(lambdaExpression.Body);
+
+        return this.Translate(preprocessedExpression);
     }
 
     private BsonDocument Translate(Expression? node)
@@ -57,9 +59,10 @@ internal class MongoDBFilterTranslator
         };
 
     private BsonDocument TranslateEqualityComparison(BinaryExpression binary)
-        => (this.TryBindProperty(binary.Left, out var property) && TryGetConstant(binary.Right, out var value))
-            || (this.TryBindProperty(binary.Right, out property) && TryGetConstant(binary.Left, out value))
-                ? this.GenerateEqualityComparison(property, value, binary.NodeType)
+        => this.TryBindProperty(binary.Left, out var property) && binary.Right is ConstantExpression { Value: var rightConstant }
+            ? this.GenerateEqualityComparison(property, rightConstant, binary.NodeType)
+            : this.TryBindProperty(binary.Right, out property) && binary.Left is ConstantExpression { Value: var leftConstant }
+                ? this.GenerateEqualityComparison(property, leftConstant, binary.NodeType)
                 : throw new NotSupportedException("Invalid equality/comparison");
 
     private BsonDocument GenerateEqualityComparison(VectorStoreRecordPropertyModel property, object? value, ExpressionType nodeType)
@@ -184,7 +187,7 @@ internal class MongoDBFilterTranslator
 
                 for (var i = 0; i < newArray.Expressions.Count; i++)
                 {
-                    if (!TryGetConstant(newArray.Expressions[i], out var elementValue))
+                    if (newArray.Expressions[i] is not ConstantExpression { Value: var elementValue })
                     {
                         throw new NotSupportedException("Invalid element in array");
                     }
@@ -194,9 +197,7 @@ internal class MongoDBFilterTranslator
 
                 return ProcessInlineEnumerable(elements, item);
 
-            // Contains over captured enumerable (we inline)
-            case var _ when TryGetConstant(source, out var constantEnumerable)
-                            && constantEnumerable is IEnumerable enumerable and not string:
+            case ConstantExpression { Value: IEnumerable enumerable and not string }:
                 return ProcessInlineEnumerable(enumerable, item);
 
             default:
@@ -264,26 +265,5 @@ internal class MongoDBFilterTranslator
         }
 
         return true;
-    }
-
-    private static bool TryGetConstant(Expression expression, out object? constantValue)
-    {
-        switch (expression)
-        {
-            case ConstantExpression { Value: var v }:
-                constantValue = v;
-                return true;
-
-            // This identifies compiler-generated closure types which contain captured variables.
-            case MemberExpression { Expression: ConstantExpression constant, Member: FieldInfo fieldInfo }
-                when constant.Type.Attributes.HasFlag(TypeAttributes.NestedPrivate)
-                     && Attribute.IsDefined(constant.Type, typeof(CompilerGeneratedAttribute), inherit: true):
-                constantValue = fieldInfo.GetValue(constant.Value);
-                return true;
-
-            default:
-                constantValue = null;
-                return false;
-        }
     }
 }

--- a/dotnet/src/Connectors/Connectors.Memory.Pinecone/PineconeFilterTranslator.cs
+++ b/dotnet/src/Connectors/Connectors.Memory.Pinecone/PineconeFilterTranslator.cs
@@ -7,9 +7,8 @@ using System.Diagnostics;
 using System.Diagnostics.CodeAnalysis;
 using System.Linq;
 using System.Linq.Expressions;
-using System.Reflection;
-using System.Runtime.CompilerServices;
 using Microsoft.Extensions.VectorData.ConnectorSupport;
+using Microsoft.Extensions.VectorData.ConnectorSupport.Filter;
 using Pinecone;
 
 namespace Microsoft.SemanticKernel.Connectors.Pinecone;
@@ -31,7 +30,10 @@ internal class PineconeFilterTranslator
         Debug.Assert(lambdaExpression.Parameters.Count == 1);
         this._recordParameter = lambdaExpression.Parameters[0];
 
-        return this.Translate(lambdaExpression.Body);
+        var preprocessor = new FilterTranslationPreprocessor { InlineCapturedVariables = true };
+        var preprocessedExpression = preprocessor.Visit(lambdaExpression.Body);
+
+        return this.Translate(preprocessedExpression);
     }
 
     private Metadata Translate(Expression? node)
@@ -60,9 +62,10 @@ internal class PineconeFilterTranslator
         };
 
     private Metadata TranslateEqualityComparison(BinaryExpression binary)
-        => (this.TryBindProperty(binary.Left, out var property) && TryGetConstant(binary.Right, out var value))
-            || (this.TryBindProperty(binary.Right, out property) && TryGetConstant(binary.Left, out value))
-                ? this.GenerateEqualityComparison(property, value, binary.NodeType)
+        => this.TryBindProperty(binary.Left, out var property) && binary.Right is ConstantExpression { Value: var rightConstant }
+            ? this.GenerateEqualityComparison(property, rightConstant, binary.NodeType)
+            : this.TryBindProperty(binary.Right, out property) && binary.Left is ConstantExpression { Value: var leftConstant }
+                ? this.GenerateEqualityComparison(property, leftConstant, binary.NodeType)
                 : throw new NotSupportedException("Invalid equality/comparison");
 
     private Metadata GenerateEqualityComparison(VectorStoreRecordPropertyModel property, object? value, ExpressionType nodeType)
@@ -187,7 +190,7 @@ internal class PineconeFilterTranslator
 
                 for (var i = 0; i < newArray.Expressions.Count; i++)
                 {
-                    if (!TryGetConstant(newArray.Expressions[i], out var elementValue))
+                    if (newArray.Expressions[i] is not ConstantExpression { Value: var elementValue })
                     {
                         throw new NotSupportedException("Invalid element in array");
                     }
@@ -197,9 +200,7 @@ internal class PineconeFilterTranslator
 
                 return ProcessInlineEnumerable(elements, item);
 
-            // Contains over captured enumerable (we inline)
-            case var _ when TryGetConstant(source, out var constantEnumerable)
-                            && constantEnumerable is IEnumerable enumerable and not string:
+            case ConstantExpression { Value: IEnumerable enumerable and not string }:
                 return ProcessInlineEnumerable(enumerable, item);
 
             default:
@@ -267,27 +268,6 @@ internal class PineconeFilterTranslator
         }
 
         return true;
-    }
-
-    private static bool TryGetConstant(Expression expression, out object? constantValue)
-    {
-        switch (expression)
-        {
-            case ConstantExpression { Value: var v }:
-                constantValue = v;
-                return true;
-
-            // This identifies compiler-generated closure types which contain captured variables.
-            case MemberExpression { Expression: ConstantExpression constant, Member: FieldInfo fieldInfo }
-                when constant.Type.Attributes.HasFlag(TypeAttributes.NestedPrivate)
-                     && Attribute.IsDefined(constant.Type, typeof(CompilerGeneratedAttribute), inherit: true):
-                constantValue = fieldInfo.GetValue(constant.Value);
-                return true;
-
-            default:
-                constantValue = null;
-                return false;
-        }
     }
 
     private static MetadataValue? ToMetadata(object? value)

--- a/dotnet/src/Connectors/Connectors.Memory.Postgres/PostgresFilterTranslator.cs
+++ b/dotnet/src/Connectors/Connectors.Memory.Postgres/PostgresFilterTranslator.cs
@@ -31,7 +31,7 @@ internal sealed class PostgresFilterTranslator : SqlFilterTranslator
         this._sql.Append(']');
     }
 
-    protected override void TranslateContainsOverCapturedArray(Expression source, Expression item, object? value)
+    protected override void TranslateContainsOverParameterizedArray(Expression source, Expression item, object? value)
     {
         this.Translate(item);
         this._sql.Append(" = ANY (");
@@ -39,17 +39,17 @@ internal sealed class PostgresFilterTranslator : SqlFilterTranslator
         this._sql.Append(')');
     }
 
-    protected override void TranslateCapturedVariable(string name, object? capturedValue)
+    protected override void TranslateQueryParameter(string name, object? value)
     {
         // For null values, simply inline rather than parameterize; parameterized NULLs require setting NpgsqlDbType which is a bit more complicated,
         // plus in any case equality with NULL requires different SQL (x IS NULL rather than x = y)
-        if (capturedValue is null)
+        if (value is null)
         {
             this._sql.Append("NULL");
         }
         else
         {
-            this._parameterValues.Add(capturedValue);
+            this._parameterValues.Add(value);
             this._sql.Append('$').Append(this._parameterIndex++);
         }
     }

--- a/dotnet/src/Connectors/Connectors.Memory.SqlServer/SqlServerFilterTranslator.cs
+++ b/dotnet/src/Connectors/Connectors.Memory.SqlServer/SqlServerFilterTranslator.cs
@@ -60,7 +60,7 @@ internal sealed class SqlServerFilterTranslator : SqlFilterTranslator
     protected override void TranslateContainsOverArrayColumn(Expression source, Expression item)
         => throw new NotSupportedException("Unsupported Contains expression");
 
-    protected override void TranslateContainsOverCapturedArray(Expression source, Expression item, object? value)
+    protected override void TranslateContainsOverParameterizedArray(Expression source, Expression item, object? value)
     {
         if (value is not IEnumerable elements)
         {
@@ -88,17 +88,17 @@ internal sealed class SqlServerFilterTranslator : SqlFilterTranslator
         this._sql.Append(')');
     }
 
-    protected override void TranslateCapturedVariable(string name, object? capturedValue)
+    protected override void TranslateQueryParameter(string name, object? value)
     {
         // For null values, simply inline rather than parameterize; parameterized NULLs require setting NpgsqlDbType which is a bit more complicated,
         // plus in any case equality with NULL requires different SQL (x IS NULL rather than x = y)
-        if (capturedValue is null)
+        if (value is null)
         {
             this._sql.Append("NULL");
         }
         else
         {
-            this._parameterValues.Add(capturedValue);
+            this._parameterValues.Add(value);
             // SQL Server parameters can't start with a digit (but underscore is OK).
             this._sql.Append("@_").Append(this._parameterIndex++);
         }

--- a/dotnet/src/Connectors/Connectors.Memory.Sqlite/SqliteFilterTranslator.cs
+++ b/dotnet/src/Connectors/Connectors.Memory.Sqlite/SqliteFilterTranslator.cs
@@ -23,7 +23,7 @@ internal sealed class SqliteFilterTranslator : SqlFilterTranslator
     protected override void TranslateContainsOverArrayColumn(Expression source, Expression item)
         => throw new NotSupportedException("Unsupported Contains expression");
 
-    protected override void TranslateContainsOverCapturedArray(Expression source, Expression item, object? value)
+    protected override void TranslateContainsOverParameterizedArray(Expression source, Expression item, object? value)
     {
         if (value is not IEnumerable elements)
         {
@@ -51,11 +51,11 @@ internal sealed class SqliteFilterTranslator : SqlFilterTranslator
         this._sql.Append(')');
     }
 
-    protected override void TranslateCapturedVariable(string name, object? capturedValue)
+    protected override void TranslateQueryParameter(string name, object? value)
     {
         // For null values, simply inline rather than parameterize; parameterized NULLs require setting NpgsqlDbType which is a bit more complicated,
         // plus in any case equality with NULL requires different SQL (x IS NULL rather than x = y)
-        if (capturedValue is null)
+        if (value is null)
         {
             this._sql.Append("NULL");
         }
@@ -73,7 +73,7 @@ internal sealed class SqliteFilterTranslator : SqlFilterTranslator
                 } while (this._parameters.ContainsKey(name));
             }
 
-            this._parameters.Add(name, capturedValue);
+            this._parameters.Add(name, value);
             this._sql.Append('@').Append(name);
         }
     }

--- a/dotnet/src/Connectors/VectorData.Abstractions/ConnectorSupport/Filter/FilterTranslationPreprocessor.cs
+++ b/dotnet/src/Connectors/VectorData.Abstractions/ConnectorSupport/Filter/FilterTranslationPreprocessor.cs
@@ -1,0 +1,54 @@
+﻿// Copyright (c) Microsoft. All rights reserved.
+
+using System;
+using System.Diagnostics.CodeAnalysis;
+using System.Linq.Expressions;
+using System.Reflection;
+using System.Runtime.CompilerServices;
+
+namespace Microsoft.Extensions.VectorData.ConnectorSupport.Filter;
+
+/// <summary>
+/// A processor for user-provided filter expressions which performs various common transformations before actual translation takes place.
+/// This is an internal support type meant for use by connectors only, and not for use by applications.
+/// </summary>
+[Experimental("MEVD9001")]
+public class FilterTranslationPreprocessor : ExpressionVisitor
+{
+    /// <summary>
+    /// Whether to inline captured variables in the filter expression (when the database doesn't support parameters).
+    /// </summary>
+    public bool InlineCapturedVariables { get; init; }
+
+    /// <summary>
+    /// Whether to transform captured variables in the filter expression to <see cref="QueryParameterExpression"/> (when the database supports parameters).
+    /// </summary>
+    public bool TransformCapturedVariablesToQueryParameterExpressions { get; init; }
+
+    /// <inheritdoc />
+    protected override Expression VisitMember(MemberExpression node)
+    {
+        // This identifies compiler-generated closure types which contain captured variables.
+        // Some databases - mostly relational ones - support out-of-band parameters which can be referenced via placeholders
+        // from the query itself. For those databases, we transform the captured variable to QueryParameterExpression (this simplifies things for those
+        // connectors, and centralizes the pattern matching in a single centralized place).
+        // For databases which don't support parameters, we simply inline the captured variable as a constant in the tree, so that translators don't
+        // even need to be aware of the captured variable.
+        // For all other databases, we simply inline the captured variable as a constant in the tree.
+        if (node is MemberExpression { Expression: ConstantExpression constant, Member: FieldInfo fieldInfo }
+            && constant.Type.Attributes.HasFlag(TypeAttributes.NestedPrivate)
+            && Attribute.IsDefined(constant.Type, typeof(CompilerGeneratedAttribute), inherit: true))
+        {
+            return (this.InlineCapturedVariables, this.TransformCapturedVariablesToQueryParameterExpressions) switch
+            {
+                (true, false) => Expression.Constant(fieldInfo.GetValue(constant.Value), node.Type),
+                (false, true) => new QueryParameterExpression(fieldInfo.Name, fieldInfo.GetValue(constant.Value), node.Type),
+
+                (true, true) => throw new InvalidOperationException("InlineCapturedVariables and TransformCapturedVariablesToQueryParameterExpressions cannot both be true."),
+                (false, false) => base.VisitMember(node)
+            };
+        }
+
+        return base.VisitMember(node);
+    }
+}

--- a/dotnet/src/Connectors/VectorData.Abstractions/ConnectorSupport/Filter/QueryParameterExpression.cs
+++ b/dotnet/src/Connectors/VectorData.Abstractions/ConnectorSupport/Filter/QueryParameterExpression.cs
@@ -1,0 +1,33 @@
+﻿// Copyright (c) Microsoft. All rights reserved.
+
+using System;
+using System.Diagnostics.CodeAnalysis;
+using System.Linq.Expressions;
+
+namespace Microsoft.Extensions.VectorData.ConnectorSupport.Filter;
+
+/// <summary>
+/// An expression representation a query parameter (captured variable) in the filter expression.
+/// </summary>
+[Experimental("MEVD9001")]
+public class QueryParameterExpression(string name, object? value, Type type) : Expression
+{
+    /// <summary>
+    /// The name of the parameter.
+    /// </summary>
+    public string Name { get; } = name;
+
+    /// <summary>
+    /// The value of the parameter.
+    /// </summary>
+    public object? Value { get; } = value;
+
+    /// <inheritdoc />
+    public override ExpressionType NodeType => ExpressionType.Extension;
+
+    /// <inheritdoc />
+    public override Type Type => type;
+
+    /// <inheritdoc />
+    protected override Expression VisitChildren(ExpressionVisitor visitor) => this;
+}


### PR DESCRIPTION
This is a refactor-only change, with no functional changes. It extracts out all logic for identifying and processing captured variables ("parameters") out to a new FilterTranslationProcessor connectos support type in MEVD.

* Most databases don't support parameterization; for these we simply inline the captured variables. Connector translators see these as constants without ever having to know about captured variables etc.
* SQL databases do support parameterization. For these, the preprocessor transforms the captured variable (which is a complex tree construct) into a simple QueryParameterExpression, which can easily be pattern-matched in connector translator code.

This is preparatory work for #11673 (we need a centralized place to do this kind of thing).