### PR TITLE
.Net: Upgrade pgvector and implement support for other embedding types 

### DIFF
--- a/dotnet/Directory.Packages.props
+++ b/dotnet/Directory.Packages.props
@@ -153,7 +153,7 @@
     <PackageVersion Include="Fluid.Core" Version="2.11.1" />
     <!-- Memory stores -->
     <PackageVersion Include="Microsoft.Azure.Cosmos" Version="3.48.0-preview.0" />
-    <PackageVersion Include="Pgvector" Version="0.2.0" />
+    <PackageVersion Include="Pgvector" Version="0.3.1" />
     <PackageVersion Include="NRedisStack" Version="0.12.0" />
     <PackageVersion Include="Milvus.Client" Version="2.3.0-preview.1" />
     <PackageVersion Include="Testcontainers" Version="4.4.0" />

--- a/dotnet/src/Connectors/Connectors.Memory.PgVector/IPostgresVectorStoreDbClient.cs
+++ b/dotnet/src/Connectors/Connectors.Memory.PgVector/IPostgresVectorStoreDbClient.cs
@@ -133,7 +133,7 @@ internal interface IPostgresVectorStoreDbClient
     /// <param name="options">The options that control the behavior of the search.</param>
     /// <param name="cancellationToken">The <see cref="CancellationToken"/> to monitor for cancellation requests. The default is <see cref="CancellationToken.None"/>.</param>
     /// <returns>An asynchronous stream of result objects that the nearest matches to the <see cref="Vector"/>.</returns>
-    IAsyncEnumerable<(Dictionary<string, object?> Row, double Distance)> GetNearestMatchesAsync<TRecord>(string tableName, CollectionModel model, VectorPropertyModel vectorProperty, Vector vectorValue, int limit,
+    IAsyncEnumerable<(Dictionary<string, object?> Row, double Distance)> GetNearestMatchesAsync<TRecord>(string tableName, CollectionModel model, VectorPropertyModel vectorProperty, object vectorValue, int limit,
         RecordSearchOptions<TRecord> options, CancellationToken cancellationToken = default);
 
     IAsyncEnumerable<Dictionary<string, object?>> GetMatchingRecordsAsync<TRecord>(string tableName, CollectionModel model,

--- a/dotnet/src/Connectors/Connectors.Memory.PgVector/PostgresConstants.cs
+++ b/dotnet/src/Connectors/Connectors.Memory.PgVector/PostgresConstants.cs
@@ -1,9 +1,7 @@
 ﻿// Copyright (c) Microsoft. All rights reserved.
 
-using System;
 using System.Collections.Generic;
 using Microsoft.Extensions.VectorData;
-using Microsoft.Extensions.VectorData.ProviderServices;
 
 namespace Microsoft.SemanticKernel.Connectors.PgVector;
 
@@ -11,67 +9,6 @@ internal static class PostgresConstants
 {
     /// <summary>The name of this vector store for telemetry purposes.</summary>
     public const string VectorStoreSystemName = "postgresql";
-
-    /// <summary>Validation options.</summary>
-    public static readonly CollectionModelBuildingOptions ModelBuildingOptions = new()
-    {
-        RequiresAtLeastOneVector = false,
-        SupportsMultipleKeys = false,
-        SupportsMultipleVectors = true,
-
-        SupportedKeyPropertyTypes =
-        [
-            typeof(short),
-            typeof(int),
-            typeof(long),
-            typeof(string),
-            typeof(Guid)
-        ],
-
-        SupportedDataPropertyTypes =
-        [
-            typeof(bool),
-            typeof(short),
-            typeof(int),
-            typeof(long),
-            typeof(float),
-            typeof(double),
-            typeof(decimal),
-            typeof(string),
-            typeof(DateTime),
-            typeof(DateTimeOffset),
-            typeof(Guid),
-            typeof(byte[]),
-        ],
-
-        SupportedEnumerableDataPropertyElementTypes =
-        [
-            typeof(bool),
-            typeof(short),
-            typeof(int),
-            typeof(long),
-            typeof(float),
-            typeof(double),
-            typeof(decimal),
-            typeof(string),
-            typeof(DateTime),
-            typeof(DateTimeOffset),
-            typeof(Guid),
-        ],
-
-        SupportedVectorPropertyTypes =
-        [
-            typeof(ReadOnlyMemory<float>),
-            typeof(ReadOnlyMemory<float>?)
-        ]
-    };
-
-    /// <summary>A <see cref="HashSet{T}"/> of types that vector properties on the provided model may have.</summary>
-    public static readonly HashSet<Type> SupportedVectorTypes =
-    [
-        typeof(ReadOnlyMemory<float>),
-        typeof(ReadOnlyMemory<float>?)
-    ];
 
     /// <summary>The default schema name.</summary>
     public const string DefaultSchema = "public";

--- a/dotnet/src/Connectors/Connectors.Memory.PgVector/PostgresDbClient.cs
+++ b/dotnet/src/Connectors/Connectors.Memory.PgVector/PostgresDbClient.cs
@@ -10,7 +10,6 @@ using System.Threading.Tasks;
 using Microsoft.Extensions.VectorData;
 using Microsoft.Extensions.VectorData.ProviderServices;
 using Npgsql;
-using Pgvector;
 
 namespace Microsoft.SemanticKernel.Connectors.PgVector;
 
@@ -185,7 +184,7 @@ internal class PostgresDbClient(NpgsqlDataSource dataSource, string schema = Pos
 
     /// <inheritdoc />
     public async IAsyncEnumerable<(Dictionary<string, object?> Row, double Distance)> GetNearestMatchesAsync<TRecord>(
-        string tableName, CollectionModel model, VectorPropertyModel vectorProperty, Vector vectorValue, int limit,
+        string tableName, CollectionModel model, VectorPropertyModel vectorProperty, object vectorValue, int limit,
         RecordSearchOptions<TRecord> options, [EnumeratorCancellation] CancellationToken cancellationToken = default)
     {
         NpgsqlConnection connection = await this.DataSource.OpenConnectionAsync(cancellationToken).ConfigureAwait(false);

--- a/dotnet/src/Connectors/Connectors.Memory.PgVector/PostgresModelBuilder.cs
+++ b/dotnet/src/Connectors/Connectors.Memory.PgVector/PostgresModelBuilder.cs
@@ -1,0 +1,102 @@
+﻿// Copyright (c) Microsoft. All rights reserved.
+
+using System;
+using System.Collections;
+using System.Collections.Generic;
+using Microsoft.Extensions.AI;
+using Microsoft.Extensions.VectorData.ProviderServices;
+using Pgvector;
+
+namespace Microsoft.SemanticKernel.Connectors.PgVector;
+
+internal class PostgresModelBuilder() : CollectionModelBuilder(PostgresModelBuilder.ModelBuildingOptions)
+{
+    public static readonly HashSet<Type> SupportedVectorTypes =
+    [
+        typeof(ReadOnlyMemory<float>),
+        typeof(ReadOnlyMemory<float>?),
+
+#if NET8_0_OR_GREATER
+        typeof(ReadOnlyMemory<Half>),
+        typeof(ReadOnlyMemory<Half>?),
+#endif
+
+        typeof(BitArray),
+        typeof(SparseVector)
+    ];
+
+    public static readonly CollectionModelBuildingOptions ModelBuildingOptions = new()
+    {
+        RequiresAtLeastOneVector = false,
+        SupportsMultipleKeys = false,
+        SupportsMultipleVectors = true,
+
+        SupportedKeyPropertyTypes =
+        [
+            typeof(short),
+            typeof(int),
+            typeof(long),
+            typeof(string),
+            typeof(Guid)
+        ],
+
+        SupportedDataPropertyTypes =
+        [
+            typeof(bool),
+            typeof(short),
+            typeof(int),
+            typeof(long),
+            typeof(float),
+            typeof(double),
+            typeof(decimal),
+            typeof(string),
+            typeof(DateTime),
+            typeof(DateTimeOffset),
+            typeof(Guid),
+            typeof(byte[]),
+        ],
+
+        SupportedEnumerableDataPropertyElementTypes =
+        [
+            typeof(bool),
+            typeof(short),
+            typeof(int),
+            typeof(long),
+            typeof(float),
+            typeof(double),
+            typeof(decimal),
+            typeof(string),
+            typeof(DateTime),
+            typeof(DateTimeOffset),
+            typeof(Guid)
+        ],
+
+        SupportedVectorPropertyTypes = SupportedVectorTypes
+    };
+
+    /// <inheritdoc />
+    protected override void SetupEmbeddingGeneration(
+        VectorPropertyModel vectorProperty,
+        IEmbeddingGenerator embeddingGenerator,
+        Type? embeddingType)
+    {
+        if (!vectorProperty.TrySetupEmbeddingGeneration<Embedding<float>, ReadOnlyMemory<float>>(embeddingGenerator, embeddingType)
+#if NET8_0_OR_GREATER
+            && !vectorProperty.TrySetupEmbeddingGeneration<Embedding<Half>, ReadOnlyMemory<Half>>(embeddingGenerator, embeddingType)
+#endif
+            )
+        {
+            throw new InvalidOperationException(
+                VectorDataStrings.IncompatibleEmbeddingGenerator(
+                    embeddingGeneratorType: embeddingGenerator.GetType(),
+                    supportedInputTypes: vectorProperty.GetSupportedInputTypes(),
+                    supportedOutputTypes:
+                    [
+                        typeof(ReadOnlyMemory<float>),
+#if NET8_0_OR_GREATER
+                        typeof(ReadOnlyMemory<Half>)
+#endif
+                    ]));
+        }
+    }
+}

--- a/dotnet/src/Connectors/Connectors.Memory.PgVector/PostgresPropertyMapping.cs
+++ b/dotnet/src/Connectors/Connectors.Memory.PgVector/PostgresPropertyMapping.cs
@@ -150,14 +150,14 @@ internal static class PostgresPropertyMapping
 
         var pgType = unwrappedEmbeddingType switch
         {
-            Type t when t == typeof(ReadOnlyMemory<float>) => "vector",
+            Type t when t == typeof(ReadOnlyMemory<float>) => "VECTOR",
 
 #if NET8_0_OR_GREATER
-            Type t when t == typeof(ReadOnlyMemory<Half>) => "halfvec",
+            Type t when t == typeof(ReadOnlyMemory<Half>) => "HALFVEC",
 #endif
 
-            Type t when t == typeof(SparseVector) => "sparsevec",
-            Type t when t == typeof(BitArray) => "bit",
+            Type t when t == typeof(SparseVector) => "SPARSEVEC",
+            Type t when t == typeof(BitArray) => "BIT",
 
             _ => throw new NotSupportedException($"Type {vectorProperty.EmbeddingType.Name} is not supported by this store.")
         };

--- a/dotnet/src/Connectors/Connectors.Memory.PgVector/PostgresPropertyMapping.cs
+++ b/dotnet/src/Connectors/Connectors.Memory.PgVector/PostgresPropertyMapping.cs
@@ -16,7 +16,7 @@ namespace Microsoft.SemanticKernel.Connectors.PgVector;
 
 internal static class PostgresPropertyMapping
 {
-    public static Vector? MapVectorForStorageModel(object? vector)
+    public static object? MapVectorForStorageModel(object? vector)
         => vector switch
         {
             ReadOnlyMemory<float> floatMemory
@@ -24,7 +24,15 @@ internal static class PostgresPropertyMapping
                     MemoryMarshal.TryGetArray(floatMemory, out ArraySegment<float> segment) &&
                     segment.Count == segment.Array!.Length ? segment.Array : floatMemory.ToArray()),
 
-            // TODO: Implement support for Half, binary, sparse embeddings (#11083)
+#if NET8_0_OR_GREATER
+            ReadOnlyMemory<Half> halfMemory
+                => new Pgvector.HalfVector(
+                    MemoryMarshal.TryGetArray(halfMemory, out ArraySegment<Half> segment) &&
+                    segment.Count == segment.Array!.Length ? segment.Array : halfMemory.ToArray()),
+#endif
+
+            BitArray bitArray => bitArray,
+            SparseVector sparseVector => sparseVector,
 
             null => null,
 
@@ -138,32 +146,44 @@ internal static class PostgresPropertyMapping
     /// <returns>The PostgreSQL vector type name.</returns>
     public static (string PgType, bool IsNullable) GetPgVectorTypeName(VectorPropertyModel vectorProperty)
     {
-        return ($"VECTOR({vectorProperty.Dimensions})", Nullable.GetUnderlyingType(vectorProperty.EmbeddingType) != null);
+        var unwrappedEmbeddingType = Nullable.GetUnderlyingType(vectorProperty.EmbeddingType) ?? vectorProperty.EmbeddingType;
+
+        var pgType = unwrappedEmbeddingType switch
+        {
+            Type t when t == typeof(ReadOnlyMemory<float>) => "vector",
+
+#if NET8_0_OR_GREATER
+            Type t when t == typeof(ReadOnlyMemory<Half>) => "halfvec",
+#endif
+
+            Type t when t == typeof(SparseVector) => "sparsevec",
+            Type t when t == typeof(BitArray) => "bit",
+
+            _ => throw new NotSupportedException($"Type {vectorProperty.EmbeddingType.Name} is not supported by this store.")
+        };
+
+        return ($"{pgType}({vectorProperty.Dimensions})", unwrappedEmbeddingType != vectorProperty.EmbeddingType);
     }
 
     public static NpgsqlParameter GetNpgsqlParameter(object? value)
-    {
-        if (value == null)
+        => value switch
         {
-            return new NpgsqlParameter() { Value = DBNull.Value };
-        }
+            null => new NpgsqlParameter { Value = DBNull.Value },
 
-        // If it's an IEnumerable<T>, use reflection to determine if it needs to be converted to a list
-        if (value is IEnumerable enumerable && !(value is string))
-        {
-            Type propertyType = value.GetType();
-            if (propertyType.IsGenericType && propertyType.GetGenericTypeDefinition() == typeof(List<>))
-            {
+            // If it's an IEnumerable<T>, use reflection to determine if it needs to be converted to a list.
+            // Exclude strings which are enumerable (but should not be treated as arrays), and BitArray which
+            // represents a pgvector binary embedding.
+            IEnumerable enumerable and not string and not BitArray when value.GetType() is var propertyType
                 // If it's already a List<T>, return it directly
-                return new NpgsqlParameter() { Value = value };
-            }
+                => new NpgsqlParameter
+                {
+                    Value = propertyType.IsGenericType && propertyType.GetGenericTypeDefinition() == typeof(List<>)
+                        ? value
+                        : ConvertToListIfNecessary(enumerable)
+                },
 
-            return new NpgsqlParameter() { Value = ConvertToListIfNecessary(enumerable) };
-        }
-
-        // Return the value directly if it's not IEnumerable
-        return new NpgsqlParameter() { Value = value };
-    }
+            _ => new NpgsqlParameter { Value = value }
+        };
 
     /// <summary>
     /// Returns information about indexes to create, validating that the dimensions of the vector are supported.

--- a/dotnet/src/Connectors/Connectors.Memory.Qdrant/QdrantMapper.cs
+++ b/dotnet/src/Connectors/Connectors.Memory.Qdrant/QdrantMapper.cs
@@ -64,7 +64,7 @@ internal sealed class QdrantMapper<TRecord>(CollectionModel model, bool hasNamed
                     GetVector(
                         property,
                         generatedEmbeddings?[i] is GeneratedEmbeddings<Embedding<float>> e
-                            ? e[recordIndex]
+                            ? e[recordIndex].Vector
                             : property.GetValueAsObject(dataModel!)));
             }
 

--- a/dotnet/src/Connectors/Connectors.Memory.Redis/RedisJsonMapper.cs
+++ b/dotnet/src/Connectors/Connectors.Memory.Redis/RedisJsonMapper.cs
@@ -74,7 +74,7 @@ internal sealed class RedisJsonMapper<TConsumerDataModel>(
         {
             JsonObject topLevelJsonObject => topLevelJsonObject,
             JsonArray and [JsonObject arrayEntryJsonObject] => arrayEntryJsonObject,
-            JsonValue when model.DataProperties.Count + model.VectorProperties.Count == 1 => new JsonObject
+            JsonValue when model.DataProperties.Count + (includeVectors ? model.VectorProperties.Count : 0) == 1 => new JsonObject
             {
                 [model.DataProperties.Concat<PropertyModel>(model.VectorProperties).First().StorageName] = storageModel.Node
             },

--- a/dotnet/src/Connectors/Connectors.Memory.Weaviate/WeaviateCollectionCreateMapping.cs
+++ b/dotnet/src/Connectors/Connectors.Memory.Weaviate/WeaviateCollectionCreateMapping.cs
@@ -121,7 +121,7 @@ internal static class WeaviateCollectionCreateMapping
             DistanceFunction.CosineDistance => Cosine,
             DistanceFunction.NegativeDotProductSimilarity => Dot,
             DistanceFunction.EuclideanSquaredDistance => EuclideanSquared,
-            DistanceFunction.Hamming => Hamming,
+            DistanceFunction.HammingDistance => Hamming,
             DistanceFunction.ManhattanDistance => Manhattan,
             _ => throw new NotSupportedException(
                 $"Distance function '{distanceFunction}' on {nameof(VectorStoreVectorProperty)} '{vectorPropertyName}' is not supported by the Weaviate VectorStore. " +
@@ -129,7 +129,7 @@ internal static class WeaviateCollectionCreateMapping
                     DistanceFunction.CosineDistance,
                     DistanceFunction.NegativeDotProductSimilarity,
                     DistanceFunction.EuclideanSquaredDistance,
-                    DistanceFunction.Hamming,
+                    DistanceFunction.HammingDistance,
                     DistanceFunction.ManhattanDistance)}")
         };
     }

--- a/dotnet/src/Connectors/Connectors.PgVector.UnitTests/PostgresMapperTests.cs
+++ b/dotnet/src/Connectors/Connectors.PgVector.UnitTests/PostgresMapperTests.cs
@@ -181,7 +181,7 @@ public sealed class PostgresMapperTests
     }
 
     private static CollectionModel GetModel<TRecord>(VectorStoreRecordDefinition definition)
-        => new CollectionModelBuilder(PostgresConstants.ModelBuildingOptions).Build(typeof(TRecord), definition, defaultEmbeddingGenerator: null);
+        => new CollectionModelBuilder(PostgresModelBuilder.ModelBuildingOptions).Build(typeof(TRecord), definition, defaultEmbeddingGenerator: null);
 
 #pragma warning disable CA1812
     private sealed class TestRecord<TKey>

--- a/dotnet/src/Connectors/Connectors.PgVector.UnitTests/PostgresPropertyMappingTests.cs
+++ b/dotnet/src/Connectors/Connectors.PgVector.UnitTests/PostgresPropertyMappingTests.cs
@@ -35,8 +35,8 @@ public sealed class PostgresPropertyMappingTests
         var storageModelVector = PostgresPropertyMapping.MapVectorForStorageModel(vector);
 
         // Assert
-        Assert.IsType<Vector>(storageModelVector);
-        Assert.True(storageModelVector.ToArray().Length > 0);
+        var actual = Assert.IsType<Vector>(storageModelVector);
+        Assert.True(actual.ToArray().Length > 0);
     }
 
     [Fact]

--- a/dotnet/src/Connectors/Connectors.PgVector.UnitTests/PostgresSqlBuilderTests.cs
+++ b/dotnet/src/Connectors/Connectors.PgVector.UnitTests/PostgresSqlBuilderTests.cs
@@ -50,7 +50,7 @@ public class PostgresSqlBuilderTests
             ]
         };
 
