### PR TITLE
Python: Return thread id and run id in agent response metadata

### DIFF
--- a/python/semantic_kernel/agents/azure_ai/agent_thread_actions.py
+++ b/python/semantic_kernel/agents/azure_ai/agent_thread_actions.py
@@ -42,14 +42,10 @@ from semantic_kernel.agents.azure_ai.agent_content_generation import (
     get_function_call_contents,
 )
 from semantic_kernel.agents.azure_ai.azure_ai_agent_utils import AzureAIAgentUtils
-from semantic_kernel.agents.open_ai.assistant_content_generation import (
-    merge_streaming_function_results,
-)
+from semantic_kernel.agents.open_ai.assistant_content_generation import merge_streaming_function_results
 from semantic_kernel.agents.open_ai.function_action_result import FunctionActionResult
 from semantic_kernel.agents.open_ai.run_polling_options import RunPollingOptions
-from semantic_kernel.connectors.ai.function_calling_utils import (
-    kernel_function_metadata_to_function_call_format,
-)
+from semantic_kernel.connectors.ai.function_calling_utils import kernel_function_metadata_to_function_call_format
 from semantic_kernel.contents.chat_message_content import ChatMessageContent
 from semantic_kernel.contents.function_call_content import FunctionCallContent
 from semantic_kernel.contents.utils.author_role import AuthorRole
@@ -304,7 +300,7 @@ class AgentThreadActions:
                             message_id=message_call_details.message_creation.message_id,  # type: ignore
                         )
                         if message:
-                            content = generate_message_content(agent.name, message)
+                            content = generate_message_content(agent.name, message, completed_step)
                             if content and len(content.items) > 0:
                                 message_count += 1
                                 logger.debug(

--- a/python/semantic_kernel/agents/open_ai/assistant_thread_actions.py
+++ b/python/semantic_kernel/agents/open_ai/assistant_thread_actions.py
@@ -33,9 +33,7 @@ from semantic_kernel.agents.open_ai.assistant_content_generation import (
 )
 from semantic_kernel.agents.open_ai.function_action_result import FunctionActionResult
 from semantic_kernel.agents.open_ai.run_polling_options import RunPollingOptions
-from semantic_kernel.connectors.ai.function_calling_utils import (
-    kernel_function_metadata_to_function_call_format,
-)
+from semantic_kernel.connectors.ai.function_calling_utils import kernel_function_metadata_to_function_call_format
 from semantic_kernel.contents.file_reference_content import FileReferenceContent
 from semantic_kernel.contents.function_call_content import FunctionCallContent
 from semantic_kernel.contents.streaming_file_reference_content import StreamingFileReferenceContent
@@ -338,7 +336,7 @@ class AssistantThreadActions:
                         message_id=completed_step.step_details.message_creation.message_id,  # type: ignore
                     )
                     if message:
-                        content = generate_message_content(agent.name, message)
+                        content = generate_message_content(agent.name, message, completed_step)
                         if content and len(content.items) > 0:
                             message_count += 1
                             logger.debug(

--- a/python/tests/integration/agents/azureai_agent/test_azureai_agent_integration.py
+++ b/python/tests/integration/agents/azureai_agent/test_azureai_agent_integration.py
@@ -82,6 +82,8 @@ class TestAzureAIAgentIntegration:
         assert isinstance(response.message, ChatMessageContent)
         assert response.message.role == AuthorRole.ASSISTANT
         assert response.message.content is not None
+        assert "thread_id" in response.message.metadata
+        assert "run_id" in response.message.metadata
 
     async def test_get_response_with_thread(self, azureai_agent: AzureAIAgent, agent_test_base: AgentTestBase):
         """Test get response of the agent with a thread."""

--- a/python/tests/integration/agents/openai_assistant_agent/test_openai_assistant_agent_integration.py
+++ b/python/tests/integration/agents/openai_assistant_agent/test_openai_assistant_agent_integration.py
@@ -101,6 +101,8 @@ class TestOpenAIAssistantAgentIntegration:
         assert isinstance(response.message, ChatMessageContent)
         assert response.message.role == AuthorRole.ASSISTANT
         assert response.message.content is not None
+        assert "thread_id" in response.message.metadata
+        assert "run_id" in response.message.metadata
 
     @pytest.mark.parametrize("assistant_agent", ["azure", "openai"], indirect=True, ids=["azure", "openai"])
     async def test_get_response_with_thread(

--- a/python/tests/integration/agents/openai_responses_agent/test_openai_responses_agent_integration.py
+++ b/python/tests/integration/agents/openai_responses_agent/test_openai_responses_agent_integration.py
@@ -102,6 +102,7 @@ class TestOpenAIResponsesAgentIntegration:
         assert isinstance(response.message, ChatMessageContent)
         assert response.message.role == AuthorRole.ASSISTANT
         assert response.message.content is not None
+        assert "thread_id" in response.message.metadata
 
     @pytest.mark.parametrize("responses_agent", ["azure", "openai"], indirect=True, ids=["azure", "openai"])
     async def test_get_response_with_thread(


### PR DESCRIPTION
### Motivation and Context

<!-- Thank you for your contribution to the semantic-kernel repo!
Please help reviewers and future users, providing the following information:
  1. Why is this change required?
  2. What problem does it solve?
  3. What scenario does it contribute to?
  4. If it fixes an open issue, please link to the issue here.
-->
We are currently not returning the thread id and run id from the Azure AI and Assistant agents. These properties will be useful for evaluation purposes.

### Description

<!-- Describe your changes, the overall approach, the underlying design.
     These notes will help understanding how your code works. Thanks! -->
Return the thread id and run id in the agent response metadata.


### Contribution Checklist

<!-- Before submitting this PR, please make sure: -->

- [x] The code builds clean without any errors or warnings
- [x] The PR follows the [SK Contribution Guidelines](https://github.com/microsoft/semantic-kernel/blob/main/CONTRIBUTING.md) and the [pre-submission formatting script](https://github.com/microsoft/semantic-kernel/blob/main/CONTRIBUTING.md#development-scripts) raises no violations
- [x] All unit tests pass, and I have added new tests where possible
- [x] I didn't break anyone :smile:
