### PR TITLE
.Net: Updates to SessionsPythonPlugin

### DIFF
--- a/dotnet/src/Plugins/Plugins.Core/CodeInterpreter/SessionsPythonSettings.cs
+++ b/dotnet/src/Plugins/Plugins.Core/CodeInterpreter/SessionsPythonSettings.cs
@@ -1,6 +1,7 @@
 ﻿// Copyright (c) Microsoft. All rights reserved.
 
 using System;
+using System.Collections.Generic;
 using System.ComponentModel;
 using System.Text.Json.Serialization;
 
@@ -22,6 +23,11 @@ public class SessionsPythonSettings
     /// </summary>
     [JsonIgnore]
     public Uri Endpoint { get; set; }
+
+    /// <summary>
+    /// List of allowed domains to download from.
+    /// </summary>
+    public IEnumerable<string>? AllowedDomains { get; set; }
 
     /// <summary>
     /// The session identifier.


### PR DESCRIPTION
### Motivation, Context and Description

This PR provides control over which domains requests can be sent to. Additionally, it moves functionality that is common to all operations of the plugin to one private method to remove duplication.

Contributes to: https://github.com/microsoft/semantic-kernel/issues/10070
