### PR TITLE
.Net: Add format script helper

### DIFF
--- a/dotnet/format.ps1
+++ b/dotnet/format.ps1
@@ -1,0 +1,55 @@
+$ErrorActionPreference = 'Stop'
+
+# --- config -------------------------------------------------------
+$exclude = @(
+  'Experimental.Orchestration.Flow.csproj',
+  'Experimental.Orchestration.Flow.UnitTests.csproj',
+  'Experimental.Orchestration.Flow.IntegrationTests.csproj'
+)
+$repoRoot = (git rev-parse --show-toplevel).Trim()
+$repoRoot = (Resolve-Path $repoRoot).Path       # canonical form
+pushd $repoRoot
+# -----------------------------------------------------------------
+
+$targets =
+  git diff --name-only main..HEAD |
+  ForEach-Object {
+      Write-Host "$_ was changed"
+
+      $dir = Split-Path (Join-Path $repoRoot $_) -Parent   # << absolute
+      while ($dir -and $dir -ne $repoRoot) {
+          $proj = Get-ChildItem -LiteralPath $dir -Filter *.csproj -File -ErrorAction Ignore |
+                  Select-Object -First 1
+          if ($proj) {
+              if ($exclude -notcontains $proj.Name) { $proj.FullName }
+              break
+          }
+          $dir = Split-Path $dir -Parent
+      }
+  } |
+  Sort-Object -Unique
+
+if (-not $targets) {
+#    $targets = Get-ChildItem $repoRoot -Recurse -Filter *.sln |
+#               Select-Object -Expand FullName
+  Write-Host "No code changes found"
+}
+
+if ($PSVersionTable.PSVersion.Major -ge 7) {
+    $targets | ForEach-Object -Parallel {
+        param($t) ; Write-Host "  $t" ; dotnet format --verbosity normal $t
+    }
+} else {
+    $jobs = foreach ($t in $targets) {
+        Start-Job -ScriptBlock {
+            param($target)
+            Write-Host "  $target"
+            dotnet format --verbosity normal $target
+        } -ArgumentList $t
+    }
+
+    # wait for all to finish and surface errors
+    $jobs | Receive-Job -Wait -AutoRemoveJob
+}
+
+popd


### PR DESCRIPTION
### Motivation and Context

As a small improvement to the C# development life cycle, this scripts allows us to identify and correct quickly on branches any format warning that we might have missed.

This will format only the projects that had code changes during the development of your current branch compared to main, ignoring the ones that were untouched.

This was inspired in the current logic that exists in the pipeline, but could easily be ran locally for simplification and faster development.