### PR TITLE
Pincone cleanup

### DIFF
--- a/dotnet/samples/Concepts/Memory/VectorStoreLangchainInterop/PineconeFactory.cs
+++ b/dotnet/samples/Concepts/Memory/VectorStoreLangchainInterop/PineconeFactory.cs
@@ -2,7 +2,7 @@
 
 using Microsoft.Extensions.VectorData;
 using Microsoft.SemanticKernel.Connectors.Pinecone;
-using Sdk = Pinecone;
+using Pinecone;
 
 namespace Memory.VectorStoreLangchainInterop;
 
@@ -33,15 +33,15 @@ public static class PineconeFactory
     /// </summary>
     /// <param name="pineconeClient">Pinecone client that can be used to manage the collections and points in a Pinecone store.</param>
     /// <returns>The <see cref="VectorStore"/>.</returns>
-    public static VectorStore CreatePineconeLangchainInteropVectorStore(Sdk.PineconeClient pineconeClient)
+    public static VectorStore CreatePineconeLangchainInteropVectorStore(PineconeClient pineconeClient)
         => new PineconeLangchainInteropVectorStore(new PineconeVectorStore(pineconeClient), pineconeClient);
 
     private sealed class PineconeLangchainInteropVectorStore(
         VectorStore innerStore,
-        Sdk.PineconeClient pineconeClient)
+        PineconeClient pineconeClient)
         : VectorStore
     {
-        private readonly Sdk.PineconeClient _pineconeClient = pineconeClient;
+        private readonly PineconeClient _pineconeClient = pineconeClient;
 
         public override VectorStoreCollection<TKey, TRecord> GetCollection<TKey, TRecord>(string name, VectorStoreRecordDefinition? vectorStoreRecordDefinition = null)
         {

--- a/dotnet/samples/Concepts/Memory/VectorStore_Langchain_Interop.cs
+++ b/dotnet/samples/Concepts/Memory/VectorStore_Langchain_Interop.cs
@@ -6,7 +6,7 @@ using Microsoft.Extensions.VectorData;
 using Microsoft.SemanticKernel.Connectors.AzureOpenAI;
 using Microsoft.SemanticKernel.Embeddings;
 using StackExchange.Redis;
-using Sdk = Pinecone;
+using Pinecone;
 
 namespace Memory;
 
@@ -31,7 +31,7 @@ public class VectorStore_Langchain_Interop(ITestOutputHelper output) : BaseTest(
     [Fact]
     public async Task ReadDataFromLangchainPineconeAsync()
     {
-        var pineconeClient = new Sdk.PineconeClient(TestConfiguration.Pinecone.ApiKey);
+        var pineconeClient = new PineconeClient(TestConfiguration.Pinecone.ApiKey);
         var vectorStore = PineconeFactory.CreatePineconeLangchainInteropVectorStore(pineconeClient);
         await this.ReadDataFromCollectionAsync(vectorStore, "pets");
     }

--- a/dotnet/src/Connectors/Connectors.Memory.Pinecone/PineconeCollection.cs
+++ b/dotnet/src/Connectors/Connectors.Memory.Pinecone/PineconeCollection.cs
@@ -13,7 +13,7 @@ using Microsoft.Extensions.VectorData;
 using Microsoft.Extensions.VectorData.ConnectorSupport;
 using Microsoft.Extensions.VectorData.Properties;
 using Pinecone;
-using Sdk = Pinecone;
+using Pinecone;
 
 namespace Microsoft.SemanticKernel.Connectors.Pinecone;
 
@@ -33,7 +33,7 @@ public sealed class PineconeCollection<TKey, TRecord> : VectorStoreCollection<TK
     /// <summary>Metadata about vector store record collection.</summary>
     private readonly VectorStoreCollectionMetadata _collectionMetadata;
 
-    private readonly Sdk.PineconeClient _pineconeClient;
+    private readonly PineconeClient _pineconeClient;
     private readonly PineconeCollectionOptions<TRecord> _options;
     private readonly Extensions.VectorData.ConnectorSupport.CollectionModel _model;
     private readonly PineconeMapper<TRecord> _mapper;
@@ -50,7 +50,7 @@ public sealed class PineconeCollection<TKey, TRecord> : VectorStoreCollection<TK
     /// <exception cref="ArgumentNullException">Thrown if the <paramref name="pineconeClient"/> is null.</exception>
     /// <param name="name">The name of the collection that this <see cref="PineconeCollection{TKey, TRecord}"/> will access.</param>
     /// <exception cref="ArgumentException">Thrown for any misconfigured options.</exception>
-    public PineconeCollection(Sdk.PineconeClient pineconeClient, string name, PineconeCollectionOptions<TRecord>? options = null)
+    public PineconeCollection(PineconeClient pineconeClient, string name, PineconeCollectionOptions<TRecord>? options = null)
     {
         Verify.NotNull(pineconeClient);
         VerifyCollectionName(name);
@@ -164,7 +164,7 @@ public sealed class PineconeCollection<TKey, TRecord> : VectorStoreCollection<TK
             throw new NotSupportedException(VectorDataStrings.IncludeVectorsNotSupportedWithEmbeddingGeneration);
         }
 
-        Sdk.FetchRequest request = new()
+        FetchRequest request = new()
         {
             Namespace = this._options.IndexNamespace,
             Ids = [this.GetStringKey(key)]
@@ -211,7 +211,7 @@ public sealed class PineconeCollection<TKey, TRecord> : VectorStoreCollection<TK
             yield break;
         }
 
-        Sdk.FetchRequest request = new()
+        FetchRequest request = new()
         {
             Namespace = this._options.IndexNamespace,
             Ids = keysList
@@ -236,7 +236,7 @@ public sealed class PineconeCollection<TKey, TRecord> : VectorStoreCollection<TK
     /// <inheritdoc />
     public override Task DeleteAsync(TKey key, CancellationToken cancellationToken = default)
     {
-        Sdk.DeleteRequest request = new()
+        DeleteRequest request = new()
         {
             Namespace = this._options.IndexNamespace,
             Ids = [this.GetStringKey(key)]
@@ -264,7 +264,7 @@ public sealed class PineconeCollection<TKey, TRecord> : VectorStoreCollection<TK
             return Task.CompletedTask;
         }
 
-        Sdk.DeleteRequest request = new()
+        DeleteRequest request = new()
         {
             Namespace = this._options.IndexNamespace,
             Ids = keysList
@@ -299,7 +299,7 @@ public sealed class PineconeCollection<TKey, TRecord> : VectorStoreCollection<TK
 
         var vector = this._mapper.MapFromDataToStorageModel(record, generatedEmbedding);
 
-        Sdk.UpsertRequest request = new()
+        UpsertRequest request = new()
         {
             Namespace = this._options.IndexNamespace,
             Vectors = [vector],
@@ -349,7 +349,7 @@ public sealed class PineconeCollection<TKey, TRecord> : VectorStoreCollection<TK
             return;
         }
 
-        Sdk.UpsertRequest request = new()
+        UpsertRequest request = new()
         {
             Namespace = this._options.IndexNamespace,
             Vectors = vectors,
@@ -441,7 +441,7 @@ public sealed class PineconeCollection<TKey, TRecord> : VectorStoreCollection<TK
         };
 #pragma warning restore CS0618
 
-        Sdk.QueryRequest request = new()
+        QueryRequest request = new()
         {
             TopK = (uint)(top + options.Skip),
             Namespace = this._options.IndexNamespace,
@@ -451,7 +451,7 @@ public sealed class PineconeCollection<TKey, TRecord> : VectorStoreCollection<TK
             Filter = filter,
         };
 
-        Sdk.QueryResponse response = await this.RunIndexOperationAsync(
+        QueryResponse response = await this.RunIndexOperationAsync(
             "VectorizedSearch",
             indexClient => indexClient.QueryAsync(request, cancellationToken: cancellationToken)).ConfigureAwait(false);
 
@@ -467,7 +467,7 @@ public sealed class PineconeCollection<TKey, TRecord> : VectorStoreCollection<TK
         var records = skippedResults.Select(
             x => new VectorSearchResult<TRecord>(
                 this._mapper.MapFromStorageToDataModel(
-                    new Sdk.Vector()
+                    new Vector()
                     {
                         Id = x.Id,
                         Values = x.Values ?? Array.Empty<float>(),
@@ -508,7 +508,7 @@ public sealed class PineconeCollection<TKey, TRecord> : VectorStoreCollection<TK
             throw new NotSupportedException(VectorDataStrings.IncludeVectorsNotSupportedWithEmbeddingGeneration);
         }
 
-        Sdk.QueryRequest request = new()
+        QueryRequest request = new()
         {
             TopK = (uint)(top + options.Skip),
             Namespace = this._options.IndexNamespace,
@@ -521,7 +521,7 @@ public sealed class PineconeCollection<TKey, TRecord> : VectorStoreCollection<TK
             Filter = new PineconeFilterTranslator().Translate(filter, this._model),
         };
 
-        Sdk.QueryResponse response = await this.RunIndexOperationAsync(
+        QueryResponse response = await this.RunIndexOperationAsync(
             "Get",
             indexClient => indexClient.QueryAsync(request, cancellationToken: cancellationToken)).ConfigureAwait(false);
 
@@ -535,7 +535,7 @@ public sealed class PineconeCollection<TKey, TRecord> : VectorStoreCollection<TK
             .Skip(options.Skip)
             .Select(
                 x => this._mapper.MapFromStorageToDataModel(
-                    new Sdk.Vector()
+                    new Vector()
                     {
                         Id = x.Id,
                         Values = x.Values ?? Array.Empty<float>(),
@@ -558,7 +558,7 @@ public sealed class PineconeCollection<TKey, TRecord> : VectorStoreCollection<TK
         return
             serviceKey is not null ? null :
             serviceType == typeof(VectorStoreCollectionMetadata) ? this._collectionMetadata :
-            serviceType == typeof(Sdk.PineconeClient) ? this._pineconeClient :
+            serviceType == typeof(PineconeClient) ? this._pineconeClient :
             serviceType.IsInstanceOfType(this) ? this :
             null;
     }

--- a/dotnet/src/Connectors/Connectors.Memory.Pinecone/PineconeServiceCollectionExtensions.cs
+++ b/dotnet/src/Connectors/Connectors.Memory.Pinecone/PineconeServiceCollectionExtensions.cs
@@ -4,7 +4,7 @@ using Microsoft.Extensions.AI;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.VectorData;
 using Microsoft.SemanticKernel.Connectors.Pinecone;
-using Sdk = Pinecone;
+using Pinecone;
 
 namespace Microsoft.SemanticKernel;
 
@@ -14,7 +14,7 @@ namespace Microsoft.SemanticKernel;
 public static class PineconeServiceCollectionExtensions
 {
     /// <summary>
-    /// Register a Pinecone <see cref="VectorStore"/> with the specified service ID and where <see cref="Sdk.PineconeClient"/> is retrieved from the dependency injection container.
+    /// Register a Pinecone <see cref="VectorStore"/> with the specified service ID and where <see cref="PineconeClient"/> is retrieved from the dependency injection container.
     /// </summary>
     /// <param name="services">The <see cref="IServiceCollection"/> to register the <see cref="VectorStore"/> on.</param>
     /// <param name="options">Optional options to further configure the <see cref="VectorStore"/>.</param>
@@ -28,7 +28,7 @@ public static class PineconeServiceCollectionExtensions
             serviceId,
             (sp, obj) =>
             {
-                var pineconeClient = sp.GetRequiredService<Sdk.PineconeClient>();
+                var pineconeClient = sp.GetRequiredService<PineconeClient>();
                 options ??= sp.GetService<PineconeVectorStoreOptions>() ?? new()
                 {
                     EmbeddingGenerator = sp.GetService<IEmbeddingGenerator>()
@@ -41,7 +41,7 @@ public static class PineconeServiceCollectionExtensions
     }
 
     /// <summary>
-    /// Register a Pinecone <see cref="VectorStore"/> with the specified service ID and where <see cref="Sdk.PineconeClient"/> is constructed using the provided apikey.
+    /// Register a Pinecone <see cref="VectorStore"/> with the specified service ID and where <see cref="PineconeClient"/> is constructed using the provided apikey.
     /// </summary>
     /// <param name="services">The <see cref="IServiceCollection"/> to register the <see cref="VectorStore"/> on.</param>
     /// <param name="apiKey">The api key for Pinecone.</param>
@@ -54,7 +54,7 @@ public static class PineconeServiceCollectionExtensions
             serviceId,
             (sp, obj) =>
             {
-                var pineconeClient = new Sdk.PineconeClient(apiKey);
+                var pineconeClient = new PineconeClient(apiKey);
                 options ??= sp.GetService<PineconeVectorStoreOptions>() ?? new()
                 {
                     EmbeddingGenerator = sp.GetService<IEmbeddingGenerator>()
@@ -68,7 +68,7 @@ public static class PineconeServiceCollectionExtensions
 
     /// <summary>
     /// Register a Pinecone <see cref="VectorStoreCollection{TKey, TRecord}"/> and <see cref="IVectorSearch{TRecord}"/> with the
-    /// specified service ID and where <see cref="Sdk.PineconeClient"/> is retrieved from the dependency injection container.
+    /// specified service ID and where <see cref="PineconeClient"/> is retrieved from the dependency injection container.
     /// </summary>
     /// <typeparam name="TRecord">The type of the data model that the collection should contain.</typeparam>
     /// <param name="services">The <see cref="IServiceCollection"/> to register the <see cref="VectorStoreCollection{TKey, TRecord}"/> on.</param>
@@ -89,7 +89,7 @@ public static class PineconeServiceCollectionExtensions
             serviceId,
             (sp, obj) =>
             {
-                var pineconeClient = sp.GetRequiredService<Sdk.PineconeClient>();
+                var pineconeClient = sp.GetRequiredService<PineconeClient>();
                 options ??= sp.GetService<PineconeCollectionOptions<TRecord>>() ?? new()
                 {
                     EmbeddingGenerator = sp.GetService<IEmbeddingGenerator>()
@@ -105,7 +105,7 @@ public static class PineconeServiceCollectionExtensions
 
     /// <summary>
     /// Register a Pinecone <see cref="VectorStoreCollection{TKey, TRecord}"/> and <see cref="IVectorSearch{TRecord}"/> with the
-    /// provided <see cref="Sdk.PineconeClient"/> and the specified service ID.
+    /// provided <see cref="PineconeClient"/> and the specified service ID.
     /// </summary>
     /// <typeparam name="TRecord">The type of the data model that the collection should contain.</typeparam>
     /// <param name="services">The <see cref="IServiceCollection"/> to register the <see cref="VectorStoreCollection{TKey, TRecord}"/> on.</param>
@@ -126,7 +126,7 @@ public static class PineconeServiceCollectionExtensions
             serviceId,
             (sp, obj) =>
             {
-                var pineconeClient = new Sdk.PineconeClient(apiKey);
+                var pineconeClient = new PineconeClient(apiKey);
                 options ??= sp.GetService<PineconeCollectionOptions<TRecord>>() ?? new()
                 {
                     EmbeddingGenerator = sp.GetService<IEmbeddingGenerator>()

--- a/dotnet/src/Connectors/Connectors.Memory.Pinecone/PineconeVectorStore.cs
+++ b/dotnet/src/Connectors/Connectors.Memory.Pinecone/PineconeVectorStore.cs
@@ -7,7 +7,6 @@ using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.Extensions.VectorData;
 using Pinecone;
-using Sdk = Pinecone;
 
 namespace Microsoft.SemanticKernel.Connectors.Pinecone;
 
@@ -19,7 +18,7 @@ namespace Microsoft.SemanticKernel.Connectors.Pinecone;
 /// </remarks>
 public sealed class PineconeVectorStore : VectorStore
 {
-    private readonly Sdk.PineconeClient _pineconeClient;
+    private readonly PineconeClient _pineconeClient;
     private readonly PineconeVectorStoreOptions _options;
 
     /// <summary>Metadata about vector store.</summary>
@@ -33,7 +32,7 @@ public sealed class PineconeVectorStore : VectorStore
     /// </summary>
     /// <param name="pineconeClient">Pinecone client that can be used to manage the collections and points in a Pinecone store.</param>
     /// <param name="options">Optional configuration options for this class.</param>
-    public PineconeVectorStore(Sdk.PineconeClient pineconeClient, PineconeVectorStoreOptions? options = default)
+    public PineconeVectorStore(PineconeClient pineconeClient, PineconeVectorStoreOptions? options = default)
     {
         Verify.NotNull(pineconeClient);
 
@@ -96,7 +95,7 @@ public sealed class PineconeVectorStore : VectorStore
         return
             serviceKey is not null ? null :
             serviceType == typeof(VectorStoreMetadata) ? this._metadata :
-            serviceType == typeof(Sdk.PineconeClient) ? this._pineconeClient :
+            serviceType == typeof(PineconeClient) ? this._pineconeClient :
             serviceType.IsInstanceOfType(this) ? this :
             null;
     }

--- a/dotnet/src/Connectors/Connectors.Pinecone.UnitTests/PineconeCollectionTests.cs
+++ b/dotnet/src/Connectors/Connectors.Pinecone.UnitTests/PineconeCollectionTests.cs
@@ -5,7 +5,7 @@ using System.Collections.Generic;
 using Microsoft.Extensions.VectorData;
 using Microsoft.SemanticKernel.Connectors.Pinecone;
 using Xunit;
-using Sdk = Pinecone;
+using Pinecone;
 
 namespace SemanticKernel.Connectors.Pinecone.UnitTests;
 
@@ -34,7 +34,7 @@ public class PineconeCollectionTests
                 new VectorStoreVectorProperty("Vector", typeof(ReadOnlyMemory<float>?), 4),
             }
         };
-        var pineconeClient = new Sdk.PineconeClient("fake api key");
+        var pineconeClient = new PineconeClient("fake api key");
 
         // Act.
         var sut = new PineconeCollection<string, SinglePropsModel>(

--- a/dotnet/src/Connectors/Connectors.Pinecone.UnitTests/PineconeServiceCollectionExtensionsTests.cs
+++ b/dotnet/src/Connectors/Connectors.Pinecone.UnitTests/PineconeServiceCollectionExtensionsTests.cs
@@ -6,7 +6,7 @@ using Microsoft.Extensions.VectorData;
 using Microsoft.SemanticKernel;
 using Microsoft.SemanticKernel.Connectors.Pinecone;
 using Xunit;
-using Sdk = Pinecone;
+using Pinecone;
 
 namespace SemanticKernel.Connectors.Pinecone.UnitTests;
 
@@ -26,8 +26,8 @@ public class PineconeServiceCollectionExtensionsTests
     public void AddVectorStoreRegistersClass()
     {
         // Arrange.
-        var client = new Sdk.PineconeClient("fake api key");
-        this._serviceCollection.AddSingleton<Sdk.PineconeClient>(client);
+        var client = new PineconeClient("fake api key");
+        this._serviceCollection.AddSingleton<PineconeClient>(client);
 
         // Act.
         this._serviceCollection.AddPineconeVectorStore();
@@ -49,8 +49,8 @@ public class PineconeServiceCollectionExtensionsTests
     public void AddVectorStoreRecordCollectionRegistersClass()
     {
         // Arrange.
-        var client = new Sdk.PineconeClient("fake api key");
-        this._serviceCollection.AddSingleton<Sdk.PineconeClient>(client);
+        var client = new PineconeClient("fake api key");
+        this._serviceCollection.AddSingleton<PineconeClient>(client);
 
         // Act.
         this._serviceCollection.AddPineconeVectorStoreRecordCollection<TestRecord>("testcollection");


### PR DESCRIPTION
we no longer provide a public PineconeClient type, so there is no need to use fully qualified name when using the official Pincone types