### PR TITLE
.Net: [MEVD] Removed null key filtering for Upsert operations

### DIFF
--- a/dotnet/src/Connectors/Connectors.Memory.SqliteVec/SqliteCollection.cs
+++ b/dotnet/src/Connectors/Connectors.Memory.SqliteVec/SqliteCollection.cs
@@ -712,7 +712,7 @@ public sealed class SqliteCollection<TKey, TRecord> : VectorStoreCollection<TKey
         }
     }
 
-    private async Task<IReadOnlyList<TKey?>> InternalUpsertBatchAsync(
+    private async Task<IReadOnlyList<TKey>> InternalUpsertBatchAsync(
         SqliteConnection connection,
         List<Dictionary<string, object?>> storageModels,
         SqliteWhereCondition condition,
@@ -766,11 +766,11 @@ public sealed class SqliteCollection<TKey, TRecord> : VectorStoreCollection<TKey
             () => dataCommand.ExecuteReaderAsync(cancellationToken),
             cancellationToken).ConfigureAwait(false);
 
-        var keys = new List<TKey?>();
+        var keys = new List<TKey>();
 
         while (await reader.ReadAsync(cancellationToken).ConfigureAwait(false))
         {
-            var key = reader.GetFieldValue<TKey?>(0);
+            var key = reader.GetFieldValue<TKey>(0);
 
             keys.Add(key);
 

--- a/dotnet/src/Connectors/Connectors.Memory.SqliteVec/SqliteCollection.cs
+++ b/dotnet/src/Connectors/Connectors.Memory.SqliteVec/SqliteCollection.cs
@@ -712,7 +712,7 @@ public sealed class SqliteCollection<TKey, TRecord> : VectorStoreCollection<TKey
         }
     }
 
-    private async Task<IReadOnlyList<TKey>> InternalUpsertBatchAsync(
+    private async Task<IReadOnlyList<TKey?>> InternalUpsertBatchAsync(
         SqliteConnection connection,
         List<Dictionary<string, object?>> storageModels,
         SqliteWhereCondition condition,
@@ -766,16 +766,13 @@ public sealed class SqliteCollection<TKey, TRecord> : VectorStoreCollection<TKey
             () => dataCommand.ExecuteReaderAsync(cancellationToken),
             cancellationToken).ConfigureAwait(false);
 
-        var keys = new List<TKey>();
+        var keys = new List<TKey?>();
 
         while (await reader.ReadAsync(cancellationToken).ConfigureAwait(false))
         {
             var key = reader.GetFieldValue<TKey?>(0);
 
-            if (key is not null)
-            {
-                keys.Add(key);
-            }
+            keys.Add(key);
 
             await reader.NextResultAsync(cancellationToken).ConfigureAwait(false);
         }


### PR DESCRIPTION
### Motivation and Context

<!-- Thank you for your contribution to the semantic-kernel repo!
Please help reviewers and future users, providing the following information:
  1. Why is this change required?
  2. What problem does it solve?
  3. What scenario does it contribute to?
  4. If it fixes an open issue, please link to the issue here.
-->

Resolves: https://github.com/microsoft/semantic-kernel/issues/11401

- Removed key `null` filtering for Upsert operations in SQLite connector. 
- Investigated all connectors and it looks like the filtering occurred only in SQLite connector.

### Contribution Checklist

<!-- Before submitting this PR, please make sure: -->

- [x] The code builds clean without any errors or warnings
- [x] The PR follows the [SK Contribution Guidelines](https://github.com/microsoft/semantic-kernel/blob/main/CONTRIBUTING.md) and the [pre-submission formatting script](https://github.com/microsoft/semantic-kernel/blob/main/CONTRIBUTING.md#development-scripts) raises no violations
- [x] All unit tests pass, and I have added new tests where possible
- [x] I didn't break anyone :smile:
