### PR TITLE
Python: Add extra_body attribute to OpenAI Chat settings

### DIFF
--- a/python/semantic_kernel/connectors/ai/open_ai/prompt_execution_settings/azure_chat_prompt_execution_settings.py
+++ b/python/semantic_kernel/connectors/ai/open_ai/prompt_execution_settings/azure_chat_prompt_execution_settings.py
@@ -168,4 +168,4 @@ class ExtraBody(KernelBaseModel):
 class AzureChatPromptExecutionSettings(OpenAIChatPromptExecutionSettings):
     """Specific settings for the Azure OpenAI Chat Completion endpoint."""
 
-    extra_body: dict[str, Any] | ExtraBody | None = None
+    extra_body: dict[str, Any] | ExtraBody | None = None  # type: ignore[assignment]

--- a/python/semantic_kernel/connectors/ai/open_ai/prompt_execution_settings/open_ai_prompt_execution_settings.py
+++ b/python/semantic_kernel/connectors/ai/open_ai/prompt_execution_settings/open_ai_prompt_execution_settings.py
@@ -101,6 +101,7 @@ class OpenAIChatPromptExecutionSettings(OpenAIPromptExecutionSettings):
             description="Adjusts reasoning effort (low/medium/high). Lower values reduce response time and token usage."
         ),
     ] = None
+    extra_body: dict[str, Any] | None = None
 
     @field_validator("functions", "function_call", mode="after")
     @classmethod


### PR DESCRIPTION
### Motivation and Context

SK'S `OpenAIChatPromptExecutions` do not allow one to configure the `extra_body` input to a chat completions create. This is something specified on the Azure OpenAI connector but not on OpenAI. Because there are also custom attributes as part of AOAI, we're providing a base class attribute, and we will keep the child class attribute as-is. 

<!-- Thank you for your contribution to the semantic-kernel repo!
Please help reviewers and future users, providing the following information:
  1. Why is this change required?
  2. What problem does it solve?
  3. What scenario does it contribute to?
  4. If it fixes an open issue, please link to the issue here.
-->

### Description

Introduce the `extra_body` attribute on OpenAI Chat Prompt Execution Settings.
- Closes #11813

<!-- Describe your changes, the overall approach, the underlying design.
     These notes will help understanding how your code works. Thanks! -->

### Contribution Checklist

<!-- Before submitting this PR, please make sure: -->

- [X] The code builds clean without any errors or warnings
- [X] The PR follows the [SK Contribution Guidelines](https://github.com/microsoft/semantic-kernel/blob/main/CONTRIBUTING.md) and the [pre-submission formatting script](https://github.com/microsoft/semantic-kernel/blob/main/CONTRIBUTING.md#development-scripts) raises no violations
- [X] All unit tests pass, and I have added new tests where possible
- [X] I didn't break anyone :smile:
