### PR TITLE
Small InMemory bug fix.

### DIFF
--- a/dotnet/src/Connectors/Connectors.Memory.InMemory/InMemoryVectorStoreRecordCollection.cs
+++ b/dotnet/src/Connectors/Connectors.Memory.InMemory/InMemoryVectorStoreRecordCollection.cs
@@ -480,7 +480,10 @@ public sealed class InMemoryVectorStoreRecordCollection<TKey, TRecord> : IVector
             throw new NotSupportedException(VectorDataStrings.IncludeVectorsNotSupportedWithEmbeddingGeneration);
         }
 
-        var records = this.GetCollectionDictionary().Values.Cast<TRecord>()
+        var records = this.GetCollectionDictionary()
+            .Values
+            .Cast<InMemoryVectorRecordWrapper<TRecord>>()
+            .Select(x => x.Record)
             .AsQueryable()
             .Where(filter);
 


### PR DESCRIPTION
### Motivation and Context

We changed the storage type of the InMemory store to contain a wrapper with both
the original record and generated vectors, and this code was returning the wrapper
instead of the original record on get.

### Description

<!-- Describe your changes, the overall approach, the underlying design.
     These notes will help understanding how your code works. Thanks! -->

### Contribution Checklist

<!-- Before submitting this PR, please make sure: -->

- [ ] The code builds clean without any errors or warnings
- [ ] The PR follows the [SK Contribution Guidelines](https://github.com/microsoft/semantic-kernel/blob/main/CONTRIBUTING.md) and the [pre-submission formatting script](https://github.com/microsoft/semantic-kernel/blob/main/CONTRIBUTING.md#development-scripts) raises no violations
- [ ] All unit tests pass, and I have added new tests where possible
- [ ] I didn't break anyone :smile:
