### PR TITLE
Python: Per deprecation message and date remove add_chat_message from AzureAIAgent and OpenAIAssistantAgent

### DIFF
--- a/python/semantic_kernel/agents/azure_ai/azure_ai_agent.py
+++ b/python/semantic_kernel/agents/azure_ai/azure_ai_agent.py
@@ -5,8 +5,6 @@ import sys
 from collections.abc import AsyncIterable, Awaitable, Callable, Iterable
 from typing import TYPE_CHECKING, Any, ClassVar, Literal, TypeVar
 
-from typing_extensions import deprecated
-
 if sys.version_info >= (3, 12):
     from typing import override  # pragma: no cover
 else:
@@ -18,7 +16,6 @@ from azure.ai.projects.models import (
     AgentsApiResponseFormat,
     AgentsApiResponseFormatMode,
     ResponseFormatJsonSchemaType,
-    ThreadMessage,
     ThreadMessageOptions,
     ToolDefinition,
     TruncationObject,
@@ -613,18 +610,3 @@ class AzureAIAgent(Agent):
         assert thread.id is not None  # nosec
 
         return AzureAIChannel(client=self.client, thread_id=thread.id)
-
-    @deprecated(
-        "Pass messages directly to get_response(...)/invoke(...) instead. This method will be removed after May 1st 2025."  # noqa: E501
-    )
-    async def add_chat_message(self, thread_id: str, message: str | ChatMessageContent) -> "ThreadMessage | None":
-        """Add a chat message to the thread.
-
-        Args:
-            thread_id: The ID of the thread
-            message: The chat message to add
-
-        Returns:
-            ThreadMessage | None: The thread message
-        """
-        return await AgentThreadActions.create_message(client=self.client, thread_id=thread_id, message=message)

--- a/python/semantic_kernel/agents/open_ai/open_ai_assistant_agent.py
+++ b/python/semantic_kernel/agents/open_ai/open_ai_assistant_agent.py
@@ -6,8 +6,6 @@ from collections.abc import AsyncIterable, Awaitable, Callable, Iterable
 from copy import copy
 from typing import TYPE_CHECKING, Any, ClassVar, Literal
 
-from typing_extensions import deprecated
-
 from semantic_kernel.utils.feature_stage_decorator import release_candidate
 
 if sys.version_info >= (3, 12):
@@ -59,7 +57,6 @@ if TYPE_CHECKING:
     from openai.types.beta.assistant_tool_param import AssistantToolParam
     from openai.types.beta.code_interpreter_tool_param import CodeInterpreterToolParam
     from openai.types.beta.thread_create_params import Message as ThreadCreateMessage
-    from openai.types.beta.threads.message import Message
     from openai.types.beta.threads.run_create_params import TruncationStrategy
 
     from semantic_kernel.kernel import Kernel
@@ -437,30 +434,6 @@ class OpenAIAssistantAgent(Agent):
         assert thread.id is not None  # nosec
 
         return OpenAIAssistantChannel(client=self.client, thread_id=thread.id)
-
-    # endregion
-
-    # region Message Handling
-
-    @deprecated(
-        "Pass messages directly to get_response(...)/invoke(...) instead. This method will be removed after May 1st 2025."  # noqa: E501
-    )
-    async def add_chat_message(
-        self, thread_id: str, message: "str | ChatMessageContent", **kwargs: Any
-    ) -> "Message | None":
-        """Add a chat message to the thread.
-
-        Args:
-            thread_id: The ID of the thread
-            message: The chat message to add
-            kwargs: Additional keyword arguments
-
-        Returns:
-            The thread message or None
-        """
-        return await AssistantThreadActions.create_message(
-            client=self.client, thread_id=thread_id, message=message, **kwargs
-        )
 
     # endregion
 

--- a/python/tests/unit/agents/azure_ai_agent/test_azure_ai_agent.py
+++ b/python/tests/unit/agents/azure_ai_agent/test_azure_ai_agent.py
@@ -33,14 +33,6 @@ async def test_azure_ai_agent_init_with_plugins_via_constructor(
     assert len(agent.kernel.plugins) == 1
 
 
-async def test_azure_ai_agent_add_chat_message(ai_project_client, ai_agent_definition):
-    agent = AzureAIAgent(client=ai_project_client, definition=ai_agent_definition)
-    with patch(
-        "semantic_kernel.agents.azure_ai.agent_thread_actions.AgentThreadActions.create_message",
-    ):
-        await agent.add_chat_message("threadId", ChatMessageContent(role="user", content="text"))  # pass anything
-
-
 async def test_azure_ai_agent_get_response(ai_project_client, ai_agent_definition):
     agent = AzureAIAgent(client=ai_project_client, definition=ai_agent_definition)
 

--- a/python/tests/unit/agents/openai_assistant/test_azure_assistant_agent.py
+++ b/python/tests/unit/agents/openai_assistant/test_azure_assistant_agent.py
@@ -176,27 +176,6 @@ def test_configure_response_format_invalid_input_type():
 
 
 @pytest.mark.parametrize(
-    "message",
-    [
-        pytest.param(ChatMessageContent(role=AuthorRole.USER, content="text")),
-        pytest.param("text"),
-    ],
-)
-async def test_open_ai_assistant_agent_add_chat_message(message):
-    client = AsyncMock(spec=AsyncOpenAI)
-    definition = AsyncMock(spec=Assistant)
-    definition.id = "agent123"
-    definition.name = "agentName"
-    definition.description = "desc"
-    definition.instructions = "test agent"
-    agent = AzureAssistantAgent(client=client, definition=definition)
-    with patch(
-        "semantic_kernel.agents.open_ai.assistant_thread_actions.AssistantThreadActions.create_message",
-    ):
-        await agent.add_chat_message("threadId", message)
-
-
-@pytest.mark.parametrize(
     "arguments, include_args",
     [
         pytest.param({"extra_args": "extra_args"}, True),

--- a/python/tests/unit/agents/openai_assistant/test_openai_assistant_agent.py
+++ b/python/tests/unit/agents/openai_assistant/test_openai_assistant_agent.py
@@ -116,21 +116,6 @@ def test_configure_response_format_invalid_input_type():
 
 
 @pytest.mark.parametrize(
-    "message",
-    [
-        pytest.param(ChatMessageContent(role=AuthorRole.USER, content="text")),
-        pytest.param("text"),
-    ],
-)
-async def test_open_ai_assistant_agent_add_chat_message(message, openai_client, assistant_definition):
-    agent = OpenAIAssistantAgent(client=openai_client, definition=assistant_definition)
-    with patch(
-        "semantic_kernel.agents.open_ai.assistant_thread_actions.AssistantThreadActions.create_message",
-    ):
-        await agent.add_chat_message("threadId", message)
-
-
-@pytest.mark.parametrize(
     "arguments, include_args",
     [
         pytest.param({"extra_args": "extra_args"}, True),


### PR DESCRIPTION
### Motivation and Context

Per the deprecation message on the method `add_chat_message(...)` currently on the `AzureAIAgent` and `OpenAIAssistantAgent` classes, we are removing the method in favor of passing in any messages directly to the `get_response(...)`, `invoke(...)` or `invoke_stream(...)`. The underlying thread abstraction handles adding the messages to the thread as part of invocation.

<!-- Thank you for your contribution to the semantic-kernel repo!
Please help reviewers and future users, providing the following information:
  1. Why is this change required?
  2. What problem does it solve?
  3. What scenario does it contribute to?
  4. If it fixes an open issue, please link to the issue here.
-->

### Description

Remove the methods per the deprecation message and date.

<!-- Describe your changes, the overall approach, the underlying design.
     These notes will help understanding how your code works. Thanks! -->

### Contribution Checklist

<!-- Before submitting this PR, please make sure: -->

- [X] The code builds clean without any errors or warnings
- [X] The PR follows the [SK Contribution Guidelines](https://github.com/microsoft/semantic-kernel/blob/main/CONTRIBUTING.md) and the [pre-submission formatting script](https://github.com/microsoft/semantic-kernel/blob/main/CONTRIBUTING.md#development-scripts) raises no violations
- [X] All unit tests pass, and I have added new tests where possible
- [X] I didn't break anyone :smile:
