### PR TITLE
Python: Deep-copy `function_result.value` in `invoke_function_call` to prevent state mutation

### DIFF
--- a/python/semantic_kernel/kernel.py
+++ b/python/semantic_kernel/kernel.py
@@ -406,6 +406,10 @@ class Kernel(KernelFilterExtension, KernelFunctionExtension, KernelServicesExten
         )
         await stack(invocation_context)
 
+        # Snapshot the tool's return value so later mutations don't leak back
+        if invocation_context.function_result and invocation_context.function_result.value is not None:
+            invocation_context.function_result.value = deepcopy(invocation_context.function_result.value)
+
         frc = FunctionResultContent.from_function_call_content_and_result(
             function_call_content=function_call,
             result=invocation_context.function_result,


### PR DESCRIPTION
### Motivation and Context

The existing implementation of `kernel.invoke_function_call(...)` stores mutable tool return values by reference. Subsequent mutations to the same in-memory state bleed into earlier chat messages, which corrupts conversation history and breaks reproducibility. By deep-copying the function result immediately after execution, we can guarantee an immutable snapshot of each tool's output at the time of invocation, which preserves previous tool invocations and removes unwanted side effects.

<!-- Thank you for your contribution to the semantic-kernel repo!
Please help reviewers and future users, providing the following information:
  1. Why is this change required?
  2. What problem does it solve?
  3. What scenario does it contribute to?
  4. If it fixes an open issue, please link to the issue here.
-->

### Description

After `await stack(invocation_context)` in `kernel.invoke_function_call(...)`, we now have:
```python
if invocation_context.function_result and invocation_context.function_result.value is not None:
    invocation_context.function_result.value = copy.deepcopy(
        invocation_context.function_result.value
    )
```
This has no change to our public API or user-facing behavior; internal state handling is now robust against undesired mutations.
- Adds a unit test to exercise the new behavior and assert on the proper mutations/states.

<!-- Describe your changes, the overall approach, the underlying design.
     These notes will help understanding how your code works. Thanks! -->

### Contribution Checklist

<!-- Before submitting this PR, please make sure: -->

- [X] The code builds clean without any errors or warnings
- [X] The PR follows the [SK Contribution Guidelines](https://github.com/microsoft/semantic-kernel/blob/main/CONTRIBUTING.md) and the [pre-submission formatting script](https://github.com/microsoft/semantic-kernel/blob/main/CONTRIBUTING.md#development-scripts) raises no violations
- [X] All unit tests pass, and I have added new tests where possible
- [X] I didn't break anyone :smile:
