### PR TITLE
Python: Disable Milvus memory store integration tests

### DIFF
--- a/python/tests/integration/memory/memory_stores/test_milvus_memory_store.py
+++ b/python/tests/integration/memory/memory_stores/test_milvus_memory_store.py
@@ -4,8 +4,16 @@
 import numpy as np
 import pytest
 
-from semantic_kernel.connectors.memory.milvus import MilvusMemoryStore
-from semantic_kernel.memory.memory_record import MemoryRecord
+pytest.skip(
+    (
+        "Temporarily disabling this test module due to import error from milvus: "
+        "AttributeError: module 'marshmallow' has no attribute '__version_info__'"
+    ),
+    allow_module_level=True,
+)
+
+from semantic_kernel.connectors.memory.milvus import MilvusMemoryStore  # noqa: E402
+from semantic_kernel.memory.memory_record import MemoryRecord  # noqa: E402
 
 try:
     from milvus import default_server


### PR DESCRIPTION
### Motivation and Context

<!-- Thank you for your contribution to the semantic-kernel repo!
Please help reviewers and future users, providing the following information:
  1. Why is this change required?
  2. What problem does it solve?
  3. What scenario does it contribute to?
  4. If it fixes an open issue, please link to the issue here.
-->
The Milvus memory store integration tests have been failing, blocking some PR merges.

### Description

<!-- Describe your changes, the overall approach, the underlying design.
     These notes will help understanding how your code works. Thanks! -->
Temporarily skipping the Milvus memory store integration test.

### Contribution Checklist

<!-- Before submitting this PR, please make sure: -->

- [x] The code builds clean without any errors or warnings
- [x] The PR follows the [SK Contribution Guidelines](https://github.com/microsoft/semantic-kernel/blob/main/CONTRIBUTING.md) and the [pre-submission formatting script](https://github.com/microsoft/semantic-kernel/blob/main/CONTRIBUTING.md#development-scripts) raises no violations
- [x] All unit tests pass, and I have added new tests where possible
- [x] I didn't break anyone :smile:
