### PR TITLE
.Net: Exclude some code for which we don't need to add code coverage

### DIFF
--- a/dotnet/src/SemanticKernel.Core/Functions/KernelFunctionFromPrompt.cs
+++ b/dotnet/src/SemanticKernel.Core/Functions/KernelFunctionFromPrompt.cs
@@ -533,6 +533,7 @@ internal sealed class KernelFunctionFromPrompt : KernelFunction
     /// <summary>
     /// Captures usage details, including token information.
     /// </summary>
+    [ExcludeFromCodeCoverage]
     private void CaptureUsageDetails(string? modelId, IReadOnlyDictionary<string, object?>? metadata, ILogger logger)
     {
         if (!logger.IsEnabled(LogLevel.Information) &&

--- a/dotnet/src/SemanticKernel.Core/KernelExtensions.cs
+++ b/dotnet/src/SemanticKernel.Core/KernelExtensions.cs
@@ -929,6 +929,7 @@ public static class KernelExtensions
     /// <summary>Creates a plugin containing one function per child directory of the specified <paramref name="pluginDirectory"/>.</summary>
     [RequiresUnreferencedCode("Uses reflection to handle various aspects of the function creation and invocation, making it incompatible with AOT scenarios.")]
     [RequiresDynamicCode("Uses reflection to handle various aspects of the function creation and invocation, making it incompatible with AOT scenarios.")]
+    [ExcludeFromCodeCoverage]
     private static KernelPlugin CreatePluginFromPromptDirectory(
         string pluginDirectory,
         string? pluginName = null,

--- a/dotnet/src/SemanticKernel.Core/Memory/MemoryBuilder.cs
+++ b/dotnet/src/SemanticKernel.Core/Memory/MemoryBuilder.cs
@@ -13,6 +13,7 @@ namespace Microsoft.SemanticKernel.Memory;
 /// A builder for Memory plugin.
 /// </summary>
 [Experimental("SKEXP0001")]
+[ExcludeFromCodeCoverage]
 public sealed class MemoryBuilder
 {
     private Func<IMemoryStore>? _memoryStoreFactory = null;

--- a/dotnet/src/SemanticKernel.Core/Memory/SemanticTextMemory.cs
+++ b/dotnet/src/SemanticKernel.Core/Memory/SemanticTextMemory.cs
@@ -16,6 +16,7 @@ namespace Microsoft.SemanticKernel.Memory;
 /// in a semantic memory store.
 /// </summary>
 [Experimental("SKEXP0001")]
+[ExcludeFromCodeCoverage]
 public sealed class SemanticTextMemory : ISemanticTextMemory
 {
     private readonly ITextEmbeddingGenerationService _embeddingGenerator;


### PR DESCRIPTION
### Motivation and Context

Core is very close to the code coverage threshold so excluding some functions from code coverage

1. CaptureUsageDetails
2. CreatePluginFromPromptDirectory no longer a recommended pattern
3. MemoryBuilder and SemanticTextMemory are being deprecated

### Description

Before
![image](https://github.com/user-attachments/assets/49780beb-33b5-404e-95ec-cd4b6c52dab6)

After
![image](https://github.com/user-attachments/assets/d131ce1c-f91d-4600-b2be-5889f3b54234)

### Contribution Checklist

<!-- Before submitting this PR, please make sure: -->

- [ ] The code builds clean without any errors or warnings
- [ ] The PR follows the [SK Contribution Guidelines](https://github.com/microsoft/semantic-kernel/blob/main/CONTRIBUTING.md) and the [pre-submission formatting script](https://github.com/microsoft/semantic-kernel/blob/main/CONTRIBUTING.md#development-scripts) raises no violations
- [ ] All unit tests pass, and I have added new tests where possible
- [ ] I didn't break anyone :smile:
