### PR TITLE
.Net: Remove [Experimental] from MEVD GetService(), VectorStoreMetadata

### DIFF
--- a/dotnet/src/Connectors/VectorData.Abstractions/VectorSearch/IKeywordHybridSearch.cs
+++ b/dotnet/src/Connectors/VectorData.Abstractions/VectorSearch/IKeywordHybridSearch.cs
@@ -2,7 +2,6 @@
 
 using System;
 using System.Collections.Generic;
-using System.Diagnostics.CodeAnalysis;
 using System.Threading;
 
 namespace Microsoft.Extensions.VectorData;
@@ -40,6 +39,5 @@ public interface IKeywordHybridSearch<TRecord>
     /// including itself or any services it might be wrapping. For example, to access the <see cref="VectorStoreRecordCollectionMetadata"/> for the instance,
     /// <see cref="GetService"/> may be used to request it.
     /// </remarks>
-    [Experimental("MEVD9000")]
     object? GetService(Type serviceType, object? serviceKey = null);
 }

--- a/dotnet/src/Connectors/VectorData.Abstractions/VectorSearch/IVectorSearch.cs
+++ b/dotnet/src/Connectors/VectorData.Abstractions/VectorSearch/IVectorSearch.cs
@@ -2,7 +2,6 @@
 
 using System;
 using System.Collections.Generic;
-using System.Diagnostics.CodeAnalysis;
 using System.Threading;
 using Microsoft.Extensions.AI;
 
@@ -66,6 +65,5 @@ public interface IVectorSearch<TRecord>
     /// including itself or any services it might be wrapping. For example, to access the <see cref="VectorStoreRecordCollectionMetadata"/> for the instance,
     /// <see cref="GetService"/> may be used to request it.
     /// </remarks>
-    [Experimental("MEVD9000")]
     object? GetService(Type serviceType, object? serviceKey = null);
 }

--- a/dotnet/src/Connectors/VectorData.Abstractions/VectorSearch/IVectorizableTextSearch.cs
+++ b/dotnet/src/Connectors/VectorData.Abstractions/VectorSearch/IVectorizableTextSearch.cs
@@ -2,7 +2,6 @@
 
 using System;
 using System.Collections.Generic;
-using System.Diagnostics.CodeAnalysis;
 using System.Threading;
 
 namespace Microsoft.Extensions.VectorData;
@@ -38,6 +37,5 @@ public interface IVectorizableTextSearch<TRecord>
     /// including itself or any services it might be wrapping. For example, to access the <see cref="VectorStoreRecordCollectionMetadata"/> for the instance,
     /// <see cref="GetService"/> may be used to request it.
     /// </remarks>
-    [Experimental("MEVD9000")]
     object? GetService(Type serviceType, object? serviceKey = null);
 }

--- a/dotnet/src/Connectors/VectorData.Abstractions/VectorSearch/VectorSearchExtensions.cs
+++ b/dotnet/src/Connectors/VectorData.Abstractions/VectorSearch/VectorSearchExtensions.cs
@@ -1,12 +1,10 @@
 ﻿// Copyright (c) Microsoft. All rights reserved.
 
 using System;
-using System.Diagnostics.CodeAnalysis;
 
 namespace Microsoft.Extensions.VectorData;
 
 /// <summary>Provides a collection of static methods for extending <see cref="IVectorizedSearch{TRecord}"/> instances.</summary>
-[Experimental("MEVD9000")]
 public static class VectorSearchExtensions
 {
     /// <summary>

--- a/dotnet/src/Connectors/VectorData.Abstractions/VectorStorage/IVectorStore.cs
+++ b/dotnet/src/Connectors/VectorData.Abstractions/VectorStorage/IVectorStore.cs
@@ -2,7 +2,6 @@
 
 using System;
 using System.Collections.Generic;
-using System.Diagnostics.CodeAnalysis;
 using System.Threading;
 using System.Threading.Tasks;
 
@@ -69,6 +68,5 @@ public interface IVectorStore
     /// including itself or any services it might be wrapping. For example, to access the <see cref="VectorStoreMetadata"/> for the instance,
     /// <see cref="GetService"/> may be used to request it.
     /// </remarks>
-    [Experimental("MEVD9000")]
     object? GetService(Type serviceType, object? serviceKey = null);
 }

--- a/dotnet/src/Connectors/VectorData.Abstractions/VectorStorage/VectorStoreExtensions.cs
+++ b/dotnet/src/Connectors/VectorData.Abstractions/VectorStorage/VectorStoreExtensions.cs
@@ -1,12 +1,10 @@
 ﻿// Copyright (c) Microsoft. All rights reserved.
 
 using System;
-using System.Diagnostics.CodeAnalysis;
 
 namespace Microsoft.Extensions.VectorData;
 
 /// <summary>Provides a collection of static methods for extending <see cref="IVectorStore"/> instances.</summary>
-[Experimental("MEVD9000")]
 public static class VectorStoreExtensions
 {
     /// <summary>

--- a/dotnet/src/Connectors/VectorData.Abstractions/VectorStorage/VectorStoreMetadata.cs
+++ b/dotnet/src/Connectors/VectorData.Abstractions/VectorStorage/VectorStoreMetadata.cs
@@ -1,11 +1,8 @@
 ﻿// Copyright (c) Microsoft. All rights reserved.
 
-using System.Diagnostics.CodeAnalysis;
-
 namespace Microsoft.Extensions.VectorData;
 
 /// <summary>Provides metadata about an <see cref="IVectorStore"/>.</summary>
-[Experimental("MEVD9000")]
 public class VectorStoreMetadata
 {
     /// <summary>The name of the vector store system.</summary>

--- a/dotnet/src/Connectors/VectorData.Abstractions/VectorStorage/VectorStoreRecordCollectionMetadata.cs
+++ b/dotnet/src/Connectors/VectorData.Abstractions/VectorStorage/VectorStoreRecordCollectionMetadata.cs
@@ -1,11 +1,8 @@
 ﻿// Copyright (c) Microsoft. All rights reserved.
 
-using System.Diagnostics.CodeAnalysis;
-
 namespace Microsoft.Extensions.VectorData;
 
 /// <summary>Provides metadata about an <see cref="IVectorStoreRecordCollection{TKey, TRecord}"/>.</summary>
-[Experimental("MEVD9000")]
 public class VectorStoreRecordCollectionMetadata
 {
     /// <summary>The name of the vector store system.</summary>


### PR DESCRIPTION
Note that this also removes [Experimental] from VectorStoreMetadata (we don't have to do that, but it seems fine to me).