### PR TITLE
.Net: [MEVD] Fixed SQLite filtering behavior

### DIFF
--- a/dotnet/src/Connectors/Connectors.Memory.Sqlite/SqliteCollection.cs
+++ b/dotnet/src/Connectors/Connectors.Memory.Sqlite/SqliteCollection.cs
@@ -306,7 +306,7 @@ public sealed class SqliteCollection<TKey, TRecord> : VectorStoreCollection<TKey
 
         if (options.IncludeVectors)
         {
-            command = SqliteCommandBuilder.BuildSelectLeftJoinCommand(
+            command = SqliteCommandBuilder.BuildSelectInnerJoinCommand(
                 connection,
                 this._vectorTableName,
                 this._dataTableName,
@@ -568,7 +568,7 @@ public sealed class SqliteCollection<TKey, TRecord> : VectorStoreCollection<TKey
         const string OperationName = "VectorizedSearch";
 
         using var connection = await this.GetConnectionAsync(cancellationToken).ConfigureAwait(false);
-        using var command = SqliteCommandBuilder.BuildSelectLeftJoinCommand<TRecord>(
+        using var command = SqliteCommandBuilder.BuildSelectInnerJoinCommand<TRecord>(
             connection,
             this._vectorTableName,
             this._dataTableName,
@@ -679,7 +679,7 @@ public sealed class SqliteCollection<TKey, TRecord> : VectorStoreCollection<TKey
                 throw new NotSupportedException(VectorDataStrings.IncludeVectorsNotSupportedWithEmbeddingGeneration);
             }
 
-            command = SqliteCommandBuilder.BuildSelectLeftJoinCommand<TRecord>(
+            command = SqliteCommandBuilder.BuildSelectInnerJoinCommand<TRecord>(
                 connection,
                 this._vectorTableName,
                 this._dataTableName,

--- a/dotnet/src/Connectors/Connectors.Sqlite.UnitTests/SqliteCommandBuilderTests.cs
+++ b/dotnet/src/Connectors/Connectors.Sqlite.UnitTests/SqliteCommandBuilderTests.cs
@@ -256,7 +256,7 @@ public sealed class SqliteCommandBuilderTests : IDisposable
         }
 
         // Act
-        var command = SqliteCommandBuilder.BuildSelectLeftJoinCommand(
+        var command = SqliteCommandBuilder.BuildSelectInnerJoinCommand(
             this._connection,
             VectorTable,
             DataTable,

--- a/dotnet/src/Connectors/Connectors.Sqlite.UnitTests/SqliteCommandBuilderTests.cs
+++ b/dotnet/src/Connectors/Connectors.Sqlite.UnitTests/SqliteCommandBuilderTests.cs
@@ -229,7 +229,7 @@ public sealed class SqliteCommandBuilderTests : IDisposable
     [InlineData(null)]
     [InlineData("")]
     [InlineData("Age")]
-    public void ItBuildsSelectLeftJoinCommand(string? orderByPropertyName)
+    public void ItBuildsSelectInnerJoinCommand(string? orderByPropertyName)
     {
         // Arrange
         const string DataTable = "DataTable";
@@ -270,7 +270,7 @@ public sealed class SqliteCommandBuilderTests : IDisposable
         Assert.Contains("SELECT \"DataTable\".\"Id\",\"DataTable\".\"Name\",\"VectorTable\".\"Age\",\"VectorTable\".\"Address\"", command.CommandText);
         Assert.Contains("FROM \"VectorTable\"", command.CommandText);
 
-        Assert.Contains("LEFT JOIN \"DataTable\" ON \"VectorTable\".\"Id\" = \"DataTable\".\"Id\"", command.CommandText);
+        Assert.Contains("INNER JOIN \"DataTable\" ON \"VectorTable\".\"Id\" = \"DataTable\".\"Id\"", command.CommandText);
 
         Assert.Contains("\"Name\" = @Name0", command.CommandText);
         Assert.Contains("\"Age\" IN (@Age0, @Age1, @Age2)", command.CommandText);

--- a/dotnet/src/VectorDataIntegrationTests/SqliteIntegrationTests/SqliteIntegrationTests.csproj
+++ b/dotnet/src/VectorDataIntegrationTests/SqliteIntegrationTests/SqliteIntegrationTests.csproj
@@ -10,17 +10,17 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="xunit"/>
+    <PackageReference Include="xunit" />
     <PackageReference Include="xunit.runner.visualstudio">
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>
-    <PackageReference Include="Microsoft.NET.Test.Sdk"/>
+    <PackageReference Include="Microsoft.NET.Test.Sdk" />
   </ItemGroup>
 
   <ItemGroup>
-    <ProjectReference Include="..\..\Connectors\Connectors.Memory.Sqlite\Connectors.Memory.Sqlite.csproj"/>
-    <ProjectReference Include="..\VectorDataIntegrationTests\VectorDataIntegrationTests.csproj"/>
+    <ProjectReference Include="..\..\Connectors\Connectors.Memory.Sqlite\Connectors.Memory.Sqlite.csproj" />
+    <ProjectReference Include="..\VectorDataIntegrationTests\VectorDataIntegrationTests.csproj" />
   </ItemGroup>
 
 </Project>

--- a/dotnet/src/VectorDataIntegrationTests/SqliteIntegrationTests/VectorSearch/SqliteVectorSearchWithFilterConformanceTests.cs
+++ b/dotnet/src/VectorDataIntegrationTests/SqliteIntegrationTests/VectorSearch/SqliteVectorSearchWithFilterConformanceTests.cs
@@ -1,0 +1,13 @@
+﻿// Copyright (c) Microsoft. All rights reserved.
+
+using SqliteIntegrationTests.Support;
+using VectorDataSpecificationTests.VectorSearch;
+using Xunit;
+
+namespace SqliteIntegrationTests.VectorSearch;
+
+public class SqliteVectorSearchWithFilterConformanceTests(SqliteFixture fixture) :
+    VectorSearchWithFilterConformanceTests<string>(fixture),
+    IClassFixture<SqliteFixture>
+{
+}

--- a/dotnet/src/VectorDataIntegrationTests/VectorDataIntegrationTests/Support/TestStore.cs
+++ b/dotnet/src/VectorDataIntegrationTests/VectorDataIntegrationTests/Support/TestStore.cs
@@ -92,7 +92,7 @@ public abstract class TestStore
         {
             var results = collection.SearchEmbeddingAsync(
                 new ReadOnlyMemory<float>(vector),
-                top: 1000, // TODO: this should be recordCount, but see #11655
+                top: recordCount,
                 new() { Filter = filter });
             var count = await results.CountAsync();
             if (count == recordCount)

--- a/dotnet/src/VectorDataIntegrationTests/VectorDataIntegrationTests/VectorSearch/VectorSearchDistanceFunctionComplianceTests.cs
+++ b/dotnet/src/VectorDataIntegrationTests/VectorDataIntegrationTests/VectorSearch/VectorSearchDistanceFunctionComplianceTests.cs
@@ -175,7 +175,7 @@ public abstract class VectorSearchDistanceFunctionComplianceTests<TKey>(VectorSt
             ]
         };
 
-    private sealed class SearchRecord
+    public class SearchRecord
     {
         public TKey Key { get; set; } = default!;
         public ReadOnlyMemory<float> Vector { get; set; }

--- a/dotnet/src/VectorDataIntegrationTests/VectorDataIntegrationTests/VectorSearch/VectorSearchDistanceFunctionComplianceTests.cs
+++ b/dotnet/src/VectorDataIntegrationTests/VectorDataIntegrationTests/VectorSearch/VectorSearchDistanceFunctionComplianceTests.cs
@@ -175,7 +175,7 @@ public abstract class VectorSearchDistanceFunctionComplianceTests<TKey>(VectorSt
             ]
         };
 
-    public class SearchRecord
+    private class SearchRecord
     {
         public TKey Key { get; set; } = default!;
         public ReadOnlyMemory<float> Vector { get; set; }

--- a/dotnet/src/VectorDataIntegrationTests/VectorDataIntegrationTests/VectorSearch/VectorSearchDistanceFunctionComplianceTests.cs
+++ b/dotnet/src/VectorDataIntegrationTests/VectorDataIntegrationTests/VectorSearch/VectorSearchDistanceFunctionComplianceTests.cs
@@ -175,7 +175,7 @@ public abstract class VectorSearchDistanceFunctionComplianceTests<TKey>(VectorSt
             ]
         };
 
-    private class SearchRecord
+    private sealed class SearchRecord
     {
         public TKey Key { get; set; } = default!;
         public ReadOnlyMemory<float> Vector { get; set; }

--- a/dotnet/src/VectorDataIntegrationTests/VectorDataIntegrationTests/VectorSearch/VectorSearchWithFilterConformanceTests.cs
+++ b/dotnet/src/VectorDataIntegrationTests/VectorDataIntegrationTests/VectorSearch/VectorSearchWithFilterConformanceTests.cs
@@ -56,7 +56,7 @@ public abstract class VectorSearchWithFilterConformanceTests<TKey>(VectorStoreFi
         Assert.Equal("apples", results[0].Text);
     }
 
-    private class SearchRecord
+    private sealed class SearchRecord
     {
         [VectorStoreKey]
         public TKey Key { get; set; } = default!;

--- a/dotnet/src/VectorDataIntegrationTests/VectorDataIntegrationTests/VectorSearch/VectorSearchWithFilterConformanceTests.cs
+++ b/dotnet/src/VectorDataIntegrationTests/VectorDataIntegrationTests/VectorSearch/VectorSearchWithFilterConformanceTests.cs
@@ -53,6 +53,7 @@ public abstract class VectorSearchWithFilterConformanceTests<TKey>(VectorStoreFi
 
         // Assert
         Assert.Single(results);
+        Assert.Equal("apples", results[0].Text);
     }
 
     private class SearchRecord

--- a/dotnet/src/VectorDataIntegrationTests/VectorDataIntegrationTests/VectorSearch/VectorSearchWithFilterConformanceTests.cs
+++ b/dotnet/src/VectorDataIntegrationTests/VectorDataIntegrationTests/VectorSearch/VectorSearchWithFilterConformanceTests.cs
@@ -1,0 +1,69 @@
+﻿// Copyright (c) Microsoft. All rights reserved.
+
+using Microsoft.Extensions.VectorData;
+using VectorDataSpecificationTests.Support;
+using VectorDataSpecificationTests.Xunit;
+using Xunit;
+
+namespace VectorDataSpecificationTests.VectorSearch;
+
+public abstract class VectorSearchWithFilterConformanceTests<TKey>(VectorStoreFixture fixture) where TKey : notnull
+{
+    [ConditionalFact]
+    public async Task SearchWithFilterShouldReturnExpectedResultsAsync()
+    {
+        // Arrange
+        var collectionName = fixture.GetUniqueCollectionName();
+        var collection = fixture.TestStore.DefaultVectorStore.GetCollection<TKey, SearchRecord>(collectionName);
+
+        List<SearchRecord>? results = null;
+
+        // Act
+        try
+        {
+            await collection.CreateCollectionIfNotExistsAsync();
+
+            await collection.UpsertAsync(
+            [
+                new SearchRecord
+                {
+                    Key = fixture.GenerateNextKey<TKey>(),
+                    Text = "apples",
+                    Vector = new ReadOnlyMemory<float>([1f, 1f, 1f])
+                },
+                new SearchRecord
+                {
+                    Key = fixture.GenerateNextKey<TKey>(),
+                    Text = "oranges",
+                    Vector = new ReadOnlyMemory<float>([10f, 20f, 35f])
+                }
+            ]);
+
+            var vectorSearchResults = await collection.SearchEmbeddingAsync(new ReadOnlyMemory<float>([10f, 20f, 35f]), 1, new()
+            {
+                Filter = r => r.Text == "apples"
+            }).ToListAsync();
+
+            results = [.. vectorSearchResults.Select(l => l.Record)];
+        }
+        finally
+        {
+            await collection.DeleteCollectionAsync();
+        }
+
+        // Assert
+        Assert.Single(results);
+    }
+
+    private class SearchRecord
+    {
+        [VectorStoreKey]
+        public TKey Key { get; set; } = default!;
+
+        [VectorStoreData]
+        public string? Text { get; set; }
+
+        [VectorStoreVector(Dimensions: 3)]
+        public ReadOnlyMemory<float> Vector { get; set; }
+    }
+}

--- a/dotnet/src/VectorDataIntegrationTests/VectorDataIntegrationTests/VectorSearch/VectorSearchWithFilterConformanceTests.cs
+++ b/dotnet/src/VectorDataIntegrationTests/VectorDataIntegrationTests/VectorSearch/VectorSearchWithFilterConformanceTests.cs
@@ -14,9 +14,9 @@ public abstract class VectorSearchWithFilterConformanceTests<TKey>(VectorStoreFi
     {
         // Arrange
         var collectionName = fixture.GetUniqueCollectionName();
-        var collection = fixture.TestStore.DefaultVectorStore.GetCollection<TKey, SearchRecord>(collectionName);
+        var collection = fixture.TestStore.DefaultVectorStore.GetCollection<TKey, VectorSearchWithFilterRecord>(collectionName);
 
-        List<SearchRecord>? results = null;
+        List<VectorSearchWithFilterRecord>? results = null;
 
         // Act
         try
@@ -25,13 +25,13 @@ public abstract class VectorSearchWithFilterConformanceTests<TKey>(VectorStoreFi
 
             await collection.UpsertAsync(
             [
-                new SearchRecord
+                new VectorSearchWithFilterRecord
                 {
                     Key = fixture.GenerateNextKey<TKey>(),
                     Text = "apples",
                     Vector = new ReadOnlyMemory<float>([1f, 1f, 1f])
                 },
-                new SearchRecord
+                new VectorSearchWithFilterRecord
                 {
                     Key = fixture.GenerateNextKey<TKey>(),
                     Text = "oranges",
@@ -56,7 +56,7 @@ public abstract class VectorSearchWithFilterConformanceTests<TKey>(VectorStoreFi
         Assert.Equal("apples", results[0].Text);
     }
 
-    private sealed class SearchRecord
+    public class VectorSearchWithFilterRecord
     {
         [VectorStoreKey]
         public TKey Key { get; set; } = default!;

--- a/dotnet/src/VectorDataIntegrationTests/VectorDataIntegrationTests/VectorSearch/VectorSearchWithFilterConformanceTests.cs
+++ b/dotnet/src/VectorDataIntegrationTests/VectorDataIntegrationTests/VectorSearch/VectorSearchWithFilterConformanceTests.cs
@@ -23,7 +23,7 @@ public abstract class VectorSearchWithFilterConformanceTests<TKey>(VectorStoreFi
         {
             await collection.CreateCollectionIfNotExistsAsync();
 
-            await collection.UpsertAsync(
+            List<VectorSearchWithFilterRecord> records =
             [
                 new VectorSearchWithFilterRecord
                 {
@@ -37,7 +37,11 @@ public abstract class VectorSearchWithFilterConformanceTests<TKey>(VectorStoreFi
                     Text = "oranges",
                     Vector = new ReadOnlyMemory<float>([10f, 20f, 35f])
                 }
-            ]);
+            ];
+
+            await collection.UpsertAsync(records);
+
+            await fixture.TestStore.WaitForDataAsync(collection, records.Count);
 
             var vectorSearchResults = await collection.SearchEmbeddingAsync(new ReadOnlyMemory<float>([10f, 20f, 35f]), 1, new()
             {


### PR DESCRIPTION
### Motivation and Context

<!-- Thank you for your contribution to the semantic-kernel repo!
Please help reviewers and future users, providing the following information:
  1. Why is this change required?
  2. What problem does it solve?
  3. What scenario does it contribute to?
  4. If it fixes an open issue, please link to the issue here.
-->

Resolves: https://github.com/microsoft/semantic-kernel/issues/11655

This PR fixes incorrect SQLite filtering behavior for vector search operation by using Common Table Expression (CTE) for pre-filtering, since filtering within `JOIN` and `WHERE` is not currently supported in `sqlite-vec` extension (more information [here](https://github.com/asg017/sqlite-vec/issues/196)).

Also added base integration test to validate the behavior with vector search and filter and enabled it for SQLite. 

### Contribution Checklist

<!-- Before submitting this PR, please make sure: -->

- [x] The code builds clean without any errors or warnings
- [x] The PR follows the [SK Contribution Guidelines](https://github.com/microsoft/semantic-kernel/blob/main/CONTRIBUTING.md) and the [pre-submission formatting script](https://github.com/microsoft/semantic-kernel/blob/main/CONTRIBUTING.md#development-scripts) raises no violations
- [x] All unit tests pass, and I have added new tests where possible
- [x] I didn't break anyone :smile:
