### PR TITLE
Exclude python and net samples folders

### DIFF
--- a/.github/.linkspector.yml
+++ b/.github/.linkspector.yml
@@ -21,7 +21,7 @@ excludedDirs:
   - ./dotnet/samples/Demos/CopilotAgentPlugins
   # Exclude folders that contains documents with links prone to becoming broken and temporarily unavailable. This should be removed when the link checker is implemented as a background job that does not block PRs.
   - ./docs/decisions/
-  - ./dotnet/samples
+  - ./dotnet/samples/
   - ./python/samples/
 baseUrl: https://github.com/microsoft/semantic-kernel/
 aliveStatusCodes: 

--- a/.github/.linkspector.yml
+++ b/.github/.linkspector.yml
@@ -19,8 +19,10 @@ excludedDirs:
   - ./python/samples/demos/process_with_dapr
   - ./dotnet/samples/Demos/ProcessWithDapr
   - ./dotnet/samples/Demos/CopilotAgentPlugins
-  # Exclude the decisions folder that contains documents with links prone to becoming broken and temporarily unavailable. This should be removed when the link checker is implemented as a background job that does not block PRs.
+  # Exclude folders that contains documents with links prone to becoming broken and temporarily unavailable. This should be removed when the link checker is implemented as a background job that does not block PRs.
   - ./docs/decisions/
+  - ./dotnet/samples
+  - ./python/samples/
 baseUrl: https://github.com/microsoft/semantic-kernel/
 aliveStatusCodes: 
   - 200

--- a/.github/.linkspector.yml
+++ b/.github/.linkspector.yml
@@ -20,9 +20,9 @@ excludedDirs:
   - ./dotnet/samples/Demos/ProcessWithDapr
   - ./dotnet/samples/Demos/CopilotAgentPlugins
   # Exclude folders that contains documents with links prone to becoming broken and temporarily unavailable. This should be removed when the link checker is implemented as a background job that does not block PRs.
-  - ./docs/decisions/
-  - ./dotnet/samples/
-  - ./python/samples/
+  - ./docs/decisions
+  - ./dotnet/samples
+  - ./python/samples
 baseUrl: https://github.com/microsoft/semantic-kernel/
 aliveStatusCodes: 
   - 200


### PR DESCRIPTION
### Motivation, Context and Description

This PR excludes the `./dotnet/samples/` and `./python/samples/` folders from being inspected by the markdown link checker because some of the links become temporarily unavailable and block PRs.
