### PR TITLE
Remove double support for mongodb and weaviate and ensure redis works.

### DIFF
--- a/dotnet/src/Connectors/Connectors.Memory.Redis/RedisHashSetCollection.cs
+++ b/dotnet/src/Connectors/Connectors.Memory.Redis/RedisHashSetCollection.cs
@@ -11,6 +11,7 @@ using System.Threading.Tasks;
 using Microsoft.Extensions.AI;
 using Microsoft.Extensions.VectorData;
 using Microsoft.Extensions.VectorData.ProviderServices;
+using Microsoft.SemanticKernel.Connectors.PgVector;
 using NRedisStack.RedisStackCommands;
 using NRedisStack.Search;
 using NRedisStack.Search.Literals.Enums;
@@ -112,7 +113,7 @@ public sealed class RedisHashSetCollection<TKey, TRecord> : VectorStoreCollectio
         options ??= RedisHashSetCollectionOptions.Default;
         this._prefixCollectionNameToKeyNames = options.PrefixCollectionNameToKeyNames;
 
-        this._model = new CollectionModelBuilder(ModelBuildingOptions)
+        this._model = new RedisModelBuilder(ModelBuildingOptions)
             .Build(typeof(TRecord), options.VectorStoreRecordDefinition, options.EmbeddingGenerator);
 
         // Lookup storage property names.

--- a/dotnet/src/Connectors/Connectors.Memory.Redis/RedisJsonCollection.cs
+++ b/dotnet/src/Connectors/Connectors.Memory.Redis/RedisJsonCollection.cs
@@ -13,6 +13,7 @@ using System.Threading.Tasks;
 using Microsoft.Extensions.AI;
 using Microsoft.Extensions.VectorData;
 using Microsoft.Extensions.VectorData.ProviderServices;
+using Microsoft.SemanticKernel.Connectors.PgVector;
 using NRedisStack.Json.DataTypes;
 using NRedisStack.RedisStackCommands;
 using NRedisStack.Search;
@@ -107,8 +108,8 @@ public sealed class RedisJsonCollection<TKey, TRecord> : VectorStoreCollection<T
         this._jsonSerializerOptions = options.JsonSerializerOptions ?? JsonSerializerOptions.Default;
 
         this._model = isDynamic ?
-            new CollectionModelBuilder(ModelBuildingOptions).Build(typeof(TRecord), options.VectorStoreRecordDefinition, options.EmbeddingGenerator) :
-            new CollectionJsonModelBuilder(ModelBuildingOptions).Build(typeof(TRecord), options.VectorStoreRecordDefinition, options.EmbeddingGenerator, this._jsonSerializerOptions);
+            new RedisModelBuilder(ModelBuildingOptions).Build(typeof(TRecord), options.VectorStoreRecordDefinition, options.EmbeddingGenerator) :
+            new RedisJsonModelBuilder(ModelBuildingOptions).Build(typeof(TRecord), options.VectorStoreRecordDefinition, options.EmbeddingGenerator, this._jsonSerializerOptions);
 
         // Lookup storage property names.
         this._dataStoragePropertyNames = this._model.DataProperties.Select(p => p.StorageName).ToArray();

--- a/dotnet/src/Connectors/Connectors.Memory.Redis/RedisJsonModelBuilder.cs
+++ b/dotnet/src/Connectors/Connectors.Memory.Redis/RedisJsonModelBuilder.cs
@@ -1,0 +1,32 @@
+﻿// Copyright (c) Microsoft. All rights reserved.
+
+using System;
+using Microsoft.Extensions.AI;
+using Microsoft.Extensions.VectorData.ProviderServices;
+
+namespace Microsoft.SemanticKernel.Connectors.PgVector;
+
+internal class RedisJsonModelBuilder(CollectionModelBuildingOptions options) : CollectionJsonModelBuilder(options)
+{
+    /// <inheritdoc />
+    protected override void SetupEmbeddingGeneration(
+        VectorPropertyModel vectorProperty,
+        IEmbeddingGenerator embeddingGenerator,
+        Type? embeddingType)
+    {
+        if (!vectorProperty.TrySetupEmbeddingGeneration<Embedding<float>, ReadOnlyMemory<float>>(embeddingGenerator, embeddingType)
+            && !vectorProperty.TrySetupEmbeddingGeneration<Embedding<double>, ReadOnlyMemory<double>>(embeddingGenerator, embeddingType)
+            )
+        {
+            throw new InvalidOperationException(
+                VectorDataStrings.IncompatibleEmbeddingGenerator(
+                    embeddingGeneratorType: embeddingGenerator.GetType(),
+                    supportedInputTypes: vectorProperty.GetSupportedInputTypes(),
+                    supportedOutputTypes:
+                    [
+                        typeof(ReadOnlyMemory<float>),
+                        typeof(ReadOnlyMemory<double>)
+                    ]));
+        }
+    }
+}

--- a/dotnet/src/Connectors/Connectors.Memory.Redis/RedisModelBuilder.cs
+++ b/dotnet/src/Connectors/Connectors.Memory.Redis/RedisModelBuilder.cs
@@ -1,0 +1,32 @@
+﻿// Copyright (c) Microsoft. All rights reserved.
+
+using System;
+using Microsoft.Extensions.AI;
+using Microsoft.Extensions.VectorData.ProviderServices;
+
+namespace Microsoft.SemanticKernel.Connectors.PgVector;
+
+internal class RedisModelBuilder(CollectionModelBuildingOptions options) : CollectionModelBuilder(options)
+{
+    /// <inheritdoc />
+    protected override void SetupEmbeddingGeneration(
+        VectorPropertyModel vectorProperty,
+        IEmbeddingGenerator embeddingGenerator,
+        Type? embeddingType)
+    {
+        if (!vectorProperty.TrySetupEmbeddingGeneration<Embedding<float>, ReadOnlyMemory<float>>(embeddingGenerator, embeddingType)
+            && !vectorProperty.TrySetupEmbeddingGeneration<Embedding<double>, ReadOnlyMemory<double>>(embeddingGenerator, embeddingType)
+            )
+        {
+            throw new InvalidOperationException(
+                VectorDataStrings.IncompatibleEmbeddingGenerator(
+                    embeddingGeneratorType: embeddingGenerator.GetType(),
+                    supportedInputTypes: vectorProperty.GetSupportedInputTypes(),
+                    supportedOutputTypes:
+                    [
+                        typeof(ReadOnlyMemory<float>),
+                        typeof(ReadOnlyMemory<double>)
+                    ]));
+        }
+    }
+}

--- a/dotnet/src/Connectors/Connectors.Memory.Weaviate/WeaviateCollection.cs
+++ b/dotnet/src/Connectors/Connectors.Memory.Weaviate/WeaviateCollection.cs
@@ -294,11 +294,6 @@ public sealed class WeaviateCollection<TKey, TRecord> : VectorStoreCollection<TK
                 generatedEmbeddings ??= new IReadOnlyList<Embedding>?[vectorPropertyCount];
                 generatedEmbeddings[i] = (IReadOnlyList<Embedding<float>>)await floatTask.ConfigureAwait(false);
             }
-            else if (vectorProperty.TryGenerateEmbeddings<TRecord, Embedding<double>, ReadOnlyMemory<float>>(records, cancellationToken, out var doubleTask))
-            {
-                generatedEmbeddings ??= new IReadOnlyList<Embedding>?[vectorPropertyCount];
-                generatedEmbeddings[i] = await doubleTask.ConfigureAwait(false);
-            }
             else
             {
                 throw new InvalidOperationException(
@@ -333,18 +328,6 @@ public sealed class WeaviateCollection<TKey, TRecord> : VectorStoreCollection<TK
         switch (vectorProperty.EmbeddingGenerator)
         {
             case IEmbeddingGenerator<TInput, Embedding<float>> generator:
-            {
-                var embedding = await generator.GenerateEmbeddingAsync(value, new() { Dimensions = vectorProperty.Dimensions }, cancellationToken).ConfigureAwait(false);
-
-                await foreach (var record in this.SearchCoreAsync(embedding.Vector, top, vectorProperty, operationName: "Search", options, cancellationToken).ConfigureAwait(false))
-                {
-                    yield return record;
-                }
-
-                yield break;
-            }
-
-            case IEmbeddingGenerator<TInput, Embedding<double>> generator:
             {
                 var embedding = await generator.GenerateEmbeddingAsync(value, new() { Dimensions = vectorProperty.Dimensions }, cancellationToken).ConfigureAwait(false);
 

--- a/dotnet/src/Connectors/Connectors.Memory.Weaviate/WeaviateDynamicDataModelMapper.cs
+++ b/dotnet/src/Connectors/Connectors.Memory.Weaviate/WeaviateDynamicDataModelMapper.cs
@@ -85,7 +85,6 @@ internal sealed class WeaviateDynamicMapper : IWeaviateMapper<Dictionary<string,
                 var vectorValue = generatedEmbeddings?[i] switch
                 {
                     IReadOnlyList<Embedding<float>> e => e[recordIndex].Vector,
-                    IReadOnlyList<Embedding<double>> e => e[recordIndex].Vector,
                     null => dataModel.TryGetValue(property.ModelName, out var v) ? v : null,
                     _ => throw new NotSupportedException($"Unsupported embedding type '{generatedEmbeddings?[i]?.GetType().Name}' for property '{property.ModelName}'.")
                 };

--- a/dotnet/src/Connectors/Connectors.Memory.Weaviate/WeaviateModelBuilder.cs
+++ b/dotnet/src/Connectors/Connectors.Memory.Weaviate/WeaviateModelBuilder.cs
@@ -56,8 +56,6 @@ internal class WeaviateModelBuilder(bool hasNamedVectors) : CollectionJsonModelB
     internal static readonly HashSet<Type> s_supportedVectorTypes =
     [
         typeof(ReadOnlyMemory<float>),
-        typeof(ReadOnlyMemory<float>?),
-        typeof(ReadOnlyMemory<double>),
-        typeof(ReadOnlyMemory<double>?)
+        typeof(ReadOnlyMemory<float>?)
     ];
 }

--- a/dotnet/src/InternalUtilities/connectors/Memory/MongoDB/MongoConstants.cs
+++ b/dotnet/src/InternalUtilities/connectors/Memory/MongoDB/MongoConstants.cs
@@ -59,8 +59,6 @@ internal static class MongoConstants
     internal static readonly HashSet<Type> SupportedVectorTypes =
     [
         typeof(ReadOnlyMemory<float>),
-        typeof(ReadOnlyMemory<float>?),
-        typeof(ReadOnlyMemory<double>),
-        typeof(ReadOnlyMemory<double>?)
+        typeof(ReadOnlyMemory<float>?)
     ];
 }

--- a/dotnet/src/InternalUtilities/connectors/Memory/MongoDB/MongoDynamicMapper.cs
+++ b/dotnet/src/InternalUtilities/connectors/Memory/MongoDB/MongoDynamicMapper.cs
@@ -56,7 +56,6 @@ internal sealed class MongoDynamicMapper(CollectionModel model) : IMongoMapper<D
                 document[property.StorageName] = embedding switch
                 {
                     Embedding<float> e => BsonArray.Create(e.Vector.ToArray()),
-                    Embedding<double> e => BsonArray.Create(e.Vector.ToArray()),
                     _ => throw new UnreachableException()
                 };
             }
@@ -145,7 +144,7 @@ internal sealed class MongoDynamicMapper(CollectionModel model) : IMongoMapper<D
         };
     }
 
-    private static object? GetVectorPropertyValue(string propertyName, Type propertyType, BsonValue value)
+    private static ReadOnlyMemory<float>? GetVectorPropertyValue(string propertyName, Type propertyType, BsonValue value)
     {
         if (value.IsBsonNull)
         {
@@ -156,8 +155,6 @@ internal sealed class MongoDynamicMapper(CollectionModel model) : IMongoMapper<D
         {
             Type t when t == typeof(ReadOnlyMemory<float>) || t == typeof(ReadOnlyMemory<float>?) =>
                 new ReadOnlyMemory<float>(value.AsBsonArray.Select(item => (float)item.AsDouble).ToArray()),
-            Type t when t == typeof(ReadOnlyMemory<double>) || t == typeof(ReadOnlyMemory<double>?) =>
-                new ReadOnlyMemory<double>(value.AsBsonArray.Select(item => item.AsDouble).ToArray()),
             _ => throw new NotSupportedException($"Mapping for property {propertyName} with type {propertyType.FullName} is not supported in dynamic data model.")
         };
     }
@@ -172,7 +169,6 @@ internal sealed class MongoDynamicMapper(CollectionModel model) : IMongoMapper<D
         return vector switch
         {
             ReadOnlyMemory<float> memoryFloat => memoryFloat.ToArray(),
-            ReadOnlyMemory<double> memoryDouble => memoryDouble.ToArray(),
             _ => throw new NotSupportedException($"Mapping for type {vector.GetType().FullName} is not supported in dynamic data model.")
         };
     }

--- a/dotnet/src/InternalUtilities/connectors/Memory/MongoDB/MongoMapper.cs
+++ b/dotnet/src/InternalUtilities/connectors/Memory/MongoDB/MongoMapper.cs
@@ -77,7 +77,6 @@ internal sealed class MongoMapper<TRecord> : IMongoMapper<TRecord>
                     document[property.StorageName] = embedding switch
                     {
                         Embedding<float> e => BsonArray.Create(e.Vector.ToArray()),
-                        Embedding<double> e => BsonArray.Create(e.Vector.ToArray()),
                         _ => throw new UnreachableException()
                     };
                 }

--- a/dotnet/src/VectorDataIntegrationTests/RedisIntegrationTests/RedisHashSetEmbeddingTypeTests.cs
+++ b/dotnet/src/VectorDataIntegrationTests/RedisIntegrationTests/RedisHashSetEmbeddingTypeTests.cs
@@ -3,6 +3,7 @@
 using RedisIntegrationTests.Support;
 using VectorDataSpecificationTests;
 using VectorDataSpecificationTests.Support;
+using VectorDataSpecificationTests.Xunit;
 using Xunit;
 
 #pragma warning disable CA2000 // Dispose objects before losing scope
@@ -12,6 +13,12 @@ namespace RedisIntegrationTests;
 public class RedisHashSetEmbeddingTypeTests(RedisHashSetEmbeddingTypeTests.Fixture fixture)
     : EmbeddingTypeTests<string>(fixture), IClassFixture<RedisHashSetEmbeddingTypeTests.Fixture>
 {
+    [ConditionalFact]
+    public virtual Task ReadOnlyMemory_of_double()
+        => this.Test<ReadOnlyMemory<double>>(
+            new ReadOnlyMemory<double>([1d, 2d, 3d]),
+            new ReadOnlyMemoryEmbeddingGenerator<double>(new([1d, 2d, 3d])));
+
     public new class Fixture : EmbeddingTypeTests<string>.Fixture
     {
         public override TestStore TestStore => RedisTestStore.HashSetInstance;

--- a/dotnet/src/VectorDataIntegrationTests/RedisIntegrationTests/RedisJsonEmbeddingTypeTests.cs
+++ b/dotnet/src/VectorDataIntegrationTests/RedisIntegrationTests/RedisJsonEmbeddingTypeTests.cs
@@ -3,6 +3,7 @@
 using RedisIntegrationTests.Support;
 using VectorDataSpecificationTests;
 using VectorDataSpecificationTests.Support;
+using VectorDataSpecificationTests.Xunit;
 using Xunit;
 
 #pragma warning disable CA2000 // Dispose objects before losing scope
@@ -12,6 +13,12 @@ namespace RedisIntegrationTests;
 public class RedisJsonEmbeddingTypeTests(RedisJsonEmbeddingTypeTests.Fixture fixture)
     : EmbeddingTypeTests<string>(fixture), IClassFixture<RedisJsonEmbeddingTypeTests.Fixture>
 {
+    [ConditionalFact]
+    public virtual Task ReadOnlyMemory_of_double()
+        => this.Test<ReadOnlyMemory<double>>(
+            new ReadOnlyMemory<double>([3d, 2d, 1d]),
+            new ReadOnlyMemoryEmbeddingGenerator<double>(new([3d, 2d, 1d])));
+
     public new class Fixture : EmbeddingTypeTests<string>.Fixture
     {
         public override TestStore TestStore => RedisTestStore.JsonInstance;


### PR DESCRIPTION
### Motivation and Context

#11654

MongoDB and Weaviate don't actually support double but Redis explicitly does.

### Description

- Removing double vector support from Weaviate
- Removing double vector support from MongoDB
- Adding tests to verify double support for Redis and fixing any issues related to it.

### Contribution Checklist

<!-- Before submitting this PR, please make sure: -->

- [ ] The code builds clean without any errors or warnings
- [ ] The PR follows the [SK Contribution Guidelines](https://github.com/microsoft/semantic-kernel/blob/main/CONTRIBUTING.md) and the [pre-submission formatting script](https://github.com/microsoft/semantic-kernel/blob/main/CONTRIBUTING.md#development-scripts) raises no violations
- [ ] All unit tests pass, and I have added new tests where possible
- [ ] I didn't break anyone :smile:
