### PR TITLE
.Net: Remove concurrent "batching" implementations in MEVD

### DIFF
--- a/dotnet/src/Connectors/Connectors.AzureCosmosDBNoSQL.UnitTests/AzureCosmosDBNoSQLDynamicDataModelMapperTests.cs
+++ b/dotnet/src/Connectors/Connectors.AzureCosmosDBNoSQL.UnitTests/AzureCosmosDBNoSQLDynamicDataModelMapperTests.cs
@@ -90,7 +90,7 @@ public sealed class AzureCosmosDBNoSQLDynamicDataModelMapperTests
         };
 
         // Act
-        var storageModel = sut.MapFromDataToStorageModel(dataModel, generatedEmbeddings: null);
+        var storageModel = sut.MapFromDataToStorageModel(dataModel, recordIndex: 0, generatedEmbeddings: null);
 
         // Assert
         Assert.Equal("key", (string?)storageModel["id"]);
@@ -142,7 +142,7 @@ public sealed class AzureCosmosDBNoSQLDynamicDataModelMapperTests
         var sut = new AzureCosmosDBNoSQLDynamicDataModelMapper(s_model, s_jsonSerializerOptions);
 
         // Act
-        var storageModel = sut.MapFromDataToStorageModel(dataModel, generatedEmbeddings: null);
+        var storageModel = sut.MapFromDataToStorageModel(dataModel, recordIndex: 0, generatedEmbeddings: null);
 
         // Assert
         Assert.Null(storageModel["StringDataProp"]);
@@ -274,7 +274,7 @@ public sealed class AzureCosmosDBNoSQLDynamicDataModelMapperTests
         var sut = new AzureCosmosDBNoSQLDynamicDataModelMapper(s_model, s_jsonSerializerOptions);
 
         // Act
-        var storageModel = sut.MapFromDataToStorageModel(dataModel, generatedEmbeddings: null);
+        var storageModel = sut.MapFromDataToStorageModel(dataModel, recordIndex: 0, generatedEmbeddings: null);
 
         // Assert
         Assert.Equal("key", (string?)storageModel["id"]);

--- a/dotnet/src/Connectors/Connectors.AzureCosmosDBNoSQL.UnitTests/AzureCosmosDBNoSQLVectorStoreRecordMapperTests.cs
+++ b/dotnet/src/Connectors/Connectors.AzureCosmosDBNoSQL.UnitTests/AzureCosmosDBNoSQLVectorStoreRecordMapperTests.cs
@@ -46,7 +46,7 @@ public sealed class AzureCosmosDBNoSQLVectorStoreRecordMapperTests
         };
 
         // Act
-        var document = this._sut.MapFromDataToStorageModel(hotel, generatedEmbeddings: null);
+        var document = this._sut.MapFromDataToStorageModel(hotel, recordIndex: 0, generatedEmbeddings: null);
 
         // Assert
         Assert.NotNull(document);

--- a/dotnet/src/Connectors/Connectors.Memory.AzureAISearch/AzureAISearchVectorStoreRecordCollection.cs
+++ b/dotnet/src/Connectors/Connectors.Memory.AzureAISearch/AzureAISearchVectorStoreRecordCollection.cs
@@ -220,14 +220,13 @@ public sealed class AzureAISearchVectorStoreRecordCollection<TKey, TRecord> :
         var innerOptions = this.ConvertGetDocumentOptions(options);
         var includeVectors = options?.IncludeVectors ?? false;
 
-        // Get records in parallel.
-        var tasks = keys.Select(key => this.GetDocumentAndMapToDataModelAsync(key, includeVectors, innerOptions, cancellationToken));
-        var results = await Task.WhenAll(tasks).ConfigureAwait(false);
-        foreach (var result in results)
+        foreach (var key in keys)
         {
-            if (result is not null)
+            var record = await this.GetDocumentAndMapToDataModelAsync(key, includeVectors, innerOptions, cancellationToken).ConfigureAwait(false);
+
+            if (record is not null)
             {
-                yield return result;
+                yield return record;
             }
         }
     }

--- a/dotnet/src/Connectors/Connectors.Memory.AzureCosmosDBMongoDB/AzureCosmosDBMongoDBVectorStoreRecordCollection.cs
+++ b/dotnet/src/Connectors/Connectors.Memory.AzureCosmosDBMongoDB/AzureCosmosDBMongoDBVectorStoreRecordCollection.cs
@@ -216,41 +216,32 @@ public sealed class AzureCosmosDBMongoDBVectorStoreRecordCollection<TKey, TRecor
     {
         Verify.NotNull(record);
 
+        (_, var generatedEmbeddings) = await ProcessEmbeddingsAsync(this._model, [record], cancellationToken).ConfigureAwait(false);
+
+        await this.UpsertCoreAsync(record, recordIndex: 0, generatedEmbeddings, cancellationToken).ConfigureAwait(false);
+    }
+
+    /// <inheritdoc />
+    public override async Task UpsertAsync(IEnumerable<TRecord> records, CancellationToken cancellationToken = default)
+    {
+        Verify.NotNull(records);
+
+        (records, var generatedEmbeddings) = await ProcessEmbeddingsAsync(this._model, records, cancellationToken).ConfigureAwait(false);
+
+        var i = 0;
+
+        foreach (var record in records)
+        {
+            await this.UpsertCoreAsync(record, i++, generatedEmbeddings, cancellationToken).ConfigureAwait(false);
+        }
+    }
+
+    private async Task UpsertCoreAsync(TRecord record, int recordIndex, IReadOnlyList<Embedding>?[]? generatedEmbeddings, CancellationToken cancellationToken = default)
+    {
         const string OperationName = "ReplaceOne";
 
-        Embedding?[]? generatedEmbeddings = null;
-
-        var vectorPropertyCount = this._model.VectorProperties.Count;
-        for (var i = 0; i < vectorPropertyCount; i++)
-        {
-            var vectorProperty = this._model.VectorProperties[i];
-
-            if (vectorProperty.EmbeddingGenerator is null)
-            {
-                continue;
-            }
-
-            // TODO: Ideally we'd group together vector properties using the same generator (and with the same input and output properties),
-            // and generate embeddings for them in a single batch. That's some more complexity though.
-            if (vectorProperty.TryGenerateEmbedding<TRecord, Embedding<float>, ReadOnlyMemory<float>>(record, cancellationToken, out var floatTask))
-            {
-                generatedEmbeddings ??= new Embedding?[vectorPropertyCount];
-                generatedEmbeddings[i] = await floatTask.ConfigureAwait(false);
-            }
-            else if (vectorProperty.TryGenerateEmbedding<TRecord, Embedding<double>, ReadOnlyMemory<double>>(record, cancellationToken, out var doubleTask))
-            {
-                generatedEmbeddings ??= new Embedding?[vectorPropertyCount];
-                generatedEmbeddings[i] = await doubleTask.ConfigureAwait(false);
-            }
-            else
-            {
-                throw new InvalidOperationException(
-                    $"The embedding generator configured on property '{vectorProperty.ModelName}' cannot produce an embedding of type '{typeof(Embedding<float>).Name}' for the given input type.");
-            }
-        }
-
         var replaceOptions = new ReplaceOptions { IsUpsert = true };
-        var storageModel = this._mapper.MapFromDataToStorageModel(record, generatedEmbeddings);
+        var storageModel = this._mapper.MapFromDataToStorageModel(record, recordIndex, generatedEmbeddings);
 
         var key = storageModel[MongoDBConstants.MongoReservedKeyPropertyName].AsString;
 
@@ -260,13 +251,60 @@ public sealed class AzureCosmosDBMongoDBVectorStoreRecordCollection<TKey, TRecor
                 .ConfigureAwait(false)).ConfigureAwait(false);
     }
 
-    /// <inheritdoc />
-    public override async Task UpsertAsync(IEnumerable<TRecord> records, CancellationToken cancellationToken = default)
+    private static async ValueTask<(IEnumerable<TRecord> records, IReadOnlyList<Embedding>?[]?)> ProcessEmbeddingsAsync(
+        CollectionModel model,
+        IEnumerable<TRecord> records,
+        CancellationToken cancellationToken)
     {
-        Verify.NotNull(records);
+        IReadOnlyList<TRecord>? recordsList = null;
 
-        var tasks = records.Select(record => this.UpsertAsync(record, cancellationToken));
-        await Task.WhenAll(tasks).ConfigureAwait(false);
+        // If an embedding generator is defined, invoke it once per property for all records.
+        IReadOnlyList<Embedding>?[]? generatedEmbeddings = null;
+
+        var vectorPropertyCount = model.VectorProperties.Count;
+        for (var i = 0; i < vectorPropertyCount; i++)
+        {
+            var vectorProperty = model.VectorProperties[i];
+
+            if (vectorProperty.EmbeddingGenerator is null)
+            {
+                continue;
+            }
+
+            // We have a property with embedding generation; materialize the records' enumerable if needed, to
+            // prevent multiple enumeration.
+            if (recordsList is null)
+            {
+                recordsList = records is IReadOnlyList<TRecord> r ? r : records.ToList();
+
+                if (recordsList.Count == 0)
+                {
+                    return (records, null);
+                }
+
+                records = recordsList;
+            }
+
+            // TODO: Ideally we'd group together vector properties using the same generator (and with the same input and output properties),
+            // and generate embeddings for them in a single batch. That's some more complexity though.
+            if (vectorProperty.TryGenerateEmbeddings<TRecord, Embedding<float>, ReadOnlyMemory<float>>(records, cancellationToken, out var floatTask))
+            {
+                generatedEmbeddings ??= new IReadOnlyList<Embedding>?[vectorPropertyCount];
+                generatedEmbeddings[i] = await floatTask.ConfigureAwait(false);
+            }
+            else if (vectorProperty.TryGenerateEmbeddings<TRecord, Embedding<double>, ReadOnlyMemory<double>>(records, cancellationToken, out var doubleTask))
+            {
+                generatedEmbeddings ??= new IReadOnlyList<Embedding>?[vectorPropertyCount];
+                generatedEmbeddings[i] = await doubleTask.ConfigureAwait(false);
+            }
+            else
+            {
+                throw new InvalidOperationException(
+                    $"The embedding generator configured on property '{vectorProperty.ModelName}' cannot produce an embedding of type '{typeof(Embedding<float>).Name}' for the given input type.");
+            }
+        }
+
+        return (records, generatedEmbeddings);
     }
 
     #region Search

--- a/dotnet/src/Connectors/Connectors.Memory.AzureCosmosDBNoSQL/AzureCosmosDBNoSQLVectorStoreRecordMapper.cs
+++ b/dotnet/src/Connectors/Connectors.Memory.AzureCosmosDBNoSQL/AzureCosmosDBNoSQLVectorStoreRecordMapper.cs
@@ -1,5 +1,6 @@
 ﻿// Copyright (c) Microsoft. All rights reserved.
 
+using System.Collections.Generic;
 using System.Diagnostics;
 using System.Text.Json;
 using System.Text.Json.Nodes;
@@ -18,7 +19,7 @@ internal sealed class AzureCosmosDBNoSQLVectorStoreRecordMapper<TRecord>(Collect
 {
     private readonly KeyPropertyModel _keyProperty = model.KeyProperty;
 
-    public JsonObject MapFromDataToStorageModel(TRecord dataModel, MEAI.Embedding?[]? generatedEmbeddings)
+    public JsonObject MapFromDataToStorageModel(TRecord dataModel, int recordIndex, IReadOnlyList<MEAI.Embedding>?[]? generatedEmbeddings)
     {
         var jsonObject = JsonSerializer.SerializeToNode(dataModel, jsonSerializerOptions)!.AsObject();
 
@@ -33,11 +34,12 @@ internal sealed class AzureCosmosDBNoSQLVectorStoreRecordMapper<TRecord>(Collect
         {
             for (var i = 0; i < model.VectorProperties.Count; i++)
             {
-                if (generatedEmbeddings[i] is not null)
+                if (generatedEmbeddings?[i]?[recordIndex] is MEAI.Embedding embedding)
                 {
                     var property = model.VectorProperties[i];
+
                     Debug.Assert(property.EmbeddingGenerator is not null);
-                    var embedding = generatedEmbeddings[i];
+
                     jsonObject[property.StorageName] = embedding switch
                     {
                         Embedding<float> e => JsonSerializer.SerializeToNode(e.Vector, jsonSerializerOptions),

--- a/dotnet/src/Connectors/Connectors.Memory.AzureCosmosDBNoSQL/ICosmosNoSQLMapper.cs
+++ b/dotnet/src/Connectors/Connectors.Memory.AzureCosmosDBNoSQL/ICosmosNoSQLMapper.cs
@@ -1,5 +1,6 @@
 ﻿// Copyright (c) Microsoft. All rights reserved.
 
+using System.Collections.Generic;
 using System.Text.Json.Nodes;
 using MEAI = Microsoft.Extensions.AI;
 
@@ -10,7 +11,7 @@ internal interface ICosmosNoSQLMapper<TRecord>
     /// <summary>
     /// Maps from the consumer record data model to the storage model.
     /// </summary>
-    JsonObject MapFromDataToStorageModel(TRecord dataModel, MEAI.Embedding?[]? generatedEmbeddings);
+    JsonObject MapFromDataToStorageModel(TRecord dataModel, int recordIndex, IReadOnlyList<MEAI.Embedding>?[]? generatedEmbeddings);
 
     /// <summary>
     /// Maps from the storage model to the consumer record data model.

--- a/dotnet/src/Connectors/Connectors.Memory.InMemory/InMemoryVectorStoreRecordCollection.cs
+++ b/dotnet/src/Connectors/Connectors.Memory.InMemory/InMemoryVectorStoreRecordCollection.cs
@@ -183,47 +183,11 @@ public sealed class InMemoryVectorStoreRecordCollection<TKey, TRecord> : VectorS
     }
 
     /// <inheritdoc />
-    public override async IAsyncEnumerable<TRecord> GetAsync(IEnumerable<TKey> keys, GetRecordOptions? options = null, [EnumeratorCancellation] CancellationToken cancellationToken = default)
-    {
-        Verify.NotNull(keys);
-
-        if (options?.IncludeVectors == true && this._model.VectorProperties.Any(p => p.EmbeddingGenerator is not null))
-        {
-            throw new NotSupportedException(VectorDataStrings.IncludeVectorsNotSupportedWithEmbeddingGeneration);
-        }
-
-        foreach (var key in keys)
-        {
-            var record = await this.GetAsync(key, options, cancellationToken).ConfigureAwait(false);
-
-            if (record is not null)
-            {
-                yield return record;
-            }
-        }
-    }
-
-    /// <inheritdoc />
     public override Task DeleteAsync(TKey key, CancellationToken cancellationToken = default)
     {
         var collectionDictionary = this.GetCollectionDictionary();
 
         collectionDictionary.TryRemove(key, out _);
-        return Task.CompletedTask;
-    }
-
-    /// <inheritdoc />
-    public override Task DeleteAsync(IEnumerable<TKey> keys, CancellationToken cancellationToken = default)
-    {
-        Verify.NotNull(keys);
-
-        var collectionDictionary = this.GetCollectionDictionary();
-
-        foreach (var key in keys)
-        {
-            collectionDictionary.TryRemove(key, out _);
-        }
-
         return Task.CompletedTask;
     }
 

--- a/dotnet/src/Connectors/Connectors.Memory.Redis/RedisJsonVectorStoreRecordCollection.cs
+++ b/dotnet/src/Connectors/Connectors.Memory.Redis/RedisJsonVectorStoreRecordCollection.cs
@@ -313,16 +313,6 @@ public sealed class RedisJsonVectorStoreRecordCollection<TKey, TRecord> : Vector
     }
 
     /// <inheritdoc />
-    public override Task DeleteAsync(IEnumerable<TKey> keys, CancellationToken cancellationToken = default)
-    {
-        Verify.NotNull(keys);
-
-        // Remove records in parallel.
-        var tasks = keys.Select(key => this.DeleteAsync(key, cancellationToken));
-        return Task.WhenAll(tasks);
-    }
-
-    /// <inheritdoc />
     public override async Task UpsertAsync(TRecord record, CancellationToken cancellationToken = default)
     {
         Verify.NotNull(record);

--- a/dotnet/src/Connectors/Connectors.Memory.Weaviate/WeaviateVectorStoreRecordCollection.cs
+++ b/dotnet/src/Connectors/Connectors.Memory.Weaviate/WeaviateVectorStoreRecordCollection.cs
@@ -229,27 +229,6 @@ public sealed class WeaviateVectorStoreRecordCollection<TKey, TRecord> : VectorS
     }
 
     /// <inheritdoc />
-    public override async IAsyncEnumerable<TRecord> GetAsync(
-        IEnumerable<TKey> keys,
-        GetRecordOptions? options = null,
-        [EnumeratorCancellation] CancellationToken cancellationToken = default)
-    {
-        Verify.NotNull(keys);
-
-        var tasks = keys.Select(key => this.GetAsync(key, options, cancellationToken));
-
-        var records = await Task.WhenAll(tasks).ConfigureAwait(false);
-
-        foreach (var record in records)
-        {
-            if (record is not null)
-            {
-                yield return record;
-            }
-        }
-    }
-
-    /// <inheritdoc />
     public override Task UpsertAsync(TRecord record, CancellationToken cancellationToken = default)
         => this.UpsertAsync([record], cancellationToken);
 

--- a/dotnet/src/Connectors/Connectors.MongoDB.UnitTests/MongoDBDynamicDataModelMapperTests.cs
+++ b/dotnet/src/Connectors/Connectors.MongoDB.UnitTests/MongoDBDynamicDataModelMapperTests.cs
@@ -78,7 +78,7 @@ public sealed class MongoDBDynamicDataModelMapperTests
         };
 
         // Act
-        var storageModel = sut.MapFromDataToStorageModel(dataModel, generatedEmbeddings: null);
+        var storageModel = sut.MapFromDataToStorageModel(dataModel, recordIndex: 0, generatedEmbeddings: null);
 
         // Assert
         Assert.Equal("key", storageModel["_id"]);
@@ -127,7 +127,7 @@ public sealed class MongoDBDynamicDataModelMapperTests
         var sut = new MongoDBDynamicDataModelMapper(model);
 
         // Act
-        var storageModel = sut.MapFromDataToStorageModel(dataModel, generatedEmbeddings: null);
+        var storageModel = sut.MapFromDataToStorageModel(dataModel, recordIndex: 0, generatedEmbeddings: null);
 
         // Assert
         Assert.Equal(BsonNull.Value, storageModel["StringDataProp"]);
@@ -251,7 +251,7 @@ public sealed class MongoDBDynamicDataModelMapperTests
         var sut = new MongoDBDynamicDataModelMapper(model);
 
         // Act
-        var storageModel = sut.MapFromDataToStorageModel(dataModel, generatedEmbeddings: null);
+        var storageModel = sut.MapFromDataToStorageModel(dataModel, recordIndex: 0, generatedEmbeddings: null);
 
         // Assert
         Assert.Equal("key", (string?)storageModel["_id"]);

--- a/dotnet/src/Connectors/Connectors.MongoDB.UnitTests/MongoDBVectorStoreRecordMapperTests.cs
+++ b/dotnet/src/Connectors/Connectors.MongoDB.UnitTests/MongoDBVectorStoreRecordMapperTests.cs
@@ -48,7 +48,7 @@ public sealed class MongoDBVectorStoreRecordMapperTests
         };
 
         // Act
-        var document = this._sut.MapFromDataToStorageModel(hotel, generatedEmbeddings: null);
+        var document = this._sut.MapFromDataToStorageModel(hotel, recordIndex: 0, generatedEmbeddings: null);
 
         // Assert
         Assert.NotNull(document);

--- a/dotnet/src/Connectors/VectorData.Abstractions/VectorStorage/VectorStoreCollection.cs
+++ b/dotnet/src/Connectors/VectorData.Abstractions/VectorStorage/VectorStoreCollection.cs
@@ -79,7 +79,7 @@ public abstract class VectorStoreCollection<TKey, TRecord> : IVectorSearch<TReco
     /// <remarks>
     /// <para>
     /// The exact method of retrieval is implementation-specific and can vary based on database support.
-    /// The default implementation of this method retrieves the record one by one, but implementations which supporting batching can override to provide a more efficient implementation.
+    /// The default implementation of this method retrieves the records one after the other, but implementations which supporting batching can override to provide a more efficient implementation.
     /// </para>
     /// <para>
     /// Only found records are returned, so the result set might be smaller than the requested keys.
@@ -120,7 +120,7 @@ public abstract class VectorStoreCollection<TKey, TRecord> : IVectorSearch<TReco
     /// <remarks>
     /// <para>
     /// The exact method of deleting is implementation-specific and can vary based on database support.
-    /// The default implementation of this method deletes the records one by one, but implementations which supporting batching can override to provide a more efficient implementation.
+    /// The default implementation of this method deletes the records one after the other, but implementations which supporting batching can override to provide a more efficient implementation.
     /// </para>
     /// <para>
     /// If a record isn't found, it is ignored and the batch succeeds.

--- a/dotnet/src/InternalUtilities/connectors/Memory/MongoDB/IMongoDBMapper.cs
+++ b/dotnet/src/InternalUtilities/connectors/Memory/MongoDB/IMongoDBMapper.cs
@@ -1,5 +1,6 @@
 ﻿// Copyright (c) Microsoft. All rights reserved.
 
+using System.Collections.Generic;
 using Microsoft.Extensions.AI;
 using MongoDB.Bson;
 
@@ -8,7 +9,7 @@ internal interface IMongoDBMapper<TRecord>
     /// <summary>
     /// Maps from the consumer record data model to the storage model.
     /// </summary>
-    BsonDocument MapFromDataToStorageModel(TRecord dataModel, Embedding?[]? generatedEmbeddings);
+    BsonDocument MapFromDataToStorageModel(TRecord dataModel, int recordIndex, IReadOnlyList<Embedding>?[]? generatedEmbeddings);
 
     /// <summary>
     /// Maps from the storage model to the consumer record data model.

--- a/dotnet/src/InternalUtilities/connectors/Memory/MongoDB/MongoDBVectorStoreRecordMapper.cs
+++ b/dotnet/src/InternalUtilities/connectors/Memory/MongoDB/MongoDBVectorStoreRecordMapper.cs
@@ -1,6 +1,7 @@
 ﻿// Copyright (c) Microsoft. All rights reserved.
 
 using System;
+using System.Collections.Generic;
 using System.Diagnostics;
 using System.Diagnostics.CodeAnalysis;
 using System.Reflection;
@@ -49,7 +50,7 @@ internal sealed class MongoDBVectorStoreRecordMapper<TRecord> : IMongoDBMapper<T
             type => type == typeof(TRecord));
     }
 
-    public BsonDocument MapFromDataToStorageModel(TRecord dataModel, Embedding?[]? generatedEmbeddings)
+    public BsonDocument MapFromDataToStorageModel(TRecord dataModel, int recordIndex, IReadOnlyList<Embedding>?[]? generatedEmbeddings)
     {
         var document = dataModel.ToBsonDocument();
 
@@ -69,11 +70,12 @@ internal sealed class MongoDBVectorStoreRecordMapper<TRecord> : IMongoDBMapper<T
         {
             for (var i = 0; i < this._model.VectorProperties.Count; i++)
             {
-                if (generatedEmbeddings[i] is not null)
+                if (generatedEmbeddings?[i]?[recordIndex] is Embedding embedding)
                 {
                     var property = this._model.VectorProperties[i];
+
                     Debug.Assert(property.EmbeddingGenerator is not null);
-                    var embedding = generatedEmbeddings[i];
+
                     document[property.StorageName] = embedding switch
                     {
                         Embedding<float> e => BsonArray.Create(e.Vector.ToArray()),


### PR DESCRIPTION
* Add default non-concurrent implementations to VectorStoreCollection for GetAsync and DeleteAsync - but not for UpsertAsync. The reason is that when upserting, the provider (usually) needs to generate embeddings, and this is definitely not something that should happen separately for every record (IEmbeddingGenerators support batching, and a single call should be made for the vector property of all records).
* Some providers were actually implementing batched UpsertAsync this way - fixed them to generate embeddings once before upserting. This just aligns those providers to use the same techniques as other providers which support native batching.

Closes #11854