-        var model = new CollectionModelBuilder(PostgresConstants.ModelBuildingOptions).Build(typeof(Dictionary<string, object?>), recordDefinition, defaultEmbeddingGenerator: null);
+        var model = new CollectionModelBuilder(PostgresModelBuilder.ModelBuildingOptions).Build(typeof(Dictionary<string, object?>), recordDefinition, defaultEmbeddingGenerator: null);
 
         var cmdInfo = PostgresSqlBuilder.BuildCreateTableCommand("public", "testcollection", model, ifNotExists: ifNotExists);
 
@@ -279,7 +279,7 @@ public class PostgresSqlBuilderTests
             ]
         };
 
-        var model = new CollectionModelBuilder(PostgresConstants.ModelBuildingOptions).Build(typeof(Dictionary<string, object?>), recordDefinition, defaultEmbeddingGenerator: null);
+        var model = new CollectionModelBuilder(PostgresModelBuilder.ModelBuildingOptions).Build(typeof(Dictionary<string, object?>), recordDefinition, defaultEmbeddingGenerator: null);
 
         var key = 123;
 
@@ -324,7 +324,7 @@ public class PostgresSqlBuilderTests
 
         var keys = new List<long> { 123, 124 };
 
-        var model = new CollectionModelBuilder(PostgresConstants.ModelBuildingOptions).Build(typeof(Dictionary<string, object?>), recordDefinition, defaultEmbeddingGenerator: null);
+        var model = new CollectionModelBuilder(PostgresModelBuilder.ModelBuildingOptions).Build(typeof(Dictionary<string, object?>), recordDefinition, defaultEmbeddingGenerator: null);
 
         // Act
         var cmdInfo = PostgresSqlBuilder.BuildGetBatchCommand("public", "testcollection", model, keys, includeVectors: true);

--- a/dotnet/src/Connectors/Connectors.Weaviate.UnitTests/WeaviateCollectionCreateMappingTests.cs
+++ b/dotnet/src/Connectors/Connectors.Weaviate.UnitTests/WeaviateCollectionCreateMappingTests.cs
@@ -90,7 +90,7 @@ public sealed class WeaviateCollectionCreateMappingTests
     [InlineData(DistanceFunction.CosineDistance, "cosine")]
     [InlineData(DistanceFunction.NegativeDotProductSimilarity, "dot")]
     [InlineData(DistanceFunction.EuclideanSquaredDistance, "l2-squared")]
-    [InlineData(DistanceFunction.Hamming, "hamming")]
+    [InlineData(DistanceFunction.HammingDistance, "hamming")]
     [InlineData(DistanceFunction.ManhattanDistance, "manhattan")]
     public void ItReturnsCorrectSchemaWithValidDistanceFunction(string distanceFunction, string expectedDistanceFunction)
     {

--- a/dotnet/src/Connectors/VectorData.Abstractions/RecordDefinition/DistanceFunction.cs
+++ b/dotnet/src/Connectors/VectorData.Abstractions/RecordDefinition/DistanceFunction.cs
@@ -71,7 +71,7 @@ public static class DistanceFunction
     /// <summary>
     /// The number of differences between vectors at each dimensions.
     /// </summary>
-    public const string Hamming = nameof(Hamming);
+    public const string HammingDistance = nameof(HammingDistance);
 
     /// <summary>
     /// Measures the Manhattan distance between two vectors.

--- a/dotnet/src/IntegrationTests/Connectors/Memory/BaseVectorStoreRecordCollectionTests.cs
+++ b/dotnet/src/IntegrationTests/Connectors/Memory/BaseVectorStoreRecordCollectionTests.cs
@@ -36,7 +36,7 @@ public abstract class BaseVectorStoreRecordCollectionTests<TKey>
     [InlineData(DistanceFunction.DotProductSimilarity, 1, -1, 0, new int[] { 0, 2, 1 })]
     [InlineData(DistanceFunction.EuclideanDistance, 0, 2, 1.73, new int[] { 0, 2, 1 })]
     [InlineData(DistanceFunction.EuclideanSquaredDistance, 0, 4, 3, new int[] { 0, 2, 1 })]
-    [InlineData(DistanceFunction.Hamming, 0, 1, 3, new int[] { 0, 1, 2 })]
+    [InlineData(DistanceFunction.HammingDistance, 0, 1, 3, new int[] { 0, 1, 2 })]
     [InlineData(DistanceFunction.ManhattanDistance, 0, 2, 3, new int[] { 0, 1, 2 })]
     public async Task VectorSearchShouldReturnExpectedScoresAsync(string distanceFunction, double expectedExactMatchScore, double expectedOppositeScore, double expectedOrthogonalScore, int[] resultOrder)
     {

--- a/dotnet/src/IntegrationTests/Connectors/Memory/Weaviate/CommonWeaviateVectorStoreRecordCollectionTests.cs
+++ b/dotnet/src/IntegrationTests/Connectors/Memory/Weaviate/CommonWeaviateVectorStoreRecordCollectionTests.cs
@@ -38,6 +38,6 @@ public class CommonWeaviateVectorStoreRecordCollectionTests(WeaviateVectorStoreF
 
     protected override HashSet<string> GetSupportedDistanceFunctions()
     {
-        return [DistanceFunction.CosineDistance, DistanceFunction.NegativeDotProductSimilarity, DistanceFunction.EuclideanSquaredDistance, DistanceFunction.Hamming, DistanceFunction.ManhattanDistance];
+        return [DistanceFunction.CosineDistance, DistanceFunction.NegativeDotProductSimilarity, DistanceFunction.EuclideanSquaredDistance, DistanceFunction.HammingDistance, DistanceFunction.ManhattanDistance];
     }
 }

--- a/dotnet/src/VectorDataIntegrationTests/AzureAISearchIntegrationTests/AzureAISearchEmbeddingTypeTests.cs
+++ b/dotnet/src/VectorDataIntegrationTests/AzureAISearchIntegrationTests/AzureAISearchEmbeddingTypeTests.cs
@@ -1,8 +1,8 @@
 ﻿// Copyright (c) Microsoft. All rights reserved.
 
+using AzureAISearchIntegrationTests.Support;
 using VectorDataSpecificationTests;
 using VectorDataSpecificationTests.Support;
-using AzureAISearchIntegrationTests.Support;
 using Xunit;
 
 #pragma warning disable CA2000 // Dispose objects before losing scope

--- a/dotnet/src/VectorDataIntegrationTests/AzureAISearchIntegrationTests/AzureAISearchEmbeddingTypeTests.cs
+++ b/dotnet/src/VectorDataIntegrationTests/AzureAISearchIntegrationTests/AzureAISearchEmbeddingTypeTests.cs
@@ -1,0 +1,22 @@
+﻿// Copyright (c) Microsoft. All rights reserved.
+
+using VectorDataSpecificationTests;
+using VectorDataSpecificationTests.Support;
+using AzureAISearchIntegrationTests.Support;
+using Xunit;
+
+#pragma warning disable CA2000 // Dispose objects before losing scope
+
+namespace AzureAISearchIntegrationTests;
+
+public class AzureAISearchEmbeddingTypeTests(AzureAISearchEmbeddingTypeTests.Fixture fixture)
+    : EmbeddingTypeTests<string>(fixture), IClassFixture<AzureAISearchEmbeddingTypeTests.Fixture>
+{
+    public new class Fixture : EmbeddingTypeTests<string>.Fixture
+    {
+        public override TestStore TestStore => AzureAISearchTestStore.Instance;
+
+        // Azure AI search only supports lowercase letters, digits or dashes.
+        public override string CollectionName => "embedding-type-tests";
+    }
+}

--- a/dotnet/src/VectorDataIntegrationTests/AzureAISearchIntegrationTests/Support/AzureAISearchTestStore.cs
+++ b/dotnet/src/VectorDataIntegrationTests/AzureAISearchIntegrationTests/Support/AzureAISearchTestStore.cs
@@ -52,9 +52,10 @@ internal sealed class AzureAISearchTestStore : TestStore
         VectorStoreCollection<TKey, TRecord> collection,
         int recordCount,
         Expression<Func<TRecord, bool>>? filter = null,
-        int vectorSize = 3)
+        int? vectorSize = null,
+        object? dummyVector = null)
     {
-        await base.WaitForDataAsync(collection, recordCount, filter, vectorSize);
+        await base.WaitForDataAsync(collection, recordCount, filter, vectorSize, dummyVector);
 
         // There seems to be some asynchronicity/race condition specific to Azure AI Search which isn't taken care
         // of by the generic retry loop in the base implementation.

--- a/dotnet/src/VectorDataIntegrationTests/CosmosMongoDBIntegrationTests/CosmosMongoEmbeddingTypeTests.cs
+++ b/dotnet/src/VectorDataIntegrationTests/CosmosMongoDBIntegrationTests/CosmosMongoEmbeddingTypeTests.cs
@@ -1,0 +1,19 @@
+﻿// Copyright (c) Microsoft. All rights reserved.
+
+using VectorDataSpecificationTests;
+using VectorDataSpecificationTests.Support;
+using CosmosMongoDBIntegrationTests.Support;
+using Xunit;
+
+#pragma warning disable CA2000 // Dispose objects before losing scope
+
+namespace CosmosMongoDBIntegrationTests;
+
+public class CosmosMongoEmbeddingTypeTests(CosmosMongoEmbeddingTypeTests.Fixture fixture)
+    : EmbeddingTypeTests<string>(fixture), IClassFixture<CosmosMongoEmbeddingTypeTests.Fixture>
+{
+    public new class Fixture : EmbeddingTypeTests<string>.Fixture
+    {
+        public override TestStore TestStore => CosmosMongoTestStore.Instance;
+    }
+}

--- a/dotnet/src/VectorDataIntegrationTests/CosmosMongoDBIntegrationTests/CosmosMongoEmbeddingTypeTests.cs
+++ b/dotnet/src/VectorDataIntegrationTests/CosmosMongoDBIntegrationTests/CosmosMongoEmbeddingTypeTests.cs
@@ -1,8 +1,8 @@
 ﻿// Copyright (c) Microsoft. All rights reserved.
 
+using CosmosMongoDBIntegrationTests.Support;
 using VectorDataSpecificationTests;
 using VectorDataSpecificationTests.Support;
-using CosmosMongoDBIntegrationTests.Support;
 using Xunit;
 
 #pragma warning disable CA2000 // Dispose objects before losing scope

--- a/dotnet/src/VectorDataIntegrationTests/CosmosNoSqlIntegrationTests/CosmosNoSqlEmbeddingTypeTests.cs
+++ b/dotnet/src/VectorDataIntegrationTests/CosmosNoSqlIntegrationTests/CosmosNoSqlEmbeddingTypeTests.cs
@@ -1,0 +1,19 @@
+﻿// Copyright (c) Microsoft. All rights reserved.
+
+using VectorDataSpecificationTests;
+using VectorDataSpecificationTests.Support;
+using CosmosNoSqlIntegrationTests.Support;
+using Xunit;
+
+#pragma warning disable CA2000 // Dispose objects before losing scope
+
+namespace CosmosNoSqlIntegrationTests;
+
+public class CosmosNoSqlEmbeddingTypeTests(CosmosNoSqlEmbeddingTypeTests.Fixture fixture)
+    : EmbeddingTypeTests<string>(fixture), IClassFixture<CosmosNoSqlEmbeddingTypeTests.Fixture>
+{
+    public new class Fixture : EmbeddingTypeTests<string>.Fixture
+    {
+        public override TestStore TestStore => CosmosNoSqlTestStore.Instance;
+    }
+}

--- a/dotnet/src/VectorDataIntegrationTests/CosmosNoSqlIntegrationTests/CosmosNoSqlEmbeddingTypeTests.cs
+++ b/dotnet/src/VectorDataIntegrationTests/CosmosNoSqlIntegrationTests/CosmosNoSqlEmbeddingTypeTests.cs
@@ -1,8 +1,8 @@
 ﻿// Copyright (c) Microsoft. All rights reserved.
 
+using CosmosNoSqlIntegrationTests.Support;
 using VectorDataSpecificationTests;
 using VectorDataSpecificationTests.Support;
-using CosmosNoSqlIntegrationTests.Support;
 using Xunit;
 
 #pragma warning disable CA2000 // Dispose objects before losing scope

--- a/dotnet/src/VectorDataIntegrationTests/InMemoryIntegrationTests/InMemoryEmbeddingTypeTests.cs
+++ b/dotnet/src/VectorDataIntegrationTests/InMemoryIntegrationTests/InMemoryEmbeddingTypeTests.cs
@@ -1,8 +1,8 @@
 ﻿// Copyright (c) Microsoft. All rights reserved.
 
+using InMemoryIntegrationTests.Support;
 using VectorDataSpecificationTests;
 using VectorDataSpecificationTests.Support;
-using InMemoryIntegrationTests.Support;
 using Xunit;
 
 #pragma warning disable CA2000 // Dispose objects before losing scope

--- a/dotnet/src/VectorDataIntegrationTests/InMemoryIntegrationTests/InMemoryEmbeddingTypeTests.cs
+++ b/dotnet/src/VectorDataIntegrationTests/InMemoryIntegrationTests/InMemoryEmbeddingTypeTests.cs
@@ -1,0 +1,21 @@
+﻿// Copyright (c) Microsoft. All rights reserved.
+
+using VectorDataSpecificationTests;
+using VectorDataSpecificationTests.Support;
+using InMemoryIntegrationTests.Support;
+using Xunit;
+
+#pragma warning disable CA2000 // Dispose objects before losing scope
+
+namespace InMemoryIntegrationTests;
+
+public class InMemoryEmbeddingTypeTests(InMemoryEmbeddingTypeTests.Fixture fixture)
+    : EmbeddingTypeTests<Guid>(fixture), IClassFixture<InMemoryEmbeddingTypeTests.Fixture>
+{
+    public new class Fixture : EmbeddingTypeTests<Guid>.Fixture
+    {
+        public override TestStore TestStore => InMemoryTestStore.Instance;
+
+        public override bool RecreateCollection => true;
+    }
+}

--- a/dotnet/src/VectorDataIntegrationTests/MongoDBIntegrationTests/MongoDBEmbeddingTypeTests.cs
+++ b/dotnet/src/VectorDataIntegrationTests/MongoDBIntegrationTests/MongoDBEmbeddingTypeTests.cs
@@ -1,0 +1,19 @@
+﻿// Copyright (c) Microsoft. All rights reserved.
+
+using VectorDataSpecificationTests;
+using VectorDataSpecificationTests.Support;
+using MongoDBIntegrationTests.Support;
+using Xunit;
+
+#pragma warning disable CA2000 // Dispose objects before losing scope
+
+namespace MongoDBIntegrationTests;
+
+public class MongoDBEmbeddingTypeTests(MongoDBEmbeddingTypeTests.Fixture fixture)
+    : EmbeddingTypeTests<string>(fixture), IClassFixture<MongoDBEmbeddingTypeTests.Fixture>
+{
+    public new class Fixture : EmbeddingTypeTests<string>.Fixture
+    {
+        public override TestStore TestStore => MongoDBTestStore.Instance;
+    }
+}

--- a/dotnet/src/VectorDataIntegrationTests/MongoDBIntegrationTests/MongoDBEmbeddingTypeTests.cs
+++ b/dotnet/src/VectorDataIntegrationTests/MongoDBIntegrationTests/MongoDBEmbeddingTypeTests.cs
@@ -1,8 +1,8 @@
 ﻿// Copyright (c) Microsoft. All rights reserved.
 
+using MongoDBIntegrationTests.Support;
 using VectorDataSpecificationTests;
 using VectorDataSpecificationTests.Support;
-using MongoDBIntegrationTests.Support;
 using Xunit;
 
 #pragma warning disable CA2000 // Dispose objects before losing scope

--- a/dotnet/src/VectorDataIntegrationTests/PgVectorIntegrationTests/PostgresEmbeddingTypeTests.cs
+++ b/dotnet/src/VectorDataIntegrationTests/PgVectorIntegrationTests/PostgresEmbeddingTypeTests.cs
@@ -1,0 +1,41 @@
+﻿// Copyright (c) Microsoft. All rights reserved.
+
+using System.Collections;
+using Microsoft.Extensions.VectorData;
+using Pgvector;
+using PgVectorIntegrationTests.Support;
+using VectorDataSpecificationTests;
+using VectorDataSpecificationTests.Support;
+using VectorDataSpecificationTests.Xunit;
+using Xunit;
+
+#pragma warning disable CA2000 // Dispose objects before losing scope
+
+namespace PgVectorIntegrationTests;
+
+public class PostgresEmbeddingTypeTests(PostgresEmbeddingTypeTests.Fixture fixture)
+    : EmbeddingTypeTests<int>(fixture), IClassFixture<PostgresEmbeddingTypeTests.Fixture>
+{
+#if NET8_0_OR_GREATER
+    [ConditionalFact]
+    public virtual Task ReadOnlyMemory_of_Half()
+        => this.Test<ReadOnlyMemory<Half>>(
+            new ReadOnlyMemory<Half>([(byte)1, (byte)2, (byte)3]),
+            new ReadOnlyMemoryEmbeddingGenerator<Half>(new([(byte)1, (byte)2, (byte)3])));
+#endif
+
+    // TODO: Figure out the embedding generation story for binaryvec/sparsevec - need an Embedding wrapper
+
+    [ConditionalFact]
+    public virtual Task BitArray()
+        => this.Test<BitArray>(new BitArray([true, false, true]), distanceFunction: DistanceFunction.HammingDistance, embeddingGenerator: null);
+
+    [ConditionalFact]
+    public virtual Task SparseVector()
+        => this.Test<SparseVector>(new SparseVector(new ReadOnlyMemory<float>([1, 2, 3])), embeddingGenerator: null);
+
+    public new class Fixture : EmbeddingTypeTests<int>.Fixture
+    {
+        public override TestStore TestStore => PostgresTestStore.Instance;
+    }
+}

--- a/dotnet/src/VectorDataIntegrationTests/PgVectorIntegrationTests/VectorSearch/PostgresVectorSearchDistanceFunctionComplianceTests.cs
+++ b/dotnet/src/VectorDataIntegrationTests/PgVectorIntegrationTests/VectorSearch/PostgresVectorSearchDistanceFunctionComplianceTests.cs
@@ -10,7 +10,7 @@ public class PostgresVectorSearchDistanceFunctionComplianceTests(PostgresFixture
 {
     public override Task EuclideanSquaredDistance() => Assert.ThrowsAsync<NotSupportedException>(base.EuclideanSquaredDistance);
 
-    public override Task Hamming() => Assert.ThrowsAsync<NotSupportedException>(base.Hamming);
+    public override Task HammingDistance() => Assert.ThrowsAsync<NotSupportedException>(base.HammingDistance);
 
     public override Task NegativeDotProductSimilarity() => Assert.ThrowsAsync<NotSupportedException>(base.NegativeDotProductSimilarity);
 }

--- a/dotnet/src/VectorDataIntegrationTests/PineconeIntegrationTests/PineconeEmbeddingTypeTests.cs
+++ b/dotnet/src/VectorDataIntegrationTests/PineconeIntegrationTests/PineconeEmbeddingTypeTests.cs
@@ -1,8 +1,8 @@
 ﻿// Copyright (c) Microsoft. All rights reserved.
 
+using PineconeIntegrationTests.Support;
 using VectorDataSpecificationTests;
 using VectorDataSpecificationTests.Support;
-using PineconeIntegrationTests.Support;
 using Xunit;
 
 #pragma warning disable CA2000 // Dispose objects before losing scope

--- a/dotnet/src/VectorDataIntegrationTests/PineconeIntegrationTests/PineconeEmbeddingTypeTests.cs
+++ b/dotnet/src/VectorDataIntegrationTests/PineconeIntegrationTests/PineconeEmbeddingTypeTests.cs
@@ -1,0 +1,22 @@
+﻿// Copyright (c) Microsoft. All rights reserved.
+
+using VectorDataSpecificationTests;
+using VectorDataSpecificationTests.Support;
+using PineconeIntegrationTests.Support;
+using Xunit;
+
+#pragma warning disable CA2000 // Dispose objects before losing scope
+
+namespace PineconeIntegrationTests;
+
+public class PineconeEmbeddingTypeTests(PineconeEmbeddingTypeTests.Fixture fixture)
+    : EmbeddingTypeTests<string>(fixture), IClassFixture<PineconeEmbeddingTypeTests.Fixture>
+{
+    public new class Fixture : EmbeddingTypeTests<string>.Fixture
+    {
+        public override TestStore TestStore => PineconeTestStore.Instance;
+
+        // https://docs.pinecone.io/troubleshooting/restrictions-on-index-names
+        public override string CollectionName => "embedding-type-tests";
+    }
+}

--- a/dotnet/src/VectorDataIntegrationTests/PineconeIntegrationTests/VectorSearch/PineconeVectorSearchDistanceFunctionComplianceTests.cs
+++ b/dotnet/src/VectorDataIntegrationTests/PineconeIntegrationTests/VectorSearch/PineconeVectorSearchDistanceFunctionComplianceTests.cs
@@ -33,8 +33,8 @@ public class PineconeVectorSearchDistanceFunctionComplianceTests(PineconeFixture
         await ArtificialDelayToWorkaroundEmulatorLimitations();
     }
 
-    public override Task Hamming()
-        => Assert.ThrowsAsync<NotSupportedException>(base.Hamming);
+    public override Task HammingDistance()
+        => Assert.ThrowsAsync<NotSupportedException>(base.HammingDistance);
 
     public override Task ManhattanDistance()
         => Assert.ThrowsAsync<NotSupportedException>(base.ManhattanDistance);

--- a/dotnet/src/VectorDataIntegrationTests/QdrantIntegrationTests/QdrantEmbeddingTypeTests.cs
+++ b/dotnet/src/VectorDataIntegrationTests/QdrantIntegrationTests/QdrantEmbeddingTypeTests.cs
@@ -1,8 +1,8 @@
 ﻿// Copyright (c) Microsoft. All rights reserved.
 
+using QdrantIntegrationTests.Support;
 using VectorDataSpecificationTests;
 using VectorDataSpecificationTests.Support;
-using QdrantIntegrationTests.Support;
 using Xunit;
 
 #pragma warning disable CA2000 // Dispose objects before losing scope

--- a/dotnet/src/VectorDataIntegrationTests/QdrantIntegrationTests/QdrantEmbeddingTypeTests.cs
+++ b/dotnet/src/VectorDataIntegrationTests/QdrantIntegrationTests/QdrantEmbeddingTypeTests.cs
@@ -1,0 +1,19 @@
+﻿// Copyright (c) Microsoft. All rights reserved.
+
+using VectorDataSpecificationTests;
+using VectorDataSpecificationTests.Support;
+using QdrantIntegrationTests.Support;
+using Xunit;
+
+#pragma warning disable CA2000 // Dispose objects before losing scope
+
+namespace QdrantIntegrationTests;
+
+public class QdrantEmbeddingTypeTests(QdrantEmbeddingTypeTests.Fixture fixture)
+    : EmbeddingTypeTests<Guid>(fixture), IClassFixture<QdrantEmbeddingTypeTests.Fixture>
+{
+    public new class Fixture : EmbeddingTypeTests<Guid>.Fixture
+    {
+        public override TestStore TestStore => QdrantTestStore.NamedVectorsInstance;
+    }
+}

--- a/dotnet/src/VectorDataIntegrationTests/RedisIntegrationTests/RedisHashSetEmbeddingTypeTests.cs
+++ b/dotnet/src/VectorDataIntegrationTests/RedisIntegrationTests/RedisHashSetEmbeddingTypeTests.cs
@@ -1,0 +1,19 @@
+﻿// Copyright (c) Microsoft. All rights reserved.
+
+using VectorDataSpecificationTests;
+using VectorDataSpecificationTests.Support;
+using RedisIntegrationTests.Support;
+using Xunit;
+
+#pragma warning disable CA2000 // Dispose objects before losing scope
+
+namespace RedisIntegrationTests;
+
+public class RedisHashSetEmbeddingTypeTests(RedisHashSetEmbeddingTypeTests.Fixture fixture)
+    : EmbeddingTypeTests<string>(fixture), IClassFixture<RedisHashSetEmbeddingTypeTests.Fixture>
+{
+    public new class Fixture : EmbeddingTypeTests<string>.Fixture
+    {
+        public override TestStore TestStore => RedisTestStore.HashSetInstance;
+    }
+}

--- a/dotnet/src/VectorDataIntegrationTests/RedisIntegrationTests/RedisHashSetEmbeddingTypeTests.cs
+++ b/dotnet/src/VectorDataIntegrationTests/RedisIntegrationTests/RedisHashSetEmbeddingTypeTests.cs
@@ -1,8 +1,8 @@
 ﻿// Copyright (c) Microsoft. All rights reserved.
 
+using RedisIntegrationTests.Support;
 using VectorDataSpecificationTests;
 using VectorDataSpecificationTests.Support;
-using RedisIntegrationTests.Support;
 using Xunit;
 
 #pragma warning disable CA2000 // Dispose objects before losing scope

--- a/dotnet/src/VectorDataIntegrationTests/RedisIntegrationTests/RedisJsonEmbeddingTypeTests.cs
+++ b/dotnet/src/VectorDataIntegrationTests/RedisIntegrationTests/RedisJsonEmbeddingTypeTests.cs
@@ -1,8 +1,8 @@
 ﻿// Copyright (c) Microsoft. All rights reserved.
 
+using RedisIntegrationTests.Support;
 using VectorDataSpecificationTests;
 using VectorDataSpecificationTests.Support;
-using RedisIntegrationTests.Support;
 using Xunit;
 
 #pragma warning disable CA2000 // Dispose objects before losing scope

--- a/dotnet/src/VectorDataIntegrationTests/RedisIntegrationTests/RedisJsonEmbeddingTypeTests.cs
+++ b/dotnet/src/VectorDataIntegrationTests/RedisIntegrationTests/RedisJsonEmbeddingTypeTests.cs
@@ -1,0 +1,19 @@
+﻿// Copyright (c) Microsoft. All rights reserved.
+
+using VectorDataSpecificationTests;
+using VectorDataSpecificationTests.Support;
+using RedisIntegrationTests.Support;
+using Xunit;
+
+#pragma warning disable CA2000 // Dispose objects before losing scope
+
+namespace RedisIntegrationTests;
+
+public class RedisJsonEmbeddingTypeTests(RedisJsonEmbeddingTypeTests.Fixture fixture)
+    : EmbeddingTypeTests<string>(fixture), IClassFixture<RedisJsonEmbeddingTypeTests.Fixture>
+{
+    public new class Fixture : EmbeddingTypeTests<string>.Fixture
+    {
+        public override TestStore TestStore => RedisTestStore.JsonInstance;
+    }
+}

--- a/dotnet/src/VectorDataIntegrationTests/SqlServerIntegrationTests/SqlServerEmbeddingTypeTests.cs
+++ b/dotnet/src/VectorDataIntegrationTests/SqlServerIntegrationTests/SqlServerEmbeddingTypeTests.cs
@@ -1,0 +1,19 @@
+﻿// Copyright (c) Microsoft. All rights reserved.
+
+using VectorDataSpecificationTests;
+using VectorDataSpecificationTests.Support;
+using SqlServerIntegrationTests.Support;
+using Xunit;
+
+#pragma warning disable CA2000 // Dispose objects before losing scope
+
+namespace SqlServerIntegrationTests;
+
+public class SqlServerEmbeddingTypeTests(SqlServerEmbeddingTypeTests.Fixture fixture)
+    : EmbeddingTypeTests<Guid>(fixture), IClassFixture<SqlServerEmbeddingTypeTests.Fixture>
+{
+    public new class Fixture : EmbeddingTypeTests<Guid>.Fixture
+    {
+        public override TestStore TestStore => SqlServerTestStore.Instance;
+    }
+}

--- a/dotnet/src/VectorDataIntegrationTests/SqlServerIntegrationTests/SqlServerEmbeddingTypeTests.cs
+++ b/dotnet/src/VectorDataIntegrationTests/SqlServerIntegrationTests/SqlServerEmbeddingTypeTests.cs
@@ -1,8 +1,8 @@
 ﻿// Copyright (c) Microsoft. All rights reserved.
 
+using SqlServerIntegrationTests.Support;
 using VectorDataSpecificationTests;
 using VectorDataSpecificationTests.Support;
-using SqlServerIntegrationTests.Support;
 using Xunit;
 
 #pragma warning disable CA2000 // Dispose objects before losing scope

--- a/dotnet/src/VectorDataIntegrationTests/SqlServerIntegrationTests/VectorSearch/SqlServerVectorSearchDistanceFunctionComplianceTests.cs
+++ b/dotnet/src/VectorDataIntegrationTests/SqlServerIntegrationTests/VectorSearch/SqlServerVectorSearchDistanceFunctionComplianceTests.cs
@@ -15,7 +15,7 @@ public class SqlServerVectorSearchDistanceFunctionComplianceTests(SqlServerFixtu
 
     public override Task EuclideanSquaredDistance() => Assert.ThrowsAsync<NotSupportedException>(base.EuclideanSquaredDistance);
 
-    public override Task Hamming() => Assert.ThrowsAsync<NotSupportedException>(base.Hamming);
+    public override Task HammingDistance() => Assert.ThrowsAsync<NotSupportedException>(base.HammingDistance);
 
     public override Task ManhattanDistance() => Assert.ThrowsAsync<NotSupportedException>(base.ManhattanDistance);
 }

--- a/dotnet/src/VectorDataIntegrationTests/SqliteVecIntegrationTests/SqliteEmbeddingTypeTests.cs
+++ b/dotnet/src/VectorDataIntegrationTests/SqliteVecIntegrationTests/SqliteEmbeddingTypeTests.cs
@@ -1,0 +1,19 @@
+﻿// Copyright (c) Microsoft. All rights reserved.
+
+using VectorDataSpecificationTests;
+using VectorDataSpecificationTests.Support;
+using SqliteVecIntegrationTests.Support;
+using Xunit;
+
+#pragma warning disable CA2000 // Dispose objects before losing scope
+
+namespace SqliteIntegrationTests;
+
+public class SqliteEmbeddingTypeTests(SqliteEmbeddingTypeTests.Fixture fixture)
+    : EmbeddingTypeTests<string>(fixture), IClassFixture<SqliteEmbeddingTypeTests.Fixture>
+{
+    public new class Fixture : EmbeddingTypeTests<string>.Fixture
+    {
+        public override TestStore TestStore => SqliteTestStore.Instance;
+    }
+}

--- a/dotnet/src/VectorDataIntegrationTests/SqliteVecIntegrationTests/SqliteEmbeddingTypeTests.cs
+++ b/dotnet/src/VectorDataIntegrationTests/SqliteVecIntegrationTests/SqliteEmbeddingTypeTests.cs
@@ -1,8 +1,8 @@
 ﻿// Copyright (c) Microsoft. All rights reserved.
 
+using SqliteVecIntegrationTests.Support;
 using VectorDataSpecificationTests;
 using VectorDataSpecificationTests.Support;
-using SqliteVecIntegrationTests.Support;
 using Xunit;
 
 #pragma warning disable CA2000 // Dispose objects before losing scope

--- a/dotnet/src/VectorDataIntegrationTests/VectorDataIntegrationTests/EmbeddingTypeTests.cs
+++ b/dotnet/src/VectorDataIntegrationTests/VectorDataIntegrationTests/EmbeddingTypeTests.cs
@@ -1,0 +1,136 @@
+﻿// Copyright (c) Microsoft. All rights reserved.
+
+using Microsoft.Extensions.AI;
+using Microsoft.Extensions.VectorData;
+using VectorDataSpecificationTests.Support;
+using VectorDataSpecificationTests.Xunit;
+using Xunit;
+
+#pragma warning disable CS8618 // Non-nullable field must contain a non-null value when exiting constructor. Consider adding the 'required' modifier or declaring as nullable.
+#pragma warning disable CA2000 // Dispose objects before losing scope
+
+namespace VectorDataSpecificationTests;
+
+/// <summary>
+/// Tests that the various embedding types natively supported by the provider (<c>ReadOnlyMemory&lt;float&gt;</c>, <c>ReadOnlyMemory&lt;Half&gt;</c>...) work correctly.
+/// </summary>
+public abstract class EmbeddingTypeTests<TKey>(EmbeddingTypeTests<TKey>.Fixture fixture)
+    where TKey : notnull
+{
+    [ConditionalFact]
+    public virtual Task ReadOnlyMemory_of_float()
+        => this.Test<ReadOnlyMemory<float>>(
+            new ReadOnlyMemory<float>([1, 2, 3]),
+            new ReadOnlyMemoryEmbeddingGenerator<float>(new([1, 2, 3])));
+
+    protected virtual async Task Test<TVector>(TVector value, IEmbeddingGenerator? embeddingGenerator = null, string? distanceFunction = null, int dimensions = 3)
+        where TVector : notnull
+    {
+        var collection = fixture.VectorStore.GetCollection<TKey, Record<TVector>>(fixture.CollectionName, fixture.CreateRecordDefinition<TVector>(embeddingGenerator: null, distanceFunction, dimensions));
+
+        await collection.DeleteCollectionAsync();
+        await collection.CreateCollectionAsync();
+
+        var key = fixture.GenerateNextKey<TKey>();
+        var record = new Record<TVector>
+        {
+            Key = key,
+            Vector = value,
+            Int = 42
+        };
+
+        await collection.UpsertAsync(record);
+
+        await fixture.TestStore.WaitForDataAsync(collection, recordCount: 1, dummyVector: value);
+
+        var result1 = await collection.GetAsync(key, new() { IncludeVectors = true });
+        Assert.Equal(42, result1!.Int);
+
+        var result2 = await collection.SearchEmbeddingAsync(value, top: 1, new() { IncludeVectors = true }).SingleAsync();
+        Assert.Equal(42, result2.Record.Int);
+
+        // Test embedding generation
+        if (embeddingGenerator is not null)
+        {
+            if (fixture.RecreateCollection)
+            {
+                await collection.DeleteCollectionAsync();
+            }
+            else
+            {
+                await collection.DeleteAsync(key);
+            }
+
+            var collection2 = fixture.VectorStore.GetCollection<TKey, RecordWithString>(fixture.CollectionName, fixture.CreateRecordDefinition<string>(embeddingGenerator, distanceFunction, dimensions));
+
+            if (fixture.RecreateCollection)
+            {
+                await collection2.CreateCollectionAsync();
+            }
+
+            var key2 = fixture.GenerateNextKey<TKey>();
+            var record2 = new RecordWithString
+            {
+                Key = key,
+                Vector = "does not matter",
+                Int = 43
+            };
+
+            await collection2.UpsertAsync(record2);
+
+            await fixture.TestStore.WaitForDataAsync(collection2, recordCount: 1, dummyVector: value);
+
+            var result3 = await collection2.GetAsync(key);
+            Assert.Equal(43, result3!.Int);
+
+            var result4 = await collection2.SearchAsync("does not matter", top: 1).SingleAsync();
+            Assert.Equal(43, result4.Record.Int);
+        }
+    }
+
+    protected sealed class ReadOnlyMemoryEmbeddingGenerator<T>(ReadOnlyMemory<T> data) : IEmbeddingGenerator<string, Embedding<T>>
+    {
+        public Task<GeneratedEmbeddings<Embedding<T>>> GenerateAsync(IEnumerable<string> values, EmbeddingGenerationOptions? options = null, CancellationToken cancellationToken = default)
+            => Task.FromResult(new GeneratedEmbeddings<Embedding<T>>([new(data)]));
+
+        public object? GetService(Type serviceType, object? serviceKey = null) => null;
+        public void Dispose() { }
+    }
+
+    public class RecordWithString
+    {
+        public TKey Key { get; set; }
+        public string Vector { get; set; }
+        public int Int { get; set; }
+    }
+
+    public class Record<TVector>
+    {
+        public TKey Key { get; set; }
+        public TVector Vector { get; set; }
+        public int Int { get; set; }
+    }
+
+    public abstract class Fixture : VectorStoreFixture
+    {
+        public virtual string CollectionName => "EmbeddingTypeTests";
+
+        public virtual VectorStoreRecordDefinition CreateRecordDefinition<TVectorProperty>(IEmbeddingGenerator? embeddingGenerator, string? distanceFunction, int dimensions)
+            => new()
+            {
+                Properties =
+                [
+                    new VectorStoreKeyProperty("Key", typeof(TKey)),
+                    new VectorStoreVectorProperty("Vector", typeof(TVectorProperty), dimensions)
+                    {
+                        DistanceFunction = distanceFunction ?? this.DefaultDistanceFunction,
+                        IndexKind = this.DefaultIndexKind
+                    },
+                    new VectorStoreDataProperty("Int", typeof(int))
+                ],
+                EmbeddingGenerator = embeddingGenerator
+            };
+
+        public virtual bool RecreateCollection => false;
+    }
+}

--- a/dotnet/src/VectorDataIntegrationTests/VectorDataIntegrationTests/Support/TestStore.cs
+++ b/dotnet/src/VectorDataIntegrationTests/VectorDataIntegrationTests/Support/TestStore.cs
@@ -78,20 +78,22 @@ public abstract class TestStore
         VectorStoreCollection<TKey, TRecord> collection,
         int recordCount,
         Expression<Func<TRecord, bool>>? filter = null,
-        int vectorSize = 3)
+        int? vectorSize = null,
+        object? dummyVector = null)
         where TKey : notnull
         where TRecord : class
     {
-        var vector = new float[vectorSize];
-        for (var i = 0; i < vectorSize; i++)
+        if (vectorSize is not null && dummyVector is not null)
         {
-            vector[i] = 1.0f;
+            throw new ArgumentException("vectorSize or dummyVector can't both be set");
         }
+
+        var vector = dummyVector ?? new ReadOnlyMemory<float>(Enumerable.Range(0, vectorSize ?? 3).Select(i => (float)i).ToArray());
 
         for (var i = 0; i < 20; i++)
         {
             var results = collection.SearchEmbeddingAsync(
-                new ReadOnlyMemory<float>(vector),
+                vector,
                 top: recordCount,
                 new() { Filter = filter });
             var count = await results.CountAsync();

--- a/dotnet/src/VectorDataIntegrationTests/VectorDataIntegrationTests/Support/VectorStoreFixture.cs
+++ b/dotnet/src/VectorDataIntegrationTests/VectorDataIntegrationTests/Support/VectorStoreFixture.cs
@@ -1,5 +1,6 @@
 ﻿// Copyright (c) Microsoft. All rights reserved.
 
+using Microsoft.Extensions.VectorData;
 using Xunit;
 
 namespace VectorDataSpecificationTests.Support;
@@ -9,6 +10,7 @@ public abstract class VectorStoreFixture : IAsyncLifetime
     private int _nextKeyValue = 1;
 
     public abstract TestStore TestStore { get; }
+    public virtual VectorStore VectorStore => this.TestStore.DefaultVectorStore;
 
     public virtual string DefaultDistanceFunction => this.TestStore.DefaultDistanceFunction;
     public virtual string DefaultIndexKind => this.TestStore.DefaultIndexKind;

--- a/dotnet/src/VectorDataIntegrationTests/VectorDataIntegrationTests/VectorSearch/VectorSearchDistanceFunctionComplianceTests.cs
+++ b/dotnet/src/VectorDataIntegrationTests/VectorDataIntegrationTests/VectorSearch/VectorSearchDistanceFunctionComplianceTests.cs
@@ -35,8 +35,8 @@ public abstract class VectorSearchDistanceFunctionComplianceTests<TKey>(VectorSt
         => this.SimpleSearch(DistanceFunction.EuclideanSquaredDistance, 0, 4, 3, [0, 2, 1]);
 
     [ConditionalFact]
-    public virtual Task Hamming()
-        => this.SimpleSearch(DistanceFunction.Hamming, 0, 1, 3, [0, 1, 2]);
+    public virtual Task HammingDistance()
+        => this.SimpleSearch(DistanceFunction.HammingDistance, 0, 1, 3, [0, 1, 2]);
 
     [ConditionalFact]
     public virtual Task ManhattanDistance()

--- a/dotnet/src/VectorDataIntegrationTests/WeaviateIntegrationTests/WeaviateEmbeddingTypeTests.cs
+++ b/dotnet/src/VectorDataIntegrationTests/WeaviateIntegrationTests/WeaviateEmbeddingTypeTests.cs
@@ -1,0 +1,19 @@
+﻿// Copyright (c) Microsoft. All rights reserved.
+
+using VectorDataSpecificationTests;
+using VectorDataSpecificationTests.Support;
+using WeaviateIntegrationTests.Support;
+using Xunit;
+
+#pragma warning disable CA2000 // Dispose objects before losing scope
+
+namespace WeaviateIntegrationTests;
+
+public class WeaviateEmbeddingTypeTests(WeaviateEmbeddingTypeTests.Fixture fixture)
+    : EmbeddingTypeTests<Guid>(fixture), IClassFixture<WeaviateEmbeddingTypeTests.Fixture>
+{
+    public new class Fixture : EmbeddingTypeTests<Guid>.Fixture
+    {
+        public override TestStore TestStore => WeaviateTestStore.NamedVectorsInstance;
+    }
+}


### PR DESCRIPTION
~**NOTE: This PR is based on top of #11918, review last commit only**~

* This bumps the pgvector dependency and adds support for Half, binary and sparse embeddings.
* A big part of the motivation here was to confirm that the embedding and embedding generation machinery actually works well for non-default embedding types.

Closes #11083