### PR TITLE
.Net: Try to reduce mongodb test flakiness

### DIFF
--- a/dotnet/src/IntegrationTests/Connectors/Memory/MongoDB/MongoDBVectorStoreFixture.cs
+++ b/dotnet/src/IntegrationTests/Connectors/Memory/MongoDB/MongoDBVectorStoreFixture.cs
@@ -3,42 +3,41 @@
 using System;
 using System.Collections.Generic;
 using System.Threading.Tasks;
-using Docker.DotNet;
-using Docker.DotNet.Models;
 using Microsoft.Extensions.VectorData;
 using MongoDB.Driver;
+using Testcontainers.MongoDb;
 using Xunit;
 
 namespace SemanticKernel.IntegrationTests.Connectors.MongoDB;
 
+#pragma warning disable CS8618 // Non-nullable field must contain a non-null value when exiting constructor. Consider adding the 'required' modifier or declaring as nullable.
+
 public class MongoDBVectorStoreFixture : IAsyncLifetime
 {
+    private readonly MongoDbContainer _container = new MongoDbBuilder()
+        .WithImage("mongodb/mongodb-atlas-local:7.0.6")
+        .Build();
+
     private readonly List<string> _testCollections = ["sk-test-hotels", "sk-test-contacts", "sk-test-addresses"];
 
     /// <summary>Main test collection for tests.</summary>
     public string TestCollection => this._testCollections[0];
 
     /// <summary><see cref="IMongoDatabase"/> that can be used to manage the collections in MongoDB.</summary>
-    public IMongoDatabase MongoDatabase { get; }
+    public IMongoDatabase MongoDatabase { get; private set; }
 
     /// <summary>Gets the manually created vector store record definition for MongoDB test model.</summary>
     public VectorStoreRecordDefinition HotelVectorStoreRecordDefinition { get; private set; }
 
-    /// <summary>The id of the MongoDB container that we are testing with.</summary>
-    private string? _containerId = null;
-
-    /// <summary>The Docker client we are using to create a MongoDB container with.</summary>
-    private readonly DockerClient _client;
-
-    /// <summary>
-    /// Initializes a new instance of the <see cref="MongoDBVectorStoreFixture"/> class.
-    /// </summary>
-    public MongoDBVectorStoreFixture()
+    public async Task InitializeAsync()
     {
-        using var dockerClientConfiguration = new DockerClientConfiguration();
-        this._client = dockerClientConfiguration.CreateClient();
+        await this._container.StartAsync();
 
-        var mongoClient = new MongoClient("mongodb://localhost:27017/?directConnection=true");
+        var mongoClient = new MongoClient(new MongoClientSettings
+        {
+            Server = new MongoServerAddress(this._container.Hostname, this._container.GetMappedPublicPort(MongoDbBuilder.MongoDbPort)),
+            DirectConnection = true,
+        });
 
         this.MongoDatabase = mongoClient.GetDatabase("test");
 
@@ -57,11 +56,6 @@ public class MongoDBVectorStoreFixture : IAsyncLifetime
                 new VectorStoreRecordVectorProperty("DescriptionEmbedding", typeof(ReadOnlyMemory<float>?), 4) { IndexKind = IndexKind.IvfFlat, DistanceFunction = DistanceFunction.CosineSimilarity }
             ]
         };
-    }
-
-    public async Task InitializeAsync()
-    {
-        this._containerId = await SetupMongoDBContainerAsync(this._client);
 
         foreach (var collection in this._testCollections)
         {
@@ -81,52 +75,6 @@ public class MongoDBVectorStoreFixture : IAsyncLifetime
             }
         }
 
-        if (this._containerId != null)
-        {
-            await this._client.Containers.StopContainerAsync(this._containerId, new ContainerStopParameters());
-            await this._client.Containers.RemoveContainerAsync(this._containerId, new ContainerRemoveParameters());
-        }
+        await this._container.StopAsync();
     }
-
-    #region private
-
-    private static async Task<string> SetupMongoDBContainerAsync(DockerClient client)
-    {
-        const string Image = "mongodb/mongodb-atlas-local";
-        const string Tag = "latest";
-
-        await client.Images.CreateImageAsync(
-            new ImagesCreateParameters
-            {
-                FromImage = Image,
-                Tag = Tag,
-            },
-            null,
-            new Progress<JSONMessage>());
-
-        var container = await client.Containers.CreateContainerAsync(new CreateContainerParameters()
-        {
-            Image = $"{Image}:{Tag}",
-            HostConfig = new HostConfig()
-            {
-                PortBindings = new Dictionary<string, IList<PortBinding>>
-                {
-                    { "27017", new List<PortBinding> { new() { HostPort = "27017" } } },
-                },
-                PublishAllPorts = true
-            },
-            ExposedPorts = new Dictionary<string, EmptyStruct>
-            {
-                { "27017", default },
-            },
-        });
-
-        await client.Containers.StartContainerAsync(
-            container.ID,
-            new ContainerStartParameters());
-
-        return container.ID;
-    }
-
-    #endregion
 }

--- a/dotnet/src/IntegrationTests/Connectors/Memory/MongoDB/MongoDBVectorStoreRecordCollectionTests.cs
+++ b/dotnet/src/IntegrationTests/Connectors/Memory/MongoDB/MongoDBVectorStoreRecordCollectionTests.cs
@@ -8,6 +8,8 @@ using Microsoft.Extensions.VectorData;
 using Microsoft.SemanticKernel.Connectors.MongoDB;
 using MongoDB.Bson;
 using MongoDB.Bson.Serialization.Attributes;
+using MongoDB.Driver;
+using xRetry;
 using Xunit;
 
 namespace SemanticKernel.IntegrationTests.Connectors.MongoDB;
@@ -20,7 +22,7 @@ public class MongoDBVectorStoreRecordCollectionTests(MongoDBVectorStoreFixture f
     // If null, all tests will be enabled
     private const string? SkipReason = null;
 
-    [Theory(Skip = SkipReason)]
+    [RetryTheory(typeof(MongoCommandException), Skip = SkipReason)]
     [InlineData("sk-test-hotels", true)]
     [InlineData("nonexistentcollection", false)]
     public async Task CollectionExistsReturnsCollectionStateAsync(string collectionName, bool expectedExists)
@@ -35,7 +37,7 @@ public class MongoDBVectorStoreRecordCollectionTests(MongoDBVectorStoreFixture f
         Assert.Equal(expectedExists, actual);
     }
 
-    [Fact(Skip = SkipReason)]
+    [RetryFact(typeof(MongoCommandException), Skip = SkipReason)]
     public async Task ItCanCreateCollectionAsync()
     {
         // Arrange
@@ -50,7 +52,7 @@ public class MongoDBVectorStoreRecordCollectionTests(MongoDBVectorStoreFixture f
         await sut.DeleteCollectionAsync();
     }
 
-    [Theory(Skip = SkipReason)]
+    [RetryTheory(typeof(MongoCommandException), Skip = SkipReason)]
     [InlineData(true, true)]
     [InlineData(true, false)]
     [InlineData(false, true)]
@@ -105,7 +107,7 @@ public class MongoDBVectorStoreRecordCollectionTests(MongoDBVectorStoreFixture f
         }
     }
 
-    [Fact(Skip = SkipReason)]
+    [RetryFact(typeof(MongoCommandException), Skip = SkipReason)]
     public async Task ItCanDeleteCollectionAsync()
     {
         // Arrange
@@ -123,7 +125,7 @@ public class MongoDBVectorStoreRecordCollectionTests(MongoDBVectorStoreFixture f
         Assert.False(await sut.CollectionExistsAsync());
     }
 
-    [Fact(Skip = SkipReason)]
+    [RetryFact(typeof(MongoCommandException), Skip = SkipReason)]
     public async Task ItCanGetAndDeleteRecordAsync()
     {
         // Arrange
@@ -147,7 +149,7 @@ public class MongoDBVectorStoreRecordCollectionTests(MongoDBVectorStoreFixture f
         Assert.Null(getResult);
     }
 
-    [Fact(Skip = SkipReason)]
+    [RetryFact(typeof(MongoCommandException), Skip = SkipReason)]
     public async Task ItCanGetAndDeleteBatchAsync()
     {
         // Arrange
@@ -179,7 +181,7 @@ public class MongoDBVectorStoreRecordCollectionTests(MongoDBVectorStoreFixture f
         Assert.Empty(getResults);
     }
 
-    [Fact(Skip = SkipReason)]
+    [RetryFact(typeof(MongoCommandException), Skip = SkipReason)]
     public async Task ItCanUpsertRecordAsync()
     {
         // Arrange
@@ -207,7 +209,7 @@ public class MongoDBVectorStoreRecordCollectionTests(MongoDBVectorStoreFixture f
         Assert.Equal(10, getResult.HotelRating);
     }
 
-    [Fact(Skip = SkipReason)]
+    [RetryFact(typeof(MongoCommandException), Skip = SkipReason)]
     public async Task UpsertWithModelWorksCorrectlyAsync()
     {
         // Arrange
@@ -239,7 +241,7 @@ public class MongoDBVectorStoreRecordCollectionTests(MongoDBVectorStoreFixture f
         Assert.Equal("Test Name", getResult.HotelName);
     }
 
-    [Fact(Skip = SkipReason)]
+    [RetryFact(typeof(MongoCommandException), Skip = SkipReason)]
     public async Task UpsertWithVectorStoreModelWorksCorrectlyAsync()
     {
         // Arrange
@@ -259,7 +261,7 @@ public class MongoDBVectorStoreRecordCollectionTests(MongoDBVectorStoreFixture f
         Assert.Equal("Test Name", getResult.HotelName);
     }
 
-    [Fact(Skip = SkipReason)]
+    [RetryFact(typeof(MongoCommandException), Skip = SkipReason)]
     public async Task UpsertWithBsonModelWorksCorrectlyAsync()
     {
         // Arrange
@@ -291,7 +293,7 @@ public class MongoDBVectorStoreRecordCollectionTests(MongoDBVectorStoreFixture f
         Assert.Equal("Test Name", getResult.HotelName);
     }
 
-    [Fact(Skip = SkipReason)]
+    [RetryFact(typeof(MongoCommandException), Skip = SkipReason)]
     public async Task UpsertWithBsonVectorStoreModelWorksCorrectlyAsync()
     {
         // Arrange
@@ -311,7 +313,7 @@ public class MongoDBVectorStoreRecordCollectionTests(MongoDBVectorStoreFixture f
         Assert.Equal("Test Name", getResult.HotelName);
     }
 
-    [Fact(Skip = SkipReason)]
+    [RetryFact(typeof(MongoCommandException), Skip = SkipReason)]
     public async Task UpsertWithBsonVectorStoreWithNameModelWorksCorrectlyAsync()
     {
         // Arrange
@@ -331,7 +333,7 @@ public class MongoDBVectorStoreRecordCollectionTests(MongoDBVectorStoreFixture f
         Assert.Equal("Test Name", getResult.HotelName);
     }
 
-    [Fact(Skip = SkipReason)]
+    [RetryFact(typeof(MongoCommandException), Skip = SkipReason)]
     public async Task VectorizedSearchReturnsValidResultsByDefaultAsync()
     {
         // Arrange
@@ -361,7 +363,7 @@ public class MongoDBVectorStoreRecordCollectionTests(MongoDBVectorStoreFixture f
         Assert.Equal(1, searchResults.First(l => l.Record.HotelId == "key1").Score);
     }
 
-    [Fact(Skip = SkipReason)]
+    [RetryFact(typeof(MongoCommandException), Skip = SkipReason)]
     public async Task VectorizedSearchReturnsValidResultsWithOffsetAsync()
     {
         // Arrange
@@ -392,7 +394,7 @@ public class MongoDBVectorStoreRecordCollectionTests(MongoDBVectorStoreFixture f
         Assert.DoesNotContain("key2", ids);
     }
 
-    [Fact(Skip = SkipReason)]
+    [RetryFact(typeof(MongoCommandException), Skip = SkipReason)]
     public async Task VectorizedSearchReturnsValidResultsWithFilterAsync()
     {
         // Arrange
@@ -423,7 +425,7 @@ public class MongoDBVectorStoreRecordCollectionTests(MongoDBVectorStoreFixture f
         Assert.DoesNotContain("key4", ids);
     }
 
-    [Fact(Skip = SkipReason)]
+    [RetryFact(typeof(MongoCommandException), Skip = SkipReason)]
     public async Task ItCanUpsertAndRetrieveUsingTheDynamicMapperAsync()
     {
         // Arrange

--- a/dotnet/src/IntegrationTests/IntegrationTests.csproj
+++ b/dotnet/src/IntegrationTests/IntegrationTests.csproj
@@ -65,6 +65,7 @@
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>
     <PackageReference Include="Testcontainers.Milvus" />
+    <PackageReference Include="Testcontainers.MongoDB"/>
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\Agents\AzureAI\Agents.AzureAI.csproj" />


### PR DESCRIPTION
### Motivation and Context

The docker container for mongo db is often not accessible when running the tests

### Description

- Switching to the mongo db test container to try and reduce the flakiness of the tests
- Adding retries

### Contribution Checklist

<!-- Before submitting this PR, please make sure: -->

- [ ] The code builds clean without any errors or warnings
- [ ] The PR follows the [SK Contribution Guidelines](https://github.com/microsoft/semantic-kernel/blob/main/CONTRIBUTING.md) and the [pre-submission formatting script](https://github.com/microsoft/semantic-kernel/blob/main/CONTRIBUTING.md#development-scripts) raises no violations
- [ ] All unit tests pass, and I have added new tests where possible
- [ ] I didn't break anyone :smile:
