### PR TITLE
.Net: Replace text search behavior delegate options with Func

### DIFF
--- a/dotnet/src/SemanticKernel.Core/Data/TextSearchBehavior/TextSearchBehaviorOptions.cs
+++ b/dotnet/src/SemanticKernel.Core/Data/TextSearchBehavior/TextSearchBehaviorOptions.cs
@@ -90,7 +90,7 @@ public sealed class TextSearchBehaviorOptions
     /// will not be used if providing this delegate.
     /// </para>
     /// </remarks>
-    public ContextFormatterType? ContextFormatter { get; init; }
+    public Func<List<TextSearchResult>, string>? ContextFormatter { get; init; }
 
     /// <summary>
     /// Choices for controlling the behavior of the <see cref="TextSearchBehavior"/>.
@@ -108,11 +108,4 @@ public sealed class TextSearchBehaviorOptions
         /// </summary>
         ViaPlugin
     }
-
-    /// <summary>
-    /// Delegate type for formatting the output context for the component.
-    /// </summary>
-    /// <param name="results">The results returned by the text search.</param>
-    /// <returns>The formatted context.</returns>
-    public delegate string ContextFormatterType(List<TextSearchResult> results);
 }

--- a/dotnet/src/SemanticKernel.UnitTests/Data/TextSearchBehaviorTests.cs
+++ b/dotnet/src/SemanticKernel.UnitTests/Data/TextSearchBehaviorTests.cs
@@ -205,14 +205,11 @@ public class TextSearchBehaviorTests
             It.IsAny<CancellationToken>()))
             .ReturnsAsync(new KernelSearchResults<TextSearchResult>(searchResults.Object));
 
-        var customFormatter = new TextSearchBehaviorOptions.ContextFormatterType(results =>
-            $"Custom formatted context with {results.Count} results.");
-
         var options = new TextSearchBehaviorOptions
         {
             SearchTime = TextSearchBehaviorOptions.RagBehavior.BeforeAIInvoke,
             Top = 2,
-            ContextFormatter = customFormatter
+            ContextFormatter = results => $"Custom formatted context with {results.Count} results."
         };
 
         var component = new TextSearchBehavior(mockTextSearch.Object, options);


### PR DESCRIPTION
### Description

Replace text search behavior delegate options with Func

### Contribution Checklist

<!-- Before submitting this PR, please make sure: -->

- [ ] The code builds clean without any errors or warnings
- [ ] The PR follows the [SK Contribution Guidelines](https://github.com/microsoft/semantic-kernel/blob/main/CONTRIBUTING.md) and the [pre-submission formatting script](https://github.com/microsoft/semantic-kernel/blob/main/CONTRIBUTING.md#development-scripts) raises no violations
- [ ] All unit tests pass, and I have added new tests where possible
- [ ] I didn't break anyone :smile:
