### PR TITLE
.Net Agents - CodeQL Fix

### DIFF
--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -5,6 +5,7 @@
 name: "CodeQL"
 
 on:
+  workflow_dispatch:
   push:
     # TODO: Add "feature*" back in again, once we determine the cause of the ongoing CodeQL failures.
     branches: ["main", "experimental*", "*-development"]

--- a/dotnet/samples/GettingStartedWithAgents/AzureAIAgent/Step08_AzureAIAgent_Declarative.cs
+++ b/dotnet/samples/GettingStartedWithAgents/AzureAIAgent/Step08_AzureAIAgent_Declarative.cs
@@ -396,7 +396,7 @@ public class Step08_AzureAIAgent_Declarative : BaseAzureAgentTest
         Microsoft.SemanticKernel.Agents.AgentThread? agentThread = null;
         try
         {
-            await foreach (var response in agent!.InvokeAsync([], agentThread, options))
+            await foreach (var response in agent!.InvokeAsync(Array.Empty<ChatMessageContent>(), agentThread, options))
             {
                 agentThread = response.Thread;
                 this.WriteAgentChatMessage(response);

--- a/dotnet/samples/GettingStartedWithAgents/BedrockAgent/Step07_BedrockAgent_Declarative.cs
+++ b/dotnet/samples/GettingStartedWithAgents/BedrockAgent/Step07_BedrockAgent_Declarative.cs
@@ -5,7 +5,6 @@ using Microsoft.Extensions.DependencyInjection;
 using Microsoft.SemanticKernel;
 using Microsoft.SemanticKernel.Agents;
 using Microsoft.SemanticKernel.Agents.Bedrock;
-using Microsoft.SemanticKernel.ChatCompletion;
 
 namespace GettingStarted.BedrockAgents;
 

--- a/dotnet/samples/GettingStartedWithAgents/BedrockAgent/Step07_BedrockAgent_Declarative.cs
+++ b/dotnet/samples/GettingStartedWithAgents/BedrockAgent/Step07_BedrockAgent_Declarative.cs
@@ -198,7 +198,7 @@ public class Step07_BedrockAgent_Declarative : BaseBedrockAgentTest
         AgentThread? agentThread = null;
         try
         {
-            await foreach (AgentResponseItem<ChatMessageContent> response in agent.InvokeAsync(new ChatMessageContent(AuthorRole.User, input)))
+            await foreach (AgentResponseItem<ChatMessageContent> response in agent.InvokeAsync(input))
             {
                 agentThread = response.Thread;
                 WriteAgentChatMessage(response);

--- a/dotnet/samples/GettingStartedWithAgents/OpenAIAssistant/Step07_Assistant_Declarative.cs
+++ b/dotnet/samples/GettingStartedWithAgents/OpenAIAssistant/Step07_Assistant_Declarative.cs
@@ -158,7 +158,7 @@ public class Step07_Assistant_Declarative : BaseAssistantTest
         AgentThread? agentThread = null;
         try
         {
-            await foreach (var response in agent.InvokeAsync([], agentThread, options))
+            await foreach (var response in agent.InvokeAsync(Array.Empty<ChatMessageContent>(), agentThread, options))
             {
                 agentThread = response.Thread;
                 this.WriteAgentChatMessage(response);

--- a/dotnet/samples/GettingStartedWithAgents/Step09_Declarative.cs
+++ b/dotnet/samples/GettingStartedWithAgents/Step09_Declarative.cs
@@ -116,7 +116,7 @@ public class Step09_Declarative(ITestOutputHelper output) : BaseAgentsTest(outpu
             }
         };
 
-        await foreach (ChatMessageContent response in agent.InvokeAsync([], options: options))
+        await foreach (ChatMessageContent response in agent.InvokeAsync(Array.Empty<ChatMessageContent>(), options: options))
         {
             this.WriteAgentChatMessage(response);
         }


### PR DESCRIPTION
### Motivation and Context
<!-- Thank you for your contribution to the semantic-kernel repo!
Please help reviewers and future users, providing the following information:
  1. Why is this change required?
  2. What problem does it solve?
  3. What scenario does it contribute to?
  4. If it fixes an open issue, please link to the issue here.
-->

CodeQL failures:

https://github.com/microsoft/semantic-kernel/actions/runs/14886865134/job/41808680816#step:4:2319

### Description
<!-- Describe your changes, the overall approach, the underlying design.
     These notes will help understanding how your code works. Thanks! -->

Method calls viewed as ambigious when invoked with empty collection expression "`[]`":

1. `Agent.InvokeAsync(string, AgentThread?, AgentInvokeOptions?, CancellationToken)'`
1. `Agent.InvokeAsync(ICollection<ChatMessageContent>, AgentThread?, AgentInvokeOptions?, CancellationToken)`

Passing workflow: https://github.com/microsoft/semantic-kernel/actions/runs/14890743858

### Contribution Checklist
<!-- Before submitting this PR, please make sure: -->

- [X] The code builds clean without any errors or warnings
- [X] The PR follows the [SK Contribution Guidelines](https://github.com/microsoft/semantic-kernel/blob/main/CONTRIBUTING.md) and the [pre-submission formatting script](https://github.com/microsoft/semantic-kernel/blob/main/CONTRIBUTING.md#development-scripts) raises no violations
- [X] All unit tests pass, and I have added new tests where possible
- [X] I didn't break anyone :smile:
