### PR TITLE
.Net: Serialize python code execution result

### DIFF
--- a/dotnet/src/Plugins/Plugins.Core/CodeInterpreter/SessionsPythonCodeExecutionResult.cs
+++ b/dotnet/src/Plugins/Plugins.Core/CodeInterpreter/SessionsPythonCodeExecutionResult.cs
@@ -1,6 +1,6 @@
 ﻿// Copyright (c) Microsoft. All rights reserved.
 
-using System.Text;
+using System.Text.Json;
 using System.Text.Json.Serialization;
 
 namespace Microsoft.SemanticKernel.Plugins.Core.CodeInterpreter;
@@ -27,17 +27,13 @@ public sealed class SessionsPythonCodeExecutionResult
     /// </summary>
     public override string ToString()
     {
-        StringBuilder sb = new();
-
-        sb.AppendLine($"Status: {this.Status}");
-        if (this.Result is not null)
+        return JsonSerializer.Serialize(new
         {
-            sb.AppendLine($"Result: {this.Result.ExecutionResult}");
-            sb.AppendLine($"Stdout: {this.Result.StdOut}");
-            sb.AppendLine($"Stderr: {this.Result.StdErr}");
-        }
-
-        return sb.ToString();
+            status = this.Status,
+            result = this.Result?.ExecutionResult,
+            stdOut = this.Result?.StdOut,
+            stdErr = this.Result?.StdErr
+        });
     }
 
     /// <summary>

--- a/dotnet/src/Plugins/Plugins.UnitTests/Core/SessionsPythonCodeExecutionResultTests.cs
+++ b/dotnet/src/Plugins/Plugins.UnitTests/Core/SessionsPythonCodeExecutionResultTests.cs
@@ -26,9 +26,6 @@ public class SessionsPythonCodeExecutionResultTests
         string resultString = result.ToString();
 
         // Assert
-        Assert.Contains("Status: Succeeded", resultString);
-        Assert.Contains("Result: 42", resultString);
-        Assert.Contains("Stdout: Hello World", resultString);
-        Assert.Contains("Stderr: Error", resultString);
+        Assert.Equal("{\"status\":\"Succeeded\",\"result\":\"42\",\"stdOut\":\"Hello World\",\"stdErr\":\"Error\"}", resultString);
     }
 }


### PR DESCRIPTION
### Motivation, Context and Description

This PR changes the format of Python code execution results from a string, which is the result of concatenating property values, to the product of serializing the result property values. The idea is that AI models can reason well about JSONs but may not reason as effectively over custom strings.