### PR TITLE
.Net: Rename TextRagComponent, add prompt tests and improve prompts.

### DIFF
--- a/dotnet/src/IntegrationTests/Agents/CommonInterfaceConformance/AgentWithTextSearchBehaviorConformance/AgentWithTextSearchBehavior.cs
+++ b/dotnet/src/IntegrationTests/Agents/CommonInterfaceConformance/AgentWithTextSearchBehaviorConformance/AgentWithTextSearchBehavior.cs
@@ -28,11 +28,11 @@ public abstract class AgentWithTextSearchBehavior<TFixture>(Func<TFixture> creat
     [InlineData("What is DeltaSoft's market share in the enterprise software sector?", "35", "DeltaSoft holds a 35% market share in the enterprise software sector.", "Its closest competitor holds 25%.")]
     // Generate knowledge.
     [InlineData("When was the Eiffel Tower completed?", "1889", "The Eiffel Tower was completed in 1889.", "It is located in Paris, France.")]
-    [InlineData("At what temperature in Celcius does water boil?", "100", "Water boils at 212 degrees fahrenheit.", "Water boils at 100 degrees Celsius.")]
+    [InlineData("At what temperature in Celsius does water boil?", "100", "Water boils at 212 degrees fahrenheit.", "Water boils at 100 degrees Celsius.")]
     [InlineData("What did Einstein say about imagination?", "Imagination is more important than knowledge", "Albert Einstein said, 'Imagination is more important than knowledge.'")]
     // Data contradicting Generate knowledge.
     [InlineData("When was the Eiffel Tower completed?", "2005", "The Eiffel Tower was completed in 2005.", "It is located in Paris, France.")]
-    [InlineData("At what temperature in Celcius does water boil?", "150", "Water boils at 300 degrees fahrenheit.", "Water boils at 150 degrees Celsius.")]
+    [InlineData("At what temperature in Celsius does water boil?", "150", "Water boils at 300 degrees fahrenheit.", "Water boils at 150 degrees Celsius.")]
     // Check for citations
     [InlineData("When was the Eiffel Tower completed?", "http://mydata.mycompany.com/dataset2", "It is located in Paris, France.", "The Eiffel Tower was completed in 1889.")]
     [InlineData("What was Gamma Solutions' profit margin in FY 2024?", "http://mydata.mycompany.com/dataset1", "Gamma Solutions had a profit margin of 22% in FY 2024.", "This was an improvement from 18% in FY 2023.")]

--- a/dotnet/src/IntegrationTests/Agents/CommonInterfaceConformance/AgentWithTextSearchBehaviorConformance/AgentWithTextSearchBehavior.cs
+++ b/dotnet/src/IntegrationTests/Agents/CommonInterfaceConformance/AgentWithTextSearchBehaviorConformance/AgentWithTextSearchBehavior.cs
@@ -1,0 +1,89 @@
+﻿// Copyright (c) Microsoft. All rights reserved.
+
+using System;
+using System.Linq;
+using System.Threading;
+using System.Threading.Tasks;
+using Microsoft.SemanticKernel.Data;
+using Moq;
+using Xunit;
+using Xunit.Abstractions;
+
+namespace SemanticKernel.IntegrationTests.Agents.CommonInterfaceConformance.AgentWithTextSearchBehaviorConformance;
+
+public abstract class AgentWithTextSearchBehavior<TFixture>(Func<TFixture> createAgentFixture, ITestOutputHelper output) : IAsyncLifetime
+    where TFixture : AgentFixture
+{
+#pragma warning disable CS8618 // Non-nullable field must contain a non-null value when exiting constructor. Consider adding the 'required' modifier or declaring as nullable.
+    private TFixture _agentFixture;
+#pragma warning restore CS8618 // Non-nullable field must contain a non-null value when exiting constructor. Consider adding the 'required' modifier or declaring as nullable.
+
+    protected TFixture Fixture => this._agentFixture;
+
+    [Theory]
+    // Private data.
+    [InlineData("What was Acme Corp's revenue in Q1 2025?", "12.5", "Acme Corp reported a revenue of $12.5 million in Q1 2025.", "This represents a 15% increase from Q4 2024.")]
+    [InlineData("What was BetaTech Inc.'s stock price on May 1, 2025?", "45.67", "The stock price of BetaTech Inc. closed at $45.67 on May 1, 2025.", "It saw a 3% increase from the previous day.")]
+    [InlineData("What was Gamma Solutions' profit margin in FY 2024?", "22", "Gamma Solutions had a profit margin of 22% in FY 2024.", "This was an improvement from 18% in FY 2023.")]
+    [InlineData("What is DeltaSoft's market share in the enterprise software sector?", "35", "DeltaSoft holds a 35% market share in the enterprise software sector.", "Its closest competitor holds 25%.")]
+    // Generate knowledge.
+    [InlineData("When was the Eiffel Tower completed?", "1889", "The Eiffel Tower was completed in 1889.", "It is located in Paris, France.")]
+    [InlineData("At what temperature in Celcius does water boil?", "100", "Water boils at 212 degrees fahrenheit.", "Water boils at 100 degrees Celsius.")]
+    [InlineData("What did Einstein say about imagination?", "Imagination is more important than knowledge", "Albert Einstein said, 'Imagination is more important than knowledge.'")]
+    // Data contradicting Generate knowledge.
+    [InlineData("When was the Eiffel Tower completed?", "2005", "The Eiffel Tower was completed in 2005.", "It is located in Paris, France.")]
+    [InlineData("At what temperature in Celcius does water boil?", "150", "Water boils at 300 degrees fahrenheit.", "Water boils at 150 degrees Celsius.")]
+    // Check for citations
+    [InlineData("When was the Eiffel Tower completed?", "http://mydata.mycompany.com/dataset2", "It is located in Paris, France.", "The Eiffel Tower was completed in 1889.")]
+    [InlineData("What was Gamma Solutions' profit margin in FY 2024?", "http://mydata.mycompany.com/dataset1", "Gamma Solutions had a profit margin of 22% in FY 2024.", "This was an improvement from 18% in FY 2023.")]
+    [InlineData("When was the Eiffel Tower completed?", "DataSet2", "It is located in Paris, France.", "The Eiffel Tower was completed in 1889.")]
+    [InlineData("What was Gamma Solutions' profit margin in FY 2024?", "DataSet1", "Gamma Solutions had a profit margin of 22% in FY 2024.", "This was an improvement from 18% in FY 2023.")]
+    public async Task TextSearchBehaviorStateIsUsedByAgentInternalAsync(string question, string expectedResult, params string[] ragResults)
+    {
+        // Arrange
+        ragResults.Select(x => new TextSearchResult(x)).ToAsyncEnumerable();
+        var mockTextSearch = new Mock<ITextSearch>();
+        mockTextSearch.Setup(x => x.GetTextSearchResultsAsync(
+            It.IsAny<string>(),
+            It.IsAny<TextSearchOptions>(),
+            It.IsAny<CancellationToken>()))
+            .ReturnsAsync(
+                new KernelSearchResults<TextSearchResult>(ragResults.Select((x, i) => new TextSearchResult(x) { Name = $"DataSet{i + 1}", Link = $"http://mydata.mycompany.com/dataset{i + 1}" }).ToAsyncEnumerable()));
+
+        var textSearchBehavior = new TextSearchBehavior(mockTextSearch.Object);
+
+        var agent = this.Fixture.Agent;
+
+        var agentThread = this.Fixture.GetNewThread();
+
+        try
+        {
+            agentThread.StateParts.Add(textSearchBehavior);
+
+            // Act
+            var inputMessage = question;
+            var asyncResults1 = agent.InvokeAsync(inputMessage, agentThread);
+            var result = await asyncResults1.FirstAsync();
+
+            // Assert
+            output.WriteLine(result.Message.Content);
+            Assert.Contains(expectedResult, result.Message.Content, StringComparison.OrdinalIgnoreCase);
+        }
+        finally
+        {
+            // Cleanup
+            await this.Fixture.DeleteThread(agentThread);
+        }
+    }
+
+    public Task InitializeAsync()
+    {
+        this._agentFixture = createAgentFixture();
+        return this._agentFixture.InitializeAsync();
+    }
+
+    public Task DisposeAsync()
+    {
+        return this._agentFixture.DisposeAsync();
+    }
+}

--- a/dotnet/src/IntegrationTests/Agents/CommonInterfaceConformance/AgentWithTextSearchBehaviorConformance/AzureAIAgentWithTextSearchBehaviorTests.cs
+++ b/dotnet/src/IntegrationTests/Agents/CommonInterfaceConformance/AgentWithTextSearchBehaviorConformance/AzureAIAgentWithTextSearchBehaviorTests.cs
@@ -1,0 +1,9 @@
+﻿// Copyright (c) Microsoft. All rights reserved.
+
+using Xunit.Abstractions;
+
+namespace SemanticKernel.IntegrationTests.Agents.CommonInterfaceConformance.AgentWithTextSearchBehaviorConformance;
+
+public class AzureAIAgentWithTextSearchBehaviorTests(ITestOutputHelper output) : AgentWithTextSearchBehavior<AzureAIAgentFixture>(() => new AzureAIAgentFixture(), output)
+{
+}

--- a/dotnet/src/IntegrationTests/Agents/CommonInterfaceConformance/AgentWithTextSearchBehaviorConformance/ChatCompletionAgentWithTextSearchBehaviorTests.cs
+++ b/dotnet/src/IntegrationTests/Agents/CommonInterfaceConformance/AgentWithTextSearchBehaviorConformance/ChatCompletionAgentWithTextSearchBehaviorTests.cs
@@ -1,0 +1,9 @@
+﻿// Copyright (c) Microsoft. All rights reserved.
+
+using Xunit.Abstractions;
+
+namespace SemanticKernel.IntegrationTests.Agents.CommonInterfaceConformance.AgentWithTextSearchBehaviorConformance;
+
+public class ChatCompletionAgentWithTextSearchBehaviorTests(ITestOutputHelper output) : AgentWithTextSearchBehavior<ChatCompletionAgentFixture>(() => new ChatCompletionAgentFixture(), output)
+{
+}

--- a/dotnet/src/IntegrationTests/Agents/CommonInterfaceConformance/AgentWithTextSearchBehaviorConformance/OpenAIAssistantAgentWithTextSearchBehaviorTests.cs
+++ b/dotnet/src/IntegrationTests/Agents/CommonInterfaceConformance/AgentWithTextSearchBehaviorConformance/OpenAIAssistantAgentWithTextSearchBehaviorTests.cs
@@ -1,0 +1,9 @@
+﻿// Copyright (c) Microsoft. All rights reserved.
+
+using Xunit.Abstractions;
+
+namespace SemanticKernel.IntegrationTests.Agents.CommonInterfaceConformance.AgentWithTextSearchBehaviorConformance;
+
+public class OpenAIAssistantAgentWithTextSearchBehaviorTests(ITestOutputHelper output) : AgentWithTextSearchBehavior<OpenAIAssistantAgentFixture>(() => new OpenAIAssistantAgentFixture(), output)
+{
+}

--- a/dotnet/src/SemanticKernel.Core/Data/TextSearchBehavior/TextSearchBehaviorOptions.cs
+++ b/dotnet/src/SemanticKernel.Core/Data/TextSearchBehavior/TextSearchBehaviorOptions.cs
@@ -3,15 +3,14 @@
 using System;
 using System.Collections.Generic;
 using System.Diagnostics.CodeAnalysis;
-using Microsoft.SemanticKernel.Data;
 
-namespace Microsoft.SemanticKernel.Memory;
+namespace Microsoft.SemanticKernel.Data;
 
 /// <summary>
-/// Contains options for the <see cref="TextRagComponent"/>.
+/// Contains options for the <see cref="TextSearchBehavior"/>.
 /// </summary>
 [Experimental("SKEXP0130")]
-public sealed class TextRagComponentOptions
+public sealed class TextSearchBehaviorOptions
 {
     private int _top = 3;
 
@@ -62,7 +61,7 @@ public sealed class TextRagComponentOptions
     /// to those chunks, in order to provide some context to the model.
     /// </summary>
     /// <value>
-    /// Defaults to &quot;Consider the following information when responding to the user:&quot;
+    /// Defaults to &quot;Consider the following information from source documents when responding to the user:&quot;
     /// </value>
     public string? ContextPrompt { get; init; }
 
@@ -71,7 +70,7 @@ public sealed class TextRagComponentOptions
     /// to those chunks, in order to instruct the model to include citations.
     /// </summary>
     /// <value>
-    /// Defaults to &quot;Include citations to the relevant information where it is referenced in the response.:&quot;
+    /// Defaults to &quot;Include citations to the source document including name and link.:&quot;
     /// </value>
     public string? IncludeCitationsPrompt { get; init; }
 
@@ -81,7 +80,7 @@ public sealed class TextRagComponentOptions
     /// <remarks>
     /// <para>
     /// If provided, this delegate will be used to do the following:
-    /// 1. Create the output context provided by the <see cref="TextRagComponent"/> when invoking the AI model.
+    /// 1. Create the output context provided by the <see cref="TextSearchBehavior"/> when invoking the AI model.
     /// 2. Create the response text when invoking the component via a plugin.
     /// </para>
     /// <para>
@@ -94,7 +93,7 @@ public sealed class TextRagComponentOptions
     public ContextFormatterType? ContextFormatter { get; init; }
 
     /// <summary>
-    /// Choices for controlling the behavior of the <see cref="TextRagComponent"/>.
+    /// Choices for controlling the behavior of the <see cref="TextSearchBehavior"/>.
     /// </summary>
     public enum RagBehavior
     {

--- a/dotnet/src/SemanticKernel.Core/Data/TextSearchStore/TextSearchStore.cs
+++ b/dotnet/src/SemanticKernel.Core/Data/TextSearchStore/TextSearchStore.cs
@@ -9,7 +9,6 @@ using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.Extensions.VectorData;
 using Microsoft.SemanticKernel.Embeddings;
-using Microsoft.SemanticKernel.Memory;
 
 namespace Microsoft.SemanticKernel.Data;
 
@@ -24,7 +23,7 @@ namespace Microsoft.SemanticKernel.Data;
 /// with the <see cref="VectorStoreTextSearch{TRecord}"/> class instead.
 /// </para>
 /// <para>
-/// This class can also be used with the <see cref="TextRagComponent"/> to easily add RAG capabilities to an Agent.
+/// This class can also be used with the <see cref="TextSearchBehavior"/> to easily add RAG capabilities to an Agent.
 /// </para>
 /// </remarks>
 /// <typeparam name="TKey">The key type to use with the vector store.</typeparam>

--- a/dotnet/src/SemanticKernel.UnitTests/Data/TextSearchBehaviorTests.cs
+++ b/dotnet/src/SemanticKernel.UnitTests/Data/TextSearchBehaviorTests.cs
@@ -6,16 +6,15 @@ using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.Extensions.AI;
 using Microsoft.SemanticKernel.Data;
-using Microsoft.SemanticKernel.Memory;
 using Moq;
 using Xunit;
 
-namespace SemanticKernel.UnitTests.Memory;
+namespace SemanticKernel.UnitTests.Data;
 
 /// <summary>
-/// Contains tests for <see cref="TextRagComponent"/>
+/// Contains tests for <see cref="TextSearchBehavior"/>
 /// </summary>
-public class TextRagComponentTests
+public class TextSearchBehaviorTests
 {
     [Theory]
     [InlineData(null, null, "Consider the following information when responding to the user:", "Include citations to the relevant information where it is referenced in the response.")]
@@ -56,15 +55,15 @@ public class TextRagComponentTests
             It.IsAny<CancellationToken>()))
             .ReturnsAsync(new KernelSearchResults<TextSearchResult>(searchResults.Object));
 
-        var options = new TextRagComponentOptions
+        var options = new TextSearchBehaviorOptions
         {
-            SearchTime = TextRagComponentOptions.RagBehavior.BeforeAIInvoke,
+            SearchTime = TextSearchBehaviorOptions.RagBehavior.BeforeAIInvoke,
             Top = 2,
             ContextPrompt = overrideContextPrompt,
             IncludeCitationsPrompt = overrideCitationsPrompt
         };
 
-        var component = new TextRagComponent(mockTextSearch.Object, options);
+        var component = new TextSearchBehavior(mockTextSearch.Object, options);
 
         // Act
         var result = await component.OnModelInvokeAsync([new ChatMessage(ChatRole.User, "Sample user question?")], CancellationToken.None);
@@ -93,14 +92,14 @@ public class TextRagComponentTests
     {
         // Arrange
         var mockTextSearch = new Mock<ITextSearch>();
-        var options = new TextRagComponentOptions
+        var options = new TextSearchBehaviorOptions
         {
-            SearchTime = TextRagComponentOptions.RagBehavior.ViaPlugin,
+            SearchTime = TextSearchBehaviorOptions.RagBehavior.ViaPlugin,
             PluginFunctionName = overridePluginFunctionName,
             PluginFunctionDescription = overridePluginFunctionDescription
         };
 
-        var component = new TextRagComponent(mockTextSearch.Object, options);
+        var component = new TextSearchBehavior(mockTextSearch.Object, options);
 
         // Act
         var aiFunctions = component.AIFunctions;
@@ -153,13 +152,13 @@ public class TextRagComponentTests
             It.IsAny<CancellationToken>()))
             .ReturnsAsync(new KernelSearchResults<TextSearchResult>(searchResults.Object));
 
-        var options = new TextRagComponentOptions
+        var options = new TextSearchBehaviorOptions
         {
             ContextPrompt = overrideContextPrompt,
             IncludeCitationsPrompt = overrideCitationsPrompt
         };
 
-        var component = new TextRagComponent(mockTextSearch.Object, options);
+        var component = new TextSearchBehavior(mockTextSearch.Object, options);
 
         // Act
         var result = await component.SearchAsync("Sample user question?", CancellationToken.None);
@@ -210,17 +209,17 @@ public class TextRagComponentTests
             It.IsAny<CancellationToken>()))
             .ReturnsAsync(new KernelSearchResults<TextSearchResult>(searchResults.Object));
 
-        var customFormatter = new TextRagComponentOptions.ContextFormatterType(results =>
+        var customFormatter = new TextSearchBehaviorOptions.ContextFormatterType(results =>
             $"Custom formatted context with {results.Count} results.");
 
-        var options = new TextRagComponentOptions
+        var options = new TextSearchBehaviorOptions
         {
-            SearchTime = TextRagComponentOptions.RagBehavior.BeforeAIInvoke,
+            SearchTime = TextSearchBehaviorOptions.RagBehavior.BeforeAIInvoke,
             Top = 2,
             ContextFormatter = customFormatter
         };
 
-        var component = new TextRagComponent(mockTextSearch.Object, options);
+        var component = new TextSearchBehavior(mockTextSearch.Object, options);
 
         // Act
         var result = await component.OnModelInvokeAsync([new ChatMessage(ChatRole.User, "Sample user question?")], CancellationToken.None);

--- a/dotnet/src/SemanticKernel.UnitTests/Data/TextSearchBehaviorTests.cs
+++ b/dotnet/src/SemanticKernel.UnitTests/Data/TextSearchBehaviorTests.cs
@@ -17,7 +17,7 @@ namespace SemanticKernel.UnitTests.Data;
 public class TextSearchBehaviorTests
 {
     [Theory]
-    [InlineData(null, null, "Consider the following information when responding to the user:", "Include citations to the relevant information where it is referenced in the response.")]
+    [InlineData(null, null, "Consider the following information from source documents when responding to the user:", "Include citations to the source document including name and link.")]
     [InlineData("Custom context prompt", "Custom citations prompt", "Custom context prompt", "Custom citations prompt")]
     public async Task OnModelInvokeShouldIncludeSearchResultsInOutputAsync(
         string? overrideContextPrompt,
@@ -70,13 +70,11 @@ public class TextSearchBehaviorTests
 
         // Assert
         Assert.Contains(expectedContextPrompt, result);
-        Assert.Contains("Item 1:", result);
-        Assert.Contains("Name: Doc1", result);
-        Assert.Contains("Link: http://example.com/doc1", result);
+        Assert.Contains("SourceDocName: Doc1", result);
+        Assert.Contains("SourceDocLink: http://example.com/doc1", result);
         Assert.Contains("Contents: Content of Doc1", result);
-        Assert.Contains("Item 2:", result);
-        Assert.Contains("Name: Doc2", result);
-        Assert.Contains("Link: http://example.com/doc2", result);
+        Assert.Contains("SourceDocName: Doc2", result);
+        Assert.Contains("SourceDocLink: http://example.com/doc2", result);
         Assert.Contains("Contents: Content of Doc2", result);
         Assert.Contains(expectedCitationsPrompt, result);
     }
@@ -113,7 +111,7 @@ public class TextSearchBehaviorTests
     }
 
     [Theory]
-    [InlineData(null, null, "Consider the following information when responding to the user:", "Include citations to the relevant information where it is referenced in the response.")]
+    [InlineData(null, null, "Consider the following information from source documents when responding to the user:", "Include citations to the source document including name and link.")]
     [InlineData("Custom context prompt", "Custom citations prompt", "Custom context prompt", "Custom citations prompt")]
     public async Task SearchAsyncShouldIncludeSearchResultsInOutputAsync(
         string? overrideContextPrompt,
@@ -165,13 +163,11 @@ public class TextSearchBehaviorTests
 
         // Assert
         Assert.Contains(expectedContextPrompt, result);
-        Assert.Contains("Item 1:", result);
-        Assert.Contains("Name: Doc1", result);
-        Assert.Contains("Link: http://example.com/doc1", result);
+        Assert.Contains("SourceDocName: Doc1", result);
+        Assert.Contains("SourceDocLink: http://example.com/doc1", result);
         Assert.Contains("Contents: Content of Doc1", result);
-        Assert.Contains("Item 2:", result);
-        Assert.Contains("Name: Doc2", result);
-        Assert.Contains("Link: http://example.com/doc2", result);
+        Assert.Contains("SourceDocName: Doc2", result);
+        Assert.Contains("SourceDocLink: http://example.com/doc2", result);
         Assert.Contains("Contents: Content of Doc2", result);
         Assert.Contains(expectedCitationsPrompt, result);
     }


### PR DESCRIPTION
### Description

- Rename TextRagComponent to TextSearchBehavior
- Add Prompt tests
- Improve prompts

### Contribution Checklist

<!-- Before submitting this PR, please make sure: -->

- [ ] The code builds clean without any errors or warnings
- [ ] The PR follows the [SK Contribution Guidelines](https://github.com/microsoft/semantic-kernel/blob/main/CONTRIBUTING.md) and the [pre-submission formatting script](https://github.com/microsoft/semantic-kernel/blob/main/CONTRIBUTING.md#development-scripts) raises no violations
- [ ] All unit tests pass, and I have added new tests where possible
- [ ] I didn't break anyone :smile:
