### PR TITLE
.Net: Obsolete `ITextEmbeddingGenerationService` Phase 1 

### DIFF
--- a/dotnet/samples/Concepts/Memory/VectorStore_VectorSearch_MultiStore_InMemory.cs
+++ b/dotnet/samples/Concepts/Memory/VectorStore_VectorSearch_MultiStore_InMemory.cs
@@ -30,7 +30,7 @@ public class VectorStore_VectorSearch_MultiStore_InMemory(ITestOutputHelper outp
             .CreateBuilder();
 
         // Register an embedding generation service with the DI container.
-        kernelBuilder.AddAzureOpenAITextEmbeddingGeneration(
+        kernelBuilder.AddAzureOpenAIEmbeddingGenerator(
             deploymentName: TestConfiguration.AzureOpenAIEmbeddings.DeploymentName,
             endpoint: TestConfiguration.AzureOpenAIEmbeddings.Endpoint,
             credential: new AzureCliCredential());
@@ -50,7 +50,7 @@ public class VectorStore_VectorSearch_MultiStore_InMemory(ITestOutputHelper outp
 
         // Run the process and pass a key generator function to it, to generate unique record keys.
         // The key generator function is required, since different vector stores may require different key types.
-        // E.g. InMemory supports any comparible type, but others may only support string or Guid or ulong, etc.
+        // E.g. InMemory supports any compatible type, but others may only support string or Guid or ulong, etc.
         // For this example we'll use int.
         var uniqueId = 0;
         await processor.IngestDataAndSearchAsync("skglossaryWithDI", () => uniqueId++);
@@ -73,7 +73,7 @@ public class VectorStore_VectorSearch_MultiStore_InMemory(ITestOutputHelper outp
 
         // Run the process and pass a key generator function to it, to generate unique record keys.
         // The key generator function is required, since different vector stores may require different key types.
-        // E.g. InMemory supports any comparible type, but others may only support string or Guid or ulong, etc.
+        // E.g. InMemory supports any compatible type, but others may only support string or Guid or ulong, etc.
         // For this example we'll use int.
         var uniqueId = 0;
         await processor.IngestDataAndSearchAsync("skglossaryWithoutDI", () => uniqueId++);

--- a/dotnet/samples/Demos/ModelContextProtocolClientServer/MCPServer/Extensions/VectorStoreExtensions.cs
+++ b/dotnet/samples/Demos/ModelContextProtocolClientServer/MCPServer/Extensions/VectorStoreExtensions.cs
@@ -1,7 +1,7 @@
 ﻿// Copyright (c) Microsoft. All rights reserved.
 
+using Microsoft.Extensions.AI;
 using Microsoft.Extensions.VectorData;
-using Microsoft.SemanticKernel.Embeddings;
 
 namespace MCPServer;
 
@@ -25,14 +25,14 @@ public static class VectorStoreExtensions
     /// <param name="vectorStore">The instance of <see cref="IVectorStore"/> used to create the collection.</param>
     /// <param name="collectionName">The name of the collection.</param>
     /// <param name="entries">The list of strings to create records from.</param>
-    /// <param name="embeddingGenerationService">The text embedding generation service.</param>
+    /// <param name="embeddingGenerator">The text embedding generation service.</param>
     /// <param name="createRecord">The delegate which can create a record for each string and its embedding.</param>
     /// <returns>The created collection.</returns>
     public static async Task<IVectorStoreRecordCollection<TKey, TRecord>> CreateCollectionFromListAsync<TKey, TRecord>(
         this IVectorStore vectorStore,
         string collectionName,
         string[] entries,
-        ITextEmbeddingGenerationService embeddingGenerationService,
+        IEmbeddingGenerator<string, Embedding<float>> embeddingGenerator,
         CreateRecordFromString<TKey, TRecord> createRecord)
         where TKey : notnull
         where TRecord : notnull
@@ -44,7 +44,7 @@ public static class VectorStoreExtensions
         // Create records and generate embeddings for them.
         var tasks = entries.Select(entry => Task.Run(async () =>
         {
-            var record = createRecord(entry, await embeddingGenerationService.GenerateEmbeddingAsync(entry).ConfigureAwait(false));
+            var record = createRecord(entry, (await embeddingGenerator.GenerateAsync(entry).ConfigureAwait(false)).Vector);
             await collection.UpsertAsync(record).ConfigureAwait(false);
         }));
         await Task.WhenAll(tasks).ConfigureAwait(false);

--- a/dotnet/samples/Demos/OnnxSimpleRAG/Program.cs
+++ b/dotnet/samples/Demos/OnnxSimpleRAG/Program.cs
@@ -3,6 +3,7 @@
 using System;
 using System.IO;
 using System.Linq;
+using Microsoft.Extensions.AI;
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.VectorData;
 using Microsoft.ML.OnnxRuntimeGenAI;
@@ -11,7 +12,6 @@ using Microsoft.SemanticKernel.ChatCompletion;
 using Microsoft.SemanticKernel.Connectors.InMemory;
 using Microsoft.SemanticKernel.Connectors.Onnx;
 using Microsoft.SemanticKernel.Data;
-using Microsoft.SemanticKernel.Embeddings;
 using Microsoft.SemanticKernel.PromptTemplates.Handlebars;
 
 Console.OutputEncoding = System.Text.Encoding.UTF8;
@@ -36,17 +36,17 @@ using var ogaHandle = new OgaHandle();
 // Load the services
 var builder = Kernel.CreateBuilder()
     .AddOnnxRuntimeGenAIChatCompletion(chatModelId, chatModelPath)
-    .AddBertOnnxTextEmbeddingGeneration(embeddingModelPath, embeddingVocabPath);
+    .AddBertOnnxEmbeddingGenerator(embeddingModelPath, embeddingVocabPath);
 
 // Build Kernel
 var kernel = builder.Build();
 
 // Get the instances of the services
 using var chatService = kernel.GetRequiredService<IChatCompletionService>() as OnnxRuntimeGenAIChatCompletionService;
-var embeddingService = kernel.GetRequiredService<ITextEmbeddingGenerationService>();
+var embeddingService = kernel.GetRequiredService<IEmbeddingGenerator<string, Embedding<float>>>();
 
 // Create a vector store and a collection to store information
-var vectorStore = new InMemoryVectorStore();
+var vectorStore = new InMemoryVectorStore(new() { EmbeddingGenerator = embeddingService });
 var collection = vectorStore.GetCollection<string, InformationItem>("ExampleCollection");
 await collection.CreateCollectionIfNotExistsAsync();
 
@@ -58,15 +58,14 @@ foreach (var factTextFile in Directory.GetFiles("Facts", "*.txt"))
     await collection.UpsertAsync(new InformationItem()
     {
         Id = Guid.NewGuid().ToString(),
-        Text = factContent,
-        Embedding = await embeddingService.GenerateEmbeddingAsync(factContent)
+        Text = factContent
     });
 }
 
 // Add a plugin to search the database with.
 // TODO: Once OpenAITextEmbeddingGenerationService implements MEAI's IEmbeddingGenerator (#10811), configure it with the InMemoryVectorStore above instead of passing it here.
-#pragma warning disable CS0618 // VectorStoreTextSearch with ITextEmbeddingGenerationService is obsolete
-var vectorStoreTextSearch = new VectorStoreTextSearch<InformationItem>(collection, embeddingService);
+#pragma warning disable CS0618 // VectorStoreTextSearch with ITextEmbeddingGenerationService is obsolete.
+var vectorStoreTextSearch = new VectorStoreTextSearch<InformationItem>(collection);//, (embeddingService as ITextEmbeddingGenerationService)!);
 #pragma warning restore CS0618
 kernel.Plugins.Add(vectorStoreTextSearch.CreateWithSearch("SearchPlugin"));
 
@@ -139,5 +138,5 @@ internal sealed class InformationItem
     public string Text { get; set; } = string.Empty;
 
     [VectorStoreRecordVector(Dimensions: 384)]
-    public ReadOnlyMemory<float> Embedding { get; set; }
+    public string Embedding => this.Text;
 }

--- a/dotnet/samples/GettingStartedWithTextSearch/InMemoryVectorStoreFixture.cs
+++ b/dotnet/samples/GettingStartedWithTextSearch/InMemoryVectorStoreFixture.cs
@@ -1,12 +1,12 @@
 ﻿// Copyright (c) Microsoft. All rights reserved.
 
 using System.Reflection;
+using Microsoft.Extensions.AI;
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.VectorData;
 using Microsoft.SemanticKernel.Connectors.InMemory;
 using Microsoft.SemanticKernel.Connectors.OpenAI;
 using Microsoft.SemanticKernel.Data;
-using Microsoft.SemanticKernel.Embeddings;
 
 namespace GettingStartedWithTextSearch;
 
@@ -15,7 +15,7 @@ namespace GettingStartedWithTextSearch;
 /// </summary>
 public class InMemoryVectorStoreFixture : IAsyncLifetime
 {
-    public ITextEmbeddingGenerationService TextEmbeddingGenerationService { get; private set; }
+    public IEmbeddingGenerator<string, Embedding<float>> EmbeddingGenerator { get; private set; }
 
     public InMemoryVectorStore InMemoryVectorStore { get; private set; }
 
@@ -35,13 +35,13 @@ public class InMemoryVectorStoreFixture : IAsyncLifetime
             .Build();
         TestConfiguration.Initialize(configRoot);
 
-        // Create an InMemory vector store.
-        this.InMemoryVectorStore = new InMemoryVectorStore();
-
         // Create an embedding generation service.
-        this.TextEmbeddingGenerationService = new OpenAITextEmbeddingGenerationService(
+        this.EmbeddingGenerator = new OpenAIEmbeddingGenerator(
                 TestConfiguration.OpenAI.EmbeddingModelId,
                 TestConfiguration.OpenAI.ApiKey);
+
+        // Create an InMemory vector store.
+        this.InMemoryVectorStore = new InMemoryVectorStore(new() { EmbeddingGenerator = this.EmbeddingGenerator });
     }
 
     /// <inheritdoc/>
@@ -72,7 +72,6 @@ public class InMemoryVectorStoreFixture : IAsyncLifetime
                 Text = text,
                 Link = $"guid://{guid}",
                 Tag = index % 2 == 0 ? "Even" : "Odd",
-                Embedding = embedding
             };
         }
 
@@ -122,7 +121,7 @@ public class InMemoryVectorStoreFixture : IAsyncLifetime
         // Create records and generate embeddings for them.
         var tasks = entries.Select((entry, i) => Task.Run(async () =>
         {
-            var record = createRecord(i, entry, await this.TextEmbeddingGenerationService.GenerateEmbeddingAsync(entry).ConfigureAwait(false));
+            var record = createRecord(i, entry, (await this.EmbeddingGenerator.GenerateAsync(entry).ConfigureAwait(false)).Vector);
             await collection.UpsertAsync(record).ConfigureAwait(false);
         }));
         await Task.WhenAll(tasks).ConfigureAwait(false);
@@ -155,7 +154,7 @@ public class InMemoryVectorStoreFixture : IAsyncLifetime
         public required string Tag { get; init; }
 
         [VectorStoreRecordVector(1536)]
-        public ReadOnlyMemory<float> Embedding { get; init; }
+        public string Embedding => Text;
     }
     #endregion
 }

--- a/dotnet/samples/GettingStartedWithTextSearch/Step4_Search_With_VectorStore.cs
+++ b/dotnet/samples/GettingStartedWithTextSearch/Step4_Search_With_VectorStore.cs
@@ -23,14 +23,10 @@ public class Step4_Search_With_VectorStore(ITestOutputHelper output, InMemoryVec
     public async Task UsingInMemoryVectorStoreRecordTextSearchAsync()
     {
         // Use embedding generation service and record collection for the fixture.
-        var textEmbeddingGeneration = fixture.TextEmbeddingGenerationService;
         var collection = fixture.VectorStoreRecordCollection;
 
         // Create a text search instance using the InMemory vector store.
-        // TODO: Once OpenAITextEmbeddingGenerationService implements MEAI's IEmbeddingGenerator (#10811), configure it with the collection
-#pragma warning disable CS0618 // VectorStoreTextSearch with ITextEmbeddingGenerationService is obsolete
-        var textSearch = new VectorStoreTextSearch<DataModel>(collection, textEmbeddingGeneration);
-#pragma warning restore CS0618
+        var textSearch = new VectorStoreTextSearch<DataModel>(collection);
 
         // Search and return results as TextSearchResult items
         var query = "What is the Semantic Kernel?";
@@ -59,14 +55,11 @@ public class Step4_Search_With_VectorStore(ITestOutputHelper output, InMemoryVec
         Kernel kernel = kernelBuilder.Build();
 
         // Use embedding generation service and record collection for the fixture.
-        var textEmbeddingGeneration = fixture.TextEmbeddingGenerationService;
+        var embeddingGenerator = fixture.EmbeddingGenerator;
         var collection = fixture.VectorStoreRecordCollection;
 
         // Create a text search instance using the InMemory vector store.
-        // TODO: Once OpenAITextEmbeddingGenerationService implements MEAI's IEmbeddingGenerator (#10811), configure it with the collection
-#pragma warning disable CS0618 // VectorStoreTextSearch with ITextEmbeddingGenerationService is obsolete
-        var textSearch = new VectorStoreTextSearch<DataModel>(collection, textEmbeddingGeneration);
-#pragma warning restore CS0618
+        var textSearch = new VectorStoreTextSearch<DataModel>(collection);
 
         // Build a text search plugin with vector store search and add to the kernel
         var searchPlugin = textSearch.CreateWithGetTextSearchResults("SearchPlugin");
@@ -113,14 +106,11 @@ public class Step4_Search_With_VectorStore(ITestOutputHelper output, InMemoryVec
         Kernel kernel = kernelBuilder.Build();
 
         // Use embedding generation service and record collection for the fixture.
-        var textEmbeddingGeneration = fixture.TextEmbeddingGenerationService;
+        var embeddingGenerator = fixture.EmbeddingGenerator;
         var collection = fixture.VectorStoreRecordCollection;
 
         // Create a text search instance using the InMemory vector store.
-        // TODO: Once OpenAITextEmbeddingGenerationService implements MEAI's IEmbeddingGenerator (#10811), configure it with the collection
-#pragma warning disable CS0618 // VectorStoreTextSearch with ITextEmbeddingGenerationService is obsolete
-        var textSearch = new VectorStoreTextSearch<DataModel>(collection, textEmbeddingGeneration);
-#pragma warning restore CS0618
+        var textSearch = new VectorStoreTextSearch<DataModel>(collection);
 
         // Build a text search plugin with vector store search and add to the kernel
         var searchPlugin = textSearch.CreateWithGetTextSearchResults("SearchPlugin");

--- a/dotnet/src/Connectors/Connectors.Amazon.UnitTests/Extensions/BedrockServiceCollectionExtensionTests.cs
+++ b/dotnet/src/Connectors/Connectors.Amazon.UnitTests/Extensions/BedrockServiceCollectionExtensionTests.cs
@@ -1,7 +1,9 @@
 ﻿// Copyright (c) Microsoft. All rights reserved.
 
+using System;
 using Amazon.BedrockRuntime;
 using Amazon.Runtime;
+using Microsoft.Extensions.AI;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.SemanticKernel.ChatCompletion;
 using Microsoft.SemanticKernel.Connectors.Amazon.Core;
@@ -26,7 +28,7 @@ public class BedrockServiceCollectionExtensionTests
         // Arrange
         var services = new ServiceCollection();
         var modelId = "amazon.titan-text-premier-v1:0";
-        var bedrockRuntime = new Mock<IAmazonBedrockRuntime>().Object;
+        var bedrockRuntime = new Mock<IAmazonBedrockRuntime>(MockBehavior.Strict).Object;
 
         // Act
         services.AddBedrockChatCompletionService(modelId, bedrockRuntime);
@@ -47,7 +49,7 @@ public class BedrockServiceCollectionExtensionTests
         // Arrange
         var services = new ServiceCollection();
         var modelId = "amazon.titan-text-premier-v1:0";
-        var bedrockRuntime = new Mock<IAmazonBedrockRuntime>().Object;
+        var bedrockRuntime = new Mock<IAmazonBedrockRuntime>(MockBehavior.Strict).Object;
 
         // Act
         services.AddBedrockTextGenerationService(modelId, bedrockRuntime);
@@ -60,15 +62,37 @@ public class BedrockServiceCollectionExtensionTests
     }
 
     /// <summary>
+    /// Ensures that IServiceCollection.AddBedrockEmbeddingGenerator registers the <see cref="IEmbeddingGenerator{TInput, TEmbedding}"/> with the correct implementation.
+    /// </summary>
+    [Fact]
+    public void AddBedrockEmbeddingGeneratorRegistersCorrectService()
+    {
+        // Arrange
+        var services = new ServiceCollection();
+        var modelId = "amazon.titan-embed-text-v2:0";
+        var bedrockRuntime = new Mock<IAmazonBedrockRuntime>(MockBehavior.Strict).Object;
+
+        // Act
+        services.AddBedrockEmbeddingGenerator(modelId, bedrockRuntime);
+        var serviceProvider = services.BuildServiceProvider();
+
+        // Assert
+        var embeddingGenerator = serviceProvider.GetService<IEmbeddingGenerator<string, Embedding<float>>>();
+        Assert.NotNull(embeddingGenerator);
+        Assert.IsType<BedrockEmbeddingGenerator>(embeddingGenerator);
+    }
+
+    /// <summary>
     /// Ensures that IServiceCollection.AddBedrockTextEmbeddingGenerationService registers the <see cref="ITextEmbeddingGenerationService"/> with the correct implementation.
     /// </summary>
     [Fact]
+    [Obsolete("This test uses obsolete APIs. Use AddBedrockEmbeddingGeneratorRegistersCorrectService instead.")]
     public void AddBedrockTextEmbeddingServiceRegistersCorrectService()
     {
         // Arrange
         var services = new ServiceCollection();
         var modelId = "amazon.titan-embed-text-v2:0";
-        var bedrockRuntime = new Mock<IAmazonBedrockRuntime>().Object;
+        var bedrockRuntime = new Mock<IAmazonBedrockRuntime>(MockBehavior.Strict).Object;
 
         // Act
         services.AddBedrockTextEmbeddingGenerationService(modelId, bedrockRuntime);
@@ -84,7 +108,7 @@ public class BedrockServiceCollectionExtensionTests
     public void AwsServiceClientBeforeServiceRequestDoesNothingForNonWebServiceRequestEventArgs()
     {
         // Arrange
-        var requestEventArgs = new Mock<RequestEventArgs>();
+        var requestEventArgs = new Mock<RequestEventArgs>(MockBehavior.Strict);
 
         // Act
         BedrockClientUtilities.BedrockServiceClientRequestHandler(null!, requestEventArgs.Object);

--- a/dotnet/src/Connectors/Connectors.Amazon/Bedrock/Extensions/BedrockKernelBuilderExtensions.cs
+++ b/dotnet/src/Connectors/Connectors.Amazon/Bedrock/Extensions/BedrockKernelBuilderExtensions.cs
@@ -1,5 +1,6 @@
 ﻿// Copyright (c) Microsoft. All rights reserved.
 
+using System;
 using Amazon.BedrockRuntime;
 
 namespace Microsoft.SemanticKernel;
@@ -59,6 +60,7 @@ public static class BedrockKernelBuilderExtensions
     /// <param name="bedrockRuntime">The optional <see cref="IAmazonBedrockRuntime" /> to use. If not provided will be retrieved from the Service Collection.</param>
     /// <param name="serviceId">The optional service ID.</param>
     /// <returns>Returns back <see cref="IKernelBuilder"/> with a configured service.</returns>
+    [Obsolete("Use AddBedrockEmbeddingGenerator instead.")]
     public static IKernelBuilder AddBedrockTextEmbeddingGenerationService(
         this IKernelBuilder builder,
         string modelId,
@@ -68,6 +70,29 @@ public static class BedrockKernelBuilderExtensions
         Verify.NotNull(builder);
 
         builder.Services.AddBedrockTextEmbeddingGenerationService(modelId, bedrockRuntime, serviceId);
+
+        return builder;
+    }
+
+    /// <summary>
+    /// Add Amazon Bedrock Text Embedding Generation service to the kernel builder using IAmazonBedrockRuntime object.
+    /// </summary>
+    /// <param name="builder">The kernel builder.</param>
+    /// <param name="modelId">The model for text embedding generation.</param>
+    /// <param name="bedrockRuntime">The optional <see cref="IAmazonBedrockRuntime" /> to use. If not provided will be retrieved from the Service Collection.</param>
+    /// <param name="serviceId">The optional service ID.</param>
+    /// <param name="dimensions">The number of dimensions the resulting output embeddings should have, if supported by the model.</param>
+    /// <returns>Returns back <see cref="IKernelBuilder"/> with a configured service.</returns>
+    public static IKernelBuilder AddBedrockEmbeddingGenerator(
+        this IKernelBuilder builder,
+        string modelId,
+        IAmazonBedrockRuntime? bedrockRuntime = null,
+        string? serviceId = null,
+        int? dimensions = null)
+    {
+        Verify.NotNull(builder);
+
+        builder.Services.AddBedrockEmbeddingGenerator(modelId, bedrockRuntime, serviceId, dimensions);
 
         return builder;
     }

--- a/dotnet/src/Connectors/Connectors.Amazon/Bedrock/Extensions/BedrockServiceCollectionExtensions.cs
+++ b/dotnet/src/Connectors/Connectors.Amazon/Bedrock/Extensions/BedrockServiceCollectionExtensions.cs
@@ -3,6 +3,7 @@
 using System;
 using Amazon.BedrockRuntime;
 using Amazon.Runtime;
+using Microsoft.Extensions.AI;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Logging;
 using Microsoft.SemanticKernel.ChatCompletion;
@@ -113,6 +114,7 @@ public static class BedrockServiceCollectionExtensions
     /// <param name="bedrockRuntime">The optional <see cref="IAmazonBedrockRuntime" /> to use. If not provided will be retrieved from the Service Collection.</param>
     /// <param name="serviceId">The optional service ID.</param>
     /// <returns>Returns back <see cref="IServiceCollection"/> with a configured service.</returns>
+    [Obsolete("Use AddBedrockEmbeddingGenerator instead.")]
     public static IServiceCollection AddBedrockTextEmbeddingGenerationService(
         this IServiceCollection services,
         string modelId,
@@ -141,6 +143,51 @@ public static class BedrockServiceCollectionExtensions
             catch (Exception ex)
             {
                 throw new KernelException($"An error occurred while initializing the {nameof(BedrockTextEmbeddingGenerationService)}: {ex.Message}", ex);
+            }
+        });
+
+        return services;
+    }
+
+    /// <summary>
+    /// Add Amazon Bedrock Text Embedding Generation service to the <see cref="IServiceCollection" />.
+    /// </summary>
+    /// <param name="services">The service collection.</param>
+    /// <param name="modelId">The model for text embedding generation.</param>
+    /// <param name="bedrockRuntime">The optional <see cref="IAmazonBedrockRuntime" /> to use. If not provided will be retrieved from the Service Collection.</param>
+    /// <param name="serviceId">The optional service ID.</param>
+    /// <param name="dimensions">The number of dimensions the resulting output embeddings should have, if supported by the model.</param>
+    /// <returns>Returns back <see cref="IServiceCollection"/> with a configured service.</returns>
+    public static IServiceCollection AddBedrockEmbeddingGenerator(
+        this IServiceCollection services,
+        string modelId,
+        IAmazonBedrockRuntime? bedrockRuntime = null,
+        string? serviceId = null,
+        int? dimensions = null)
+    {
+        if (bedrockRuntime == null)
+        {
+            // Add IAmazonBedrockRuntime service client to the DI container
+            services.TryAddAWSService<IAmazonBedrockRuntime>();
+        }
+
+        services.AddKeyedSingleton<IEmbeddingGenerator<string, Embedding<float>>>(serviceId, (serviceProvider, _) =>
+        {
+            try
+            {
+                IAmazonBedrockRuntime runtime = bedrockRuntime ?? serviceProvider.GetRequiredService<IAmazonBedrockRuntime>();
+                var logger = serviceProvider.GetService<ILoggerFactory>();
+                // Check if the runtime instance is a proxy object
+                if (runtime.GetType().BaseType == typeof(AmazonServiceClient))
+                {
+                    // Cast to AmazonServiceClient and subscribe to the event
+                    ((AmazonServiceClient)runtime).BeforeRequestEvent += BedrockClientUtilities.BedrockServiceClientRequestHandler;
+                }
+                return new BedrockEmbeddingGenerator(modelId, runtime, logger, dimensions);
+            }
+            catch (Exception ex)
+            {
+                throw new KernelException($"An error occurred while initializing the {nameof(BedrockEmbeddingGenerator)}: {ex.Message}", ex);
             }
         });
 

--- a/dotnet/src/Connectors/Connectors.Amazon/Bedrock/Services/BedrockEmbeddingGenerator.cs
+++ b/dotnet/src/Connectors/Connectors.Amazon/Bedrock/Services/BedrockEmbeddingGenerator.cs
@@ -53,6 +53,7 @@ public sealed class BedrockEmbeddingGenerator : IEmbeddingGenerator<string, Embe
         return
             serviceKey is null ? null :
             serviceType.IsInstanceOfType(this) ? this :
+            serviceType.IsInstanceOfType(typeof(EmbeddingGeneratorMetadata)) ? this._metadata :
             null;
     }
 }

--- a/dotnet/src/Connectors/Connectors.Amazon/Bedrock/Services/BedrockEmbeddingGenerator.cs
+++ b/dotnet/src/Connectors/Connectors.Amazon/Bedrock/Services/BedrockEmbeddingGenerator.cs
@@ -1,0 +1,58 @@
+// Copyright (c) Microsoft. All rights reserved.
+
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading;
+using System.Threading.Tasks;
+using Amazon.BedrockRuntime;
+using Microsoft.Extensions.AI;
+using Microsoft.Extensions.Logging;
+using Microsoft.SemanticKernel.Connectors.Amazon.Core;
+
+namespace Microsoft.SemanticKernel.Connectors.Amazon;
+
+/// <summary>
+/// Represents a text embeddings generation service using Amazon Bedrock API.
+/// </summary>
+public sealed class BedrockEmbeddingGenerator : IEmbeddingGenerator<string, Embedding<float>>
+{
+    private readonly BedrockTextEmbeddingGenerationClient _embeddingGenerationClient;
+    private readonly EmbeddingGeneratorMetadata? _metadata;
+
+    /// <summary>
+    /// Initializes an instance of the <see cref="BedrockEmbeddingGenerator" /> using an <see cref="IAmazonBedrockRuntime" />.
+    /// </summary>
+    /// <param name="modelId">Bedrock model id, see https://docs.aws.amazon.com/bedrock/latest/userguide/models-regions.html</param>
+    /// <param name="bedrockRuntime">The <see cref="IAmazonBedrockRuntime"/> instance to be used.</param>
+    /// <param name="loggerFactory">The <see cref="ILoggerFactory"/> to use for logging. If null, no logging will be performed.</param>
+    /// <param name="dimensions">The number of dimensions the resulting output embeddings should have, if supported by the model.</param>
+    public BedrockEmbeddingGenerator(string modelId, IAmazonBedrockRuntime bedrockRuntime, ILoggerFactory? loggerFactory = null, int? dimensions = null)
+    {
+        this._embeddingGenerationClient = new BedrockTextEmbeddingGenerationClient(modelId, bedrockRuntime, loggerFactory);
+        this._metadata = new EmbeddingGeneratorMetadata(defaultModelId: modelId, defaultModelDimensions: dimensions);
+    }
+
+    /// <inheritdoc />
+    public async Task<GeneratedEmbeddings<Embedding<float>>> GenerateAsync(IEnumerable<string> values, EmbeddingGenerationOptions? options = null, CancellationToken cancellationToken = default)
+    {
+        var result = await this._embeddingGenerationClient.GenerateEmbeddingsAsync(values.ToList(), cancellationToken).ConfigureAwait(false);
+        return new(result.Select(e => new Embedding<float>(e)));
+    }
+
+    /// <inheritdoc />
+    public void Dispose()
+    {
+    }
+
+    /// <inheritdoc />
+    public object? GetService(Type serviceType, object? serviceKey = null)
+    {
+        Verify.NotNull(serviceType);
+
+        return
+            serviceKey is null ? null :
+            serviceType.IsInstanceOfType(this) ? this :
+            null;
+    }
+}

--- a/dotnet/src/Connectors/Connectors.Amazon/Bedrock/Services/BedrockTextEmbeddingGeneratorService.cs
+++ b/dotnet/src/Connectors/Connectors.Amazon/Bedrock/Services/BedrockTextEmbeddingGeneratorService.cs
@@ -15,6 +15,7 @@ namespace Microsoft.SemanticKernel.Connectors.Amazon;
 /// <summary>
 /// Represents a text embeddings generation service using Amazon Bedrock API.
 /// </summary>
+[Obsolete("Use BedrockEmbeddingGenerator instead.")]
 public class BedrockTextEmbeddingGenerationService : ITextEmbeddingGenerationService
 {
     private readonly Dictionary<string, object?> _attributesInternal = [];

--- a/dotnet/src/Connectors/Connectors.AzureOpenAI/Extensions/AzureOpenAIKernelBuilderExtensions.EmbeddingGenerator.cs
+++ b/dotnet/src/Connectors/Connectors.AzureOpenAI/Extensions/AzureOpenAIKernelBuilderExtensions.EmbeddingGenerator.cs
@@ -1,0 +1,127 @@
+﻿// Copyright (c) Microsoft. All rights reserved.
+
+using System.Diagnostics.CodeAnalysis;
+using System.Net.Http;
+using Azure.AI.OpenAI;
+using Azure.Core;
+using Microsoft.SemanticKernel.Connectors.AzureOpenAI;
+
+namespace Microsoft.SemanticKernel;
+
+/// <summary>
+/// Provides extension methods for <see cref="IKernelBuilder"/> to configure Azure OpenAI connectors.
+/// </summary>
+public static partial class AzureOpenAIKernelBuilderExtensions
+{
+    /// <summary>
+    /// Adds the <see cref="AzureOpenAITextEmbeddingGenerationService"/> to the <see cref="IKernelBuilder.Services"/>.
+    /// </summary>
+    /// <param name="builder">The <see cref="IKernelBuilder"/> instance to augment.</param>
+    /// <param name="deploymentName">Azure OpenAI deployment name, see https://learn.microsoft.com/azure/cognitive-services/openai/how-to/create-resource</param>
+    /// <param name="endpoint">Azure OpenAI deployment URL, see https://learn.microsoft.com/azure/cognitive-services/openai/quickstart</param>
+    /// <param name="apiKey">Azure OpenAI API key, see https://learn.microsoft.com/azure/cognitive-services/openai/quickstart</param>
+    /// <param name="serviceId">A local identifier for the given AI service</param>
+    /// <param name="modelId">Model identifier, see https://learn.microsoft.com/azure/cognitive-services/openai/quickstart</param>
+    /// <param name="dimensions">The number of dimensions the resulting output embeddings should have. Only supported in "text-embedding-3" and later models.</param>
+    /// <param name="apiVersion">Optional Azure OpenAI API version, see available here <see cref="AzureOpenAIClientOptions.ServiceVersion"/></param>
+    /// <param name="httpClient">The HttpClient to use with this service.</param>
+    /// <returns>The same instance as <paramref name="builder"/>.</returns>
+    [Experimental("SKEXP0010")]
+    public static IKernelBuilder AddAzureOpenAIEmbeddingGenerator(
+        this IKernelBuilder builder,
+        string deploymentName,
+        string endpoint,
+        string apiKey,
+        string? serviceId = null,
+        string? modelId = null,
+        int? dimensions = null,
+        string? apiVersion = null,
+        HttpClient? httpClient = null)
+    {
+        Verify.NotNull(builder);
+
+        builder.Services.AddAzureOpenAIEmbeddingGenerator(
+            deploymentName,
+            endpoint,
+            apiKey,
+            serviceId,
+            modelId,
+            dimensions,
+            apiVersion,
+            httpClient);
+
+        return builder;
+    }
+
+    /// <summary>
+    /// Adds the <see cref="AzureOpenAITextEmbeddingGenerationService"/> to the <see cref="IKernelBuilder.Services"/>.
+    /// </summary>
+    /// <param name="builder">The <see cref="IKernelBuilder"/> instance to augment.</param>
+    /// <param name="deploymentName">Azure OpenAI deployment name, see https://learn.microsoft.com/azure/cognitive-services/openai/how-to/create-resource</param>
+    /// <param name="endpoint">Azure OpenAI deployment URL, see https://learn.microsoft.com/azure/cognitive-services/openai/quickstart</param>
+    /// <param name="credential">Token credentials, e.g. DefaultAzureCredential, ManagedIdentityCredential, EnvironmentCredential, etc.</param>
+    /// <param name="serviceId">A local identifier for the given AI service</param>
+    /// <param name="modelId">Model identifier, see https://learn.microsoft.com/azure/cognitive-services/openai/quickstart</param>
+    /// <param name="dimensions">The number of dimensions the resulting output embeddings should have. Only supported in "text-embedding-3" and later models.</param>
+    /// <param name="apiVersion">Optional Azure OpenAI API version, see available here <see cref="AzureOpenAIClientOptions.ServiceVersion"/></param>
+    /// <param name="httpClient">The HttpClient to use with this service.</param>
+    /// <returns>The same instance as <paramref name="builder"/>.</returns>
+    [Experimental("SKEXP0010")]
+    public static IKernelBuilder AddAzureOpenAIEmbeddingGenerator(
+        this IKernelBuilder builder,
+        string deploymentName,
+        string endpoint,
+        TokenCredential credential,
+        string? serviceId = null,
+        string? modelId = null,
+        int? dimensions = null,
+        string? apiVersion = null,
+        HttpClient? httpClient = null)
+    {
+        Verify.NotNull(builder);
+        Verify.NotNull(credential);
+
+        builder.Services.AddAzureOpenAIEmbeddingGenerator(
+            deploymentName,
+            endpoint,
+            credential,
+            serviceId,
+            modelId,
+            dimensions,
+            apiVersion,
+            httpClient);
+
+        return builder;
+    }
+
+    /// <summary>
+    /// Adds the <see cref="AzureOpenAITextEmbeddingGenerationService"/> to the <see cref="IKernelBuilder.Services"/>.
+    /// </summary>
+    /// <param name="builder">The <see cref="IKernelBuilder"/> instance to augment.</param>
+    /// <param name="deploymentName">Azure OpenAI deployment name, see https://learn.microsoft.com/azure/cognitive-services/openai/how-to/create-resource</param>
+    /// <param name="azureOpenAIClient"><see cref="AzureOpenAIClient"/> to use for the service. If null, one must be available in the service provider when this service is resolved.</param>
+    /// <param name="serviceId">A local identifier for the given AI service</param>
+    /// <param name="modelId">Model identifier, see https://learn.microsoft.com/azure/cognitive-services/openai/quickstart</param>
+    /// <param name="dimensions">The number of dimensions the resulting output embeddings should have. Only supported in "text-embedding-3" and later models.</param>
+    /// <returns>The same instance as <paramref name="builder"/>.</returns>
+    [Experimental("SKEXP0010")]
+    public static IKernelBuilder AddAzureOpenAIEmbeddingGenerator(
+        this IKernelBuilder builder,
+        string deploymentName,
+        AzureOpenAIClient? azureOpenAIClient = null,
+        string? serviceId = null,
+        string? modelId = null,
+        int? dimensions = null)
+    {
+        Verify.NotNull(builder);
+
+        builder.Services.AddAzureOpenAIEmbeddingGenerator(
+            deploymentName,
+            azureOpenAIClient,
+            serviceId,
+            modelId,
+            dimensions);
+
+        return builder;
+    }
+}

--- a/dotnet/src/Connectors/Connectors.AzureOpenAI/Extensions/AzureOpenAIKernelBuilderExtensions.cs
+++ b/dotnet/src/Connectors/Connectors.AzureOpenAI/Extensions/AzureOpenAIKernelBuilderExtensions.cs
@@ -24,7 +24,7 @@ namespace Microsoft.SemanticKernel;
 /// <summary>
 /// Provides extension methods for <see cref="IKernelBuilder"/> to configure Azure OpenAI connectors.
 /// </summary>
-public static class AzureOpenAIKernelBuilderExtensions
+public static partial class AzureOpenAIKernelBuilderExtensions
 {
     #region Chat Completion
 
@@ -158,6 +158,7 @@ public static class AzureOpenAIKernelBuilderExtensions
     /// <param name="apiVersion">Optional Azure OpenAI API version, see available here <see cref="AzureOpenAIClientOptions.ServiceVersion"/></param>
     /// <returns>The same instance as <paramref name="builder"/>.</returns>
     [Experimental("SKEXP0010")]
+    [Obsolete("Use AddAzureOpenAIEmbeddingGenerator instead.")]
     public static IKernelBuilder AddAzureOpenAITextEmbeddingGeneration(
         this IKernelBuilder builder,
         string deploymentName,
@@ -199,6 +200,7 @@ public static class AzureOpenAIKernelBuilderExtensions
     /// <param name="apiVersion">Optional Azure OpenAI API version, see available here <see cref="AzureOpenAIClientOptions.ServiceVersion"/></param>
     /// <returns>The same instance as <paramref name="builder"/>.</returns>
     [Experimental("SKEXP0010")]
+    [Obsolete("Use AddAzureOpenAIEmbeddingGenerator instead.")]
     public static IKernelBuilder AddAzureOpenAITextEmbeddingGeneration(
         this IKernelBuilder builder,
         string deploymentName,
@@ -238,6 +240,7 @@ public static class AzureOpenAIKernelBuilderExtensions
     /// <param name="dimensions">The number of dimensions the resulting output embeddings should have. Only supported in "text-embedding-3" and later models.</param>
     /// <returns>The same instance as <paramref name="builder"/>.</returns>
     [Experimental("SKEXP0010")]
+    [Obsolete("Use AddAzureOpenAIEmbeddingGenerator instead.")]
     public static IKernelBuilder AddAzureOpenAITextEmbeddingGeneration(
         this IKernelBuilder builder,
         string deploymentName,

--- a/dotnet/src/Connectors/Connectors.AzureOpenAI/Extensions/AzureOpenAIServiceCollectionExtensions.EmbeddingGenerator.cs
+++ b/dotnet/src/Connectors/Connectors.AzureOpenAI/Extensions/AzureOpenAIServiceCollectionExtensions.EmbeddingGenerator.cs
@@ -1,0 +1,128 @@
+﻿// Copyright (c) Microsoft. All rights reserved.
+
+using System.Diagnostics.CodeAnalysis;
+using System.Net.Http;
+using Azure.AI.OpenAI;
+using Azure.Core;
+using Microsoft.Extensions.AI;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Logging;
+using Microsoft.SemanticKernel.Connectors.AzureOpenAI;
+using Microsoft.SemanticKernel.Http;
+
+namespace Microsoft.SemanticKernel;
+
+/// <summary>
+/// Provides extension methods for <see cref="IServiceCollection"/> to configure Azure OpenAI connectors.
+/// </summary>
+public static partial class AzureOpenAIServiceCollectionExtensions
+{
+    /// <summary>
+    /// Adds the <see cref="AzureOpenAITextEmbeddingGenerationService"/> to the <see cref="IServiceCollection"/>.
+    /// </summary>
+    /// <param name="services">The <see cref="IServiceCollection"/> instance to augment.</param>
+    /// <param name="deploymentName">Azure OpenAI deployment name, see https://learn.microsoft.com/azure/cognitive-services/openai/how-to/create-resource</param>
+    /// <param name="endpoint">Azure OpenAI deployment URL, see https://learn.microsoft.com/azure/cognitive-services/openai/quickstart</param>
+    /// <param name="apiKey">Azure OpenAI API key, see https://learn.microsoft.com/azure/cognitive-services/openai/quickstart</param>
+    /// <param name="serviceId">A local identifier for the given AI service</param>
+    /// <param name="modelId">Model identifier, see https://learn.microsoft.com/azure/cognitive-services/openai/quickstart</param>
+    /// <param name="dimensions">The number of dimensions the resulting output embeddings should have. Only supported in "text-embedding-3" and later models.</param>
+    /// <param name="apiVersion">Optional Azure OpenAI API version, see available here <see cref="AzureOpenAIClientOptions.ServiceVersion"/></param>
+    /// <param name="httpClient">The HttpClient to use with this service.</param>
+    /// <returns>The same instance as <paramref name="services"/>.</returns>
+    [Experimental("SKEXP0010")]
+    public static IServiceCollection AddAzureOpenAIEmbeddingGenerator(
+        this IServiceCollection services,
+        string deploymentName,
+        string endpoint,
+        string apiKey,
+        string? serviceId = null,
+        string? modelId = null,
+        int? dimensions = null,
+        string? apiVersion = null,
+        HttpClient? httpClient = null)
+    {
+        Verify.NotNull(services);
+
+        return services.AddKeyedSingleton<IEmbeddingGenerator<string, Embedding<float>>>(serviceId, (serviceProvider, _) =>
+            new AzureOpenAITextEmbeddingGenerationService(
+                deploymentName,
+                endpoint,
+                apiKey,
+                modelId,
+                HttpClientProvider.GetHttpClient(httpClient, serviceProvider),
+                serviceProvider.GetService<ILoggerFactory>(),
+                dimensions,
+                apiVersion));
+    }
+
+    /// <summary>
+    /// Adds the <see cref="AzureOpenAITextEmbeddingGenerationService"/> to the <see cref="IServiceCollection"/>.
+    /// </summary>
+    /// <param name="services">The <see cref="IServiceCollection"/> instance to augment.</param>
+    /// <param name="deploymentName">Azure OpenAI deployment name, see https://learn.microsoft.com/azure/cognitive-services/openai/how-to/create-resource</param>
+    /// <param name="endpoint">Azure OpenAI deployment URL, see https://learn.microsoft.com/azure/cognitive-services/openai/quickstart</param>
+    /// <param name="credential">Token credentials, e.g. DefaultAzureCredential, ManagedIdentityCredential, EnvironmentCredential, etc.</param>
+    /// <param name="serviceId">A local identifier for the given AI service</param>
+    /// <param name="modelId">Model identifier, see https://learn.microsoft.com/azure/cognitive-services/openai/quickstart</param>
+    /// <param name="dimensions">The number of dimensions the resulting output embeddings should have. Only supported in "text-embedding-3" and later models.</param>
+    /// <param name="apiVersion">Optional Azure OpenAI API version, see available here <see cref="AzureOpenAIClientOptions.ServiceVersion"/></param>
+    /// <param name="httpClient">The HttpClient to use with this service.</param>
+    /// <returns>The same instance as <paramref name="services"/>.</returns>
+    [Experimental("SKEXP0010")]
+    public static IServiceCollection AddAzureOpenAIEmbeddingGenerator(
+        this IServiceCollection services,
+        string deploymentName,
+        string endpoint,
+        TokenCredential credential,
+        string? serviceId = null,
+        string? modelId = null,
+        int? dimensions = null,
+        string? apiVersion = null,
+        HttpClient? httpClient = null)
+    {
+        Verify.NotNull(services);
+        Verify.NotNull(credential);
+
+        return services.AddKeyedSingleton<IEmbeddingGenerator<string, Embedding<float>>>(serviceId, (serviceProvider, _) =>
+            new AzureOpenAITextEmbeddingGenerationService(
+                deploymentName,
+                endpoint,
+                credential,
+                modelId,
+                HttpClientProvider.GetHttpClient(httpClient, serviceProvider),
+                serviceProvider.GetService<ILoggerFactory>(),
+                dimensions,
+                apiVersion));
+    }
+
+    /// <summary>
+    /// Adds the <see cref="AzureOpenAITextEmbeddingGenerationService"/> to the <see cref="IServiceCollection"/>.
+    /// </summary>
+    /// <param name="services">The <see cref="IServiceCollection"/> instance to augment.</param>
+    /// <param name="deploymentName">Azure OpenAI deployment name, see https://learn.microsoft.com/azure/cognitive-services/openai/how-to/create-resource</param>
+    /// <param name="azureOpenAIClient"><see cref="AzureOpenAIClient"/> to use for the service. If null, one must be available in the service provider when this service is resolved.</param>
+    /// <param name="serviceId">A local identifier for the given AI service</param>
+    /// <param name="modelId">Model identifier, see https://learn.microsoft.com/azure/cognitive-services/openai/quickstart</param>
+    /// <param name="dimensions">The number of dimensions the resulting output embeddings should have. Only supported in "text-embedding-3" and later models.</param>
+    /// <returns>The same instance as <paramref name="services"/>.</returns>
+    [Experimental("SKEXP0010")]
+    public static IServiceCollection AddAzureOpenAIEmbeddingGenerator(
+        this IServiceCollection services,
+        string deploymentName,
+        AzureOpenAIClient? azureOpenAIClient = null,
+        string? serviceId = null,
+        string? modelId = null,
+        int? dimensions = null)
+    {
+        Verify.NotNull(services);
+
+        return services.AddKeyedSingleton<IEmbeddingGenerator<string, Embedding<float>>>(serviceId, (serviceProvider, _) =>
+            new AzureOpenAITextEmbeddingGenerationService(
+                deploymentName,
+                azureOpenAIClient ?? serviceProvider.GetRequiredService<AzureOpenAIClient>(),
+                modelId,
+                serviceProvider.GetService<ILoggerFactory>(),
+                dimensions));
+    }
+}

--- a/dotnet/src/Connectors/Connectors.AzureOpenAI/Extensions/AzureOpenAIServiceCollectionExtensions.cs
+++ b/dotnet/src/Connectors/Connectors.AzureOpenAI/Extensions/AzureOpenAIServiceCollectionExtensions.cs
@@ -24,7 +24,7 @@ namespace Microsoft.SemanticKernel;
 /// <summary>
 /// Provides extension methods for <see cref="IServiceCollection"/> to configure Azure OpenAI connectors.
 /// </summary>
-public static class AzureOpenAIServiceCollectionExtensions
+public static partial class AzureOpenAIServiceCollectionExtensions
 {
     #region Chat Completion
 
@@ -160,6 +160,7 @@ public static class AzureOpenAIServiceCollectionExtensions
     /// <param name="httpClient">The HttpClient to use with this service.</param>
     /// <returns>The same instance as <paramref name="services"/>.</returns>
     [Experimental("SKEXP0010")]
+    [Obsolete("Use AddAzureOpenAIEmbeddingGenerator instead.")]
     public static IServiceCollection AddAzureOpenAITextEmbeddingGeneration(
         this IServiceCollection services,
         string deploymentName,
@@ -199,6 +200,7 @@ public static class AzureOpenAIServiceCollectionExtensions
     /// <param name="httpClient">The HttpClient to use with this service.</param>
     /// <returns>The same instance as <paramref name="services"/>.</returns>
     [Experimental("SKEXP0010")]
+    [Obsolete("Use AddAzureOpenAIEmbeddingGenerator instead.")]
     public static IServiceCollection AddAzureOpenAITextEmbeddingGeneration(
         this IServiceCollection services,
         string deploymentName,
@@ -236,6 +238,7 @@ public static class AzureOpenAIServiceCollectionExtensions
     /// <param name="dimensions">The number of dimensions the resulting output embeddings should have. Only supported in "text-embedding-3" and later models.</param>
     /// <returns>The same instance as <paramref name="services"/>.</returns>
     [Experimental("SKEXP0010")]
+    [Obsolete("Use AddAzureOpenAIEmbeddingGenerator instead.")]
     public static IServiceCollection AddAzureOpenAITextEmbeddingGeneration(
         this IServiceCollection services,
         string deploymentName,

--- a/dotnet/src/Connectors/Connectors.HuggingFace.UnitTests/HuggingFaceKernelBuilderExtensionsTests.cs
+++ b/dotnet/src/Connectors/Connectors.HuggingFace.UnitTests/HuggingFaceKernelBuilderExtensionsTests.cs
@@ -1,5 +1,7 @@
 ﻿// Copyright (c) Microsoft. All rights reserved.
 
+using System;
+using Microsoft.Extensions.AI;
 using Microsoft.SemanticKernel;
 using Microsoft.SemanticKernel.Connectors.HuggingFace;
 using Microsoft.SemanticKernel.Embeddings;
@@ -25,6 +27,21 @@ public class HuggingFaceKernelBuilderExtensionsTests
     }
 
     [Fact]
+    public void AddHuggingFaceEmbeddingGeneratorCreatesService()
+    {
+        var builder = Kernel.CreateBuilder();
+        builder.AddHuggingFaceEmbeddingGenerator("model");
+
+        var kernel = builder.Build();
+        var service = kernel.GetRequiredService<IEmbeddingGenerator<string, Embedding<float>>>();
+
+        Assert.NotNull(kernel);
+        Assert.NotNull(service);
+        Assert.IsType<HuggingFaceEmbeddingGenerator>(service);
+    }
+
+    [Fact]
+    [Obsolete("This test uses obsolete APIs. Use AddHuggingFaceEmbeddingGeneratorCreatesService instead.")]
     public void AddHuggingFaceTextEmbeddingGenerationCreatesService()
     {
         var builder = Kernel.CreateBuilder();

--- a/dotnet/src/Connectors/Connectors.HuggingFace.UnitTests/HuggingFaceServiceCollectionExtensionsTests.cs
+++ b/dotnet/src/Connectors/Connectors.HuggingFace.UnitTests/HuggingFaceServiceCollectionExtensionsTests.cs
@@ -1,5 +1,7 @@
 ﻿// Copyright (c) Microsoft. All rights reserved.
 
+using System;
+using Microsoft.Extensions.AI;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.SemanticKernel;
 using Microsoft.SemanticKernel.Connectors.HuggingFace;
@@ -25,6 +27,20 @@ public class HuggingFaceServiceCollectionExtensionsTests
     }
 
     [Fact]
+    public void AddHuggingFaceEmbeddingGeneratorToServiceCollection()
+    {
+        var services = new ServiceCollection();
+        services.AddHuggingFaceEmbeddingGenerator("model");
+
+        var serviceProvider = services.BuildServiceProvider();
+        var service = serviceProvider.GetRequiredService<IEmbeddingGenerator<string, Embedding<float>>>();
+
+        Assert.NotNull(service);
+        Assert.IsType<HuggingFaceEmbeddingGenerator>(service);
+    }
+
+    [Fact]
+    [Obsolete("This test uses obsolete APIs. Use AddHuggingFaceEmbeddingGeneratorToServiceCollection instead.")]
     public void AddHuggingFaceTextEmbeddingsGenerationToServiceCollection()
     {
         var services = new ServiceCollection();

--- a/dotnet/src/Connectors/Connectors.HuggingFace.UnitTests/Services/HuggingFaceEmbeddingGenerationTests.cs
+++ b/dotnet/src/Connectors/Connectors.HuggingFace.UnitTests/Services/HuggingFaceEmbeddingGenerationTests.cs
@@ -15,6 +15,7 @@ namespace SemanticKernel.Connectors.HuggingFace.UnitTests;
 /// <summary>
 /// Unit tests for <see cref="HuggingFaceTextEmbeddingGenerationService"/> class.
 /// </summary>
+[Obsolete("This test class uses obsolete APIs. Use HuggingFaceEmbeddingGeneratorTests instead.")]
 public sealed class HuggingFaceEmbeddingGenerationTests : IDisposable
 {
     private readonly HttpMessageHandlerStub _messageHandlerStub;

--- a/dotnet/src/Connectors/Connectors.HuggingFace.UnitTests/Services/HuggingFaceEmbeddingGeneratorTests.cs
+++ b/dotnet/src/Connectors/Connectors.HuggingFace.UnitTests/Services/HuggingFaceEmbeddingGeneratorTests.cs
@@ -1,0 +1,197 @@
+// Copyright (c) Microsoft. All rights reserved.
+
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Net.Http;
+using System.Text.Json;
+using System.Threading.Tasks;
+using Microsoft.Extensions.AI;
+using Microsoft.SemanticKernel.Connectors.HuggingFace;
+using Microsoft.SemanticKernel.Connectors.HuggingFace.Core;
+using Xunit;
+
+namespace SemanticKernel.Connectors.HuggingFace.UnitTests;
+
+/// <summary>
+/// Unit tests for <see cref="HuggingFaceEmbeddingGenerator"/> class.
+/// </summary>
+public sealed class HuggingFaceEmbeddingGeneratorTests : IDisposable
+{
+    private readonly HttpMessageHandlerStub _messageHandlerStub;
+    private readonly HttpClient _httpClient;
+
+    public HuggingFaceEmbeddingGeneratorTests()
+    {
+        this._messageHandlerStub = new HttpMessageHandlerStub();
+        this._messageHandlerStub.ResponseToReturn.Content = new StringContent(HuggingFaceTestHelper.GetTestResponse("embeddings_test_response_feature_extraction.json"));
+
+        this._httpClient = new HttpClient(this._messageHandlerStub, false);
+    }
+
+    [Fact]
+    public async Task SpecifiedModelShouldBeUsedAsync()
+    {
+        //Arrange
+        using var sut = new HuggingFaceEmbeddingGenerator("fake-model", new Uri("https://fake-random-test-host/fake-path"), httpClient: this._httpClient);
+
+        //Act
+        await sut.GenerateAsync([]);
+
+        //Assert
+        Assert.EndsWith("/fake-model", this._messageHandlerStub.RequestUri?.AbsoluteUri, StringComparison.OrdinalIgnoreCase);
+    }
+
+    [Fact]
+    public async Task UserAgentHeaderShouldBeUsedAsync()
+    {
+        //Arrange
+        using var sut = new HuggingFaceEmbeddingGenerator("fake-model", new Uri("https://fake-random-test-host/fake-path"), httpClient: this._httpClient);
+
+        //Act
+        await sut.GenerateAsync([]);
+
+        //Assert
+        Assert.True(this._messageHandlerStub.RequestHeaders?.Contains("User-Agent"));
+
+        var values = this._messageHandlerStub.RequestHeaders!.GetValues("User-Agent");
+
+        var value = values.SingleOrDefault();
+        Assert.Equal("Semantic-Kernel", value);
+    }
+
+    [Fact]
+    public async Task ProvidedEndpointShouldBeUsedAsync()
+    {
+        //Arrange
+        using var sut = new HuggingFaceEmbeddingGenerator("fake-model", new Uri("https://fake-random-test-host/fake-path"), httpClient: this._httpClient);
+
+        //Act
+        await sut.GenerateAsync([]);
+
+        //Assert
+        Assert.StartsWith("https://fake-random-test-host/fake-path", this._messageHandlerStub.RequestUri?.AbsoluteUri, StringComparison.OrdinalIgnoreCase);
+    }
+
+    [Fact]
+    public async Task HttpClientBaseAddressShouldBeUsedAsync()
+    {
+        //Arrange
+        this._httpClient.BaseAddress = new Uri("https://fake-random-test-host/fake-path");
+
+        using var sut = new HuggingFaceEmbeddingGenerator("fake-model", httpClient: this._httpClient);
+
+        //Act
+        await sut.GenerateAsync([]);
+
+        //Assert
+        Assert.StartsWith("https://fake-random-test-host/fake-path", this._messageHandlerStub.RequestUri?.AbsoluteUri, StringComparison.OrdinalIgnoreCase);
+    }
+
+    [Fact]
+    public async Task ModelUrlShouldBeBuiltSuccessfullyAsync()
+    {
+        //Arrange
+        using var sut = new HuggingFaceEmbeddingGenerator("fake-model", endpoint: new Uri("https://fake-random-test-host/fake-path"), httpClient: this._httpClient);
+
+        //Act
+        await sut.GenerateAsync([]);
+
+        //Assert
+        Assert.Equal("https://fake-random-test-host/fake-path/pipeline/feature-extraction/fake-model", this._messageHandlerStub.RequestUri?.AbsoluteUri);
+    }
+
+    [Fact]
+    public async Task ShouldSendDataToServiceAsync()
+    {
+        //Arrange
+        using var sut = new HuggingFaceEmbeddingGenerator("fake-model", new Uri("https://fake-random-test-host/fake-path"), httpClient: this._httpClient);
+        List<string> data = ["test_string_1", "test_string_2"];
+
+        //Act
+        await sut.GenerateAsync(data);
+
+        //Assert
+        var requestPayload = JsonSerializer.Deserialize<TextEmbeddingRequest>(this._messageHandlerStub.RequestContent);
+        Assert.NotNull(requestPayload);
+
+        Assert.Equivalent(data, requestPayload.Inputs);
+    }
+
+    [Fact]
+    public async Task ShouldHandleServiceResponseAsync()
+    {
+        //Arrange
+        using var sut = new HuggingFaceEmbeddingGenerator("fake-model", new Uri("https://fake-random-test-host/fake-path"), httpClient: this._httpClient);
+
+        //Act
+        var result = await sut.GenerateAsync(["something"]);
+
+        //Assert
+        Assert.NotNull(result);
+        Assert.Single(result);
+        Assert.Equal(1024, result.First().Vector.Length);
+    }
+
+    [Fact]
+    public void GetServiceShouldReturnNullWhenServiceKeyIsNull()
+    {
+        // Arrange
+        using var sut = new HuggingFaceEmbeddingGenerator("fake-model", new Uri("https://fake-random-test-host/fake-path"), httpClient: this._httpClient);
+
+        // Act
+        var result = sut.GetService(typeof(object), null);
+
+        // Assert
+        Assert.Null(result);
+    }
+
+    [Fact]
+    public void GetServiceShouldReturnThisWhenServiceTypeIsInstanceOfGenerator()
+    {
+        // Arrange
+        using var sut = new HuggingFaceEmbeddingGenerator("fake-model", new Uri("https://fake-random-test-host/fake-path"), httpClient: this._httpClient);
+
+        // Act
+        var result = sut.GetService(typeof(HuggingFaceEmbeddingGenerator), "serviceKey");
+
+        // Assert
+        Assert.Same(sut, result);
+    }
+
+    [Fact]
+    public void GetServiceShouldReturnMetadataWhenServiceTypeIsEmbeddingGeneratorMetadata()
+    {
+        // Arrange
+        using var sut = new HuggingFaceEmbeddingGenerator("fake-model", new Uri("https://fake-random-test-host/fake-path"), httpClient: this._httpClient);
+
+        // Act
+        var result = sut.GetService(typeof(EmbeddingGeneratorMetadata), "serviceKey");
+
+        // Assert
+        Assert.NotNull(result);
+        Assert.IsType<EmbeddingGeneratorMetadata>(result);
+        var metadata = (EmbeddingGeneratorMetadata)result;
+        Assert.Equal("fake-model", metadata.DefaultModelId);
+        Assert.Equal(new Uri("https://fake-random-test-host/fake-path"), metadata.ProviderUri);
+    }
+
+    [Fact]
+    public void GetServiceShouldReturnNullWhenServiceTypeIsNotSupported()
+    {
+        // Arrange
+        using var sut = new HuggingFaceEmbeddingGenerator("fake-model", new Uri("https://fake-random-test-host/fake-path"), httpClient: this._httpClient);
+
+        // Act
+        var result = sut.GetService(typeof(string), "serviceKey");
+
+        // Assert
+        Assert.Null(result);
+    }
+
+    public void Dispose()
+    {
+        this._httpClient.Dispose();
+        this._messageHandlerStub.Dispose();
+    }
+}

--- a/dotnet/src/Connectors/Connectors.HuggingFace/HuggingFaceKernelBuilderExtensions.EmbeddingGenerator.cs
+++ b/dotnet/src/Connectors/Connectors.HuggingFace/HuggingFaceKernelBuilderExtensions.EmbeddingGenerator.cs
@@ -1,0 +1,60 @@
+// Copyright (c) Microsoft. All rights reserved.
+
+using System;
+using System.Net.Http;
+
+namespace Microsoft.SemanticKernel;
+
+/// <summary>
+/// Provides extension methods for the <see cref="IKernelBuilder"/> class to configure Hugging Face connectors.
+/// </summary>
+public static partial class HuggingFaceKernelBuilderExtensions
+{
+    /// <summary>
+    /// Adds a HuggingFace embedding generator service with the specified configuration.
+    /// </summary>
+    /// <param name="builder">The <see cref="IKernelBuilder"/> instance to augment.</param>
+    /// <param name="model">The name of the Hugging Face model.</param>
+    /// <param name="endpoint">The endpoint for the embedding generator service.</param>
+    /// <param name="apiKey">The API key required for accessing the Hugging Face service.</param>
+    /// <param name="serviceId">A local identifier for the given AI service.</param>
+    /// <param name="httpClient">The HttpClient to use with this service.</param>
+    /// <returns>The same instance as <paramref name="builder"/>.</returns>
+    public static IKernelBuilder AddHuggingFaceEmbeddingGenerator(
+        this IKernelBuilder builder,
+        string model,
+        Uri? endpoint = null,
+        string? apiKey = null,
+        string? serviceId = null,
+        HttpClient? httpClient = null)
+    {
+        Verify.NotNull(builder);
+
+        builder.Services.AddHuggingFaceEmbeddingGenerator(model, endpoint, apiKey, serviceId, httpClient);
+
+        return builder;
+    }
+
+    /// <summary>
+    /// Adds a HuggingFace embedding generator service with the specified configuration.
+    /// </summary>
+    /// <param name="builder">The <see cref="IKernelBuilder"/> instance to augment.</param>
+    /// <param name="endpoint">The endpoint for the embedding generator service.</param>
+    /// <param name="apiKey">The API key required for accessing the Hugging Face service.</param>
+    /// <param name="serviceId">A local identifier for the given AI service.</param>
+    /// <param name="httpClient">The HttpClient to use with this service.</param>
+    /// <returns>The same instance as <paramref name="builder"/>.</returns>
+    public static IKernelBuilder AddHuggingFaceEmbeddingGenerator(
+        this IKernelBuilder builder,
+        Uri endpoint,
+        string? apiKey = null,
+        string? serviceId = null,
+        HttpClient? httpClient = null)
+    {
+        Verify.NotNull(builder);
+
+        builder.Services.AddHuggingFaceEmbeddingGenerator(endpoint, apiKey, serviceId, httpClient);
+
+        return builder;
+    }
+}

--- a/dotnet/src/Connectors/Connectors.HuggingFace/HuggingFaceKernelBuilderExtensions.cs
+++ b/dotnet/src/Connectors/Connectors.HuggingFace/HuggingFaceKernelBuilderExtensions.cs
@@ -8,7 +8,7 @@ namespace Microsoft.SemanticKernel;
 /// <summary>
 /// Provides extension methods for the <see cref="IKernelBuilder"/> class to configure Hugging Face connectors.
 /// </summary>
-public static class HuggingFaceKernelBuilderExtensions
+public static partial class HuggingFaceKernelBuilderExtensions
 {
     /// <summary>
     /// Adds an Hugging Face text generation service with the specified configuration.
@@ -116,6 +116,7 @@ public static class HuggingFaceKernelBuilderExtensions
     /// <param name="serviceId">A local identifier for the given AI service.</param>
     /// <param name="httpClient">The HttpClient to use with this service.</param>
     /// <returns>The same instance as <paramref name="builder"/>.</returns>
+    [Obsolete("Use AddHuggingFaceEmbeddingGenerator instead.")]
     public static IKernelBuilder AddHuggingFaceTextEmbeddingGeneration(
         this IKernelBuilder builder,
         string model,
@@ -140,6 +141,7 @@ public static class HuggingFaceKernelBuilderExtensions
     /// <param name="serviceId">A local identifier for the given AI service.</param>
     /// <param name="httpClient">The HttpClient to use with this service.</param>
     /// <returns>The same instance as <paramref name="builder"/>.</returns>
+    [Obsolete("Use AddHuggingFaceEmbeddingGenerator instead.")]
     public static IKernelBuilder AddHuggingFaceTextEmbeddingGeneration(
         this IKernelBuilder builder,
         Uri endpoint,

--- a/dotnet/src/Connectors/Connectors.HuggingFace/HuggingFaceServiceCollectionExtensions.EmbeddingGenerator.cs
+++ b/dotnet/src/Connectors/Connectors.HuggingFace/HuggingFaceServiceCollectionExtensions.EmbeddingGenerator.cs
@@ -1,0 +1,74 @@
+// Copyright (c) Microsoft. All rights reserved.
+
+using System;
+using System.Net.Http;
+using Microsoft.Extensions.AI;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Logging;
+using Microsoft.SemanticKernel.Connectors.HuggingFace;
+using Microsoft.SemanticKernel.Http;
+
+namespace Microsoft.SemanticKernel;
+
+/// <summary>
+/// Provides extension methods for the <see cref="IServiceCollection"/> interface to configure Hugging Face connectors.
+/// </summary>
+public static partial class HuggingFaceServiceCollectionExtensions
+{
+    /// <summary>
+    /// Adds a HuggingFace embedding generator service with the specified configuration.
+    /// </summary>
+    /// <param name="services">The <see cref="IServiceCollection"/> instance to augment.</param>
+    /// <param name="model">The name of the Hugging Face model.</param>
+    /// <param name="endpoint">The endpoint for the embedding generator service.</param>
+    /// <param name="apiKey">The API key required for accessing the Hugging Face service.</param>
+    /// <param name="serviceId">A local identifier for the given AI service.</param>
+    /// <param name="httpClient">The HttpClient to use with this service.</param>
+    /// <returns>The same instance as <paramref name="services"/>.</returns>
+    public static IServiceCollection AddHuggingFaceEmbeddingGenerator(
+        this IServiceCollection services,
+        string model,
+        Uri? endpoint = null,
+        string? apiKey = null,
+        string? serviceId = null,
+        HttpClient? httpClient = null)
+    {
+        Verify.NotNull(services);
+
+        return services.AddKeyedSingleton<IEmbeddingGenerator<string, Embedding<float>>>(serviceId, (serviceProvider, _) =>
+            new HuggingFaceEmbeddingGenerator(
+                model,
+                endpoint,
+                apiKey,
+                HttpClientProvider.GetHttpClient(httpClient, serviceProvider),
+                serviceProvider.GetService<ILoggerFactory>()
+            ));
+    }
+
+    /// <summary>
+    /// Adds a HuggingFace embedding generator service with the specified configuration.
+    /// </summary>
+    /// <param name="services">The <see cref="IServiceCollection"/> instance to augment.</param>
+    /// <param name="endpoint">The endpoint for the embedding generator service.</param>
+    /// <param name="apiKey">The API key required for accessing the Hugging Face service.</param>
+    /// <param name="serviceId">A local identifier for the given AI service.</param>
+    /// <param name="httpClient">The HttpClient to use with this service.</param>
+    /// <returns>The same instance as <paramref name="services"/>.</returns>
+    public static IServiceCollection AddHuggingFaceEmbeddingGenerator(
+        this IServiceCollection services,
+        Uri endpoint,
+        string? apiKey = null,
+        string? serviceId = null,
+        HttpClient? httpClient = null)
+    {
+        Verify.NotNull(services);
+
+        return services.AddKeyedSingleton<IEmbeddingGenerator<string, Embedding<float>>>(serviceId, (serviceProvider, _) =>
+            new HuggingFaceEmbeddingGenerator(
+                endpoint,
+                apiKey,
+                HttpClientProvider.GetHttpClient(httpClient, serviceProvider),
+                serviceProvider.GetService<ILoggerFactory>()
+            ));
+    }
+}

--- a/dotnet/src/Connectors/Connectors.HuggingFace/HuggingFaceServiceCollectionExtensions.cs
+++ b/dotnet/src/Connectors/Connectors.HuggingFace/HuggingFaceServiceCollectionExtensions.cs
@@ -16,7 +16,7 @@ namespace Microsoft.SemanticKernel;
 /// <summary>
 /// Provides extension methods for the <see cref="IServiceCollection"/> interface to configure Hugging Face connectors.
 /// </summary>
-public static class HuggingFaceServiceCollectionExtensions
+public static partial class HuggingFaceServiceCollectionExtensions
 {
     /// <summary>
     /// Adds an Hugging Face text generation service with the specified configuration.
@@ -140,6 +140,7 @@ public static class HuggingFaceServiceCollectionExtensions
     /// <param name="serviceId">A local identifier for the given AI service.</param>
     /// <param name="httpClient">The HttpClient to use with this service.</param>
     /// <returns>The same instance as <paramref name="services"/>.</returns>
+    [Obsolete("Use AddHuggingFaceEmbeddingGenerator instead.")]
     public static IServiceCollection AddHuggingFaceTextEmbeddingGeneration(
         this IServiceCollection services,
         string model,
@@ -169,6 +170,7 @@ public static class HuggingFaceServiceCollectionExtensions
     /// <param name="serviceId">A local identifier for the given AI service.</param>
     /// <param name="httpClient">The HttpClient to use with this service.</param>
     /// <returns>The same instance as <paramref name="services"/>.</returns>
+    [Obsolete("Use AddHuggingFaceEmbeddingGenerator instead.")]
     public static IServiceCollection AddHuggingFaceTextEmbeddingGeneration(
         this IServiceCollection services,
         Uri endpoint,

--- a/dotnet/src/Connectors/Connectors.HuggingFace/Services/HuggingFaceEmbeddingGenerator.cs
+++ b/dotnet/src/Connectors/Connectors.HuggingFace/Services/HuggingFaceEmbeddingGenerator.cs
@@ -1,0 +1,115 @@
+// Copyright (c) Microsoft. All rights reserved.
+
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Net.Http;
+using System.Threading;
+using System.Threading.Tasks;
+using Microsoft.Extensions.AI;
+using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Logging.Abstractions;
+using Microsoft.SemanticKernel.Connectors.HuggingFace.Core;
+using Microsoft.SemanticKernel.Http;
+
+namespace Microsoft.SemanticKernel.Connectors.HuggingFace;
+
+/// <summary>
+/// HuggingFace embedding generation service.
+/// </summary>
+public sealed class HuggingFaceEmbeddingGenerator : IEmbeddingGenerator<string, Embedding<float>>
+{
+    private readonly bool _isExternalHttpClient;
+    private readonly HttpClient _httpClient;
+    private readonly EmbeddingGeneratorMetadata _metadata;
+    private HuggingFaceClient Client { get; }
+
+    /// <summary>
+    /// Initializes a new instance of the <see cref="HuggingFaceEmbeddingGenerator"/> class.
+    /// </summary>
+    /// <param name="modelId">The HuggingFace model for the text generation service.</param>
+    /// <param name="endpoint">The endpoint uri including the port where HuggingFace server is hosted</param>
+    /// <param name="apiKey">Optional API key for accessing the HuggingFace service.</param>
+    /// <param name="httpClient">Optional HTTP client to be used for communication with the HuggingFace API.</param>
+    /// <param name="loggerFactory">Optional logger factory to be used for logging.</param>
+    public HuggingFaceEmbeddingGenerator(
+        string modelId,
+        Uri? endpoint = null,
+        string? apiKey = null,
+        HttpClient? httpClient = null,
+        ILoggerFactory? loggerFactory = null)
+    {
+        Verify.NotNullOrWhiteSpace(modelId);
+        this._isExternalHttpClient = httpClient is not null;
+        this._httpClient = HttpClientProvider.GetHttpClient(httpClient);
+
+        this.Client = new HuggingFaceClient(
+        modelId: modelId,
+            endpoint: endpoint ?? this._httpClient.BaseAddress,
+            apiKey: apiKey,
+            httpClient: this._httpClient,
+            logger: loggerFactory?.CreateLogger(this.GetType()) ?? NullLogger.Instance
+        );
+
+        this._metadata = new EmbeddingGeneratorMetadata(providerUri: endpoint, defaultModelId: modelId);
+    }
+
+    /// <summary>
+    /// Initializes a new instance of the <see cref="HuggingFaceEmbeddingGenerator"/> class.
+    /// </summary>
+    /// <param name="endpoint">The endpoint uri including the port where HuggingFace server is hosted</param>
+    /// <param name="apiKey">Optional API key for accessing the HuggingFace service.</param>
+    /// <param name="httpClient">Optional HTTP client to be used for communication with the HuggingFace API.</param>
+    /// <param name="loggerFactory">Optional logger factory to be used for logging.</param>
+    public HuggingFaceEmbeddingGenerator(
+        Uri endpoint,
+        string? apiKey = null,
+        HttpClient? httpClient = null,
+        ILoggerFactory? loggerFactory = null)
+    {
+        Verify.NotNull(endpoint);
+
+        this._isExternalHttpClient = httpClient is not null;
+        this._httpClient = HttpClientProvider.GetHttpClient(httpClient);
+
+        this.Client = new HuggingFaceClient(
+            modelId: null,
+            endpoint: endpoint ?? this._httpClient.BaseAddress,
+            apiKey: apiKey,
+            httpClient: this._httpClient,
+            logger: loggerFactory?.CreateLogger(this.GetType()) ?? NullLogger.Instance
+        );
+
+        this._metadata = new EmbeddingGeneratorMetadata(providerUri: endpoint);
+    }
+
+    /// <inheritdoc/>
+    public async Task<GeneratedEmbeddings<Embedding<float>>> GenerateAsync(IEnumerable<string> values, EmbeddingGenerationOptions? options = null, CancellationToken cancellationToken = default)
+    {
+        var data = values.ToList();
+        var result = await this.Client.GenerateEmbeddingsAsync(data, null, cancellationToken).ConfigureAwait(false);
+        return new GeneratedEmbeddings<Embedding<float>>(result.Select(e => new Embedding<float>(e)));
+    }
+
+    /// <inheritdoc/>
+    public void Dispose()
+    {
+        // Dispose the HttpClient only if it was created internally
+        if (!this._isExternalHttpClient)
+        {
+            this._httpClient.Dispose();
+        }
+    }
+
+    /// <inheritdoc/>
+    public object? GetService(Type serviceType, object? serviceKey = null)
+    {
+        Verify.NotNull(serviceType);
+
+        return
+            serviceKey is null ? null :
+            serviceType.IsInstanceOfType(this) ? this :
+            serviceType == typeof(EmbeddingGeneratorMetadata) ? this._metadata :
+            null;
+    }
+}

--- a/dotnet/src/Connectors/Connectors.HuggingFace/Services/HuggingFaceTextEmbeddingGenerationService.cs
+++ b/dotnet/src/Connectors/Connectors.HuggingFace/Services/HuggingFaceTextEmbeddingGenerationService.cs
@@ -16,6 +16,7 @@ namespace Microsoft.SemanticKernel.Connectors.HuggingFace;
 /// <summary>
 /// HuggingFace embedding generation service.
 /// </summary>
+[Obsolete("Use HuggingFaceEmbeddingGenerator instead.")]
 public sealed class HuggingFaceTextEmbeddingGenerationService : ITextEmbeddingGenerationService
 {
     private Dictionary<string, object?> AttributesInternal { get; } = [];

--- a/dotnet/src/Connectors/Connectors.MistralAI.UnitTests/MistralAIExtensionTests.cs
+++ b/dotnet/src/Connectors/Connectors.MistralAI.UnitTests/MistralAIExtensionTests.cs
@@ -3,6 +3,7 @@
 using System;
 using System.Net.Http;
 using System.Reflection;
+using Microsoft.Extensions.AI;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.SemanticKernel;
 using Microsoft.SemanticKernel.ChatCompletion;
@@ -35,6 +36,7 @@ public class MistralAIExtensionTests
     }
 
     [Fact]
+    [Obsolete("This test is deprecated and will be removed in a future release.")]
     public void AddMistralTextEmbeddingGenerationToServiceCollection()
     {
         // Arrange
@@ -49,6 +51,23 @@ public class MistralAIExtensionTests
         // Assert
         Assert.NotNull(service);
         Assert.IsType<MistralAITextEmbeddingGenerationService>(service);
+    }
+
+    [Fact]
+    public void AddMistralAIEmbeddingGeneratorToServiceCollection()
+    {
+        // Arrange
+        var collection = new ServiceCollection();
+        collection.AddMistralEmbeddingGenerator("model", "apiKey");
+
+        // Act
+        var kernelBuilder = collection.AddKernel();
+        var kernel = collection.BuildServiceProvider().GetRequiredService<Kernel>();
+        var service = kernel.GetRequiredService<IEmbeddingGenerator<string, Embedding<float>>>();
+
+        // Assert
+        Assert.NotNull(service);
+        Assert.IsType<MistralAIEmbeddingGenerator>(service);
     }
 
     [Fact]
@@ -69,6 +88,7 @@ public class MistralAIExtensionTests
     }
 
     [Fact]
+    [Obsolete("This test is deprecated and will be removed in a future release.")]
     public void AddMistralTextEmbeddingGenerationToKernelBuilder()
     {
         // Arrange
@@ -83,6 +103,23 @@ public class MistralAIExtensionTests
         // Assert
         Assert.NotNull(service);
         Assert.IsType<MistralAITextEmbeddingGenerationService>(service);
+    }
+
+    [Fact]
+    public void AddMistralAIEmbeddingGeneratorToKernelBuilder()
+    {
+        // Arrange
+        var collection = new ServiceCollection();
+        var kernelBuilder = collection.AddKernel();
+        kernelBuilder.AddMistralEmbeddingGenerator("model", "apiKey");
+
+        // Act
+        var kernel = collection.BuildServiceProvider().GetRequiredService<Kernel>();
+        var service = kernel.GetRequiredService<IEmbeddingGenerator<string, Embedding<float>>>();
+
+        // Assert
+        Assert.NotNull(service);
+        Assert.IsType<MistralAIEmbeddingGenerator>(service);
     }
 
     [Theory]

--- a/dotnet/src/Connectors/Connectors.MistralAI.UnitTests/Services/MistralAIEmbeddingGeneratorTests.cs
+++ b/dotnet/src/Connectors/Connectors.MistralAI.UnitTests/Services/MistralAIEmbeddingGeneratorTests.cs
@@ -1,0 +1,47 @@
+// Copyright (c) Microsoft. All rights reserved.
+
+using System.Collections.Generic;
+using System.Threading.Tasks;
+using Microsoft.Extensions.AI;
+using SemanticKernel.Connectors.MistralAI.UnitTests;
+using Xunit;
+
+namespace Microsoft.SemanticKernel.Connectors.MistralAI.UnitTests.Services;
+
+/// <summary>
+/// Unit tests for <see cref="MistralAIEmbeddingGenerator"/>.
+/// </summary>
+public sealed class MistralAIEmbeddingGeneratorTests : MistralTestBase
+{
+    [Fact]
+    public async Task ValidateGenerateAsync()
+    {
+        // Arrange
+        var content = this.GetTestResponseAsString("embeddings_response.json");
+        this.DelegatingHandler = new AssertingDelegatingHandler("https://api.mistral.ai/v1/embeddings", content);
+        this.HttpClient = new System.Net.Http.HttpClient(this.DelegatingHandler, false);
+        using var service = new MistralAIEmbeddingGenerator("mistral-small-latest", "key", httpClient: this.HttpClient, dimensions: null);
+
+        // Act
+        List<string> data = ["Hello", "world"];
+        var response = await service.GenerateAsync(data, default);
+
+        // Assert
+        Assert.NotNull(response);
+        Assert.Equal(2, response.Count);
+        Assert.Equal(1024, response[0].Vector.Length);
+        Assert.Equal(1024, response[1].Vector.Length);
+    }
+
+    [Fact]
+    public void ValidateGetService()
+    {
+        // Arrange
+        using var service = new MistralAIEmbeddingGenerator("mistral-small-latest", "key");
+
+        // Act & Assert
+        Assert.Null(service.GetService(typeof(object), null));
+        Assert.Same(service, service.GetService(typeof(MistralAIEmbeddingGenerator), service));
+        Assert.IsType<EmbeddingGeneratorMetadata>(service.GetService(typeof(EmbeddingGeneratorMetadata), typeof(EmbeddingGeneratorMetadata)));
+    }
+}

--- a/dotnet/src/Connectors/Connectors.MistralAI.UnitTests/Services/MistralAITextEmbeddingGenerationServiceTests.cs
+++ b/dotnet/src/Connectors/Connectors.MistralAI.UnitTests/Services/MistralAITextEmbeddingGenerationServiceTests.cs
@@ -1,5 +1,6 @@
 ﻿// Copyright (c) Microsoft. All rights reserved.
 
+using System;
 using System.Collections.Generic;
 using System.Net.Http;
 using System.Threading.Tasks;
@@ -11,6 +12,7 @@ namespace SemanticKernel.Connectors.MistralAI.UnitTests.Services;
 /// <summary>
 /// Unit tests for <see cref="MistralAITextEmbeddingGenerationService"/>.
 /// </summary>
+[Obsolete("This class is deprecated and will be removed in a future release.")]
 public sealed class MistralAITextEmbeddingGenerationServiceTests : MistralTestBase
 {
     [Fact]

--- a/dotnet/src/Connectors/Connectors.MistralAI/Extensions/MistralAIKernelBuilderExtensions.EmbeddingGenerator.cs
+++ b/dotnet/src/Connectors/Connectors.MistralAI/Extensions/MistralAIKernelBuilderExtensions.EmbeddingGenerator.cs
@@ -1,0 +1,47 @@
+// Copyright (c) Microsoft. All rights reserved.
+
+using System;
+using System.Net.Http;
+
+namespace Microsoft.SemanticKernel;
+
+/// <summary>
+/// Extension methods for adding MistralAI embedding generator to a kernel builder.
+/// </summary>
+public static partial class MistralAIKernelBuilderExtensions
+{
+    /// <summary>
+    /// Adds a MistralAI embedding generator service to the kernel.
+    /// </summary>
+    /// <param name="builder">The <see cref="IKernelBuilder"/> instance to augment.</param>
+    /// <param name="modelId">The name of the MistralAI modelId.</param>
+    /// <param name="apiKey">The API key required for accessing the MistralAI service.</param>
+    /// <param name="endpoint">Optional uri endpoint including the port where MistralAI server is hosted. Default is https://api.mistral.ai.</param>
+    /// <param name="serviceId">A local identifier for the given AI service.</param>
+    /// <param name="dimensions">The number of dimensions the resulting output embeddings should have, if supported by the model.</param>
+    /// <param name="httpClient">The HttpClient to use with this service.</param>
+    /// <returns>The same instance as <paramref name="builder"/>.</returns>
+    public static IKernelBuilder AddMistralEmbeddingGenerator(
+        this IKernelBuilder builder,
+        string modelId,
+        string apiKey,
+        Uri? endpoint = null,
+        string? serviceId = null,
+        int? dimensions = null,
+        HttpClient? httpClient = null)
+    {
+        Verify.NotNull(builder);
+        Verify.NotNullOrWhiteSpace(modelId);
+        Verify.NotNullOrWhiteSpace(apiKey);
+
+        builder.Services.AddMistralEmbeddingGenerator(
+            modelId,
+            apiKey,
+            endpoint,
+            serviceId,
+            dimensions,
+            httpClient);
+
+        return builder;
+    }
+}

--- a/dotnet/src/Connectors/Connectors.MistralAI/Extensions/MistralAIKernelBuilderExtensions.cs
+++ b/dotnet/src/Connectors/Connectors.MistralAI/Extensions/MistralAIKernelBuilderExtensions.cs
@@ -8,7 +8,7 @@ namespace Microsoft.SemanticKernel;
 /// <summary>
 /// Provides extension methods for the <see cref="IKernelBuilder"/> class to configure Mistral connectors.
 /// </summary>
-public static class MistralAIKernelBuilderExtensions
+public static partial class MistralAIKernelBuilderExtensions
 {
     /// <summary>
     /// Adds an Mistral chat completion service with the specified configuration.
@@ -47,6 +47,7 @@ public static class MistralAIKernelBuilderExtensions
     /// <param name="serviceId">A local identifier for the given AI service.</param>
     /// <param name="httpClient">The HttpClient to use with this service.</param>
     /// <returns>The same instance as <paramref name="builder"/>.</returns>
+    [Obsolete("Use AddMistralEmbeddingGenerator instead.")]
     public static IKernelBuilder AddMistralTextEmbeddingGeneration(
         this IKernelBuilder builder,
         string modelId,

--- a/dotnet/src/Connectors/Connectors.MistralAI/Extensions/MistralAIServiceCollectionExtensions.EmbeddingGenerator.cs
+++ b/dotnet/src/Connectors/Connectors.MistralAI/Extensions/MistralAIServiceCollectionExtensions.EmbeddingGenerator.cs
@@ -1,0 +1,51 @@
+// Copyright (c) Microsoft. All rights reserved.
+
+using System;
+using System.Net.Http;
+using Microsoft.Extensions.AI;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Logging;
+using Microsoft.SemanticKernel.Connectors.MistralAI;
+using Microsoft.SemanticKernel.Http;
+
+namespace Microsoft.SemanticKernel;
+
+/// <summary>
+/// Extension methods for adding MistralAI embedding generator to a service collection.
+/// </summary>
+public static partial class MistralAIServiceCollectionExtensions
+{
+    /// <summary>
+    /// Adds a MistralAI embedding generator service to the service collection.
+    /// </summary>
+    /// <param name="services">The <see cref="IServiceCollection"/> instance to augment.</param>
+    /// <param name="modelId">The name of the MistralAI modelId.</param>
+    /// <param name="apiKey">The API key required for accessing the MistralAI service.</param>
+    /// <param name="endpoint">Optional uri endpoint including the port where MistralAI server is hosted. Default is https://api.mistral.ai.</param>
+    /// <param name="serviceId">A local identifier for the given AI service.</param>
+    /// <param name="dimensions">The number of dimensions the resulting output embeddings should have, if supported by the model.</param>
+    /// <param name="httpClient">The HttpClient to use with this service.</param>
+    /// <returns>The same instance as <paramref name="services"/>.</returns>
+    public static IServiceCollection AddMistralEmbeddingGenerator(
+        this IServiceCollection services,
+        string modelId,
+        string apiKey,
+        Uri? endpoint = null,
+        string? serviceId = null,
+        int? dimensions = null,
+        HttpClient? httpClient = null)
+    {
+        Verify.NotNull(services);
+        Verify.NotNullOrWhiteSpace(modelId);
+        Verify.NotNullOrWhiteSpace(apiKey);
+
+        return services.AddKeyedSingleton<IEmbeddingGenerator<string, Embedding<float>>>(serviceId, (serviceProvider, _) =>
+            new MistralAIEmbeddingGenerator(
+                modelId,
+                apiKey,
+                endpoint,
+                dimensions,
+                HttpClientProvider.GetHttpClient(httpClient, serviceProvider),
+                serviceProvider.GetService<ILoggerFactory>()));
+    }
+}

--- a/dotnet/src/Connectors/Connectors.MistralAI/Extensions/MistralAIServiceCollectionExtensions.cs
+++ b/dotnet/src/Connectors/Connectors.MistralAI/Extensions/MistralAIServiceCollectionExtensions.cs
@@ -14,7 +14,7 @@ namespace Microsoft.SemanticKernel;
 /// <summary>
 /// Provides extension methods for the <see cref="IServiceCollection"/> interface to configure Mistral connectors.
 /// </summary>
-public static class MistralAIServiceCollectionExtensions
+public static partial class MistralAIServiceCollectionExtensions
 {
     /// <summary>
     /// Adds an Mistral chat completion service with the specified configuration.
@@ -69,6 +69,7 @@ public static class MistralAIServiceCollectionExtensions
     /// <param name="serviceId">A local identifier for the given AI service.</param>
     /// <param name="httpClient">The HttpClient to use with this service.</param>
     /// <returns>The same instance as <paramref name="services"/>.</returns>
+    [Obsolete("Use AddMistralEmbeddingGenerator instead.")]
     public static IServiceCollection AddMistralTextEmbeddingGeneration(
         this IServiceCollection services,
         string modelId,

--- a/dotnet/src/Connectors/Connectors.MistralAI/Services/MistralAIEmbeddingGenerator.cs
+++ b/dotnet/src/Connectors/Connectors.MistralAI/Services/MistralAIEmbeddingGenerator.cs
@@ -1,0 +1,79 @@
+// Copyright (c) Microsoft. All rights reserved.
+
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Net.Http;
+using System.Threading;
+using System.Threading.Tasks;
+using Microsoft.Extensions.AI;
+using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Logging.Abstractions;
+using Microsoft.SemanticKernel.Connectors.MistralAI.Client;
+using Microsoft.SemanticKernel.Http;
+
+namespace Microsoft.SemanticKernel.Connectors.MistralAI;
+
+/// <summary>
+/// Mistral AI embedding generator service.
+/// </summary>
+public sealed class MistralAIEmbeddingGenerator : IEmbeddingGenerator<string, Embedding<float>>
+{
+    private readonly MistralClient _client;
+    private readonly EmbeddingGeneratorMetadata? _metadata;
+
+    /// <summary>
+    /// Initializes a new instance of the <see cref="MistralAIEmbeddingGenerator"/> class.
+    /// </summary>
+    /// <param name="modelId">The Mistral modelId for the text generation service.</param>
+    /// <param name="apiKey">API key for accessing the MistralAI service.</param>
+    /// <param name="endpoint">Optional uri endpoint including the port where MistralAI server is hosted. Default is https://api.mistral.ai.</param>
+    /// <param name="dimensions">The number of dimensions the resulting output embeddings should have, if supported by the model.</param>
+    /// <param name="httpClient">Optional HTTP client to be used for communication with the MistralAI API.</param>
+    /// <param name="loggerFactory">Optional logger factory to be used for logging.</param>
+    public MistralAIEmbeddingGenerator(
+        string modelId,
+        string apiKey,
+        Uri? endpoint = null,
+        int? dimensions = null,
+        HttpClient? httpClient = null,
+        ILoggerFactory? loggerFactory = null)
+    {
+        this._client = new MistralClient(
+            modelId: modelId,
+            endpoint: endpoint ?? httpClient?.BaseAddress,
+            apiKey: apiKey,
+            httpClient: HttpClientProvider.GetHttpClient(httpClient),
+            logger: loggerFactory?.CreateLogger(this.GetType()) ?? NullLogger.Instance
+        );
+
+        this._metadata = new EmbeddingGeneratorMetadata(defaultModelId: modelId, defaultModelDimensions: dimensions);
+    }
+
+    /// <inheritdoc />
+    public async Task<GeneratedEmbeddings<Embedding<float>>> GenerateAsync(
+        IEnumerable<string> values,
+        EmbeddingGenerationOptions? options = null,
+        CancellationToken cancellationToken = default)
+    {
+        var result = await this._client.GenerateEmbeddingsAsync(values.ToList(), cancellationToken).ConfigureAwait(false);
+        return new(result.Select(e => new Embedding<float>(e)));
+    }
+
+    /// <inheritdoc />
+    public void Dispose()
+    {
+    }
+
+    /// <inheritdoc />
+    public object? GetService(Type serviceType, object? serviceKey = null)
+    {
+        Verify.NotNull(serviceType);
+
+        return
+            serviceKey is null ? null :
+            serviceType.IsInstanceOfType(this) ? this :
+            serviceType == typeof(EmbeddingGeneratorMetadata) ? this._metadata :
+            null;
+    }
+}

--- a/dotnet/src/Connectors/Connectors.MistralAI/Services/MistralAITextEmbeddingGenerationService.cs
+++ b/dotnet/src/Connectors/Connectors.MistralAI/Services/MistralAITextEmbeddingGenerationService.cs
@@ -17,6 +17,7 @@ namespace Microsoft.SemanticKernel.Connectors.MistralAI;
 /// <summary>
 /// Mistral text embedding service.
 /// </summary>
+[Obsolete("Use MistralAIEmbeddingGenerator instead.")]
 public sealed class MistralAITextEmbeddingGenerationService : ITextEmbeddingGenerationService
 {
     /// <summary>

--- a/dotnet/src/Connectors/Connectors.Onnx/OnnxKernelBuilderExtensions.cs
+++ b/dotnet/src/Connectors/Connectors.Onnx/OnnxKernelBuilderExtensions.cs
@@ -1,7 +1,9 @@
 ﻿// Copyright (c) Microsoft. All rights reserved.
 
+using System;
 using System.IO;
 using System.Text.Json;
+using Microsoft.Extensions.AI;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Logging;
 using Microsoft.SemanticKernel.ChatCompletion;
@@ -50,6 +52,7 @@ public static class OnnxKernelBuilderExtensions
     /// <param name="options">Options for the configuration of the model and service.</param>
     /// <param name="serviceId">A local identifier for the given AI service.</param>
     /// <returns>The same instance as <paramref name="builder"/>.</returns>
+    [Obsolete("Use AddBertOnnxEmbeddingGenerator instead")]
     public static IKernelBuilder AddBertOnnxTextEmbeddingGeneration(
         this IKernelBuilder builder,
         string onnxModelPath,
@@ -71,6 +74,7 @@ public static class OnnxKernelBuilderExtensions
     /// <param name="options">Options for the configuration of the model and service.</param>
     /// <param name="serviceId">A local identifier for the given AI service.</param>
     /// <returns>The same instance as <paramref name="builder"/>.</returns>
+    [Obsolete("Use AddBertOnnxEmbeddingGenerator instead")]
     public static IKernelBuilder AddBertOnnxTextEmbeddingGeneration(
         this IKernelBuilder builder,
         Stream onnxModelStream,
@@ -81,6 +85,56 @@ public static class OnnxKernelBuilderExtensions
         builder.Services.AddKeyedSingleton<ITextEmbeddingGenerationService>(
             serviceId,
             BertOnnxTextEmbeddingGenerationService.Create(onnxModelStream, vocabStream, options));
+
+        return builder;
+    }
+
+    /// <summary>Adds a text embedding generation service using a BERT ONNX model.</summary>
+    /// <param name="builder">The <see cref="IKernelBuilder"/> instance to augment.</param>
+    /// <param name="onnxModelPath">The path to the ONNX model file.</param>
+    /// <param name="vocabPath">The path to the vocab file.</param>
+    /// <param name="options">Options for the configuration of the model and service.</param>
+    /// <param name="serviceId">A local identifier for the given AI service.</param>
+    /// <returns>The same instance as <paramref name="builder"/>.</returns>
+    public static IKernelBuilder AddBertOnnxEmbeddingGenerator(
+        this IKernelBuilder builder,
+        string onnxModelPath,
+        string vocabPath,
+        BertOnnxOptions? options = null,
+        string? serviceId = null)
+    {
+        Verify.NotNull(builder);
+
+        builder.Services.AddBertOnnxEmbeddingGenerator(
+            onnxModelPath,
+            vocabPath,
+            options,
+            serviceId);
+
+        return builder;
+    }
+
+    /// <summary>Adds a text embedding generation service using a BERT ONNX model.</summary>
+    /// <param name="builder">The <see cref="IKernelBuilder"/> instance to augment.</param>
+    /// <param name="onnxModelStream">Stream containing the ONNX model. The stream will be read during this call and will not be used after this call's completion.</param>
+    /// <param name="vocabStream">Stream containing the vocab file. The stream will be read during this call and will not be used after this call's completion.</param>
+    /// <param name="options">Options for the configuration of the model and service.</param>
+    /// <param name="serviceId">A local identifier for the given AI service.</param>
+    /// <returns>The same instance as <paramref name="builder"/>.</returns>
+    public static IKernelBuilder AddBertOnnxEmbeddingGenerator(
+        this IKernelBuilder builder,
+        Stream onnxModelStream,
+        Stream vocabStream,
+        BertOnnxOptions? options = null,
+        string? serviceId = null)
+    {
+        Verify.NotNull(builder);
+
+        builder.Services.AddBertOnnxEmbeddingGenerator(
+            onnxModelStream,
+            vocabStream,
+            options,
+            serviceId);
 
         return builder;
     }

--- a/dotnet/src/Connectors/Connectors.Onnx/OnnxServiceCollectionExtensions.cs
+++ b/dotnet/src/Connectors/Connectors.Onnx/OnnxServiceCollectionExtensions.cs
@@ -1,7 +1,9 @@
 ﻿// Copyright (c) Microsoft. All rights reserved.
 
+using System;
 using System.IO;
 using System.Text.Json;
+using Microsoft.Extensions.AI;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Logging;
 using Microsoft.SemanticKernel.ChatCompletion;
@@ -50,6 +52,7 @@ public static class OnnxServiceCollectionExtensions
     /// <param name="options">Options for the configuration of the model and service.</param>
     /// <param name="serviceId">A local identifier for the given AI service.</param>
     /// <returns>The same instance as <paramref name="services"/>.</returns>
+    [Obsolete("Use AddBertOnnxEmbeddingGenerator instead.")]
     public static IServiceCollection AddBertOnnxTextEmbeddingGeneration(
         this IServiceCollection services,
         string onnxModelPath,
@@ -69,6 +72,7 @@ public static class OnnxServiceCollectionExtensions
     /// <param name="options">Options for the configuration of the model and service.</param>
     /// <param name="serviceId">A local identifier for the given AI service.</param>
     /// <returns>The same instance as <paramref name="services"/>.</returns>
+    [Obsolete("Use AddBertOnnxEmbeddingGenerator instead.")]
     public static IServiceCollection AddBertOnnxTextEmbeddingGeneration(
         this IServiceCollection services,
         Stream onnxModelStream,
@@ -77,6 +81,48 @@ public static class OnnxServiceCollectionExtensions
         string? serviceId = null)
     {
         return services.AddKeyedSingleton<ITextEmbeddingGenerationService>(
+            serviceId,
+            BertOnnxTextEmbeddingGenerationService.Create(onnxModelStream, vocabStream, options));
+    }
+
+    /// <summary>Adds a text embedding generation service using a BERT ONNX model.</summary>
+    /// <param name="services">The <see cref="IServiceCollection"/> instance to augment.</param>
+    /// <param name="onnxModelPath">The path to the ONNX model file.</param>
+    /// <param name="vocabPath">The path to the vocab file.</param>
+    /// <param name="options">Options for the configuration of the model and service.</param>
+    /// <param name="serviceId">A local identifier for the given AI service.</param>
+    /// <returns>The same instance as <paramref name="services"/>.</returns>
+    public static IServiceCollection AddBertOnnxEmbeddingGenerator(
+        this IServiceCollection services,
+        string onnxModelPath,
+        string vocabPath,
+        BertOnnxOptions? options = null,
+        string? serviceId = null)
+    {
+        Verify.NotNull(services);
+
+        return services.AddKeyedSingleton<IEmbeddingGenerator<string, Embedding<float>>>(
+            serviceId,
+            BertOnnxTextEmbeddingGenerationService.Create(onnxModelPath, vocabPath, options));
+    }
+
+    /// <summary>Adds a text embedding generation service using a BERT ONNX model.</summary>
+    /// <param name="services">The <see cref="IServiceCollection"/> instance to augment.</param>
+    /// <param name="onnxModelStream">Stream containing the ONNX model. The stream will be read during this call and will not be used after this call's completion.</param>
+    /// <param name="vocabStream">Stream containing the vocab file. The stream will be read during this call and will not be used after this call's completion.</param>
+    /// <param name="options">Options for the configuration of the model and service.</param>
+    /// <param name="serviceId">A local identifier for the given AI service.</param>
+    /// <returns>The same instance as <paramref name="services"/>.</returns>
+    public static IServiceCollection AddBertOnnxEmbeddingGenerator(
+        this IServiceCollection services,
+        Stream onnxModelStream,
+        Stream vocabStream,
+        BertOnnxOptions? options = null,
+        string? serviceId = null)
+    {
+        Verify.NotNull(services);
+
+        return services.AddKeyedSingleton<IEmbeddingGenerator<string, Embedding<float>>>(
             serviceId,
             BertOnnxTextEmbeddingGenerationService.Create(onnxModelStream, vocabStream, options));
     }

--- a/dotnet/src/Connectors/Connectors.OpenAI.UnitTests/Extensions/KernelBuilderExtensionsTests.cs
+++ b/dotnet/src/Connectors/Connectors.OpenAI.UnitTests/Extensions/KernelBuilderExtensionsTests.cs
@@ -2,6 +2,7 @@
 
 using System;
 using System.ClientModel;
+using Microsoft.Extensions.AI;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.SemanticKernel;
 using Microsoft.SemanticKernel.AudioToText;
@@ -19,7 +20,10 @@ namespace SemanticKernel.Connectors.OpenAI.UnitTests.Extensions;
 
 public class KernelBuilderExtensionsTests
 {
+    private const string ObsoleteMessage = "This test is in a deprecated feature will be removed in a future version.";
+
     [Fact]
+    [Obsolete(ObsoleteMessage)]
     public void ItCanAddTextEmbeddingGenerationService()
     {
         // Arrange
@@ -35,6 +39,7 @@ public class KernelBuilderExtensionsTests
     }
 
     [Fact]
+    [Obsolete(ObsoleteMessage)]
     public void ItCanAddTextEmbeddingGenerationServiceWithOpenAIClient()
     {
         // Arrange
@@ -47,6 +52,36 @@ public class KernelBuilderExtensionsTests
 
         // Assert
         Assert.Equal("model", service.Attributes[AIServiceExtensions.ModelIdKey]);
+    }
+
+    [Fact]
+    public void ItCanAddEmbeddingGenerator()
+    {
+        // Arrange
+        var sut = Kernel.CreateBuilder();
+
+        // Act
+        var service = sut.AddOpenAIEmbeddingGenerator("model", "key")
+            .Build()
+            .GetRequiredService<IEmbeddingGenerator<string, Embedding<float>>>();
+
+        // Assert
+        Assert.Equal("model", service.GetService<EmbeddingGeneratorMetadata>()!.DefaultModelId);
+    }
+
+    [Fact]
+    public void ItCanAddEmbeddingGeneratorServiceWithOpenAIClient()
+    {
+        // Arrange
+        var sut = Kernel.CreateBuilder();
+
+        // Act
+        var service = sut.AddOpenAIEmbeddingGenerator("model", new OpenAIClient(new ApiKeyCredential("key")))
+            .Build()
+            .GetRequiredService<IEmbeddingGenerator<string, Embedding<float>>>();
+
+        // Assert
+        Assert.Equal("model", service.GetService<EmbeddingGeneratorMetadata>()!.DefaultModelId);
     }
 
     [Fact]
@@ -110,7 +145,7 @@ public class KernelBuilderExtensionsTests
     }
 
     [Fact]
-    [Obsolete("This test is deprecated and will be removed in a future version.")]
+    [Obsolete(ObsoleteMessage)]
     public void ItCanAddFileService()
     {
         // Arrange

--- a/dotnet/src/Connectors/Connectors.OpenAI.UnitTests/Extensions/ServiceCollectionExtensionsTests.cs
+++ b/dotnet/src/Connectors/Connectors.OpenAI.UnitTests/Extensions/ServiceCollectionExtensionsTests.cs
@@ -2,6 +2,7 @@
 
 using System;
 using System.ClientModel;
+using Microsoft.Extensions.AI;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.SemanticKernel;
 using Microsoft.SemanticKernel.AudioToText;
@@ -19,6 +20,8 @@ namespace SemanticKernel.Connectors.OpenAI.UnitTests.Extensions;
 
 public class ServiceCollectionExtensionsTests
 {
+    private const string ObsoleteMessage = "This test is in a deprecated feature will be removed in a future version.";
+
     #region Chat completion
 
     [Theory]
@@ -53,6 +56,7 @@ public class ServiceCollectionExtensionsTests
     #endregion
 
     [Fact]
+    [Obsolete(ObsoleteMessage)]
     public void ItCanAddTextEmbeddingGenerationService()
     {
         // Arrange
@@ -68,6 +72,7 @@ public class ServiceCollectionExtensionsTests
     }
 
     [Fact]
+    [Obsolete(ObsoleteMessage)]
     public void ItCanAddTextEmbeddingGenerationServiceWithOpenAIClient()
     {
         // Arrange
@@ -80,6 +85,31 @@ public class ServiceCollectionExtensionsTests
 
         // Assert
         Assert.Equal("model", service.Attributes[AIServiceExtensions.ModelIdKey]);
+    }
+
+    [Fact]
+    public void ItCanAddEmbeddingGenerator()
+    {
+        // Arrange
+        var sut = new ServiceCollection();
+        // Act
+        var service = sut.AddOpenAIEmbeddingGenerator("model", "key")
+            .BuildServiceProvider()
+            .GetRequiredService<IEmbeddingGenerator<string, Embedding<float>>>();
+        // Assert
+        Assert.Equal("model", service.GetService<EmbeddingGeneratorMetadata>()!.DefaultModelId);
+    }
+
+    [Fact]
+    public void ItCanAddEmbeddingGeneratorServiceWithOpenAIClient()
+    {
+        var sut = new ServiceCollection();
+
+        var service = sut.AddOpenAIEmbeddingGenerator("model", openAIClient: new OpenAIClient(new ApiKeyCredential("key")))
+            .BuildServiceProvider()
+            .GetRequiredService<IEmbeddingGenerator<string, Embedding<float>>>();
+
+        Assert.Equal("model", service.GetService<EmbeddingGeneratorMetadata>()!.DefaultModelId);
     }
 
     [Fact]
@@ -143,7 +173,7 @@ public class ServiceCollectionExtensionsTests
     }
 
     [Fact]
-    [Obsolete("This test is deprecated and will be removed in a future version.")]
+    [Obsolete(ObsoleteMessage)]
     public void ItCanAddFileService()
     {
         // Arrange

--- a/dotnet/src/Connectors/Connectors.OpenAI.UnitTests/Services/OpenAITextEmbeddingGenerationServiceTests.cs
+++ b/dotnet/src/Connectors/Connectors.OpenAI.UnitTests/Services/OpenAITextEmbeddingGenerationServiceTests.cs
@@ -20,6 +20,7 @@ namespace SemanticKernel.Connectors.OpenAI.UnitTests.Services;
 /// <summary>
 /// Unit tests for <see cref="OpenAITextEmbeddingGenerationService"/> class.
 /// </summary>
+[Obsolete("Temporary tests for obsoleted OpenAITextEmbeddingGenerationService.")]
 public class OpenAITextEmbeddingGenerationServiceTests
 {
     [Fact]

--- a/dotnet/src/Connectors/Connectors.OpenAI/Extensions/OpenAIKernelBuilderExtensions.EmbeddingGenerator.cs
+++ b/dotnet/src/Connectors/Connectors.OpenAI/Extensions/OpenAIKernelBuilderExtensions.EmbeddingGenerator.cs
@@ -14,14 +14,14 @@ namespace Microsoft.SemanticKernel;
 public static partial class OpenAIKernelBuilderExtensions
 {
     /// <summary>
-    /// Adds <see cref="OpenAITextEmbeddingGenerationService"/> to the <see cref="IKernelBuilder.Services"/>.
+    /// Adds <see cref="OpenAIEmbeddingGenerator"/> to the <see cref="IKernelBuilder.Services"/>.
     /// </summary>
     /// <param name="builder">The <see cref="IKernelBuilder"/> instance to augment.</param>
     /// <param name="modelId">OpenAI model name, see https://platform.openai.com/docs/models</param>
     /// <param name="apiKey">OpenAI API key, see https://platform.openai.com/account/api-keys</param>
     /// <param name="orgId">OpenAI organization id. This is usually optional unless your account belongs to multiple organizations.</param>
-    /// <param name="serviceId">A local identifier for the given AI service</param>
     /// <param name="dimensions">The number of dimensions the resulting output embeddings should have. Only supported in "text-embedding-3" and later models.</param>
+    /// <param name="serviceId">A local identifier for the given AI service</param>
     /// <param name="httpClient">The HttpClient to use with this service.</param>
     /// <returns>The same instance as <paramref name="builder"/>.</returns>
     [Experimental("SKEXP0010")]
@@ -30,8 +30,8 @@ public static partial class OpenAIKernelBuilderExtensions
         string modelId,
         string apiKey,
         string? orgId = null,
-        string? serviceId = null,
         int? dimensions = null,
+        string? serviceId = null,
         HttpClient? httpClient = null)
     {
         Verify.NotNull(builder);
@@ -42,29 +42,29 @@ public static partial class OpenAIKernelBuilderExtensions
             modelId,
             apiKey,
             orgId,
-            serviceId,
             dimensions,
+            serviceId,
             httpClient);
 
         return builder;
     }
 
     /// <summary>
-    /// Adds the <see cref="OpenAITextEmbeddingGenerationService"/> to the <see cref="IKernelBuilder.Services"/>.
+    /// Adds the <see cref="OpenAIEmbeddingGenerator"/> to the <see cref="IKernelBuilder.Services"/>.
     /// </summary>
     /// <param name="builder">The <see cref="IServiceCollection"/> instance to augment.</param>
     /// <param name="modelId">OpenAI model name, see https://platform.openai.com/docs/models</param>
     /// <param name="openAIClient"><see cref="OpenAIClient"/> to use for the service. If null, one must be available in the service provider when this service is resolved.</param>
-    /// <param name="serviceId">A local identifier for the given AI service</param>
     /// <param name="dimensions">The number of dimensions the resulting output embeddings should have. Only supported in "text-embedding-3" and later models.</param>
+    /// <param name="serviceId">A local identifier for the given AI service</param>
     /// <returns>The same instance as <paramref name="builder"/>.</returns>
     [Experimental("SKEXP0010")]
     public static IKernelBuilder AddOpenAIEmbeddingGenerator(
         this IKernelBuilder builder,
         string modelId,
         OpenAIClient? openAIClient = null,
-        string? serviceId = null,
-        int? dimensions = null)
+        int? dimensions = null,
+        string? serviceId = null)
     {
         Verify.NotNull(builder);
         Verify.NotNullOrWhiteSpace(modelId);
@@ -72,8 +72,8 @@ public static partial class OpenAIKernelBuilderExtensions
         builder.Services.AddOpenAIEmbeddingGenerator(
             modelId,
             openAIClient,
-            serviceId,
-            dimensions);
+            dimensions,
+            serviceId);
 
         return builder;
     }

--- a/dotnet/src/Connectors/Connectors.OpenAI/Extensions/OpenAIKernelBuilderExtensions.EmbeddingGenerator.cs
+++ b/dotnet/src/Connectors/Connectors.OpenAI/Extensions/OpenAIKernelBuilderExtensions.EmbeddingGenerator.cs
@@ -1,0 +1,80 @@
+﻿// Copyright (c) Microsoft. All rights reserved.
+
+using System.Diagnostics.CodeAnalysis;
+using System.Net.Http;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.SemanticKernel.Connectors.OpenAI;
+using OpenAI;
+
+namespace Microsoft.SemanticKernel;
+
+/// <summary>
+/// Sponsor extensions class for <see cref="IKernelBuilder"/>.
+/// </summary>
+public static partial class OpenAIKernelBuilderExtensions
+{
+    /// <summary>
+    /// Adds <see cref="OpenAITextEmbeddingGenerationService"/> to the <see cref="IKernelBuilder.Services"/>.
+    /// </summary>
+    /// <param name="builder">The <see cref="IKernelBuilder"/> instance to augment.</param>
+    /// <param name="modelId">OpenAI model name, see https://platform.openai.com/docs/models</param>
+    /// <param name="apiKey">OpenAI API key, see https://platform.openai.com/account/api-keys</param>
+    /// <param name="orgId">OpenAI organization id. This is usually optional unless your account belongs to multiple organizations.</param>
+    /// <param name="serviceId">A local identifier for the given AI service</param>
+    /// <param name="dimensions">The number of dimensions the resulting output embeddings should have. Only supported in "text-embedding-3" and later models.</param>
+    /// <param name="httpClient">The HttpClient to use with this service.</param>
+    /// <returns>The same instance as <paramref name="builder"/>.</returns>
+    [Experimental("SKEXP0010")]
+    public static IKernelBuilder AddOpenAIEmbeddingGenerator(
+        this IKernelBuilder builder,
+        string modelId,
+        string apiKey,
+        string? orgId = null,
+        string? serviceId = null,
+        int? dimensions = null,
+        HttpClient? httpClient = null)
+    {
+        Verify.NotNull(builder);
+        Verify.NotNullOrWhiteSpace(modelId);
+        Verify.NotNullOrWhiteSpace(apiKey);
+
+        builder.Services.AddOpenAIEmbeddingGenerator(
+            modelId,
+            apiKey,
+            orgId,
+            serviceId,
+            dimensions,
+            httpClient);
+
+        return builder;
+    }
+
+    /// <summary>
+    /// Adds the <see cref="OpenAITextEmbeddingGenerationService"/> to the <see cref="IKernelBuilder.Services"/>.
+    /// </summary>
+    /// <param name="builder">The <see cref="IServiceCollection"/> instance to augment.</param>
+    /// <param name="modelId">OpenAI model name, see https://platform.openai.com/docs/models</param>
+    /// <param name="openAIClient"><see cref="OpenAIClient"/> to use for the service. If null, one must be available in the service provider when this service is resolved.</param>
+    /// <param name="serviceId">A local identifier for the given AI service</param>
+    /// <param name="dimensions">The number of dimensions the resulting output embeddings should have. Only supported in "text-embedding-3" and later models.</param>
+    /// <returns>The same instance as <paramref name="builder"/>.</returns>
+    [Experimental("SKEXP0010")]
+    public static IKernelBuilder AddOpenAIEmbeddingGenerator(
+        this IKernelBuilder builder,
+        string modelId,
+        OpenAIClient? openAIClient = null,
+        string? serviceId = null,
+        int? dimensions = null)
+    {
+        Verify.NotNull(builder);
+        Verify.NotNullOrWhiteSpace(modelId);
+
+        builder.Services.AddOpenAIEmbeddingGenerator(
+            modelId,
+            openAIClient,
+            serviceId,
+            dimensions);
+
+        return builder;
+    }
+}

--- a/dotnet/src/Connectors/Connectors.OpenAI/Extensions/OpenAIKernelBuilderExtensions.cs
+++ b/dotnet/src/Connectors/Connectors.OpenAI/Extensions/OpenAIKernelBuilderExtensions.cs
@@ -22,7 +22,7 @@ namespace Microsoft.SemanticKernel;
 /// <summary>
 /// Sponsor extensions class for <see cref="IKernelBuilder"/>.
 /// </summary>
-public static class OpenAIKernelBuilderExtensions
+public static partial class OpenAIKernelBuilderExtensions
 {
     #region Text Embedding
     /// <summary>
@@ -37,6 +37,7 @@ public static class OpenAIKernelBuilderExtensions
     /// <param name="dimensions">The number of dimensions the resulting output embeddings should have. Only supported in "text-embedding-3" and later models.</param>
     /// <returns>The same instance as <paramref name="builder"/>.</returns>
     [Experimental("SKEXP0010")]
+    [Obsolete("Use AddOpenAIEmbeddingGenerator instead.")]
     public static IKernelBuilder AddOpenAITextEmbeddingGeneration(
         this IKernelBuilder builder,
         string modelId,
@@ -72,6 +73,7 @@ public static class OpenAIKernelBuilderExtensions
     /// <param name="dimensions">The number of dimensions the resulting output embeddings should have. Only supported in "text-embedding-3" and later models.</param>
     /// <returns>The same instance as <paramref name="builder"/>.</returns>
     [Experimental("SKEXP0010")]
+    [Obsolete("Use AddOpenAIEmbeddingGenerator instead.")]
     public static IKernelBuilder AddOpenAITextEmbeddingGeneration(
         this IKernelBuilder builder,
         string modelId,

--- a/dotnet/src/Connectors/Connectors.OpenAI/Extensions/OpenAIMemoryBuilderExtensions.cs
+++ b/dotnet/src/Connectors/Connectors.OpenAI/Extensions/OpenAIMemoryBuilderExtensions.cs
@@ -1,5 +1,6 @@
 ﻿// Copyright (c) Microsoft. All rights reserved.
 
+using System;
 using System.Diagnostics.CodeAnalysis;
 using System.Net.Http;
 using Microsoft.SemanticKernel.Http;
@@ -24,6 +25,7 @@ public static class OpenAIMemoryBuilderExtensions
     /// <param name="dimensions">The number of dimensions the resulting output embeddings should have. Only supported in "text-embedding-3" and later models.</param>
     /// <returns>Self instance</returns>
     [Experimental("SKEXP0010")]
+    [Obsolete("This method will be obsoleted. Associate a EmbeddingGenerator at the VectorStore instead.")]
     public static MemoryBuilder WithOpenAITextEmbeddingGeneration(
         this MemoryBuilder builder,
         string modelId,

--- a/dotnet/src/Connectors/Connectors.OpenAI/Extensions/OpenAIServiceCollectionExtensions.EmbeddingGenerator.cs
+++ b/dotnet/src/Connectors/Connectors.OpenAI/Extensions/OpenAIServiceCollectionExtensions.EmbeddingGenerator.cs
@@ -18,14 +18,14 @@ public static partial class OpenAIServiceCollectionExtensions
 {
     #region Text Embedding
     /// <summary>
-    /// Adds the <see cref="OpenAITextEmbeddingGenerationService"/> to the <see cref="IServiceCollection"/>.
+    /// Adds the <see cref="OpenAIEmbeddingGenerator"/> to the <see cref="IServiceCollection"/>.
     /// </summary>
     /// <param name="services">The <see cref="IServiceCollection"/> instance to augment.</param>
     /// <param name="modelId">OpenAI model name, see https://platform.openai.com/docs/models</param>
     /// <param name="apiKey">OpenAI API key, see https://platform.openai.com/account/api-keys</param>
     /// <param name="orgId">OpenAI organization id. This is usually optional unless your account belongs to multiple organizations.</param>
-    /// <param name="serviceId">A local identifier for the given AI service</param>
     /// <param name="dimensions">The number of dimensions the resulting output embeddings should have. Only supported in "text-embedding-3" and later models.</param>
+    /// <param name="serviceId">A local identifier for the given AI service</param>
     /// <param name="httpClient">The HttpClient to use with this service.</param>
     /// <returns>The same instance as <paramref name="services"/>.</returns>
     [Experimental("SKEXP0010")]
@@ -34,8 +34,8 @@ public static partial class OpenAIServiceCollectionExtensions
         string modelId,
         string apiKey,
         string? orgId = null,
-        string? serviceId = null,
         int? dimensions = null,
+        string? serviceId = null,
         HttpClient? httpClient = null)
     {
         Verify.NotNull(services);
@@ -43,40 +43,40 @@ public static partial class OpenAIServiceCollectionExtensions
         Verify.NotNullOrWhiteSpace(apiKey);
 
         return services.AddKeyedSingleton<IEmbeddingGenerator<string, Embedding<float>>>(serviceId, (serviceProvider, _) =>
-            new OpenAITextEmbeddingGenerationService(
+            new OpenAIEmbeddingGenerator(
                 modelId,
                 apiKey,
                 orgId,
+                dimensions,
                 HttpClientProvider.GetHttpClient(httpClient, serviceProvider),
-                serviceProvider.GetService<ILoggerFactory>(),
-                dimensions));
+                serviceProvider.GetService<ILoggerFactory>()));
     }
 
     /// <summary>
-    /// Adds the <see cref="OpenAITextEmbeddingGenerationService"/> to the <see cref="IServiceCollection"/>.
+    /// Adds the <see cref="OpenAIEmbeddingGenerator"/> to the <see cref="IServiceCollection"/>.
     /// </summary>
     /// <param name="services">The <see cref="IServiceCollection"/> instance to augment.</param>
     /// <param name="modelId">The OpenAI model id.</param>
     /// <param name="openAIClient"><see cref="OpenAIClient"/> to use for the service. If null, one must be available in the service provider when this service is resolved.</param>
-    /// <param name="serviceId">A local identifier for the given AI service</param>
     /// <param name="dimensions">The number of dimensions the resulting output embeddings should have. Only supported in "text-embedding-3" and later models.</param>
+    /// <param name="serviceId">A local identifier for the given AI service</param>
     /// <returns>The same instance as <paramref name="services"/>.</returns>
     [Experimental("SKEXP0010")]
     public static IServiceCollection AddOpenAIEmbeddingGenerator(this IServiceCollection services,
         string modelId,
         OpenAIClient? openAIClient = null,
-        string? serviceId = null,
-        int? dimensions = null)
+        int? dimensions = null,
+        string? serviceId = null)
     {
         Verify.NotNull(services);
         Verify.NotNullOrWhiteSpace(modelId);
 
         return services.AddKeyedSingleton<IEmbeddingGenerator<string, Embedding<float>>>(serviceId, (serviceProvider, _) =>
-            new OpenAITextEmbeddingGenerationService(
+            new OpenAIEmbeddingGenerator(
                 modelId,
                 openAIClient ?? serviceProvider.GetRequiredService<OpenAIClient>(),
-                serviceProvider.GetService<ILoggerFactory>(),
-                dimensions));
+                dimensions,
+                serviceProvider.GetService<ILoggerFactory>()));
     }
     #endregion
 }

--- a/dotnet/src/Connectors/Connectors.OpenAI/Extensions/OpenAIServiceCollectionExtensions.EmbeddingGenerator.cs
+++ b/dotnet/src/Connectors/Connectors.OpenAI/Extensions/OpenAIServiceCollectionExtensions.EmbeddingGenerator.cs
@@ -1,0 +1,82 @@
+﻿// Copyright (c) Microsoft. All rights reserved.
+
+using System.Diagnostics.CodeAnalysis;
+using System.Net.Http;
+using Microsoft.Extensions.AI;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Logging;
+using Microsoft.SemanticKernel.Connectors.OpenAI;
+using Microsoft.SemanticKernel.Http;
+using OpenAI;
+
+namespace Microsoft.SemanticKernel;
+
+/// <summary>
+/// Sponsor extensions class for <see cref="IServiceCollection"/>.
+/// </summary>
+public static partial class OpenAIServiceCollectionExtensions
+{
+    #region Text Embedding
+    /// <summary>
+    /// Adds the <see cref="OpenAITextEmbeddingGenerationService"/> to the <see cref="IServiceCollection"/>.
+    /// </summary>
+    /// <param name="services">The <see cref="IServiceCollection"/> instance to augment.</param>
+    /// <param name="modelId">OpenAI model name, see https://platform.openai.com/docs/models</param>
+    /// <param name="apiKey">OpenAI API key, see https://platform.openai.com/account/api-keys</param>
+    /// <param name="orgId">OpenAI organization id. This is usually optional unless your account belongs to multiple organizations.</param>
+    /// <param name="serviceId">A local identifier for the given AI service</param>
+    /// <param name="dimensions">The number of dimensions the resulting output embeddings should have. Only supported in "text-embedding-3" and later models.</param>
+    /// <param name="httpClient">The HttpClient to use with this service.</param>
+    /// <returns>The same instance as <paramref name="services"/>.</returns>
+    [Experimental("SKEXP0010")]
+    public static IServiceCollection AddOpenAIEmbeddingGenerator(
+        this IServiceCollection services,
+        string modelId,
+        string apiKey,
+        string? orgId = null,
+        string? serviceId = null,
+        int? dimensions = null,
+        HttpClient? httpClient = null)
+    {
+        Verify.NotNull(services);
+        Verify.NotNullOrWhiteSpace(modelId);
+        Verify.NotNullOrWhiteSpace(apiKey);
+
+        return services.AddKeyedSingleton<IEmbeddingGenerator<string, Embedding<float>>>(serviceId, (serviceProvider, _) =>
+            new OpenAITextEmbeddingGenerationService(
+                modelId,
+                apiKey,
+                orgId,
+                HttpClientProvider.GetHttpClient(httpClient, serviceProvider),
+                serviceProvider.GetService<ILoggerFactory>(),
+                dimensions));
+    }
+
+    /// <summary>
+    /// Adds the <see cref="OpenAITextEmbeddingGenerationService"/> to the <see cref="IServiceCollection"/>.
+    /// </summary>
+    /// <param name="services">The <see cref="IServiceCollection"/> instance to augment.</param>
+    /// <param name="modelId">The OpenAI model id.</param>
+    /// <param name="openAIClient"><see cref="OpenAIClient"/> to use for the service. If null, one must be available in the service provider when this service is resolved.</param>
+    /// <param name="serviceId">A local identifier for the given AI service</param>
+    /// <param name="dimensions">The number of dimensions the resulting output embeddings should have. Only supported in "text-embedding-3" and later models.</param>
+    /// <returns>The same instance as <paramref name="services"/>.</returns>
+    [Experimental("SKEXP0010")]
+    public static IServiceCollection AddOpenAIEmbeddingGenerator(this IServiceCollection services,
+        string modelId,
+        OpenAIClient? openAIClient = null,
+        string? serviceId = null,
+        int? dimensions = null)
+    {
+        Verify.NotNull(services);
+        Verify.NotNullOrWhiteSpace(modelId);
+
+        return services.AddKeyedSingleton<IEmbeddingGenerator<string, Embedding<float>>>(serviceId, (serviceProvider, _) =>
+            new OpenAITextEmbeddingGenerationService(
+                modelId,
+                openAIClient ?? serviceProvider.GetRequiredService<OpenAIClient>(),
+                serviceProvider.GetService<ILoggerFactory>(),
+                dimensions));
+    }
+    #endregion
+}

--- a/dotnet/src/Connectors/Connectors.OpenAI/Extensions/OpenAIServiceCollectionExtensions.cs
+++ b/dotnet/src/Connectors/Connectors.OpenAI/Extensions/OpenAIServiceCollectionExtensions.cs
@@ -21,7 +21,7 @@ namespace Microsoft.SemanticKernel;
 /// <summary>
 /// Sponsor extensions class for <see cref="IServiceCollection"/>.
 /// </summary>
-public static class OpenAIServiceCollectionExtensions
+public static partial class OpenAIServiceCollectionExtensions
 {
     #region Text Embedding
     /// <summary>
@@ -35,6 +35,7 @@ public static class OpenAIServiceCollectionExtensions
     /// <param name="dimensions">The number of dimensions the resulting output embeddings should have. Only supported in "text-embedding-3" and later models.</param>
     /// <returns>The same instance as <paramref name="services"/>.</returns>
     [Experimental("SKEXP0010")]
+    [Obsolete("Use AddOpenAIEmbeddingGenerator instead.")]
     public static IServiceCollection AddOpenAITextEmbeddingGeneration(
         this IServiceCollection services,
         string modelId,
@@ -67,6 +68,7 @@ public static class OpenAIServiceCollectionExtensions
     /// <param name="dimensions">The number of dimensions the resulting output embeddings should have. Only supported in "text-embedding-3" and later models.</param>
     /// <returns>The same instance as <paramref name="services"/>.</returns>
     [Experimental("SKEXP0010")]
+    [Obsolete("Use AddOpenAIEmbeddingGenerator instead.")]
     public static IServiceCollection AddOpenAITextEmbeddingGeneration(this IServiceCollection services,
         string modelId,
         OpenAIClient? openAIClient = null,

--- a/dotnet/src/Connectors/Connectors.OpenAI/Services/OpenAITextEmbbedingGenerationService.cs
+++ b/dotnet/src/Connectors/Connectors.OpenAI/Services/OpenAITextEmbbedingGenerationService.cs
@@ -20,27 +20,27 @@ namespace Microsoft.SemanticKernel.Connectors.OpenAI;
 /// OpenAI implementation of <see cref="ITextEmbeddingGenerationService"/>
 /// </summary>
 [Experimental("SKEXP0010")]
-public sealed class OpenAITextEmbeddingGenerationService : ITextEmbeddingGenerationService, IEmbeddingGenerator<string, Embedding<float>>
+public sealed class OpenAIEmbeddingGenerator : IEmbeddingGenerator<string, Embedding<float>>
 {
     private readonly ClientCore _client;
-    private readonly int? _dimensions;
+    private readonly EmbeddingGeneratorMetadata _metadata;
 
     /// <summary>
-    /// Initializes a new instance of the <see cref="OpenAITextEmbeddingGenerationService"/> class.
+    /// Initializes a new instance of the <see cref="OpenAIEmbeddingGenerator"/> class.
     /// </summary>
     /// <param name="modelId">Model name</param>
     /// <param name="apiKey">OpenAI API Key</param>
     /// <param name="organization">OpenAI Organization Id (usually optional)</param>
+    /// <param name="dimensions">The number of dimensions the resulting output embeddings should have. Only supported in "text-embedding-3" and later models.</param>
     /// <param name="httpClient">Custom <see cref="HttpClient"/> for HTTP requests.</param>
     /// <param name="loggerFactory">The <see cref="ILoggerFactory"/> to use for logging. If null, no logging will be performed.</param>
-    /// <param name="dimensions">The number of dimensions the resulting output embeddings should have. Only supported in "text-embedding-3" and later models.</param>
-    public OpenAITextEmbeddingGenerationService(
+    public OpenAIEmbeddingGenerator(
         string modelId,
         string apiKey,
         string? organization = null,
+        int? dimensions = null,
         HttpClient? httpClient = null,
-        ILoggerFactory? loggerFactory = null,
-        int? dimensions = null)
+        ILoggerFactory? loggerFactory = null)
     {
         Verify.NotNullOrWhiteSpace(modelId);
         this._client = new(
@@ -49,31 +49,34 @@ public sealed class OpenAITextEmbeddingGenerationService : ITextEmbeddingGenerat
             endpoint: null,
             organizationId: organization,
             httpClient: httpClient,
-            logger: loggerFactory?.CreateLogger(typeof(OpenAITextEmbeddingGenerationService)));
+            logger: loggerFactory?.CreateLogger(typeof(OpenAIEmbeddingGenerator)));
 
-        this._dimensions = dimensions;
+        this._metadata = new EmbeddingGeneratorMetadata(
+            defaultModelId: modelId,
+            providerName: organization,
+            defaultModelDimensions: dimensions);
     }
 
     /// <summary>
-    /// Initializes a new instance of the <see cref="OpenAITextEmbeddingGenerationService"/> class.
+    /// Initializes a new instance of the <see cref="OpenAIEmbeddingGenerator"/> class.
     /// </summary>
     /// <param name="modelId">Model name</param>
     /// <param name="openAIClient">Custom <see cref="OpenAIClient"/> for HTTP requests.</param>
-    /// <param name="loggerFactory">The <see cref="ILoggerFactory"/> to use for logging. If null, no logging will be performed.</param>
     /// <param name="dimensions">The number of dimensions the resulting output embeddings should have. Only supported in "text-embedding-3" and later models.</param>
-    public OpenAITextEmbeddingGenerationService(
+    /// <param name="loggerFactory">The <see cref="ILoggerFactory"/> to use for logging. If null, no logging will be performed.</param>
+    public OpenAIEmbeddingGenerator(
         string modelId,
         OpenAIClient openAIClient,
-        ILoggerFactory? loggerFactory = null,
-        int? dimensions = null)
+        int? dimensions = null,
+        ILoggerFactory? loggerFactory = null)
     {
         Verify.NotNullOrWhiteSpace(modelId);
-        this._client = new(modelId, openAIClient, loggerFactory?.CreateLogger(typeof(OpenAITextEmbeddingGenerationService)));
-        this._dimensions = dimensions;
-    }
+        this._client = new(modelId, openAIClient, loggerFactory?.CreateLogger(typeof(OpenAIEmbeddingGenerator)));
 
-    /// <inheritdoc/>
-    public IReadOnlyDictionary<string, object?> Attributes => this._client.Attributes;
+        this._metadata = new EmbeddingGeneratorMetadata(
+            defaultModelId: modelId,
+            defaultModelDimensions: dimensions);
+    }
 
     /// <inheritdoc/>
     public Task<IList<ReadOnlyMemory<float>>> GenerateEmbeddingsAsync(
@@ -82,13 +85,13 @@ public sealed class OpenAITextEmbeddingGenerationService : ITextEmbeddingGenerat
         CancellationToken cancellationToken = default)
     {
         this._client.LogActionDetails();
-        return this._client.GetEmbeddingsAsync(this._client.ModelId, data, kernel, this._dimensions, cancellationToken);
+        return this._client.GetEmbeddingsAsync(this._client.ModelId, data, kernel, this._metadata.DefaultModelDimensions, cancellationToken);
     }
 
     /// <inheritdoc />
     public async Task<GeneratedEmbeddings<Embedding<float>>> GenerateAsync(IEnumerable<string> values, EmbeddingGenerationOptions? options = null, CancellationToken cancellationToken = default)
     {
-        var result = await this._client.GetEmbeddingsAsync(this._client.ModelId, values.ToList(), kernel: null, this._dimensions, cancellationToken).ConfigureAwait(false);
+        var result = await this._client.GetEmbeddingsAsync(this._client.ModelId, values.ToList(), kernel: null, this._metadata.DefaultModelDimensions, cancellationToken).ConfigureAwait(false);
         return new(result.Select(e => new Embedding<float>(e)));
     }
 
@@ -103,8 +106,9 @@ public sealed class OpenAITextEmbeddingGenerationService : ITextEmbeddingGenerat
         Verify.NotNull(serviceType);
 
         return
-            serviceKey is null ? null :
+            serviceKey is not null ? null :
             serviceType.IsInstanceOfType(this) ? this :
+            serviceType == typeof(EmbeddingGeneratorMetadata) ? this._metadata :
             null;
     }
 }

--- a/dotnet/src/Connectors/Connectors.OpenAI/Services/OpenAITextEmbeddingGenerationService.cs
+++ b/dotnet/src/Connectors/Connectors.OpenAI/Services/OpenAITextEmbeddingGenerationService.cs
@@ -1,0 +1,84 @@
+﻿// Copyright (c) Microsoft. All rights reserved.
+
+using System;
+using System.Collections.Generic;
+using System.Diagnostics.CodeAnalysis;
+using System.Net.Http;
+using System.Threading;
+using System.Threading.Tasks;
+using Microsoft.Extensions.Logging;
+using Microsoft.SemanticKernel.Embeddings;
+using OpenAI;
+
+namespace Microsoft.SemanticKernel.Connectors.OpenAI;
+
+/// <summary>
+/// OpenAI implementation of <see cref="ITextEmbeddingGenerationService"/>
+/// </summary>
+[Experimental("SKEXP0010")]
+[Obsolete("Use OpenAIEmbeddingGenerator instead.")]
+public sealed class OpenAITextEmbeddingGenerationService : ITextEmbeddingGenerationService
+{
+    private readonly ClientCore _client;
+    private readonly int? _dimensions;
+
+    /// <summary>
+    /// Initializes a new instance of the <see cref="OpenAITextEmbeddingGenerationService"/> class.
+    /// </summary>
+    /// <param name="modelId">Model name</param>
+    /// <param name="apiKey">OpenAI API Key</param>
+    /// <param name="organization">OpenAI Organization Id (usually optional)</param>
+    /// <param name="httpClient">Custom <see cref="HttpClient"/> for HTTP requests.</param>
+    /// <param name="loggerFactory">The <see cref="ILoggerFactory"/> to use for logging. If null, no logging will be performed.</param>
+    /// <param name="dimensions">The number of dimensions the resulting output embeddings should have. Only supported in "text-embedding-3" and later models.</param>
+    public OpenAITextEmbeddingGenerationService(
+        string modelId,
+        string apiKey,
+        string? organization = null,
+        HttpClient? httpClient = null,
+        ILoggerFactory? loggerFactory = null,
+        int? dimensions = null)
+    {
+        Verify.NotNullOrWhiteSpace(modelId);
+        this._client = new(
+            modelId: modelId,
+            apiKey: apiKey,
+            endpoint: null,
+            organizationId: organization,
+            httpClient: httpClient,
+            logger: loggerFactory?.CreateLogger(typeof(OpenAITextEmbeddingGenerationService)));
+
+        this._dimensions = dimensions;
+    }
+
+    /// <summary>
+    /// Initializes a new instance of the <see cref="OpenAITextEmbeddingGenerationService"/> class.
+    /// </summary>
+    /// <param name="modelId">Model name</param>
+    /// <param name="openAIClient">Custom <see cref="OpenAIClient"/> for HTTP requests.</param>
+    /// <param name="loggerFactory">The <see cref="ILoggerFactory"/> to use for logging. If null, no logging will be performed.</param>
+    /// <param name="dimensions">The number of dimensions the resulting output embeddings should have. Only supported in "text-embedding-3" and later models.</param>
+    public OpenAITextEmbeddingGenerationService(
+        string modelId,
+        OpenAIClient openAIClient,
+        ILoggerFactory? loggerFactory = null,
+        int? dimensions = null)
+    {
+        Verify.NotNullOrWhiteSpace(modelId);
+        this._client = new(modelId, openAIClient, loggerFactory?.CreateLogger(typeof(OpenAITextEmbeddingGenerationService)));
+        this._dimensions = dimensions;
+    }
+
+    /// <inheritdoc/>
+    public IReadOnlyDictionary<string, object?> Attributes => this._client.Attributes;
+
+    /// <inheritdoc/>
+    public Task<IList<ReadOnlyMemory<float>>> GenerateEmbeddingsAsync(
+        IList<string> data,
+        Kernel? kernel = null,
+        CancellationToken cancellationToken = default)
+    {
+        this._client.LogActionDetails();
+        return this._client.GetEmbeddingsAsync(this._client.ModelId, data, kernel, this._dimensions, cancellationToken);
+    }
+}

--- a/dotnet/src/SemanticKernel.Abstractions/AI/Embeddings/EmbeddingGenerationServiceExtensions.cs
+++ b/dotnet/src/SemanticKernel.Abstractions/AI/Embeddings/EmbeddingGenerationServiceExtensions.cs
@@ -21,7 +21,7 @@ public static class EmbeddingGenerationExtensions
     /// <summary>
     /// Gets the key used to store the dimensions value in the <see cref="IEmbeddingGenerationService{TValue, TEmbedding}"/> dictionary.
     /// </summary>
-    [Obsolete("Use IEmbeddingGenerator.GetService<EmbeddingGeneratorMetadata>().DefaultModelDimensions instead.")]
+    //[Obsolete("Use IEmbeddingGenerator.GetService<EmbeddingGeneratorMetadata>().DefaultModelDimensions instead.")]
     public static string DimensionsKey => "Dimensions";
 
     /// <summary>
@@ -34,7 +34,7 @@ public static class EmbeddingGenerationExtensions
     /// <param name="kernel">The <see cref="Kernel"/> containing services, plugins, and other state for use throughout the operation.</param>
     /// <param name="cancellationToken">Cancellation token</param>
     /// <returns>A list of embedding structs representing the input <paramref name="value"/>.</returns>
-    [Obsolete("Use IEmbeddingGenerator.GenerateAsync<TValue, Embedding<TEmbedding>> instead.")]
+    //[Obsolete("Use IEmbeddingGenerator.GenerateAsync<TValue, Embedding<TEmbedding>> instead.")]
     public static async Task<ReadOnlyMemory<TEmbedding>> GenerateEmbeddingAsync<TValue, TEmbedding>(
         this IEmbeddingGenerationService<TValue, TEmbedding> generator,
         TValue value,
@@ -52,7 +52,7 @@ public static class EmbeddingGenerationExtensions
     /// The <see cref="IEmbeddingGenerator{TInput, TEmbedding}"/>. If the <paramref name="service"/> is an <see cref="IEmbeddingGenerator{TInput, TEmbedding}"/>,
     /// the <paramref name="service"/> will be returned. Otherwise, a new <see cref="IEmbeddingGenerator{TInput, TEmbedding}"/> will be created that wraps the <paramref name="service"/>.
     /// </returns>
-    [Obsolete("Use IEmbeddingGenerator<TValue, Embedding<TEmbedding>> directly instead.")]
+    //[Obsolete("Use IEmbeddingGenerator<TValue, Embedding<TEmbedding>> directly instead.")]
     public static IEmbeddingGenerator<TValue, Embedding<TEmbedding>> AsEmbeddingGenerator<TValue, TEmbedding>(
         this IEmbeddingGenerationService<TValue, TEmbedding> service)
         where TEmbedding : unmanaged
@@ -71,7 +71,7 @@ public static class EmbeddingGenerationExtensions
     /// The <see cref="IEmbeddingGenerationService{TInput, TEmbedding}"/>. If the <paramref name="generator"/> is an <see cref="IEmbeddingGenerationService{TInput, TEmbedding}"/>,
     /// the <paramref name="generator"/> will be returned. Otherwise, a new <see cref="IEmbeddingGenerationService{TValue, TEmbedding}"/> will be created that wraps the <paramref name="generator"/>.
     /// </returns>
-    [Obsolete("Keep using IEmbeddingGenerator<TValue, Embedding<TEmbedding>> instead.")]
+    //[Obsolete("Keep using IEmbeddingGenerator<TValue, Embedding<TEmbedding>> instead.")]
     public static IEmbeddingGenerationService<TValue, TEmbedding> AsEmbeddingGenerationService<TValue, TEmbedding>(
         this IEmbeddingGenerator<TValue, Embedding<TEmbedding>> generator,
         IServiceProvider? serviceProvider = null)
@@ -91,7 +91,7 @@ public static class EmbeddingGenerationExtensions
     /// The <see cref="ITextEmbeddingGenerationService"/>. If the <paramref name="generator"/> is an <see cref="ITextEmbeddingGenerationService"/>,
     /// the <paramref name="generator"/> will be returned. Otherwise, a new <see cref="ITextEmbeddingGenerationService"/> will be created that wraps the <paramref name="generator"/>.
     /// </returns>
-    [Obsolete("Use IEmbeddingGenerator<string, Embedding<float>> directly instead.")]
+    //[Obsolete("Use IEmbeddingGenerator<string, Embedding<float>> directly instead.")]
     public static ITextEmbeddingGenerationService AsTextEmbeddingGenerationService(this IEmbeddingGenerator<string, Embedding<float>> generator, IServiceProvider? serviceProvider = null)
     {
         Verify.NotNull(generator);
@@ -105,7 +105,7 @@ public static class EmbeddingGenerationExtensions
     /// </summary>
     /// <param name="service">The service from which to get the dimensions.</param>
     /// <returns>The dimensions if it was specified in the service's attributes; otherwise, null.</returns>
-    [Obsolete("Use IEmbeddingGenerator.GetService<EmbeddingGeneratorMetadata>().DefaultModelDimensions instead.")]
+    //[Obsolete("Use IEmbeddingGenerator.GetService<EmbeddingGeneratorMetadata>().DefaultModelDimensions instead.")]
     public static int? GetDimensions<TValue, TEmbedding>(this IEmbeddingGenerationService<TValue, TEmbedding> service) where TEmbedding : unmanaged
     {
         Verify.NotNull(service);
@@ -113,7 +113,7 @@ public static class EmbeddingGenerationExtensions
     }
 
     /// <summary>Provides an implementation of <see cref="IEmbeddingGenerator{TInput, TEmbedding}"/> around an <see cref="IEmbeddingGenerationService{TValue, TEmbedding}"/>.</summary>
-    [Obsolete("Use IEmbeddingGenerator instead")]
+    //[Obsolete("Use IEmbeddingGenerator instead")]
     private sealed class EmbeddingGenerationServiceEmbeddingGenerator<TValue, TEmbedding> : IEmbeddingGenerator<TValue, Embedding<TEmbedding>>
         where TEmbedding : unmanaged
     {
@@ -162,7 +162,7 @@ public static class EmbeddingGenerationExtensions
     }
 
     /// <summary>Provides an implementation of <see cref="IEmbeddingGenerationService{TInput, TEmbedding}"/> around an <see cref="EmbeddingGeneratorEmbeddingGenerationService{TValue, TEmbedding}"/>.</summary>
-    [Obsolete("Use IEmbeddingGenerator instead")]
+    //[Obsolete("Use IEmbeddingGenerator instead")]
     private class EmbeddingGeneratorEmbeddingGenerationService<TValue, TEmbedding> : IEmbeddingGenerationService<TValue, TEmbedding>
         where TEmbedding : unmanaged
     {
@@ -209,7 +209,7 @@ public static class EmbeddingGenerationExtensions
         }
     }
 
-    [Obsolete("Use IEmbeddingGenerator instead")]
+    //[Obsolete("Use IEmbeddingGenerator instead")]
     private sealed class EmbeddingGeneratorTextEmbeddingGenerationService : EmbeddingGeneratorEmbeddingGenerationService<string, float>, ITextEmbeddingGenerationService
     {
         public EmbeddingGeneratorTextEmbeddingGenerationService(IEmbeddingGenerator<string, Embedding<float>> generator, IServiceProvider? serviceProvider) : base(generator, serviceProvider)

--- a/dotnet/src/SemanticKernel.Abstractions/AI/Embeddings/EmbeddingGenerationServiceExtensions.cs
+++ b/dotnet/src/SemanticKernel.Abstractions/AI/Embeddings/EmbeddingGenerationServiceExtensions.cs
@@ -21,6 +21,7 @@ public static class EmbeddingGenerationExtensions
     /// <summary>
     /// Gets the key used to store the dimensions value in the <see cref="IEmbeddingGenerationService{TValue, TEmbedding}"/> dictionary.
     /// </summary>
+    [Obsolete("Use IEmbeddingGenerator.GetService<EmbeddingGeneratorMetadata>().DefaultModelDimensions instead.")]
     public static string DimensionsKey => "Dimensions";
 
     /// <summary>
@@ -33,6 +34,7 @@ public static class EmbeddingGenerationExtensions
     /// <param name="kernel">The <see cref="Kernel"/> containing services, plugins, and other state for use throughout the operation.</param>
     /// <param name="cancellationToken">Cancellation token</param>
     /// <returns>A list of embedding structs representing the input <paramref name="value"/>.</returns>
+    [Obsolete("Use IEmbeddingGenerator.GenerateAsync<TValue, Embedding<TEmbedding>> instead.")]
     public static async Task<ReadOnlyMemory<TEmbedding>> GenerateEmbeddingAsync<TValue, TEmbedding>(
         this IEmbeddingGenerationService<TValue, TEmbedding> generator,
         TValue value,
@@ -50,6 +52,7 @@ public static class EmbeddingGenerationExtensions
     /// The <see cref="IEmbeddingGenerator{TInput, TEmbedding}"/>. If the <paramref name="service"/> is an <see cref="IEmbeddingGenerator{TInput, TEmbedding}"/>,
     /// the <paramref name="service"/> will be returned. Otherwise, a new <see cref="IEmbeddingGenerator{TInput, TEmbedding}"/> will be created that wraps the <paramref name="service"/>.
     /// </returns>
+    [Obsolete("Use IEmbeddingGenerator<TValue, Embedding<TEmbedding>> directly instead.")]
     public static IEmbeddingGenerator<TValue, Embedding<TEmbedding>> AsEmbeddingGenerator<TValue, TEmbedding>(
         this IEmbeddingGenerationService<TValue, TEmbedding> service)
         where TEmbedding : unmanaged
@@ -68,6 +71,7 @@ public static class EmbeddingGenerationExtensions
     /// The <see cref="IEmbeddingGenerationService{TInput, TEmbedding}"/>. If the <paramref name="generator"/> is an <see cref="IEmbeddingGenerationService{TInput, TEmbedding}"/>,
     /// the <paramref name="generator"/> will be returned. Otherwise, a new <see cref="IEmbeddingGenerationService{TValue, TEmbedding}"/> will be created that wraps the <paramref name="generator"/>.
     /// </returns>
+    [Obsolete("Keep using IEmbeddingGenerator<TValue, Embedding<TEmbedding>> instead.")]
     public static IEmbeddingGenerationService<TValue, TEmbedding> AsEmbeddingGenerationService<TValue, TEmbedding>(
         this IEmbeddingGenerator<TValue, Embedding<TEmbedding>> generator,
         IServiceProvider? serviceProvider = null)
@@ -87,6 +91,7 @@ public static class EmbeddingGenerationExtensions
     /// The <see cref="ITextEmbeddingGenerationService"/>. If the <paramref name="generator"/> is an <see cref="ITextEmbeddingGenerationService"/>,
     /// the <paramref name="generator"/> will be returned. Otherwise, a new <see cref="ITextEmbeddingGenerationService"/> will be created that wraps the <paramref name="generator"/>.
     /// </returns>
+    [Obsolete("Use IEmbeddingGenerator<string, Embedding<float>> directly instead.")]
     public static ITextEmbeddingGenerationService AsTextEmbeddingGenerationService(this IEmbeddingGenerator<string, Embedding<float>> generator, IServiceProvider? serviceProvider = null)
     {
         Verify.NotNull(generator);
@@ -100,6 +105,7 @@ public static class EmbeddingGenerationExtensions
     /// </summary>
     /// <param name="service">The service from which to get the dimensions.</param>
     /// <returns>The dimensions if it was specified in the service's attributes; otherwise, null.</returns>
+    [Obsolete("Use IEmbeddingGenerator.GetService<EmbeddingGeneratorMetadata>().DefaultModelDimensions instead.")]
     public static int? GetDimensions<TValue, TEmbedding>(this IEmbeddingGenerationService<TValue, TEmbedding> service) where TEmbedding : unmanaged
     {
         Verify.NotNull(service);
@@ -107,6 +113,7 @@ public static class EmbeddingGenerationExtensions
     }
 
     /// <summary>Provides an implementation of <see cref="IEmbeddingGenerator{TInput, TEmbedding}"/> around an <see cref="IEmbeddingGenerationService{TValue, TEmbedding}"/>.</summary>
+    [Obsolete("Use IEmbeddingGenerator instead")]
     private sealed class EmbeddingGenerationServiceEmbeddingGenerator<TValue, TEmbedding> : IEmbeddingGenerator<TValue, Embedding<TEmbedding>>
         where TEmbedding : unmanaged
     {
@@ -155,6 +162,7 @@ public static class EmbeddingGenerationExtensions
     }
 
     /// <summary>Provides an implementation of <see cref="IEmbeddingGenerationService{TInput, TEmbedding}"/> around an <see cref="EmbeddingGeneratorEmbeddingGenerationService{TValue, TEmbedding}"/>.</summary>
+    [Obsolete("Use IEmbeddingGenerator instead")]
     private class EmbeddingGeneratorEmbeddingGenerationService<TValue, TEmbedding> : IEmbeddingGenerationService<TValue, TEmbedding>
         where TEmbedding : unmanaged
     {
@@ -181,6 +189,10 @@ public static class EmbeddingGenerationExtensions
             {
                 attrs[AIServiceExtensions.ModelIdKey] = metadata.DefaultModelId;
             }
+            if (metadata?.DefaultModelDimensions is not null)
+            {
+                attrs[DimensionsKey] = metadata.DefaultModelDimensions;
+            }
         }
 
         /// <inheritdoc />
@@ -197,6 +209,7 @@ public static class EmbeddingGenerationExtensions
         }
     }
 
+    [Obsolete("Use IEmbeddingGenerator instead")]
     private sealed class EmbeddingGeneratorTextEmbeddingGenerationService : EmbeddingGeneratorEmbeddingGenerationService<string, float>, ITextEmbeddingGenerationService
     {
         public EmbeddingGeneratorTextEmbeddingGenerationService(IEmbeddingGenerator<string, Embedding<float>> generator, IServiceProvider? serviceProvider) : base(generator, serviceProvider)

--- a/dotnet/src/SemanticKernel.Abstractions/AI/Embeddings/IEmbeddingGenerationService.cs
+++ b/dotnet/src/SemanticKernel.Abstractions/AI/Embeddings/IEmbeddingGenerationService.cs
@@ -15,6 +15,7 @@ namespace Microsoft.SemanticKernel.Embeddings;
 /// <typeparam name="TValue">The type from which embeddings will be generated.</typeparam>
 /// <typeparam name="TEmbedding">The numeric type of the embedding data.</typeparam>
 [Experimental("SKEXP0001")]
+[Obsolete("Use IEmbeddingGenerator<string, float> instead.")]
 public interface IEmbeddingGenerationService<TValue, TEmbedding> : IAIService
     where TEmbedding : unmanaged
 {

--- a/dotnet/src/SemanticKernel.Abstractions/AI/Embeddings/IEmbeddingGenerationService.cs
+++ b/dotnet/src/SemanticKernel.Abstractions/AI/Embeddings/IEmbeddingGenerationService.cs
@@ -15,7 +15,7 @@ namespace Microsoft.SemanticKernel.Embeddings;
 /// <typeparam name="TValue">The type from which embeddings will be generated.</typeparam>
 /// <typeparam name="TEmbedding">The numeric type of the embedding data.</typeparam>
 [Experimental("SKEXP0001")]
-[Obsolete("Use IEmbeddingGenerator<string, float> instead.")]
+//[Obsolete("Use IEmbeddingGenerator<string, float> instead.")]
 public interface IEmbeddingGenerationService<TValue, TEmbedding> : IAIService
     where TEmbedding : unmanaged
 {

--- a/dotnet/src/SemanticKernel.Abstractions/AI/Embeddings/ITextEmbeddingGenerationService.cs
+++ b/dotnet/src/SemanticKernel.Abstractions/AI/Embeddings/ITextEmbeddingGenerationService.cs
@@ -1,6 +1,6 @@
 ﻿// Copyright (c) Microsoft. All rights reserved.
 
-using System;
+//using System;
 using System.Diagnostics.CodeAnalysis;
 
 namespace Microsoft.SemanticKernel.Embeddings;
@@ -9,5 +9,5 @@ namespace Microsoft.SemanticKernel.Embeddings;
 /// Represents a generator of text embeddings of type <c>float</c>.
 /// </summary>
 [Experimental("SKEXP0001")]
-[Obsolete("Use IEmbeddingGenerator<string, float> instead.")]
+//[Obsolete("Use IEmbeddingGenerator<string, float> instead.")]
 public interface ITextEmbeddingGenerationService : IEmbeddingGenerationService<string, float>;

--- a/dotnet/src/SemanticKernel.Abstractions/AI/Embeddings/ITextEmbeddingGenerationService.cs
+++ b/dotnet/src/SemanticKernel.Abstractions/AI/Embeddings/ITextEmbeddingGenerationService.cs
@@ -1,5 +1,6 @@
 ﻿// Copyright (c) Microsoft. All rights reserved.
 
+using System;
 using System.Diagnostics.CodeAnalysis;
 
 namespace Microsoft.SemanticKernel.Embeddings;
@@ -8,4 +9,5 @@ namespace Microsoft.SemanticKernel.Embeddings;
 /// Represents a generator of text embeddings of type <c>float</c>.
 /// </summary>
 [Experimental("SKEXP0001")]
+[Obsolete("Use IEmbeddingGenerator<string, float> instead.")]
 public interface ITextEmbeddingGenerationService : IEmbeddingGenerationService<string, float>;

--- a/dotnet/src/SemanticKernel.Core/Data/TextSearch/TextSearchExtensions.cs
+++ b/dotnet/src/SemanticKernel.Core/Data/TextSearch/TextSearchExtensions.cs
@@ -26,15 +26,16 @@ public static class TextSearchExtensions
     /// <param name="textSearch">The instance of ITextSearch to be used by the plugin.</param>
     /// <param name="pluginName">The name for the plugin.</param>
     /// <param name="description">A description of the plugin.</param>
+    /// <param name="searchOptions">Optional TextSearchOptions which override the options provided when the function is invoked.</param>
     /// <returns>A <see cref="KernelPlugin"/> instance with a Search operation that calls the provided <see cref="ITextSearch.SearchAsync(string, TextSearchOptions?, CancellationToken)"/>.</returns>
     [RequiresUnreferencedCode("Uses reflection to handle various aspects of the function creation and invocation, making it incompatible with AOT scenarios.")]
     [RequiresDynamicCode("Uses reflection to handle various aspects of the function creation and invocation, making it incompatible with AOT scenarios.")]
-    public static KernelPlugin CreateWithSearch(this ITextSearch textSearch, string pluginName, string? description = null)
+    public static KernelPlugin CreateWithSearch(this ITextSearch textSearch, string pluginName, string? description = null, TextSearchOptions? searchOptions = null)
     {
         Verify.NotNull(textSearch);
         Verify.NotNull(pluginName);
 
-        return KernelPluginFactory.CreateFromFunctions(pluginName, description, [textSearch.CreateSearch()]);
+        return KernelPluginFactory.CreateFromFunctions(pluginName, description, [textSearch.CreateSearch(searchOptions: searchOptions)]);
     }
 
     /// <summary>

--- a/dotnet/src/SemanticKernel.Core/Data/TextSearch/VectorStoreTextSearch.cs
+++ b/dotnet/src/SemanticKernel.Core/Data/TextSearch/VectorStoreTextSearch.cs
@@ -96,8 +96,8 @@ public sealed class VectorStoreTextSearch<[DynamicallyAccessedMembers(Dynamicall
 
     /// <summary>
     /// Create an instance of the <see cref="VectorStoreTextSearch{TRecord}"/> with the
-    /// provided <see cref="IVectorizableTextSearch{TRecord}"/> for performing searches and
-    /// <see cref="ITextEmbeddingGenerationService"/> for generating vectors from the text search query.
+    /// provided <see cref="IVectorSearch{TRecord}"/> for performing searches and
+    /// <see cref="ITextSearchStringMapper"/> and <see cref="ITextSearchResultMapper" /> for mapping results.
     /// </summary>
     /// <param name="vectorSearch"><see cref="IVectorSearch{TRecord}"/> instance used to perform the text search.</param>
     /// <param name="stringMapper"><see cref="ITextSearchStringMapper" /> instance that can map a TRecord to a <see cref="string"/></param>
@@ -142,6 +142,7 @@ public sealed class VectorStoreTextSearch<[DynamicallyAccessedMembers(Dynamicall
     }
 
     #region private
+    [Obsolete]
     private readonly ITextEmbeddingGenerationService? _textEmbeddingGeneration;
     private readonly IVectorSearch<TRecord>? _vectorSearch;
     private readonly ITextSearchStringMapper _stringMapper;
@@ -206,6 +207,7 @@ public sealed class VectorStoreTextSearch<[DynamicallyAccessedMembers(Dynamicall
             Skip = searchOptions.Skip,
         };
 
+#pragma warning disable CS0618, CS0612 // Type or member is obsolete
         if (this._textEmbeddingGeneration is not null)
         {
             var vectorizedQuery = await this._textEmbeddingGeneration!.GenerateEmbeddingAsync(query, cancellationToken: cancellationToken).ConfigureAwait(false);
@@ -217,6 +219,7 @@ public sealed class VectorStoreTextSearch<[DynamicallyAccessedMembers(Dynamicall
 
             yield break;
         }
+#pragma warning restore CS0612, CS0618 // Type or member is obsolete
 
         await foreach (var result in this._vectorSearch!.SearchAsync(query, searchOptions.Top, vectorSearchOptions, cancellationToken).ConfigureAwait(false))
         {

--- a/dotnet/src/SemanticKernel.Core/Memory/MemoryBuilder.cs
+++ b/dotnet/src/SemanticKernel.Core/Memory/MemoryBuilder.cs
@@ -9,6 +9,8 @@ using Microsoft.SemanticKernel.Embeddings;
 
 namespace Microsoft.SemanticKernel.Memory;
 
+#pragma warning disable CS0618 // Type or member is obsolete
+
 /// <summary>
 /// A builder for Memory plugin.
 /// </summary>

--- a/dotnet/src/SemanticKernel.Core/Memory/SemanticTextMemory.cs
+++ b/dotnet/src/SemanticKernel.Core/Memory/SemanticTextMemory.cs
@@ -9,6 +9,8 @@ using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.SemanticKernel.Embeddings;
 
+#pragma warning disable CS0618 // Type or member is obsolete
+
 namespace Microsoft.SemanticKernel.Memory;
 
 /// <summary>

--- a/dotnet/src/SemanticKernel.UnitTests/AI/ServiceConversionExtensionsTests.cs
+++ b/dotnet/src/SemanticKernel.UnitTests/AI/ServiceConversionExtensionsTests.cs
@@ -18,17 +18,24 @@ namespace SemanticKernel.UnitTests.AI;
 
 public class ServiceConversionExtensionsTests
 {
+    private const string ObsoleteMessage = "Keeping unit test until removed completely";
     [Fact]
-    public void InvalidArgumentsThrow()
+    [Obsolete(ObsoleteMessage)]
+    public void ObsoletedInvalidArgumentsThrow()
     {
         Assert.Throws<ArgumentNullException>("service", () => EmbeddingGenerationExtensions.AsEmbeddingGenerator<string, float>(null!));
         Assert.Throws<ArgumentNullException>("generator", () => EmbeddingGenerationExtensions.AsEmbeddingGenerationService<string, float>(null!));
+    }
 
+    [Fact]
+    public void InvalidArgumentsThrow()
+    {
         Assert.Throws<ArgumentNullException>("service", () => ChatCompletionServiceExtensions.AsChatClient(null!));
         Assert.Throws<ArgumentNullException>("client", () => ChatCompletionServiceExtensions.AsChatCompletionService(null!));
     }
 
     [Fact]
+    [Obsolete(ObsoleteMessage)]
     public void AsEmbeddingGeneratorMetadataReturnsExpectedData()
     {
         IEmbeddingGenerator<string, Embedding<float>> generator = new TestEmbeddingGenerationService()
@@ -48,6 +55,7 @@ public class ServiceConversionExtensionsTests
     }
 
     [Fact]
+    [Obsolete(ObsoleteMessage)]
     public void AsEmbeddingGenerationServiceReturnsExpectedAttributes()
     {
         using var generator = new TestEmbeddingGenerator()
@@ -97,6 +105,7 @@ public class ServiceConversionExtensionsTests
     }
 
     [Fact]
+    [Obsolete(ObsoleteMessage)]
     public async Task AsEmbeddingGeneratorConvertedAsExpected()
     {
         IEmbeddingGenerator<string, Embedding<float>> generator = new TestEmbeddingGenerationService()
@@ -115,6 +124,7 @@ public class ServiceConversionExtensionsTests
     }
 
     [Fact]
+    [Obsolete(ObsoleteMessage)]
     public async Task AsEmbeddingGenerationServiceConvertedAsExpected()
     {
         using IEmbeddingGenerator<string, Embedding<float>> generator = new TestEmbeddingGenerator()
@@ -688,6 +698,7 @@ public class ServiceConversionExtensionsTests
         }
     }
 
+    [Obsolete(ObsoleteMessage)]
     private sealed class TestEmbeddingGenerationService : IEmbeddingGenerationService<string, float>
     {
         public IReadOnlyDictionary<string, object?> Attributes { get; set; } = new Dictionary<string, object?>();

--- a/dotnet/src/SemanticKernel.UnitTests/Data/VectorStoreTextSearchTestBase.cs
+++ b/dotnet/src/SemanticKernel.UnitTests/Data/VectorStoreTextSearchTestBase.cs
@@ -39,6 +39,7 @@ public class VectorStoreTextSearchTestBase
     /// <summary>
     /// Create a <see cref="VectorStoreTextSearch{TRecord}"/> from a <see cref="IVectorizedSearch{TRecord}"/>.
     /// </summary>
+    [Obsolete("VectorStoreTextSearch with ITextEmbeddingGenerationService is obsolete")]
     public static async Task<VectorStoreTextSearch<DataModel>> CreateVectorStoreTextSearchAsync()
     {
         using var embeddingGenerator = new MockTextEmbeddingGenerator();
@@ -77,7 +78,7 @@ public class VectorStoreTextSearchTestBase
     /// </summary>
     public static async Task AddRecordsAsync(
         IVectorStoreRecordCollection<Guid, DataModelWithRawEmbedding> recordCollection,
-        ITextEmbeddingGenerationService embeddingService,
+        IEmbeddingGenerator<string, Embedding<float>> embeddingService,
         int? count = 10)
     {
         await recordCollection.CreateCollectionIfNotExistsAsync();
@@ -88,7 +89,7 @@ public class VectorStoreTextSearchTestBase
                 Key = Guid.NewGuid(),
                 Text = $"Record {i}",
                 Tag = i % 2 == 0 ? "Even" : "Odd",
-                Embedding = await embeddingService.GenerateEmbeddingAsync($"Record {i}")
+                Embedding = (await embeddingService.GenerateAsync($"Record {i}")).Vector
             };
             await recordCollection.UpsertAsync(dataModel);
         }
@@ -127,6 +128,7 @@ public class VectorStoreTextSearchTestBase
     /// <summary>
     /// Mock implementation of <see cref="ITextEmbeddingGenerationService"/>.
     /// </summary>
+    [Obsolete("ITextEmbeddingGenerationService is obsolete")]
     public sealed class MockTextEmbeddingGenerator : IEmbeddingGenerator<string, Embedding<float>>, ITextEmbeddingGenerationService
     {
         public Task<GeneratedEmbeddings<Embedding<float>>> GenerateAsync(IEnumerable<string> values, EmbeddingGenerationOptions? options = null, CancellationToken cancellationToken = default)


### PR DESCRIPTION
### Motivation and Context

- Resolves Partially #10811

Targeted Connectors:

- {Azure}OpenAI 
- HuggingFace 
- Bedrock 
- MistralAI

This PR obsolete `IEmbeddingGenerationService` and introduce implementations for the new `IEmbeddingGenerator<string, Embedding<float>>` interface for the alternative moving forward.