### PR TITLE
implement IDisposable for VectorStore and VectorStoreCollection base types

### DIFF
--- a/dotnet/src/Connectors/Connectors.AzureAISearch.UnitTests/AzureAISearchCollectionTests.cs
+++ b/dotnet/src/Connectors/Connectors.AzureAISearch.UnitTests/AzureAISearchCollectionTests.cs
@@ -64,7 +64,7 @@ public class AzureAISearchCollectionTests
                 .ThrowsAsync(new RequestFailedException(404, "Index not found"));
         }
 
-        var sut = new AzureAISearchCollection<string, MultiPropsModel>(this._searchIndexClientMock.Object, collectionName);
+        using var sut = new AzureAISearchCollection<string, MultiPropsModel>(this._searchIndexClientMock.Object, collectionName);
 
         // Act.
         var actual = await sut.CollectionExistsAsync(this._testCancellationToken);
@@ -98,7 +98,7 @@ public class AzureAISearchCollectionTests
             .Setup(x => x.CreateIndexAsync(It.IsAny<SearchIndex>(), this._testCancellationToken))
             .ReturnsAsync(Response.FromValue(new SearchIndex(TestCollectionName), Mock.Of<Response>()));
 
-        var sut = this.CreateRecordCollection(useDefinition);
+        using var sut = this.CreateRecordCollection(useDefinition);
 
         // Act.
         await sut.EnsureCollectionExistsAsync();
@@ -132,7 +132,7 @@ public class AzureAISearchCollectionTests
             .Setup(x => x.DeleteIndexAsync(TestCollectionName, this._testCancellationToken))
             .Returns(Task.FromResult<Response?>(null));
 
-        var sut = this.CreateRecordCollection(false);
+        using var sut = this.CreateRecordCollection(false);
 
         // Act.
         await sut.DeleteCollectionAsync(this._testCancellationToken);
@@ -154,7 +154,7 @@ public class AzureAISearchCollectionTests
                 this._testCancellationToken))
             .ReturnsAsync(Response.FromValue(CreateModel(TestRecordKey1, true), Mock.Of<Response>()));
 
-        var sut = this.CreateRecordCollection(useDefinition);
+        using var sut = this.CreateRecordCollection(useDefinition);
 
         // Act.
         var actual = await sut.GetAsync(
@@ -189,7 +189,7 @@ public class AzureAISearchCollectionTests
                 this._testCancellationToken))
             .ReturnsAsync(Response.FromValue(CreateModel(TestRecordKey1, true), Mock.Of<Response>()));
 
-        var sut = this.CreateRecordCollection(useDefinition, useCustomJsonSerializerOptions);
+        using var sut = this.CreateRecordCollection(useDefinition, useCustomJsonSerializerOptions);
 
         // Act.
         var actual = await sut.GetAsync(
@@ -227,7 +227,7 @@ public class AzureAISearchCollectionTests
                 return Response.FromValue(CreateModel(id, true), Mock.Of<Response>());
             });
 
-        var sut = this.CreateRecordCollection(useDefinition);
+        using var sut = this.CreateRecordCollection(useDefinition);
 
         // Act.
         var actual = await sut.GetAsync(
@@ -260,7 +260,7 @@ public class AzureAISearchCollectionTests
                 this._testCancellationToken))
             .ReturnsAsync(Response.FromValue(indexDocumentsResultMock.Object, Mock.Of<Response>()));
 
-        var sut = this.CreateRecordCollection(useDefinition);
+        using var sut = this.CreateRecordCollection(useDefinition);
 
         // Act.
         await sut.DeleteAsync(
@@ -295,7 +295,7 @@ public class AzureAISearchCollectionTests
                 this._testCancellationToken))
             .ReturnsAsync(Response.FromValue(indexDocumentsResultMock.Object, Mock.Of<Response>()));
 
-        var sut = this.CreateRecordCollection(useDefinition);
+        using var sut = this.CreateRecordCollection(useDefinition);
 
         // Act.
         await sut.DeleteAsync(
@@ -334,7 +334,7 @@ public class AzureAISearchCollectionTests
             .ReturnsAsync(Response.FromValue(indexDocumentsResultMock.Object, Mock.Of<Response>()));
 
         // Arrange sut.
-        var sut = this.CreateRecordCollection(useDefinition);
+        using var sut = this.CreateRecordCollection(useDefinition);
 
         var model = CreateModel(TestRecordKey1, true);
 
@@ -377,7 +377,7 @@ public class AzureAISearchCollectionTests
             .ReturnsAsync(Response.FromValue(indexDocumentsResultMock.Object, Mock.Of<Response>()));
 
         // Arrange sut.
-        var sut = this.CreateRecordCollection(useDefinition);
+        using var sut = this.CreateRecordCollection(useDefinition);
 
         var model1 = CreateModel(TestRecordKey1, true);
         var model2 = CreateModel(TestRecordKey2, true);
@@ -416,7 +416,7 @@ public class AzureAISearchCollectionTests
         };
 
         // Act.
-        var sut = new AzureAISearchCollection<string, MultiPropsModel>(
+        using var sut = new AzureAISearchCollection<string, MultiPropsModel>(
             this._searchIndexClientMock.Object,
             TestCollectionName,
             new() { VectorStoreRecordDefinition = definition });
@@ -433,7 +433,7 @@ public class AzureAISearchCollectionTests
             .Setup(x => x.SearchAsync<MultiPropsModel>(null, It.IsAny<SearchOptions>(), It.IsAny<CancellationToken>()))
             .ReturnsAsync(Response.FromValue(searchResultsMock, Mock.Of<Response>()));
 
-        var sut = new AzureAISearchCollection<string, MultiPropsModel>(
+        using var sut = new AzureAISearchCollection<string, MultiPropsModel>(
             this._searchIndexClientMock.Object,
             TestCollectionName);
         var filter = new VectorSearchFilter().EqualTo(nameof(MultiPropsModel.Data1), "Data1FilterValue");
@@ -475,7 +475,7 @@ public class AzureAISearchCollectionTests
             .Setup(x => x.SearchAsync<MultiPropsModel>(null, It.IsAny<SearchOptions>(), It.IsAny<CancellationToken>()))
             .ReturnsAsync(Response.FromValue(searchResultsMock, Mock.Of<Response>()));
 
-        var sut = new AzureAISearchCollection<string, MultiPropsModel>(
+        using var sut = new AzureAISearchCollection<string, MultiPropsModel>(
             this._searchIndexClientMock.Object,
             TestCollectionName);
         var filter = new VectorSearchFilter().EqualTo(nameof(MultiPropsModel.Data1), "Data1FilterValue");

--- a/dotnet/src/Connectors/Connectors.AzureAISearch.UnitTests/AzureAISearchVectorStoreTests.cs
+++ b/dotnet/src/Connectors/Connectors.AzureAISearch.UnitTests/AzureAISearchVectorStoreTests.cs
@@ -39,7 +39,7 @@ public class AzureAISearchVectorStoreTests
     public void GetCollectionReturnsCollection()
     {
         // Arrange.
-        var sut = new AzureAISearchVectorStore(this._searchIndexClientMock.Object);
+        using var sut = new AzureAISearchVectorStore(this._searchIndexClientMock.Object);
 
         // Act.
         var actual = sut.GetCollection<string, SinglePropsModel>(TestCollectionName);
@@ -53,7 +53,7 @@ public class AzureAISearchVectorStoreTests
     public void GetCollectionThrowsForInvalidKeyType()
     {
         // Arrange.
-        var sut = new AzureAISearchVectorStore(this._searchIndexClientMock.Object);
+        using var sut = new AzureAISearchVectorStore(this._searchIndexClientMock.Object);
 
         // Act & Assert.
         Assert.Throws<NotSupportedException>(() => sut.GetCollection<int, SinglePropsModel>(TestCollectionName));
@@ -76,7 +76,7 @@ public class AzureAISearchVectorStoreTests
         this._searchIndexClientMock
             .Setup(x => x.GetIndexNamesAsync(this._testCancellationToken))
             .Returns(pageableMock.Object);
-        var sut = new AzureAISearchVectorStore(this._searchIndexClientMock.Object);
+        using var sut = new AzureAISearchVectorStore(this._searchIndexClientMock.Object);
 
         // Act.
         var actual = sut.ListCollectionNamesAsync(this._testCancellationToken);

--- a/dotnet/src/Connectors/Connectors.CosmosMongoDB.UnitTests/CosmosMongoCollectionTests.cs
+++ b/dotnet/src/Connectors/Connectors.CosmosMongoDB.UnitTests/CosmosMongoCollectionTests.cs
@@ -44,7 +44,7 @@ public sealed class CosmosMongoCollectionTests
     public void ConstructorWithDeclarativeModelInitializesCollection()
     {
         // Act & Assert
-        var collection = new CosmosMongoCollection<string, CosmosMongoHotelModel>(
+        using var collection = new CosmosMongoCollection<string, CosmosMongoHotelModel>(
             this._mockMongoDatabase.Object,
             "collection");
 
@@ -61,7 +61,7 @@ public sealed class CosmosMongoCollectionTests
         };
 
         // Act
-        var collection = new CosmosMongoCollection<string, TestModel>(
+        using var collection = new CosmosMongoCollection<string, TestModel>(
             this._mockMongoDatabase.Object,
             "collection",
             new() { VectorStoreRecordDefinition = definition });
@@ -89,7 +89,7 @@ public sealed class CosmosMongoCollectionTests
             .Setup(l => l.ListCollectionNamesAsync(It.IsAny<ListCollectionNamesOptions>(), It.IsAny<CancellationToken>()))
             .ReturnsAsync(mockCursor.Object);
 
-        var sut = new CosmosMongoCollection<string, CosmosMongoHotelModel>(
+        using var sut = new CosmosMongoCollection<string, CosmosMongoHotelModel>(
             this._mockMongoDatabase.Object,
             collectionName);
 
@@ -139,7 +139,7 @@ public sealed class CosmosMongoCollectionTests
             .Setup(l => l.Indexes)
             .Returns(mockMongoIndexManager.Object);
 
-        var sut = new CosmosMongoCollection<string, CosmosMongoHotelModel>(
+        using var sut = new CosmosMongoCollection<string, CosmosMongoHotelModel>(
             this._mockMongoDatabase.Object,
             CollectionName);
 
@@ -163,7 +163,7 @@ public sealed class CosmosMongoCollectionTests
         // Arrange
         const string RecordKey = "key";
 
-        var sut = new CosmosMongoCollection<string, CosmosMongoHotelModel>(
+        using var sut = new CosmosMongoCollection<string, CosmosMongoHotelModel>(
             this._mockMongoDatabase.Object,
             "collection");
 
@@ -187,7 +187,7 @@ public sealed class CosmosMongoCollectionTests
         // Arrange
         List<string> recordKeys = ["key1", "key2"];
 
-        var sut = new CosmosMongoCollection<string, CosmosMongoHotelModel>(
+        using var sut = new CosmosMongoCollection<string, CosmosMongoHotelModel>(
             this._mockMongoDatabase.Object,
             "collection");
 
@@ -211,7 +211,7 @@ public sealed class CosmosMongoCollectionTests
         // Arrange
         const string CollectionName = "collection";
 
-        var sut = new CosmosMongoCollection<string, CosmosMongoHotelModel>(
+        using var sut = new CosmosMongoCollection<string, CosmosMongoHotelModel>(
             this._mockMongoDatabase.Object,
             CollectionName);
 
@@ -248,7 +248,7 @@ public sealed class CosmosMongoCollectionTests
                 It.IsAny<CancellationToken>()))
             .ReturnsAsync(mockCursor.Object);
 
-        var sut = new CosmosMongoCollection<string, CosmosMongoHotelModel>(
+        using var sut = new CosmosMongoCollection<string, CosmosMongoHotelModel>(
             this._mockMongoDatabase.Object,
             "collection");
 
@@ -286,7 +286,7 @@ public sealed class CosmosMongoCollectionTests
                 It.IsAny<CancellationToken>()))
             .ReturnsAsync(mockCursor.Object);
 
-        var sut = new CosmosMongoCollection<string, CosmosMongoHotelModel>(
+        using var sut = new CosmosMongoCollection<string, CosmosMongoHotelModel>(
             this._mockMongoDatabase.Object,
             "collection");
 
@@ -317,7 +317,7 @@ public sealed class CosmosMongoCollectionTests
         var documentSerializer = serializerRegistry.GetSerializer<BsonDocument>();
         var expectedDefinition = Builders<BsonDocument>.Filter.Eq(document => document["_id"], "key");
 
-        var sut = new CosmosMongoCollection<string, CosmosMongoHotelModel>(
+        using var sut = new CosmosMongoCollection<string, CosmosMongoHotelModel>(
             this._mockMongoDatabase.Object,
             "collection");
 
@@ -343,7 +343,7 @@ public sealed class CosmosMongoCollectionTests
         var hotel2 = new CosmosMongoHotelModel("key2") { HotelName = "Test Name 2" };
         var hotel3 = new CosmosMongoHotelModel("key3") { HotelName = "Test Name 3" };
 
-        var sut = new CosmosMongoCollection<string, CosmosMongoHotelModel>(
+        using var sut = new CosmosMongoCollection<string, CosmosMongoHotelModel>(
             this._mockMongoDatabase.Object,
             "collection");
 
@@ -418,7 +418,7 @@ public sealed class CosmosMongoCollectionTests
         // Arrange
         this.MockCollectionForSearch();
 
-        var sut = new CosmosMongoCollection<string, CosmosMongoHotelModel>(
+        using var sut = new CosmosMongoCollection<string, CosmosMongoHotelModel>(
             this._mockMongoDatabase.Object,
             "collection");
 
@@ -476,7 +476,7 @@ public sealed class CosmosMongoCollectionTests
 
         this.MockCollectionForSearch();
 
-        var sut = new CosmosMongoCollection<string, VectorSearchModel>(
+        using var sut = new CosmosMongoCollection<string, VectorSearchModel>(
             this._mockMongoDatabase.Object,
             "collection");
 
@@ -509,7 +509,7 @@ public sealed class CosmosMongoCollectionTests
         // Arrange
         this.MockCollectionForSearch();
 
-        var sut = new CosmosMongoCollection<string, CosmosMongoHotelModel>(
+        using var sut = new CosmosMongoCollection<string, CosmosMongoHotelModel>(
             this._mockMongoDatabase.Object,
             "collection");
 
@@ -525,7 +525,7 @@ public sealed class CosmosMongoCollectionTests
         // Arrange
         this.MockCollectionForSearch();
 
-        var sut = new CosmosMongoCollection<string, CosmosMongoHotelModel>(
+        using var sut = new CosmosMongoCollection<string, CosmosMongoHotelModel>(
             this._mockMongoDatabase.Object,
             "collection");
 
@@ -612,7 +612,7 @@ public sealed class CosmosMongoCollectionTests
             new() { VectorStoreRecordDefinition = definition } :
             null;
 
-        var sut = new CosmosMongoCollection<string, TDataModel>(
+        using var sut = new CosmosMongoCollection<string, TDataModel>(
             this._mockMongoDatabase.Object,
             "collection",
             options);

--- a/dotnet/src/Connectors/Connectors.CosmosMongoDB.UnitTests/CosmosMongoVectorStoreTests.cs
+++ b/dotnet/src/Connectors/Connectors.CosmosMongoDB.UnitTests/CosmosMongoVectorStoreTests.cs
@@ -23,7 +23,7 @@ public sealed class CosmosMongoVectorStoreTests
     public void GetCollectionWithNotSupportedKeyThrowsException()
     {
         // Arrange
-        var sut = new CosmosMongoVectorStore(this._mockMongoDatabase.Object);
+        using var sut = new CosmosMongoVectorStore(this._mockMongoDatabase.Object);
 
         // Act & Assert
         Assert.Throws<NotSupportedException>(() => sut.GetCollection<Guid, CosmosMongoHotelModel>("collection"));
@@ -33,7 +33,7 @@ public sealed class CosmosMongoVectorStoreTests
     public void GetCollectionWithoutFactoryReturnsDefaultCollection()
     {
         // Arrange
-        var sut = new CosmosMongoVectorStore(this._mockMongoDatabase.Object);
+        using var sut = new CosmosMongoVectorStore(this._mockMongoDatabase.Object);
 
         // Act
         var collection = sut.GetCollection<string, CosmosMongoHotelModel>("collection");
@@ -62,7 +62,7 @@ public sealed class CosmosMongoVectorStoreTests
             .Setup(l => l.ListCollectionNamesAsync(It.IsAny<ListCollectionNamesOptions>(), It.IsAny<CancellationToken>()))
             .ReturnsAsync(mockCursor.Object);
 
-        var sut = new CosmosMongoVectorStore(this._mockMongoDatabase.Object);
+        using var sut = new CosmosMongoVectorStore(this._mockMongoDatabase.Object);
 
         // Act
         var actualCollectionNames = await sut.ListCollectionNamesAsync().ToListAsync();

--- a/dotnet/src/Connectors/Connectors.CosmosNoSql.UnitTests/CosmosNoSqlCollectionTests.cs
+++ b/dotnet/src/Connectors/Connectors.CosmosNoSql.UnitTests/CosmosNoSqlCollectionTests.cs
@@ -64,7 +64,7 @@ public sealed class CosmosNoSqlCollectionTests
     public void ConstructorWithDeclarativeModelInitializesCollection()
     {
         // Act & Assert
-        var collection = new CosmosNoSqlCollection<string, CosmosNoSqlHotel>(
+        using var collection = new CosmosNoSqlCollection<string, CosmosNoSqlHotel>(
             this._mockDatabase.Object,
             "collection");
 
@@ -81,7 +81,7 @@ public sealed class CosmosNoSqlCollectionTests
         };
 
         // Act
-        var collection = new CosmosNoSqlCollection<string, TestModel>(
+        using var collection = new CosmosNoSqlCollection<string, TestModel>(
             this._mockDatabase.Object,
             "collection",
             new() { VectorStoreRecordDefinition = definition });
@@ -117,7 +117,7 @@ public sealed class CosmosNoSqlCollectionTests
                 It.IsAny<QueryRequestOptions>()))
             .Returns(mockFeedIterator.Object);
 
-        var sut = new CosmosNoSqlCollection<string, CosmosNoSqlHotel>(
+        using var sut = new CosmosNoSqlCollection<string, CosmosNoSqlHotel>(
             this._mockDatabase.Object,
             collectionName);
 
@@ -159,7 +159,7 @@ public sealed class CosmosNoSqlCollectionTests
                 It.IsAny<QueryRequestOptions>()))
             .Returns(mockFeedIterator.Object);
 
-        var sut = new CosmosNoSqlCollection<string, TestIndexingModel>(
+        using var sut = new CosmosNoSqlCollection<string, TestIndexingModel>(
             this._mockDatabase.Object,
             CollectionName,
             new() { IndexingMode = indexingMode, Automatic = indexingMode != IndexingMode.None });
@@ -259,7 +259,7 @@ public sealed class CosmosNoSqlCollectionTests
                 It.IsAny<QueryRequestOptions>()))
             .Returns(mockFeedIterator.Object);
 
-        var sut = new CosmosNoSqlCollection<string, CosmosNoSqlHotel>(
+        using var sut = new CosmosNoSqlCollection<string, CosmosNoSqlHotel>(
             this._mockDatabase.Object,
             CollectionName);
 
@@ -289,7 +289,7 @@ public sealed class CosmosNoSqlCollectionTests
         // Act
         if (useCompositeKeyCollection)
         {
-            var sut = new CosmosNoSqlCollection<CosmosNoSqlCompositeKey, CosmosNoSqlHotel>(
+            using var sut = new CosmosNoSqlCollection<CosmosNoSqlCompositeKey, CosmosNoSqlHotel>(
                 this._mockDatabase.Object,
                 "collection");
 
@@ -298,7 +298,7 @@ public sealed class CosmosNoSqlCollectionTests
         }
         else
         {
-            var sut = new CosmosNoSqlCollection<string, CosmosNoSqlHotel>(
+            using var sut = new CosmosNoSqlCollection<string, CosmosNoSqlHotel>(
                 this._mockDatabase.Object,
                 "collection");
 
@@ -321,7 +321,7 @@ public sealed class CosmosNoSqlCollectionTests
         // Arrange
         List<string> recordKeys = ["key1", "key2"];
 
-        var sut = new CosmosNoSqlCollection<string, CosmosNoSqlHotel>(
+        using var sut = new CosmosNoSqlCollection<string, CosmosNoSqlHotel>(
             this._mockDatabase.Object,
             "collection");
 
@@ -344,7 +344,7 @@ public sealed class CosmosNoSqlCollectionTests
     public async Task DeleteCollectionInvokesValidMethodsAsync()
     {
         // Arrange
-        var sut = new CosmosNoSqlCollection<string, CosmosNoSqlHotel>(
+        using var sut = new CosmosNoSqlCollection<string, CosmosNoSqlHotel>(
             this._mockDatabase.Object,
             "collection");
 
@@ -388,7 +388,7 @@ public sealed class CosmosNoSqlCollectionTests
                 It.IsAny<QueryRequestOptions>()))
             .Returns(mockFeedIterator.Object);
 
-        var sut = new CosmosNoSqlCollection<string, CosmosNoSqlHotel>(
+        using var sut = new CosmosNoSqlCollection<string, CosmosNoSqlHotel>(
             this._mockDatabase.Object,
             "collection");
 
@@ -431,7 +431,7 @@ public sealed class CosmosNoSqlCollectionTests
                 It.IsAny<QueryRequestOptions>()))
             .Returns(mockFeedIterator.Object);
 
-        var sut = new CosmosNoSqlCollection<string, CosmosNoSqlHotel>(
+        using var sut = new CosmosNoSqlCollection<string, CosmosNoSqlHotel>(
             this._mockDatabase.Object,
             "collection");
 
@@ -458,7 +458,7 @@ public sealed class CosmosNoSqlCollectionTests
         // Arrange
         var hotel = new CosmosNoSqlHotel("key") { HotelName = "Test Name" };
 
-        var sut = new CosmosNoSqlCollection<string, CosmosNoSqlHotel>(
+        using var sut = new CosmosNoSqlCollection<string, CosmosNoSqlHotel>(
             this._mockDatabase.Object,
             "collection");
 
@@ -484,7 +484,7 @@ public sealed class CosmosNoSqlCollectionTests
         var hotel2 = new CosmosNoSqlHotel("key2") { HotelName = "Test Name 2" };
         var hotel3 = new CosmosNoSqlHotel("key3") { HotelName = "Test Name 3" };
 
-        var sut = new CosmosNoSqlCollection<string, CosmosNoSqlHotel>(
+        using var sut = new CosmosNoSqlCollection<string, CosmosNoSqlHotel>(
             this._mockDatabase.Object,
             "collection");
 
@@ -528,7 +528,7 @@ public sealed class CosmosNoSqlCollectionTests
                 It.IsAny<QueryRequestOptions>()))
             .Returns(mockFeedIterator.Object);
 
-        var sut = new CosmosNoSqlCollection<string, CosmosNoSqlHotel>(
+        using var sut = new CosmosNoSqlCollection<string, CosmosNoSqlHotel>(
             this._mockDatabase.Object,
             "collection");
 
@@ -547,7 +547,7 @@ public sealed class CosmosNoSqlCollectionTests
     public async Task VectorizedSearchWithUnsupportedVectorTypeThrowsExceptionAsync()
     {
         // Arrange
-        var sut = new CosmosNoSqlCollection<string, CosmosNoSqlHotel>(
+        using var sut = new CosmosNoSqlCollection<string, CosmosNoSqlHotel>(
             this._mockDatabase.Object,
             "collection");
 
@@ -560,7 +560,7 @@ public sealed class CosmosNoSqlCollectionTests
     public async Task VectorizedSearchWithNonExistentVectorPropertyNameThrowsExceptionAsync()
     {
         // Arrange
-        var sut = new CosmosNoSqlCollection<string, CosmosNoSqlHotel>(
+        using var sut = new CosmosNoSqlCollection<string, CosmosNoSqlHotel>(
             this._mockDatabase.Object,
             "collection");
 

--- a/dotnet/src/Connectors/Connectors.CosmosNoSql.UnitTests/CosmosNoSqlVectorStoreTests.cs
+++ b/dotnet/src/Connectors/Connectors.CosmosNoSql.UnitTests/CosmosNoSqlVectorStoreTests.cs
@@ -35,7 +35,7 @@ public sealed class CosmosNoSqlVectorStoreTests
     public void GetCollectionWithNotSupportedKeyThrowsException()
     {
         // Arrange
-        var sut = new Microsoft.SemanticKernel.Connectors.CosmosNoSql.CosmosNoSqlVectorStore(this._mockDatabase.Object);
+        using var sut = new Microsoft.SemanticKernel.Connectors.CosmosNoSql.CosmosNoSqlVectorStore(this._mockDatabase.Object);
 
         // Act & Assert
         Assert.Throws<NotSupportedException>(() => sut.GetCollection<Guid, CosmosNoSqlHotel>("collection"));
@@ -45,7 +45,7 @@ public sealed class CosmosNoSqlVectorStoreTests
     public void GetCollectionWithSupportedKeyReturnsCollection()
     {
         // Arrange
-        var sut = new Microsoft.SemanticKernel.Connectors.CosmosNoSql.CosmosNoSqlVectorStore(this._mockDatabase.Object);
+        using var sut = new Microsoft.SemanticKernel.Connectors.CosmosNoSql.CosmosNoSqlVectorStore(this._mockDatabase.Object);
 
         // Act
         var collectionWithStringKey = sut.GetCollection<string, CosmosNoSqlHotel>("collection1");
@@ -60,7 +60,7 @@ public sealed class CosmosNoSqlVectorStoreTests
     public void GetCollectionWithoutFactoryReturnsDefaultCollection()
     {
         // Arrange
-        var sut = new Microsoft.SemanticKernel.Connectors.CosmosNoSql.CosmosNoSqlVectorStore(this._mockDatabase.Object);
+        using var sut = new Microsoft.SemanticKernel.Connectors.CosmosNoSql.CosmosNoSqlVectorStore(this._mockDatabase.Object);
 
         // Act
         var collection = sut.GetCollection<string, CosmosNoSqlHotel>("collection");
@@ -97,7 +97,7 @@ public sealed class CosmosNoSqlVectorStoreTests
                 It.IsAny<QueryRequestOptions>()))
             .Returns(mockFeedIterator.Object);
 
-        var sut = new Microsoft.SemanticKernel.Connectors.CosmosNoSql.CosmosNoSqlVectorStore(this._mockDatabase.Object);
+        using var sut = new Microsoft.SemanticKernel.Connectors.CosmosNoSql.CosmosNoSqlVectorStore(this._mockDatabase.Object);
 
         // Act
         var actualCollectionNames = await sut.ListCollectionNamesAsync().ToListAsync();

--- a/dotnet/src/Connectors/Connectors.InMemory.UnitTests/InMemoryVectorStoreTests.cs
+++ b/dotnet/src/Connectors/Connectors.InMemory.UnitTests/InMemoryVectorStoreTests.cs
@@ -19,7 +19,7 @@ public class InMemoryVectorStoreTests
     public void GetCollectionReturnsCollection()
     {
         // Arrange.
-        var sut = new InMemoryVectorStore();
+        using var sut = new InMemoryVectorStore();
 
         // Act.
         var actual = sut.GetCollection<string, SinglePropsModel<string>>(TestCollectionName);
@@ -33,7 +33,7 @@ public class InMemoryVectorStoreTests
     public void GetCollectionReturnsCollectionWithNonStringKey()
     {
         // Arrange.
-        var sut = new InMemoryVectorStore();
+        using var sut = new InMemoryVectorStore();
 
         // Act.
         var actual = sut.GetCollection<int, SinglePropsModel<int>>(TestCollectionName);
@@ -47,7 +47,7 @@ public class InMemoryVectorStoreTests
     public async Task GetCollectionDoesNotAllowADifferentDataTypeThanPreviouslyUsedAsync()
     {
         // Arrange.
-        var sut = new InMemoryVectorStore();
+        using var sut = new InMemoryVectorStore();
         var stringKeyCollection = sut.GetCollection<string, SinglePropsModel<string>>(TestCollectionName);
         await stringKeyCollection.EnsureCollectionExistsAsync();
 

--- a/dotnet/src/Connectors/Connectors.Memory.PgVector/PostgresCollection.cs
+++ b/dotnet/src/Connectors/Connectors.Memory.PgVector/PostgresCollection.cs
@@ -48,10 +48,9 @@ public sealed class PostgresCollection<TKey, TRecord> : VectorStoreCollection<TK
     /// </summary>
     /// <param name="dataSource">The data source to use for connecting to the database.</param>
     /// <param name="name">The name of the collection.</param>
-    /// <param name="ownsDataSource">A value indicating whether the data source should be disposed after the collection is disposed.</param>
     /// <param name="options">Optional configuration options for this class.</param>
-    public PostgresCollection(NpgsqlDataSource dataSource, string name, bool ownsDataSource, PostgresCollectionOptions? options = default)
-        : this(new PostgresDbClient(dataSource, options?.Schema, ownsDataSource), name, options)
+    public PostgresCollection(NpgsqlDataSource dataSource, string name, PostgresCollectionOptions? options = default)
+        : this(new PostgresDbClient(dataSource, options?.Schema, options?.OwnsDataSource ?? PostgresVectorStoreOptions.Default.OwnsDataSource), name, options)
     {
         Verify.NotNull(dataSource);
     }
@@ -64,8 +63,11 @@ public sealed class PostgresCollection<TKey, TRecord> : VectorStoreCollection<TK
     /// <param name="options">Optional configuration options for this class.</param>
     public PostgresCollection(string connectionString, string name, PostgresCollectionOptions? options = default)
 #pragma warning disable CA2000 // Dispose objects before losing scope
-        : this(PostgresUtils.CreateDataSource(connectionString), name, ownsDataSource: true, options)
+        : this(PostgresUtils.CreateDataSource(connectionString), name, new(options)
 #pragma warning restore CA2000 // Dispose objects before losing scope
+        {
+            OwnsDataSource = true // We created the the data source, so we own it.
+        })
     {
     }
 

--- a/dotnet/src/Connectors/Connectors.Memory.PgVector/PostgresCollection.cs
+++ b/dotnet/src/Connectors/Connectors.Memory.PgVector/PostgresCollection.cs
@@ -20,7 +20,7 @@ namespace Microsoft.SemanticKernel.Connectors.PgVector;
 /// <typeparam name="TKey">The type of the key.</typeparam>
 /// <typeparam name="TRecord">The type of the record.</typeparam>
 #pragma warning disable CA1711 // Identifiers should not have incorrect suffix
-public sealed class PostgresCollection<TKey, TRecord> : VectorStoreCollection<TKey, TRecord>, IDisposable
+public sealed class PostgresCollection<TKey, TRecord> : VectorStoreCollection<TKey, TRecord>
 #pragma warning restore CA1711 // Identifiers should not have incorrect suffix
     where TKey : notnull
     where TRecord : class
@@ -103,8 +103,12 @@ public sealed class PostgresCollection<TKey, TRecord> : VectorStoreCollection<TK
         };
     }
 
-    /// <inheritdoc/>
-    public void Dispose() => this._client.Dispose();
+    /// <inheritdoc />
+    protected override void Dispose(bool disposing)
+    {
+        this._client.Dispose();
+        base.Dispose(disposing);
+    }
 
     /// <inheritdoc/>
     public override Task<bool> CollectionExistsAsync(CancellationToken cancellationToken = default)

--- a/dotnet/src/Connectors/Connectors.Memory.PgVector/PostgresCollectionOptions.cs
+++ b/dotnet/src/Connectors/Connectors.Memory.PgVector/PostgresCollectionOptions.cs
@@ -11,9 +11,24 @@ namespace Microsoft.SemanticKernel.Connectors.PgVector;
 public sealed class PostgresCollectionOptions
 {
     /// <summary>
+    /// Initializes a new instance of the <see cref="PostgresCollectionOptions"/> class.
+    /// </summary>
+    public PostgresCollectionOptions()
+    {
+    }
+
+    internal PostgresCollectionOptions(PostgresCollectionOptions? source)
+    {
+        this.Schema = source?.Schema ?? PostgresVectorStoreOptions.Default.Schema;
+        this.OwnsDataSource = source?.OwnsDataSource ?? PostgresVectorStoreOptions.Default.OwnsDataSource;
+        this.VectorStoreRecordDefinition = source?.VectorStoreRecordDefinition;
+        this.EmbeddingGenerator = source?.EmbeddingGenerator;
+    }
+
+    /// <summary>
     /// Gets or sets the database schema.
     /// </summary>
-    public string Schema { get; set; } = "public";
+    public string Schema { get; set; } = PostgresVectorStoreOptions.Default.Schema;
 
     /// <summary>
     /// Gets or sets an optional record definition that defines the schema of the record type.
@@ -29,4 +44,9 @@ public sealed class PostgresCollectionOptions
     /// Gets or sets the default embedding generator for vector properties in this collection.
     /// </summary>
     public IEmbeddingGenerator? EmbeddingGenerator { get; set; }
+
+    /// <summary>
+    /// Gets or sets a value indicating whether the data source should be disposed after the collection is disposed.
+    /// </summary>
+    public bool OwnsDataSource { get; set; } = PostgresVectorStoreOptions.Default.OwnsDataSource;
 }

--- a/dotnet/src/Connectors/Connectors.Memory.PgVector/PostgresServiceCollectionExtensions.cs
+++ b/dotnet/src/Connectors/Connectors.Memory.PgVector/PostgresServiceCollectionExtensions.cs
@@ -35,8 +35,8 @@ public static class PostgresServiceCollectionExtensions
                 };
 
                 // The data source has been solved from the DI container, so we do not own it.
-                bool ownsDataSource = false;
-                return new PostgresVectorStore(dataSource, ownsDataSource, options);
+                options.OwnsDataSource = false;
+                return new PostgresVectorStore(dataSource, options);
             });
 
         return services;
@@ -97,8 +97,8 @@ public static class PostgresServiceCollectionExtensions
                 };
 
                 // The data source has been solved from the DI container, so we do not own it.
-                bool ownsDataSource = false;
-                return (new PostgresCollection<TKey, TRecord>(dataSource, collectionName, ownsDataSource, options) as VectorStoreCollection<TKey, TRecord>)!;
+                options.OwnsDataSource = false;
+                return (new PostgresCollection<TKey, TRecord>(dataSource, collectionName, options) as VectorStoreCollection<TKey, TRecord>)!;
             });
 
         AddVectorizedSearch<TKey, TRecord>(services, serviceId);

--- a/dotnet/src/Connectors/Connectors.Memory.PgVector/PostgresVectorStore.cs
+++ b/dotnet/src/Connectors/Connectors.Memory.PgVector/PostgresVectorStore.cs
@@ -32,15 +32,14 @@ public sealed class PostgresVectorStore : VectorStore, IDisposable
     /// Initializes a new instance of the <see cref="PostgresVectorStore"/> class.
     /// </summary>
     /// <param name="dataSource">Postgres data source.</param>
-    /// <param name="ownsDataSource">A value indicating whether the data source should be disposed after the vector store is disposed.</param>
     /// <param name="options">Optional configuration options for this class</param>
-    public PostgresVectorStore(NpgsqlDataSource dataSource, bool ownsDataSource, PostgresVectorStoreOptions? options = default)
+    public PostgresVectorStore(NpgsqlDataSource dataSource, PostgresVectorStoreOptions? options = default)
     {
         Verify.NotNull(dataSource);
 
         this._schema = options?.Schema ?? PostgresVectorStoreOptions.Default.Schema;
         this._embeddingGenerator = options?.EmbeddingGenerator;
-        this._client = new PostgresDbClient(dataSource, this._schema, ownsDataSource);
+        this._client = new PostgresDbClient(dataSource, this._schema, options?.OwnsDataSource ?? PostgresVectorStoreOptions.Default.OwnsDataSource);
 
         this._metadata = new()
         {
@@ -56,8 +55,11 @@ public sealed class PostgresVectorStore : VectorStore, IDisposable
     /// <param name="options">Optional configuration options for this class.</param>
     public PostgresVectorStore(string connectionString, PostgresVectorStoreOptions? options = default)
 #pragma warning disable CA2000 // Dispose objects before losing scope
-        : this(PostgresUtils.CreateDataSource(connectionString), ownsDataSource: true, options)
+        : this(PostgresUtils.CreateDataSource(connectionString), new(options)
 #pragma warning restore CA2000 // Dispose objects before losing scope
+        {
+            OwnsDataSource = true // We created the the data source, so we own it.
+        })
     {
     }
 

--- a/dotnet/src/Connectors/Connectors.Memory.PgVector/PostgresVectorStore.cs
+++ b/dotnet/src/Connectors/Connectors.Memory.PgVector/PostgresVectorStore.cs
@@ -13,7 +13,7 @@ namespace Microsoft.SemanticKernel.Connectors.PgVector;
 /// <summary>
 /// Represents a vector store implementation using PostgreSQL.
 /// </summary>
-public sealed class PostgresVectorStore : VectorStore, IDisposable
+public sealed class PostgresVectorStore : VectorStore
 {
     private readonly PostgresDbClient _client;
 
@@ -64,7 +64,11 @@ public sealed class PostgresVectorStore : VectorStore, IDisposable
     }
 
     /// <inheritdoc/>
-    public void Dispose() => this._client.Dispose();
+    protected override void Dispose(bool disposing)
+    {
+        this._client.Dispose();
+        base.Dispose(disposing);
+    }
 
     /// <inheritdoc />
     public override IAsyncEnumerable<string> ListCollectionNamesAsync(CancellationToken cancellationToken = default)

--- a/dotnet/src/Connectors/Connectors.Memory.PgVector/PostgresVectorStoreOptions.cs
+++ b/dotnet/src/Connectors/Connectors.Memory.PgVector/PostgresVectorStoreOptions.cs
@@ -12,6 +12,20 @@ public sealed class PostgresVectorStoreOptions
     internal static readonly PostgresVectorStoreOptions Default = new();
 
     /// <summary>
+    /// Initializes a new instance of the <see cref="PostgresVectorStoreOptions"/> class.
+    /// </summary>
+    public PostgresVectorStoreOptions()
+    {
+    }
+
+    internal PostgresVectorStoreOptions(PostgresVectorStoreOptions? source)
+    {
+        this.Schema = source?.Schema ?? Default.Schema;
+        this.OwnsDataSource = source?.OwnsDataSource ?? Default.OwnsDataSource;
+        this.EmbeddingGenerator = source?.EmbeddingGenerator;
+    }
+
+    /// <summary>
     /// Gets or sets the database schema.
     /// </summary>
     public string Schema { get; set; } = "public";
@@ -20,4 +34,9 @@ public sealed class PostgresVectorStoreOptions
     /// Gets or sets the default embedding generator to use when generating vectors embeddings with this vector store.
     /// </summary>
     public IEmbeddingGenerator? EmbeddingGenerator { get; set; }
+
+    /// <summary>
+    /// Gets or sets a value indicating whether the data source should be disposed after the vector store is disposed.
+    /// </summary>
+    public bool OwnsDataSource { get; set; } = true;
 }

--- a/dotnet/src/Connectors/Connectors.Memory.Qdrant/MockableQdrantClient.cs
+++ b/dotnet/src/Connectors/Connectors.Memory.Qdrant/MockableQdrantClient.cs
@@ -12,19 +12,24 @@ namespace Microsoft.SemanticKernel.Connectors.Qdrant;
 /// <summary>
 /// Decorator class for <see cref="QdrantClient"/> that exposes the required methods as virtual allowing for mocking in unit tests.
 /// </summary>
-internal class MockableQdrantClient
+internal class MockableQdrantClient : IDisposable
 {
     /// <summary>Qdrant client that can be used to manage the collections and points in a Qdrant store.</summary>
     private readonly QdrantClient _qdrantClient;
+    private readonly bool _ownsClient;
+    private int _referenceCount = 1;
 
     /// <summary>
     /// Initializes a new instance of the <see cref="MockableQdrantClient"/> class.
     /// </summary>
     /// <param name="qdrantClient">Qdrant client that can be used to manage the collections and points in a Qdrant store.</param>
-    public MockableQdrantClient(QdrantClient qdrantClient)
+    /// <param name="ownsClient">A value indicating whether the client should be disposed after the vector store is disposed.</param>
+    public MockableQdrantClient(QdrantClient qdrantClient, bool ownsClient = true)
     {
         Verify.NotNull(qdrantClient);
+
         this._qdrantClient = qdrantClient;
+        this._ownsClient = ownsClient;
     }
 
 #pragma warning disable CS8618 // Non-nullable field must contain a non-null value when exiting constructor. Consider declaring as nullable.
@@ -42,6 +47,17 @@ internal class MockableQdrantClient
     /// Gets the internal <see cref="QdrantClient"/> that this mockable instance wraps.
     /// </summary>
     public QdrantClient QdrantClient => this._qdrantClient;
+
+    public void Dispose()
+    {
+        if (this._ownsClient)
+        {
+            if (Interlocked.Decrement(ref this._referenceCount) == 0)
+            {
+                this._qdrantClient.Dispose();
+            }
+        }
+    }
 
     /// <summary>
     /// Check if a collection exists.
@@ -331,4 +347,14 @@ internal class MockableQdrantClient
             shardKeySelector: null,
             orderBy,
             cancellationToken);
+
+    internal MockableQdrantClient IncreaseReferenceCount()
+    {
+        if (this._ownsClient)
+        {
+            Interlocked.Increment(ref this._referenceCount);
+        }
+
+        return this;
+    }
 }

--- a/dotnet/src/Connectors/Connectors.Memory.Qdrant/QdrantCollection.cs
+++ b/dotnet/src/Connectors/Connectors.Memory.Qdrant/QdrantCollection.cs
@@ -24,7 +24,7 @@ namespace Microsoft.SemanticKernel.Connectors.Qdrant;
 /// <typeparam name="TKey">The data type of the record key. Can be either <see cref="Guid"/> or <see cref="ulong"/>, or <see cref="object"/> for dynamic mapping.</typeparam>
 /// <typeparam name="TRecord">The data model to use for adding, updating and retrieving data from storage.</typeparam>
 #pragma warning disable CA1711 // Identifiers should not have incorrect suffix
-public sealed class QdrantCollection<TKey, TRecord> : VectorStoreCollection<TKey, TRecord>, IKeywordHybridSearchable<TRecord>
+public sealed class QdrantCollection<TKey, TRecord> : VectorStoreCollection<TKey, TRecord>, IKeywordHybridSearchable<TRecord>, IDisposable
     where TKey : notnull
     where TRecord : class
 #pragma warning restore CA1711 // Identifiers should not have incorrect suffix
@@ -65,7 +65,7 @@ public sealed class QdrantCollection<TKey, TRecord> : VectorStoreCollection<TKey
     /// <exception cref="ArgumentNullException">Thrown if the <paramref name="qdrantClient"/> is null.</exception>
     /// <exception cref="ArgumentException">Thrown for any misconfigured options.</exception>
     public QdrantCollection(QdrantClient qdrantClient, string name, QdrantCollectionOptions? options = null)
-        : this(new MockableQdrantClient(qdrantClient), name, options)
+        : this(new MockableQdrantClient(qdrantClient, ownsClient: options?.OwnsClient ?? QdrantVectorStoreOptions.Default.OwnsClient), name, options)
     {
     }
 
@@ -106,6 +106,9 @@ public sealed class QdrantCollection<TKey, TRecord> : VectorStoreCollection<TKey
             CollectionName = name
         };
     }
+
+    /// <inheritdoc />
+    public void Dispose() => this._qdrantClient.Dispose();
 
     /// <inheritdoc />
     public override string Name { get; }

--- a/dotnet/src/Connectors/Connectors.Memory.Qdrant/QdrantCollection.cs
+++ b/dotnet/src/Connectors/Connectors.Memory.Qdrant/QdrantCollection.cs
@@ -24,7 +24,7 @@ namespace Microsoft.SemanticKernel.Connectors.Qdrant;
 /// <typeparam name="TKey">The data type of the record key. Can be either <see cref="Guid"/> or <see cref="ulong"/>, or <see cref="object"/> for dynamic mapping.</typeparam>
 /// <typeparam name="TRecord">The data model to use for adding, updating and retrieving data from storage.</typeparam>
 #pragma warning disable CA1711 // Identifiers should not have incorrect suffix
-public sealed class QdrantCollection<TKey, TRecord> : VectorStoreCollection<TKey, TRecord>, IKeywordHybridSearchable<TRecord>, IDisposable
+public sealed class QdrantCollection<TKey, TRecord> : VectorStoreCollection<TKey, TRecord>, IKeywordHybridSearchable<TRecord>
     where TKey : notnull
     where TRecord : class
 #pragma warning restore CA1711 // Identifiers should not have incorrect suffix
@@ -108,7 +108,11 @@ public sealed class QdrantCollection<TKey, TRecord> : VectorStoreCollection<TKey
     }
 
     /// <inheritdoc />
-    public void Dispose() => this._qdrantClient.Dispose();
+    protected override void Dispose(bool disposing)
+    {
+        this._qdrantClient.Dispose();
+        base.Dispose(disposing);
+    }
 
     /// <inheritdoc />
     public override string Name { get; }

--- a/dotnet/src/Connectors/Connectors.Memory.Qdrant/QdrantCollectionOptions.cs
+++ b/dotnet/src/Connectors/Connectors.Memory.Qdrant/QdrantCollectionOptions.cs
@@ -32,4 +32,9 @@ public sealed class QdrantCollectionOptions
     /// Gets or sets the default embedding generator for vector properties in this collection.
     /// </summary>
     public IEmbeddingGenerator? EmbeddingGenerator { get; set; }
+
+    /// <summary>
+    /// Gets or sets value indicating whether the client should be disposed after the vector store is disposed.
+    /// </summary>
+    public bool OwnsClient { get; set; } = QdrantVectorStoreOptions.Default.OwnsClient;
 }

--- a/dotnet/src/Connectors/Connectors.Memory.Qdrant/QdrantServiceCollectionExtensions.cs
+++ b/dotnet/src/Connectors/Connectors.Memory.Qdrant/QdrantServiceCollectionExtensions.cs
@@ -34,6 +34,8 @@ public static class QdrantServiceCollectionExtensions
                     EmbeddingGenerator = sp.GetService<IEmbeddingGenerator>()
                 };
 
+                // The client was restored from the DI container, so we do not own it.
+                options.OwnsClient = false;
                 return new QdrantVectorStore(qdrantClient, options);
             });
 
@@ -62,6 +64,8 @@ public static class QdrantServiceCollectionExtensions
                     EmbeddingGenerator = sp.GetService<IEmbeddingGenerator>()
                 };
 
+                // We created the client, so we own it.
+                options.OwnsClient = true;
                 return new QdrantVectorStore(qdrantClient, options);
             });
 
@@ -97,6 +101,8 @@ public static class QdrantServiceCollectionExtensions
                     EmbeddingGenerator = sp.GetService<IEmbeddingGenerator>()
                 };
 
+                // The client was restored from the DI container, so we do not own it.
+                options.OwnsClient = false;
                 return (new QdrantCollection<TKey, TRecord>(qdrantClient, collectionName, options) as VectorStoreCollection<TKey, TRecord>)!;
             });
 
@@ -142,6 +148,8 @@ public static class QdrantServiceCollectionExtensions
                     EmbeddingGenerator = sp.GetService<IEmbeddingGenerator>()
                 };
 
+                // We created the client, so we own it.
+                options.OwnsClient = true;
                 return (new QdrantCollection<TKey, TRecord>(qdrantClient, collectionName, options) as VectorStoreCollection<TKey, TRecord>)!;
             });
 

--- a/dotnet/src/Connectors/Connectors.Memory.Qdrant/QdrantVectorStore.cs
+++ b/dotnet/src/Connectors/Connectors.Memory.Qdrant/QdrantVectorStore.cs
@@ -18,7 +18,7 @@ namespace Microsoft.SemanticKernel.Connectors.Qdrant;
 /// <remarks>
 /// This class can be used with collections of any schema type, but requires you to provide schema information when getting a collection.
 /// </remarks>
-public sealed class QdrantVectorStore : VectorStore, IDisposable
+public sealed class QdrantVectorStore : VectorStore
 {
     /// <summary>Metadata about vector store.</summary>
     private readonly VectorStoreMetadata _metadata;
@@ -66,7 +66,11 @@ public sealed class QdrantVectorStore : VectorStore, IDisposable
     }
 
     /// <inheritdoc/>
-    public void Dispose() => this._qdrantClient.Dispose();
+    protected override void Dispose(bool disposing)
+    {
+        this._qdrantClient.Dispose();
+        base.Dispose(disposing);
+    }
 
 #pragma warning disable IDE0090 // Use 'new(...)'
     /// <inheritdoc />

--- a/dotnet/src/Connectors/Connectors.Memory.Qdrant/QdrantVectorStoreOptions.cs
+++ b/dotnet/src/Connectors/Connectors.Memory.Qdrant/QdrantVectorStoreOptions.cs
@@ -21,4 +21,9 @@ public sealed class QdrantVectorStoreOptions
     /// Gets or sets the default embedding generator to use when generating vectors embeddings with this vector store.
     /// </summary>
     public IEmbeddingGenerator? EmbeddingGenerator { get; set; }
+
+    /// <summary>
+    /// Gets or sets value indicating whether the client should be disposed after the vector store is disposed.
+    /// </summary>
+    public bool OwnsClient { get; set; } = true;
 }

--- a/dotnet/src/Connectors/Connectors.MongoDB.UnitTests/MongoCollectionTests.cs
+++ b/dotnet/src/Connectors/Connectors.MongoDB.UnitTests/MongoCollectionTests.cs
@@ -44,7 +44,7 @@ public sealed class MongoCollectionTests
     public void ConstructorWithDeclarativeModelInitializesCollection()
     {
         // Act & Assert
-        var collection = new MongoCollection<string, MongoHotelModel>(
+        using var collection = new MongoCollection<string, MongoHotelModel>(
             this._mockMongoDatabase.Object,
             "collection");
 
@@ -61,7 +61,7 @@ public sealed class MongoCollectionTests
         };
 
         // Act
-        var collection = new MongoCollection<string, TestModel>(
+        using var collection = new MongoCollection<string, TestModel>(
             this._mockMongoDatabase.Object,
             "collection",
             new() { VectorStoreRecordDefinition = definition });
@@ -89,7 +89,7 @@ public sealed class MongoCollectionTests
             .Setup(l => l.ListCollectionNamesAsync(It.IsAny<ListCollectionNamesOptions>(), It.IsAny<CancellationToken>()))
             .ReturnsAsync(mockCursor.Object);
 
-        var sut = new MongoCollection<string, MongoHotelModel>(
+        using var sut = new MongoCollection<string, MongoHotelModel>(
             this._mockMongoDatabase.Object,
             collectionName);
 
@@ -139,7 +139,7 @@ public sealed class MongoCollectionTests
             .Setup(l => l.Indexes)
             .Returns(mockMongoIndexManager.Object);
 
-        var sut = new MongoCollection<string, MongoHotelModel>(
+        using var sut = new MongoCollection<string, MongoHotelModel>(
             this._mockMongoDatabase.Object,
             CollectionName);
 
@@ -163,7 +163,7 @@ public sealed class MongoCollectionTests
         // Arrange
         const string RecordKey = "key";
 
-        var sut = new MongoCollection<string, MongoHotelModel>(
+        using var sut = new MongoCollection<string, MongoHotelModel>(
             this._mockMongoDatabase.Object,
             "collection");
 
@@ -187,7 +187,7 @@ public sealed class MongoCollectionTests
         // Arrange
         List<string> recordKeys = ["key1", "key2"];
 
-        var sut = new MongoCollection<string, MongoHotelModel>(
+        using var sut = new MongoCollection<string, MongoHotelModel>(
             this._mockMongoDatabase.Object,
             "collection");
 
@@ -211,7 +211,7 @@ public sealed class MongoCollectionTests
         // Arrange
         const string CollectionName = "collection";
 
-        var sut = new MongoCollection<string, MongoHotelModel>(
+        using var sut = new MongoCollection<string, MongoHotelModel>(
             this._mockMongoDatabase.Object,
             CollectionName);
 
@@ -248,7 +248,7 @@ public sealed class MongoCollectionTests
                 It.IsAny<CancellationToken>()))
             .ReturnsAsync(mockCursor.Object);
 
-        var sut = new MongoCollection<string, MongoHotelModel>(
+        using var sut = new MongoCollection<string, MongoHotelModel>(
             this._mockMongoDatabase.Object,
             "collection");
 
@@ -286,7 +286,7 @@ public sealed class MongoCollectionTests
                 It.IsAny<CancellationToken>()))
             .ReturnsAsync(mockCursor.Object);
 
-        var sut = new MongoCollection<string, MongoHotelModel>(
+        using var sut = new MongoCollection<string, MongoHotelModel>(
             this._mockMongoDatabase.Object,
             "collection");
 
@@ -317,7 +317,7 @@ public sealed class MongoCollectionTests
         var documentSerializer = serializerRegistry.GetSerializer<BsonDocument>();
         var expectedDefinition = Builders<BsonDocument>.Filter.Eq(document => document["_id"], "key");
 
-        var sut = new MongoCollection<string, MongoHotelModel>(
+        using var sut = new MongoCollection<string, MongoHotelModel>(
             this._mockMongoDatabase.Object,
             "collection");
 
@@ -343,7 +343,7 @@ public sealed class MongoCollectionTests
         var hotel2 = new MongoHotelModel("key2") { HotelName = "Test Name 2" };
         var hotel3 = new MongoHotelModel("key3") { HotelName = "Test Name 3" };
 
-        var sut = new MongoCollection<string, MongoHotelModel>(
+        using var sut = new MongoCollection<string, MongoHotelModel>(
             this._mockMongoDatabase.Object,
             "collection");
 
@@ -418,7 +418,7 @@ public sealed class MongoCollectionTests
         // Arrange
         this.MockCollectionForSearch();
 
-        var sut = new MongoCollection<string, MongoHotelModel>(
+        using var sut = new MongoCollection<string, MongoHotelModel>(
             this._mockMongoDatabase.Object,
             "collection");
 
@@ -472,7 +472,7 @@ public sealed class MongoCollectionTests
 
         this.MockCollectionForSearch();
 
-        var sut = new MongoCollection<string, VectorSearchModel>(
+        using var sut = new MongoCollection<string, VectorSearchModel>(
             this._mockMongoDatabase.Object,
             "collection");
 
@@ -505,7 +505,7 @@ public sealed class MongoCollectionTests
         // Arrange
         this.MockCollectionForSearch();
 
-        var sut = new MongoCollection<string, MongoHotelModel>(
+        using var sut = new MongoCollection<string, MongoHotelModel>(
             this._mockMongoDatabase.Object,
             "collection");
 
@@ -521,7 +521,7 @@ public sealed class MongoCollectionTests
         // Arrange
         this.MockCollectionForSearch();
 
-        var sut = new MongoCollection<string, MongoHotelModel>(
+        using var sut = new MongoCollection<string, MongoHotelModel>(
             this._mockMongoDatabase.Object,
             "collection");
 
@@ -608,7 +608,7 @@ public sealed class MongoCollectionTests
             new() { VectorStoreRecordDefinition = definition } :
             null;
 
-        var sut = new MongoCollection<string, TDataModel>(
+        using var sut = new MongoCollection<string, TDataModel>(
             this._mockMongoDatabase.Object,
             "collection",
             options);

--- a/dotnet/src/Connectors/Connectors.MongoDB.UnitTests/MongoVectorStoreTests.cs
+++ b/dotnet/src/Connectors/Connectors.MongoDB.UnitTests/MongoVectorStoreTests.cs
@@ -23,7 +23,7 @@ public sealed class MongoVectorStoreTests
     public void GetCollectionWithNotSupportedKeyThrowsException()
     {
         // Arrange
-        var sut = new MongoVectorStore(this._mockMongoDatabase.Object);
+        using var sut = new MongoVectorStore(this._mockMongoDatabase.Object);
 
         // Act & Assert
         Assert.Throws<NotSupportedException>(() => sut.GetCollection<Guid, MongoHotelModel>("collection"));
@@ -33,7 +33,7 @@ public sealed class MongoVectorStoreTests
     public void GetCollectionWithoutFactoryReturnsDefaultCollection()
     {
         // Arrange
-        var sut = new MongoVectorStore(this._mockMongoDatabase.Object);
+        using var sut = new MongoVectorStore(this._mockMongoDatabase.Object);
 
         // Act
         var collection = sut.GetCollection<string, MongoHotelModel>("collection");
@@ -62,7 +62,7 @@ public sealed class MongoVectorStoreTests
             .Setup(l => l.ListCollectionNamesAsync(It.IsAny<ListCollectionNamesOptions>(), It.IsAny<CancellationToken>()))
             .ReturnsAsync(mockCursor.Object);
 
-        var sut = new MongoVectorStore(this._mockMongoDatabase.Object);
+        using var sut = new MongoVectorStore(this._mockMongoDatabase.Object);
 
         // Act
         var actualCollectionNames = await sut.ListCollectionNamesAsync().ToListAsync();

--- a/dotnet/src/Connectors/Connectors.Pinecone.UnitTests/PineconeCollectionTests.cs
+++ b/dotnet/src/Connectors/Connectors.Pinecone.UnitTests/PineconeCollectionTests.cs
@@ -37,7 +37,7 @@ public class PineconeCollectionTests
         var pineconeClient = new PineconeClient("fake api key");
 
         // Act.
-        var sut = new PineconeCollection<string, SinglePropsModel>(
+        using var sut = new PineconeCollection<string, SinglePropsModel>(
             pineconeClient,
             TestCollectionName,
             new() { VectorStoreRecordDefinition = definition });

--- a/dotnet/src/Connectors/Connectors.Qdrant.UnitTests/QdrantCollectionTests.cs
+++ b/dotnet/src/Connectors/Connectors.Qdrant.UnitTests/QdrantCollectionTests.cs
@@ -39,7 +39,7 @@ public class QdrantCollectionTests
     public async Task CollectionExistsReturnsCollectionStateAsync(string collectionName, bool expectedExists)
     {
         // Arrange.
-        var sut = new QdrantCollection<ulong, SinglePropsModel<ulong>>(this._qdrantClientMock.Object, collectionName);
+        using var sut = new QdrantCollection<ulong, SinglePropsModel<ulong>>(this._qdrantClientMock.Object, collectionName);
 
         this._qdrantClientMock
             .Setup(x => x.CollectionExistsAsync(
@@ -58,7 +58,7 @@ public class QdrantCollectionTests
     public async Task CanCreateCollectionAsync()
     {
         // Arrange.
-        var sut = new QdrantCollection<ulong, SinglePropsModel<ulong>>(this._qdrantClientMock.Object, TestCollectionName);
+        using var sut = new QdrantCollection<ulong, SinglePropsModel<ulong>>(this._qdrantClientMock.Object, TestCollectionName);
 
         this._qdrantClientMock
             .Setup(x => x.CollectionExistsAsync(
@@ -125,7 +125,7 @@ public class QdrantCollectionTests
     public async Task CanDeleteCollectionAsync()
     {
         // Arrange.
-        var sut = new QdrantCollection<ulong, SinglePropsModel<ulong>>(this._qdrantClientMock.Object, TestCollectionName);
+        using var sut = new QdrantCollection<ulong, SinglePropsModel<ulong>>(this._qdrantClientMock.Object, TestCollectionName);
 
         this._qdrantClientMock
             .Setup(x => x.DeleteCollectionAsync(
@@ -152,7 +152,7 @@ public class QdrantCollectionTests
     public async Task CanGetRecordWithVectorsAsync<TKey>(bool useDefinition, bool hasNamedVectors, TKey testRecordKey)
         where TKey : notnull
     {
-        var sut = this.CreateRecordCollection<TKey>(useDefinition, hasNamedVectors);
+        using var sut = this.CreateRecordCollection<TKey>(useDefinition, hasNamedVectors);
 
         // Arrange.
         var retrievedPoint = CreateRetrievedPoint(hasNamedVectors, testRecordKey);
@@ -190,7 +190,7 @@ public class QdrantCollectionTests
         where TKey : notnull
     {
         // Arrange.
-        var sut = this.CreateRecordCollection<TKey>(useDefinition, hasNamedVectors);
+        using var sut = this.CreateRecordCollection<TKey>(useDefinition, hasNamedVectors);
         var retrievedPoint = CreateRetrievedPoint(hasNamedVectors, testRecordKey);
         this.SetupRetrieveMock([retrievedPoint]);
 
@@ -226,7 +226,7 @@ public class QdrantCollectionTests
         where TKey : notnull
     {
         // Arrange.
-        var sut = this.CreateRecordCollection<TKey>(useDefinition, hasNamedVectors);
+        using var sut = this.CreateRecordCollection<TKey>(useDefinition, hasNamedVectors);
         var retrievedPoint1 = CreateRetrievedPoint(hasNamedVectors, UlongTestRecordKey1);
         var retrievedPoint2 = CreateRetrievedPoint(hasNamedVectors, UlongTestRecordKey2);
         this.SetupRetrieveMock(testRecordKeys.Select(x => CreateRetrievedPoint(hasNamedVectors, x)).ToList());
@@ -267,7 +267,7 @@ public class QdrantCollectionTests
     public async Task CanDeleteUlongRecordAsync(bool useDefinition, bool hasNamedVectors)
     {
         // Arrange
-        var sut = this.CreateRecordCollection<ulong>(useDefinition, hasNamedVectors);
+        using var sut = this.CreateRecordCollection<ulong>(useDefinition, hasNamedVectors);
         this.SetupDeleteMocks();
 
         // Act
@@ -296,7 +296,7 @@ public class QdrantCollectionTests
     public async Task CanDeleteGuidRecordAsync(bool useDefinition, bool hasNamedVectors)
     {
         // Arrange
-        var sut = this.CreateRecordCollection<Guid>(useDefinition, hasNamedVectors);
+        using var sut = this.CreateRecordCollection<Guid>(useDefinition, hasNamedVectors);
         this.SetupDeleteMocks();
 
         // Act
@@ -325,7 +325,7 @@ public class QdrantCollectionTests
     public async Task CanDeleteManyUlongRecordsAsync(bool useDefinition, bool hasNamedVectors)
     {
         // Arrange
-        var sut = this.CreateRecordCollection<ulong>(useDefinition, hasNamedVectors);
+        using var sut = this.CreateRecordCollection<ulong>(useDefinition, hasNamedVectors);
         this.SetupDeleteMocks();
 
         // Act
@@ -354,7 +354,7 @@ public class QdrantCollectionTests
     public async Task CanDeleteManyGuidRecordsAsync(bool useDefinition, bool hasNamedVectors)
     {
         // Arrange
-        var sut = this.CreateRecordCollection<Guid>(useDefinition, hasNamedVectors);
+        using var sut = this.CreateRecordCollection<Guid>(useDefinition, hasNamedVectors);
         this.SetupDeleteMocks();
 
         // Act
@@ -381,7 +381,7 @@ public class QdrantCollectionTests
         where TKey : notnull
     {
         // Arrange
-        var sut = this.CreateRecordCollection<TKey>(useDefinition, hasNamedVectors);
+        using var sut = this.CreateRecordCollection<TKey>(useDefinition, hasNamedVectors);
         this.SetupUpsertMock();
 
         // Act
@@ -408,7 +408,7 @@ public class QdrantCollectionTests
         where TKey : notnull
     {
         // Arrange
-        var sut = this.CreateRecordCollection<TKey>(useDefinition, hasNamedVectors);
+        using var sut = this.CreateRecordCollection<TKey>(useDefinition, hasNamedVectors);
         this.SetupUpsertMock();
 
         var models = testRecordKeys.Select(x => CreateModel(x, true));
@@ -454,7 +454,7 @@ public class QdrantCollectionTests
         };
 
         // Act.
-        var sut = new QdrantCollection<ulong, SinglePropsModel<ulong>>(
+        using var sut = new QdrantCollection<ulong, SinglePropsModel<ulong>>(
             this._qdrantClientMock.Object,
             TestCollectionName,
             new() { VectorStoreRecordDefinition = definition });
@@ -466,7 +466,7 @@ public class QdrantCollectionTests
     public async Task CanSearchWithVectorAndFilterAsync<TKey>(bool useDefinition, bool hasNamedVectors, TKey testRecordKey)
         where TKey : notnull
     {
-        var sut = this.CreateRecordCollection<TKey>(useDefinition, hasNamedVectors);
+        using var sut = this.CreateRecordCollection<TKey>(useDefinition, hasNamedVectors);
 
         // Arrange.
         var scoredPoint = CreateScoredPoint(hasNamedVectors, testRecordKey);

--- a/dotnet/src/Connectors/Connectors.Qdrant.UnitTests/QdrantVectorStoreTests.cs
+++ b/dotnet/src/Connectors/Connectors.Qdrant.UnitTests/QdrantVectorStoreTests.cs
@@ -30,7 +30,7 @@ public class QdrantVectorStoreTests
     public void GetCollectionReturnsCollection()
     {
         // Arrange.
-        var sut = new QdrantVectorStore(this._qdrantClientMock.Object);
+        using var sut = new QdrantVectorStore(this._qdrantClientMock.Object);
 
         // Act.
         var actual = sut.GetCollection<ulong, SinglePropsModel<ulong>>(TestCollectionName);
@@ -44,7 +44,7 @@ public class QdrantVectorStoreTests
     public void GetCollectionThrowsForInvalidKeyType()
     {
         // Arrange.
-        var sut = new QdrantVectorStore(this._qdrantClientMock.Object);
+        using var sut = new QdrantVectorStore(this._qdrantClientMock.Object);
 
         // Act & Assert.
         Assert.Throws<NotSupportedException>(() => sut.GetCollection<string, SinglePropsModel<string>>(TestCollectionName));
@@ -57,7 +57,7 @@ public class QdrantVectorStoreTests
         this._qdrantClientMock
             .Setup(x => x.ListCollectionsAsync(It.IsAny<CancellationToken>()))
             .ReturnsAsync(new[] { "collection1", "collection2" });
-        var sut = new QdrantVectorStore(this._qdrantClientMock.Object);
+        using var sut = new QdrantVectorStore(this._qdrantClientMock.Object);
 
         // Act.
         var collectionNames = sut.ListCollectionNamesAsync(this._testCancellationToken);

--- a/dotnet/src/Connectors/Connectors.Redis.UnitTests/RedisHashSetCollectionTests.cs
+++ b/dotnet/src/Connectors/Connectors.Redis.UnitTests/RedisHashSetCollectionTests.cs
@@ -48,7 +48,7 @@ public class RedisHashSetCollectionTests
         {
             SetupExecuteMock(this._redisDatabaseMock, new RedisServerException("Unknown index name"));
         }
-        var sut = new RedisHashSetCollection<string, SinglePropsModel>(
+        using var sut = new RedisHashSetCollection<string, SinglePropsModel>(
             this._redisDatabaseMock.Object,
             collectionName);
 
@@ -72,7 +72,7 @@ public class RedisHashSetCollectionTests
         // Arrange.
         SetupExecuteMock(this._redisDatabaseMock, "FT.INFO", new RedisServerException("Unknown index name"));
         SetupExecuteMock(this._redisDatabaseMock, "FT.CREATE", string.Empty);
-        var sut = new RedisHashSetCollection<string, SinglePropsModel>(this._redisDatabaseMock.Object, TestCollectionName);
+        using var sut = new RedisHashSetCollection<string, SinglePropsModel>(this._redisDatabaseMock.Object, TestCollectionName);
 
         // Act.
         await sut.EnsureCollectionExistsAsync();
@@ -117,7 +117,7 @@ public class RedisHashSetCollectionTests
     {
         // Arrange
         SetupExecuteMock(this._redisDatabaseMock, string.Empty);
-        var sut = this.CreateRecordCollection(false);
+        using var sut = this.CreateRecordCollection(false);
 
         // Act
         await sut.DeleteCollectionAsync();
@@ -145,7 +145,7 @@ public class RedisHashSetCollectionTests
             new("vector_storage_name", MemoryMarshal.AsBytes(new ReadOnlySpan<float>(new float[] { 1, 2, 3, 4 })).ToArray())
         };
         this._redisDatabaseMock.Setup(x => x.HashGetAllAsync(It.IsAny<RedisKey>(), CommandFlags.None)).ReturnsAsync(hashEntries);
-        var sut = this.CreateRecordCollection(useDefinition);
+        using var sut = this.CreateRecordCollection(useDefinition);
 
         // Act
         var actual = await sut.GetAsync(
@@ -170,7 +170,7 @@ public class RedisHashSetCollectionTests
         // Arrange
         var redisValues = new RedisValue[] { new("data 1"), new("data 1") };
         this._redisDatabaseMock.Setup(x => x.HashGetAsync(It.IsAny<RedisKey>(), It.IsAny<RedisValue[]>(), CommandFlags.None)).ReturnsAsync(redisValues);
-        var sut = this.CreateRecordCollection(useDefinition);
+        using var sut = this.CreateRecordCollection(useDefinition);
 
         // Act
         var actual = await sut.GetAsync(
@@ -215,7 +215,7 @@ public class RedisHashSetCollectionTests
                 _ => throw new ArgumentException("Unexpected key."),
             };
         });
-        var sut = this.CreateRecordCollection(useDefinition);
+        using var sut = this.CreateRecordCollection(useDefinition);
 
         // Act
         var actual = await sut.GetAsync(
@@ -245,7 +245,7 @@ public class RedisHashSetCollectionTests
     {
         // Arrange
         this._redisDatabaseMock.Setup(x => x.KeyDeleteAsync(It.IsAny<RedisKey>(), CommandFlags.None)).ReturnsAsync(true);
-        var sut = this.CreateRecordCollection(useDefinition);
+        using var sut = this.CreateRecordCollection(useDefinition);
 
         // Act
         await sut.DeleteAsync(TestRecordKey1);
@@ -261,7 +261,7 @@ public class RedisHashSetCollectionTests
     {
         // Arrange
         this._redisDatabaseMock.Setup(x => x.KeyDeleteAsync(It.IsAny<RedisKey>(), CommandFlags.None)).ReturnsAsync(true);
-        var sut = this.CreateRecordCollection(useDefinition);
+        using var sut = this.CreateRecordCollection(useDefinition);
 
         // Act
         await sut.DeleteAsync([TestRecordKey1, TestRecordKey2]);
@@ -278,7 +278,7 @@ public class RedisHashSetCollectionTests
     {
         // Arrange
         this._redisDatabaseMock.Setup(x => x.HashSetAsync(It.IsAny<RedisKey>(), It.IsAny<HashEntry[]>(), CommandFlags.None)).Returns(Task.CompletedTask);
-        var sut = this.CreateRecordCollection(useDefinition);
+        using var sut = this.CreateRecordCollection(useDefinition);
         var model = CreateModel(TestRecordKey1, true);
 
         // Act
@@ -300,7 +300,7 @@ public class RedisHashSetCollectionTests
     {
         // Arrange
         this._redisDatabaseMock.Setup(x => x.HashSetAsync(It.IsAny<RedisKey>(), It.IsAny<HashEntry[]>(), CommandFlags.None)).Returns(Task.CompletedTask);
-        var sut = this.CreateRecordCollection(useDefinition);
+        using var sut = this.CreateRecordCollection(useDefinition);
 
         var model1 = CreateModel(TestRecordKey1, true);
         var model2 = CreateModel(TestRecordKey2, true);
@@ -349,7 +349,7 @@ public class RedisHashSetCollectionTests
                 new RedisValue("0.25"),
             ]),
         });
-        var sut = this.CreateRecordCollection(useDefinition);
+        using var sut = this.CreateRecordCollection(useDefinition);
 
         var filter = new VectorSearchFilter().EqualTo(nameof(SinglePropsModel.Data), "data 1");
 
@@ -438,7 +438,7 @@ public class RedisHashSetCollectionTests
         };
 
         // Act.
-        var sut = new RedisHashSetCollection<string, SinglePropsModel>(
+        using var sut = new RedisHashSetCollection<string, SinglePropsModel>(
             this._redisDatabaseMock.Object,
             TestCollectionName,
             new() { VectorStoreRecordDefinition = definition });

--- a/dotnet/src/Connectors/Connectors.Redis.UnitTests/RedisJsonCollectionTests.cs
+++ b/dotnet/src/Connectors/Connectors.Redis.UnitTests/RedisJsonCollectionTests.cs
@@ -51,7 +51,7 @@ public class RedisJsonCollectionTests
         {
             SetupExecuteMock(this._redisDatabaseMock, new RedisServerException("Unknown index name"));
         }
-        var sut = new RedisJsonCollection<string, MultiPropsModel>(
+        using var sut = new RedisJsonCollection<string, MultiPropsModel>(
             this._redisDatabaseMock.Object,
             collectionName);
 
@@ -79,7 +79,7 @@ public class RedisJsonCollectionTests
         // Arrange.
         SetupExecuteMock(this._redisDatabaseMock, "FT.INFO", new RedisServerException("Unknown index name"));
         SetupExecuteMock(this._redisDatabaseMock, "FT.CREATE", string.Empty);
-        var sut = this.CreateRecordCollection(useDefinition, useCustomJsonSerializerOptions);
+        using var sut = this.CreateRecordCollection(useDefinition, useCustomJsonSerializerOptions);
 
         // Act.
         await sut.EnsureCollectionExistsAsync();
@@ -138,7 +138,7 @@ public class RedisJsonCollectionTests
     {
         // Arrange
         SetupExecuteMock(this._redisDatabaseMock, string.Empty);
-        var sut = this.CreateRecordCollection(false);
+        using var sut = this.CreateRecordCollection(false);
 
         // Act
         await sut.DeleteCollectionAsync();
@@ -162,7 +162,7 @@ public class RedisJsonCollectionTests
     {
         // Arrange
         SetupExecuteMock(this._redisDatabaseMock, redisResultString);
-        var sut = this.CreateRecordCollection(useDefinition, useCustomJsonSerializerOptions);
+        using var sut = this.CreateRecordCollection(useDefinition, useCustomJsonSerializerOptions);
 
         // Act
         var actual = await sut.GetAsync(
@@ -195,7 +195,7 @@ public class RedisJsonCollectionTests
     {
         // Arrange
         SetupExecuteMock(this._redisDatabaseMock, redisResultString);
-        var sut = this.CreateRecordCollection(useDefinition, useCustomJsonSerializerOptions);
+        using var sut = this.CreateRecordCollection(useDefinition, useCustomJsonSerializerOptions);
 
         // Act
         var actual = await sut.GetAsync(
@@ -227,7 +227,7 @@ public class RedisJsonCollectionTests
         var redisResultString1 = """{ "data1_json_name": "data 1", "Data2": "data 2", "vector1_json_name": [1, 2, 3, 4], "Vector2": [1, 2, 3, 4] }""";
         var redisResultString2 = """{ "data1_json_name": "data 1", "Data2": "data 2", "vector1_json_name": [5, 6, 7, 8], "Vector2": [1, 2, 3, 4] }""";
         SetupExecuteMock(this._redisDatabaseMock, [redisResultString1, redisResultString2]);
-        var sut = this.CreateRecordCollection(useDefinition);
+        using var sut = this.CreateRecordCollection(useDefinition);
 
         // Act
         var actual = await sut.GetAsync(
@@ -262,7 +262,7 @@ public class RedisJsonCollectionTests
     {
         // Arrange
         SetupExecuteMock(this._redisDatabaseMock, "200");
-        var sut = this.CreateRecordCollection(useDefinition);
+        using var sut = this.CreateRecordCollection(useDefinition);
 
         // Act
         await sut.DeleteAsync(TestRecordKey1);
@@ -284,7 +284,7 @@ public class RedisJsonCollectionTests
     {
         // Arrange
         SetupExecuteMock(this._redisDatabaseMock, "200");
-        var sut = this.CreateRecordCollection(useDefinition);
+        using var sut = this.CreateRecordCollection(useDefinition);
 
         // Act
         await sut.DeleteAsync([TestRecordKey1, TestRecordKey2]);
@@ -315,7 +315,7 @@ public class RedisJsonCollectionTests
     {
         // Arrange
         SetupExecuteMock(this._redisDatabaseMock, "OK");
-        var sut = this.CreateRecordCollection(useDefinition, useCustomJsonSerializerOptions);
+        using var sut = this.CreateRecordCollection(useDefinition, useCustomJsonSerializerOptions);
         var model = CreateModel(TestRecordKey1, true);
 
         // Act
@@ -339,7 +339,7 @@ public class RedisJsonCollectionTests
     {
         // Arrange
         SetupExecuteMock(this._redisDatabaseMock, "OK");
-        var sut = this.CreateRecordCollection(useDefinition);
+        using var sut = this.CreateRecordCollection(useDefinition);
 
         var model1 = CreateModel(TestRecordKey1, true);
         var model2 = CreateModel(TestRecordKey2, true);
@@ -378,7 +378,7 @@ public class RedisJsonCollectionTests
                 new RedisValue("0.25")
             ]),
         });
-        var sut = this.CreateRecordCollection(useDefinition);
+        using var sut = this.CreateRecordCollection(useDefinition);
 
         var filter = new VectorSearchFilter().EqualTo(nameof(MultiPropsModel.Data1), "data 1");
 

--- a/dotnet/src/Connectors/Connectors.Redis.UnitTests/RedisVectorStoreTests.cs
+++ b/dotnet/src/Connectors/Connectors.Redis.UnitTests/RedisVectorStoreTests.cs
@@ -32,7 +32,7 @@ public class RedisVectorStoreTests
     public void GetCollectionReturnsJsonCollection()
     {
         // Arrange.
-        var sut = new RedisVectorStore(this._redisDatabaseMock.Object);
+        using var sut = new RedisVectorStore(this._redisDatabaseMock.Object);
 
         // Act.
         var actual = sut.GetCollection<string, SinglePropsModel<string>>(TestCollectionName);
@@ -46,7 +46,7 @@ public class RedisVectorStoreTests
     public void GetCollectionReturnsHashSetCollection()
     {
         // Arrange.
-        var sut = new RedisVectorStore(this._redisDatabaseMock.Object, new() { StorageType = RedisStorageType.HashSet });
+        using var sut = new RedisVectorStore(this._redisDatabaseMock.Object, new() { StorageType = RedisStorageType.HashSet });
 
         // Act.
         var actual = sut.GetCollection<string, SinglePropsModel<string>>(TestCollectionName);
@@ -60,7 +60,7 @@ public class RedisVectorStoreTests
     public void GetCollectionThrowsForInvalidKeyType()
     {
         // Arrange.
-        var sut = new RedisVectorStore(this._redisDatabaseMock.Object);
+        using var sut = new RedisVectorStore(this._redisDatabaseMock.Object);
 
         // Act & Assert.
         Assert.Throws<NotSupportedException>(() => sut.GetCollection<int, SinglePropsModel<int>>(TestCollectionName));
@@ -80,7 +80,7 @@ public class RedisVectorStoreTests
                     It.IsAny<string>(),
                 It.IsAny<object[]>()))
             .ReturnsAsync(RedisResult.Create(results));
-        var sut = new RedisVectorStore(this._redisDatabaseMock.Object);
+        using var sut = new RedisVectorStore(this._redisDatabaseMock.Object);
 
         // Act.
         var collectionNames = sut.ListCollectionNamesAsync();

--- a/dotnet/src/Connectors/Connectors.Weaviate.UnitTests/WeaviateCollectionTests.cs
+++ b/dotnet/src/Connectors/Connectors.Weaviate.UnitTests/WeaviateCollectionTests.cs
@@ -50,7 +50,7 @@ public sealed class WeaviateCollectionTests : IDisposable
     public void ConstructorWithDeclarativeModelInitializesCollection()
     {
         // Act & Assert
-        var collection = new WeaviateCollection<Guid, WeaviateHotel>(
+        using var collection = new WeaviateCollection<Guid, WeaviateHotel>(
             this._mockHttpClient,
             "Collection");
 
@@ -67,7 +67,7 @@ public sealed class WeaviateCollectionTests : IDisposable
         };
 
         // Act
-        var collection = new WeaviateCollection<Guid, TestModel>(
+        using var collection = new WeaviateCollection<Guid, TestModel>(
             this._mockHttpClient,
             "Collection",
             new() { VectorStoreRecordDefinition = definition });
@@ -83,7 +83,7 @@ public sealed class WeaviateCollectionTests : IDisposable
         // Arrange
         this._messageHandlerStub.ResponseToReturn = responseMessage;
 
-        var sut = new WeaviateCollection<Guid, WeaviateHotel>(this._mockHttpClient, "Collection");
+        using var sut = new WeaviateCollection<Guid, WeaviateHotel>(this._mockHttpClient, "Collection");
 
         // Act
         var actualResult = await sut.CollectionExistsAsync();
@@ -121,7 +121,7 @@ public sealed class WeaviateCollectionTests : IDisposable
     {
         // Arrange
         const string CollectionName = "Collection";
-        var sut = new WeaviateCollection<Guid, WeaviateHotel>(this._mockHttpClient, CollectionName);
+        using var sut = new WeaviateCollection<Guid, WeaviateHotel>(this._mockHttpClient, CollectionName);
 
         using var collectionExistsResponse = new HttpResponseMessage(HttpStatusCode.NotFound);
         this._messageHandlerStub.ResponseQueue.Enqueue(collectionExistsResponse);
@@ -163,7 +163,7 @@ public sealed class WeaviateCollectionTests : IDisposable
     {
         // Arrange
         const string CollectionName = "Collection";
-        var sut = new WeaviateCollection<Guid, WeaviateHotel>(this._mockHttpClient, CollectionName);
+        using var sut = new WeaviateCollection<Guid, WeaviateHotel>(this._mockHttpClient, CollectionName);
 
         // Act
         await sut.DeleteCollectionAsync();
@@ -180,7 +180,7 @@ public sealed class WeaviateCollectionTests : IDisposable
         const string CollectionName = "Collection";
         var id = new Guid("55555555-5555-5555-5555-555555555555");
 
-        var sut = new WeaviateCollection<Guid, WeaviateHotel>(this._mockHttpClient, CollectionName);
+        using var sut = new WeaviateCollection<Guid, WeaviateHotel>(this._mockHttpClient, CollectionName);
 
         // Act
         await sut.DeleteAsync(id);
@@ -197,7 +197,7 @@ public sealed class WeaviateCollectionTests : IDisposable
         const string CollectionName = "Collection";
         List<Guid> ids = [new Guid("11111111-1111-1111-1111-111111111111"), new Guid("22222222-2222-2222-2222-222222222222")];
 
-        var sut = new WeaviateCollection<Guid, WeaviateHotel>(this._mockHttpClient, CollectionName);
+        using var sut = new WeaviateCollection<Guid, WeaviateHotel>(this._mockHttpClient, CollectionName);
 
         // Act
         await sut.DeleteAsync(ids);
@@ -233,7 +233,7 @@ public sealed class WeaviateCollectionTests : IDisposable
             Content = new StringContent(JsonSerializer.Serialize(jsonObject))
         };
 
-        var sut = new WeaviateCollection<Guid, WeaviateHotel>(this._mockHttpClient, "Collection");
+        using var sut = new WeaviateCollection<Guid, WeaviateHotel>(this._mockHttpClient, "Collection");
 
         // Act
         var result = await sut.GetAsync(id);
@@ -263,7 +263,7 @@ public sealed class WeaviateCollectionTests : IDisposable
         this._messageHandlerStub.ResponseQueue.Enqueue(response1);
         this._messageHandlerStub.ResponseQueue.Enqueue(response2);
 
-        var sut = new WeaviateCollection<Guid, WeaviateHotel>(this._mockHttpClient, "Collection");
+        using var sut = new WeaviateCollection<Guid, WeaviateHotel>(this._mockHttpClient, "Collection");
 
         // Act
         var results = await sut.GetAsync([id1, id2]).ToListAsync();
@@ -292,7 +292,7 @@ public sealed class WeaviateCollectionTests : IDisposable
             Content = new StringContent(JsonSerializer.Serialize(batchResponse)),
         };
 
-        var sut = new WeaviateCollection<Guid, WeaviateHotel>(this._mockHttpClient, "Collection");
+        using var sut = new WeaviateCollection<Guid, WeaviateHotel>(this._mockHttpClient, "Collection");
 
         // Act
         await sut.UpsertAsync(hotel);
@@ -329,7 +329,7 @@ public sealed class WeaviateCollectionTests : IDisposable
             Content = new StringContent(JsonSerializer.Serialize(batchResponse)),
         };
 
-        var sut = new WeaviateCollection<Guid, WeaviateHotel>(this._mockHttpClient, "Collection");
+        using var sut = new WeaviateCollection<Guid, WeaviateHotel>(this._mockHttpClient, "Collection");
 
         // Act
         await sut.UpsertAsync([hotel1, hotel2]);
@@ -367,7 +367,7 @@ public sealed class WeaviateCollectionTests : IDisposable
         using var createCollectionResponse = new HttpResponseMessage(HttpStatusCode.OK);
         this._messageHandlerStub.ResponseQueue.Enqueue(createCollectionResponse);
 
-        var sut = new WeaviateCollection<Guid, WeaviateHotel>(this._mockHttpClient, CollectionName, options);
+        using var sut = new WeaviateCollection<Guid, WeaviateHotel>(this._mockHttpClient, CollectionName, options);
 
         // Act
         await sut.EnsureCollectionExistsAsync();
@@ -427,7 +427,7 @@ public sealed class WeaviateCollectionTests : IDisposable
             Content = new StringContent(JsonSerializer.Serialize(jsonObject))
         };
 
-        var sut = new WeaviateCollection<Guid, WeaviateHotel>(this._mockHttpClient, CollectionName);
+        using var sut = new WeaviateCollection<Guid, WeaviateHotel>(this._mockHttpClient, CollectionName);
 
         // Act
         var results = await sut.SearchEmbeddingAsync(vector, top: 3, new()
@@ -467,7 +467,7 @@ public sealed class WeaviateCollectionTests : IDisposable
     public async Task SearchEmbeddingWithUnsupportedVectorTypeThrowsExceptionAsync()
     {
         // Arrange
-        var sut = new WeaviateCollection<Guid, WeaviateHotel>(this._mockHttpClient, "Collection");
+        using var sut = new WeaviateCollection<Guid, WeaviateHotel>(this._mockHttpClient, "Collection");
 
         // Act & Assert
         await Assert.ThrowsAsync<NotSupportedException>(async () =>
@@ -478,7 +478,7 @@ public sealed class WeaviateCollectionTests : IDisposable
     public async Task SearchEmbeddingWithNonExistentVectorPropertyNameThrowsExceptionAsync()
     {
         // Arrange
-        var sut = new WeaviateCollection<Guid, WeaviateHotel>(this._mockHttpClient, "Collection");
+        using var sut = new WeaviateCollection<Guid, WeaviateHotel>(this._mockHttpClient, "Collection");
 
         // Act & Assert
         await Assert.ThrowsAsync<InvalidOperationException>(async () =>

--- a/dotnet/src/Connectors/Connectors.Weaviate.UnitTests/WeaviateVectorStoreTests.cs
+++ b/dotnet/src/Connectors/Connectors.Weaviate.UnitTests/WeaviateVectorStoreTests.cs
@@ -29,7 +29,7 @@ public sealed class WeaviateVectorStoreTests : IDisposable
     public void GetCollectionWithNotSupportedKeyThrowsException()
     {
         // Arrange
-        var sut = new WeaviateVectorStore(this._mockHttpClient);
+        using var sut = new WeaviateVectorStore(this._mockHttpClient);
 
         // Act & Assert
         Assert.Throws<NotSupportedException>(() => sut.GetCollection<string, WeaviateHotel>("Collection"));
@@ -39,7 +39,7 @@ public sealed class WeaviateVectorStoreTests : IDisposable
     public void GetCollectionWithSupportedKeyReturnsCollection()
     {
         // Arrange
-        var sut = new WeaviateVectorStore(this._mockHttpClient);
+        using var sut = new WeaviateVectorStore(this._mockHttpClient);
 
         // Act
         var collection = sut.GetCollection<Guid, WeaviateHotel>("Collection1");
@@ -63,7 +63,7 @@ public sealed class WeaviateVectorStoreTests : IDisposable
             Content = new StringContent(JsonSerializer.Serialize(response))
         };
 
-        var sut = new WeaviateVectorStore(this._mockHttpClient);
+        using var sut = new WeaviateVectorStore(this._mockHttpClient);
 
         // Act
         var actualCollectionNames = await sut.ListCollectionNamesAsync().ToListAsync();

--- a/dotnet/src/Connectors/VectorData.Abstractions/VectorStorage/VectorStore.cs
+++ b/dotnet/src/Connectors/VectorData.Abstractions/VectorStorage/VectorStore.cs
@@ -14,8 +14,10 @@ namespace Microsoft.Extensions.VectorData;
 /// <para>This type can be used with collections of any schema type, but requires you to provide schema information when getting a collection.</para>
 /// <para>Unless otherwise documented, implementations of this abstract base class can be expected to be thread-safe, and can be used concurrently from multiple threads.</para>
 /// </remarks>
-public abstract class VectorStore
+public abstract class VectorStore : IDisposable
 {
+    private bool _disposed;
+
     /// <summary>
     /// Gets a collection from the vector store.
     /// </summary>
@@ -69,4 +71,26 @@ public abstract class VectorStore
     /// <see cref="GetService"/> may be used to request it.
     /// </remarks>
     public abstract object? GetService(Type serviceType, object? serviceKey = null);
+
+    /// <summary>
+    /// Disposes the <see cref="VectorStore"/> and releases any resources it holds.
+    /// </summary>
+    /// <param name="disposing">True if called from <see cref="Dispose()"/>, false if called from a finalizer.</param>
+    protected virtual void Dispose(bool disposing)
+    {
+    }
+
+    /// <inheritdoc/>
+#pragma warning disable CA1063 // Implement IDisposable Correctly
+#pragma warning disable CA1816 // Dispose methods should call SuppressFinalize: This base class does not have a finalizer.
+    public void Dispose()
+#pragma warning restore CA1816 // Dispose methods should call SuppressFinalize
+#pragma warning restore CA1063 // Implement IDisposable Correctly
+    {
+        if (!this._disposed)
+        {
+            this.Dispose(disposing: true);
+            this._disposed = true;
+        }
+    }
 }

--- a/dotnet/src/Connectors/VectorData.Abstractions/VectorStorage/VectorStoreCollection.cs
+++ b/dotnet/src/Connectors/VectorData.Abstractions/VectorStorage/VectorStoreCollection.cs
@@ -18,11 +18,13 @@ namespace Microsoft.Extensions.VectorData;
 /// <para>Unless otherwise documented, implementations of this abstract base class can be expected to be thread-safe, and can be used concurrently from multiple threads.</para>
 /// </remarks>
 #pragma warning disable CA1711 // Identifiers should not have incorrect suffix (Collection)
-public abstract class VectorStoreCollection<TKey, TRecord> : IVectorSearchable<TRecord>
+public abstract class VectorStoreCollection<TKey, TRecord> : IVectorSearchable<TRecord>, IDisposable
 #pragma warning restore CA1711
     where TKey : notnull
     where TRecord : class
 {
+    private bool _disposed;
+
     /// <summary>
     /// Gets the name of the collection.
     /// </summary>
@@ -183,4 +185,26 @@ public abstract class VectorStoreCollection<TKey, TRecord> : IVectorSearchable<T
 
     /// <inheritdoc />
     public abstract object? GetService(Type serviceType, object? serviceKey = null);
+
+    /// <summary>
+    /// Disposes the <see cref="VectorStore"/> and releases any resources it holds.
+    /// </summary>
+    /// <param name="disposing">True if called from <see cref="Dispose()"/>, false if called from a finalizer.</param>
+    protected virtual void Dispose(bool disposing)
+    {
+    }
+
+    /// <inheritdoc/>
+#pragma warning disable CA1063 // Implement IDisposable Correctly
+#pragma warning disable CA1816 // Dispose methods should call SuppressFinalize: This base class does not have a finalizer.
+    public void Dispose()
+#pragma warning restore CA1816 // Dispose methods should call SuppressFinalize
+#pragma warning restore CA1063 // Implement IDisposable Correctly
+    {
+        if (!this._disposed)
+        {
+            this.Dispose(disposing: true);
+            this._disposed = true;
+        }
+    }
 }

--- a/dotnet/src/IntegrationTests/Connectors/Memory/AzureAISearch/AzureAISearchVectorStoreRecordCollectionTests.cs
+++ b/dotnet/src/IntegrationTests/Connectors/Memory/AzureAISearch/AzureAISearchVectorStoreRecordCollectionTests.cs
@@ -32,7 +32,7 @@ public sealed class AzureAISearchVectorStoreRecordCollectionTests(ITestOutputHel
     {
         // Arrange.
         var collectionName = expectedExists ? fixture.TestIndexName : "nonexistentcollection";
-        var sut = new AzureAISearchCollection<string, AzureAISearchHotel>(fixture.SearchIndexClient, collectionName);
+        using var sut = new AzureAISearchCollection<string, AzureAISearchHotel>(fixture.SearchIndexClient, collectionName);
 
         // Act.
         var actual = await sut.CollectionExistsAsync();
@@ -53,7 +53,7 @@ public sealed class AzureAISearchVectorStoreRecordCollectionTests(ITestOutputHel
         {
             VectorStoreRecordDefinition = useRecordDefinition ? fixture.VectorStoreRecordDefinition : null
         };
-        var sut = new AzureAISearchCollection<string, AzureAISearchHotel>(fixture.SearchIndexClient, testCollectionName, options);
+        using var sut = new AzureAISearchCollection<string, AzureAISearchHotel>(fixture.SearchIndexClient, testCollectionName, options);
 
         await sut.DeleteCollectionAsync();
 
@@ -108,7 +108,7 @@ public sealed class AzureAISearchVectorStoreRecordCollectionTests(ITestOutputHel
         // Arrange
         var tempCollectionName = fixture.TestIndexName + "-delete";
         await AzureAISearchVectorStoreFixture.CreateIndexAsync(tempCollectionName, fixture.SearchIndexClient);
-        var sut = new AzureAISearchCollection<string, AzureAISearchHotel>(fixture.SearchIndexClient, tempCollectionName);
+        using var sut = new AzureAISearchCollection<string, AzureAISearchHotel>(fixture.SearchIndexClient, tempCollectionName);
 
         // Act
         await sut.DeleteCollectionAsync();
@@ -127,7 +127,7 @@ public sealed class AzureAISearchVectorStoreRecordCollectionTests(ITestOutputHel
         {
             VectorStoreRecordDefinition = useRecordDefinition ? fixture.VectorStoreRecordDefinition : null
         };
-        var sut = new AzureAISearchCollection<string, AzureAISearchHotel>(fixture.SearchIndexClient, fixture.TestIndexName, options);
+        using var sut = new AzureAISearchCollection<string, AzureAISearchHotel>(fixture.SearchIndexClient, fixture.TestIndexName, options);
 
         // Act
         var hotel = this.CreateTestHotel("Upsert-1");
@@ -153,7 +153,7 @@ public sealed class AzureAISearchVectorStoreRecordCollectionTests(ITestOutputHel
     public async Task ItCanUpsertManyDocumentsToVectorStoreAsync()
     {
         // Arrange
-        var sut = new AzureAISearchCollection<string, AzureAISearchHotel>(fixture.SearchIndexClient, fixture.TestIndexName);
+        using var sut = new AzureAISearchCollection<string, AzureAISearchHotel>(fixture.SearchIndexClient, fixture.TestIndexName);
 
         // Act
         await sut.UpsertAsync(
@@ -176,7 +176,7 @@ public sealed class AzureAISearchVectorStoreRecordCollectionTests(ITestOutputHel
         {
             VectorStoreRecordDefinition = useRecordDefinition ? fixture.VectorStoreRecordDefinition : null
         };
-        var sut = new AzureAISearchCollection<string, AzureAISearchHotel>(fixture.SearchIndexClient, fixture.TestIndexName, options);
+        using var sut = new AzureAISearchCollection<string, AzureAISearchHotel>(fixture.SearchIndexClient, fixture.TestIndexName, options);
 
         // Act
         var getResult = await sut.GetAsync("BaseSet-1", new RecordRetrievalOptions { IncludeVectors = includeVectors });
@@ -209,7 +209,7 @@ public sealed class AzureAISearchVectorStoreRecordCollectionTests(ITestOutputHel
     public async Task ItCanGetManyDocumentsFromVectorStoreAsync()
     {
         // Arrange
-        var sut = new AzureAISearchCollection<string, AzureAISearchHotel>(fixture.SearchIndexClient, fixture.TestIndexName);
+        using var sut = new AzureAISearchCollection<string, AzureAISearchHotel>(fixture.SearchIndexClient, fixture.TestIndexName);
 
         // Act
         // Also include one non-existing key to test that the operation does not fail for these and returns only the found ones.
@@ -237,7 +237,7 @@ public sealed class AzureAISearchVectorStoreRecordCollectionTests(ITestOutputHel
         {
             VectorStoreRecordDefinition = useRecordDefinition ? fixture.VectorStoreRecordDefinition : null
         };
-        var sut = new AzureAISearchCollection<string, AzureAISearchHotel>(fixture.SearchIndexClient, fixture.TestIndexName);
+        using var sut = new AzureAISearchCollection<string, AzureAISearchHotel>(fixture.SearchIndexClient, fixture.TestIndexName);
         await sut.UpsertAsync(this.CreateTestHotel("Remove-1"));
 
         // Act
@@ -253,7 +253,7 @@ public sealed class AzureAISearchVectorStoreRecordCollectionTests(ITestOutputHel
     public async Task ItCanRemoveManyDocumentsFromVectorStoreAsync()
     {
         // Arrange
-        var sut = new AzureAISearchCollection<string, AzureAISearchHotel>(fixture.SearchIndexClient, fixture.TestIndexName);
+        using var sut = new AzureAISearchCollection<string, AzureAISearchHotel>(fixture.SearchIndexClient, fixture.TestIndexName);
         await sut.UpsertAsync(this.CreateTestHotel("RemoveMany-1"));
         await sut.UpsertAsync(this.CreateTestHotel("RemoveMany-2"));
         await sut.UpsertAsync(this.CreateTestHotel("RemoveMany-3"));
@@ -272,7 +272,7 @@ public sealed class AzureAISearchVectorStoreRecordCollectionTests(ITestOutputHel
     public async Task ItReturnsNullWhenGettingNonExistentRecordAsync()
     {
         // Arrange
-        var sut = new AzureAISearchCollection<string, AzureAISearchHotel>(fixture.SearchIndexClient, fixture.TestIndexName);
+        using var sut = new AzureAISearchCollection<string, AzureAISearchHotel>(fixture.SearchIndexClient, fixture.TestIndexName);
 
         // Act & Assert
         Assert.Null(await sut.GetAsync("BaseSet-5", new RecordRetrievalOptions { IncludeVectors = true }));
@@ -283,7 +283,7 @@ public sealed class AzureAISearchVectorStoreRecordCollectionTests(ITestOutputHel
     {
         // Arrange
         var searchIndexClient = new SearchIndexClient(new Uri("https://localhost:12345"), new AzureKeyCredential("12345"));
-        var sut = new AzureAISearchCollection<string, AzureAISearchHotel>(searchIndexClient, fixture.TestIndexName);
+        using var sut = new AzureAISearchCollection<string, AzureAISearchHotel>(searchIndexClient, fixture.TestIndexName);
 
         // Act & Assert
         await Assert.ThrowsAsync<VectorStoreException>(async () => await sut.GetAsync("BaseSet-1", new RecordRetrievalOptions { IncludeVectors = true }));
@@ -294,7 +294,7 @@ public sealed class AzureAISearchVectorStoreRecordCollectionTests(ITestOutputHel
     {
         // Arrange
         var searchIndexClient = new SearchIndexClient(new Uri(fixture.Config.ServiceUrl), new AzureKeyCredential("12345"));
-        var sut = new AzureAISearchCollection<string, AzureAISearchHotel>(searchIndexClient, fixture.TestIndexName);
+        using var sut = new AzureAISearchCollection<string, AzureAISearchHotel>(searchIndexClient, fixture.TestIndexName);
 
         // Act & Assert
         await Assert.ThrowsAsync<VectorStoreException>(async () => await sut.GetAsync("BaseSet-1", new RecordRetrievalOptions { IncludeVectors = true }));
@@ -306,7 +306,7 @@ public sealed class AzureAISearchVectorStoreRecordCollectionTests(ITestOutputHel
     public async Task ItCanSearchWithVectorAndFiltersAsync(string option, bool includeVectors)
     {
         // Arrange.
-        var sut = new AzureAISearchCollection<string, AzureAISearchHotel>(fixture.SearchIndexClient, fixture.TestIndexName);
+        using var sut = new AzureAISearchCollection<string, AzureAISearchHotel>(fixture.SearchIndexClient, fixture.TestIndexName);
 
         // Act.
         var filter = option == "equality" ? new VectorSearchFilter().EqualTo("HotelName", "Hotel 3") : new VectorSearchFilter().AnyTagEqualTo("Tags", "bar");
@@ -346,7 +346,7 @@ public sealed class AzureAISearchVectorStoreRecordCollectionTests(ITestOutputHel
     public async Task ItCanSearchWithTextAndFiltersAsync()
     {
         // Arrange.
-        var sut = new AzureAISearchCollection<string, AzureAISearchHotel>(fixture.SearchIndexClient, fixture.TestIndexName);
+        using var sut = new AzureAISearchCollection<string, AzureAISearchHotel>(fixture.SearchIndexClient, fixture.TestIndexName);
 
         // Act.
         var filter = new VectorSearchFilter().EqualTo("HotelName", "Hotel 3");
@@ -371,7 +371,7 @@ public sealed class AzureAISearchVectorStoreRecordCollectionTests(ITestOutputHel
         {
             VectorStoreRecordDefinition = fixture.VectorStoreRecordDefinition
         };
-        var sut = new AzureAISearchCollection<object, Dictionary<string, object?>>(fixture.SearchIndexClient, fixture.TestIndexName, options);
+        using var sut = new AzureAISearchCollection<object, Dictionary<string, object?>>(fixture.SearchIndexClient, fixture.TestIndexName, options);
 
         // Act
         var baseSetGetResult = await sut.GetAsync("BaseSet-1", new RecordRetrievalOptions { IncludeVectors = true });

--- a/dotnet/src/IntegrationTests/Connectors/Memory/AzureAISearch/AzureAISearchVectorStoreTests.cs
+++ b/dotnet/src/IntegrationTests/Connectors/Memory/AzureAISearch/AzureAISearchVectorStoreTests.cs
@@ -13,6 +13,8 @@ namespace SemanticKernel.IntegrationTests.Connectors.Memory.AzureAISearch;
 [Collection("AzureAISearchVectorStoreCollection")]
 [DisableVectorStoreTests(Skip = "Requires Azure AI Search Service instance up and running")]
 public class AzureAISearchVectorStoreTests(AzureAISearchVectorStoreFixture fixture)
+#pragma warning disable CA2000 // Dispose objects before losing scope
     : BaseVectorStoreTests<string, AzureAISearchHotel>(new AzureAISearchVectorStore(fixture.SearchIndexClient))
+#pragma warning restore CA2000 // Dispose objects before losing scope
 {
 }

--- a/dotnet/src/IntegrationTests/Connectors/Memory/CosmosMongoDB/CosmosMongoCollectionTests.cs
+++ b/dotnet/src/IntegrationTests/Connectors/Memory/CosmosMongoDB/CosmosMongoCollectionTests.cs
@@ -25,7 +25,7 @@ public class CosmosMongoCollectionTests(CosmosMongoVectorStoreFixture fixture)
     public async Task CollectionExistsReturnsCollectionStateAsync(string collectionName, bool expectedExists)
     {
         // Arrange
-        var sut = new CosmosMongoCollection<string, CosmosMongoHotel>(fixture.MongoDatabase, collectionName);
+        using var sut = new CosmosMongoCollection<string, CosmosMongoHotel>(fixture.MongoDatabase, collectionName);
 
         // Act
         var actual = await sut.CollectionExistsAsync();
@@ -38,7 +38,7 @@ public class CosmosMongoCollectionTests(CosmosMongoVectorStoreFixture fixture)
     public async Task ItCanEnsureCollectionExistsAsync()
     {
         // Arrange
-        var sut = new CosmosMongoCollection<string, CosmosMongoHotel>(fixture.MongoDatabase, "sk-test-create-collection");
+        using var sut = new CosmosMongoCollection<string, CosmosMongoHotel>(fixture.MongoDatabase, "sk-test-create-collection");
 
         try
         {
@@ -73,7 +73,7 @@ public class CosmosMongoCollectionTests(CosmosMongoVectorStoreFixture fixture)
             VectorStoreRecordDefinition = useRecordDefinition ? fixture.HotelVectorStoreRecordDefinition : null
         };
 
-        var sut = new CosmosMongoCollection<string, CosmosMongoHotel>(fixture.MongoDatabase, collectionName);
+        using var sut = new CosmosMongoCollection<string, CosmosMongoHotel>(fixture.MongoDatabase, collectionName);
 
         var record = this.CreateTestHotel(HotelId);
 
@@ -115,7 +115,7 @@ public class CosmosMongoCollectionTests(CosmosMongoVectorStoreFixture fixture)
         const string TempCollectionName = "temp-test";
         await fixture.MongoDatabase.CreateCollectionAsync(TempCollectionName);
 
-        var sut = new CosmosMongoCollection<string, CosmosMongoHotel>(fixture.MongoDatabase, TempCollectionName);
+        using var sut = new CosmosMongoCollection<string, CosmosMongoHotel>(fixture.MongoDatabase, TempCollectionName);
 
         Assert.True(await sut.CollectionExistsAsync());
 
@@ -131,7 +131,7 @@ public class CosmosMongoCollectionTests(CosmosMongoVectorStoreFixture fixture)
     {
         // Arrange
         const string HotelId = "55555555-5555-5555-5555-555555555555";
-        var sut = new CosmosMongoCollection<string, CosmosMongoHotel>(fixture.MongoDatabase, fixture.TestCollection);
+        using var sut = new CosmosMongoCollection<string, CosmosMongoHotel>(fixture.MongoDatabase, fixture.TestCollection);
 
         var record = this.CreateTestHotel(HotelId);
 
@@ -157,7 +157,7 @@ public class CosmosMongoCollectionTests(CosmosMongoVectorStoreFixture fixture)
         const string HotelId2 = "22222222-2222-2222-2222-222222222222";
         const string HotelId3 = "33333333-3333-3333-3333-333333333333";
 
-        var sut = new CosmosMongoCollection<string, CosmosMongoHotel>(fixture.MongoDatabase, fixture.TestCollection);
+        using var sut = new CosmosMongoCollection<string, CosmosMongoHotel>(fixture.MongoDatabase, fixture.TestCollection);
 
         var record1 = this.CreateTestHotel(HotelId1);
         var record2 = this.CreateTestHotel(HotelId2);
@@ -184,7 +184,7 @@ public class CosmosMongoCollectionTests(CosmosMongoVectorStoreFixture fixture)
     {
         // Arrange
         const string HotelId = "55555555-5555-5555-5555-555555555555";
-        var sut = new CosmosMongoCollection<string, CosmosMongoHotel>(fixture.MongoDatabase, fixture.TestCollection);
+        using var sut = new CosmosMongoCollection<string, CosmosMongoHotel>(fixture.MongoDatabase, fixture.TestCollection);
 
         var record = this.CreateTestHotel(HotelId);
 
@@ -221,7 +221,7 @@ public class CosmosMongoCollectionTests(CosmosMongoVectorStoreFixture fixture)
 
         var model = new TestModel { Id = "key", HotelName = "Test Name" };
 
-        var sut = new CosmosMongoCollection<string, TestModel>(
+        using var sut = new CosmosMongoCollection<string, TestModel>(
             fixture.MongoDatabase,
             fixture.TestCollection,
             new() { VectorStoreRecordDefinition = definition });
@@ -242,7 +242,7 @@ public class CosmosMongoCollectionTests(CosmosMongoVectorStoreFixture fixture)
         // Arrange
         var model = new VectorStoreTestModel { HotelId = "key", HotelName = "Test Name" };
 
-        var sut = new CosmosMongoCollection<string, VectorStoreTestModel>(fixture.MongoDatabase, fixture.TestCollection);
+        using var sut = new CosmosMongoCollection<string, VectorStoreTestModel>(fixture.MongoDatabase, fixture.TestCollection);
 
         // Act
         await sut.UpsertAsync(model);
@@ -269,7 +269,7 @@ public class CosmosMongoCollectionTests(CosmosMongoVectorStoreFixture fixture)
 
         var model = new BsonTestModel { Id = "key", HotelName = "Test Name" };
 
-        var sut = new CosmosMongoCollection<string, BsonTestModel>(
+        using var sut = new CosmosMongoCollection<string, BsonTestModel>(
             fixture.MongoDatabase,
             fixture.TestCollection,
             new() { VectorStoreRecordDefinition = definition });
@@ -290,7 +290,7 @@ public class CosmosMongoCollectionTests(CosmosMongoVectorStoreFixture fixture)
         // Arrange
         var model = new BsonVectorStoreTestModel { HotelId = "key", HotelName = "Test Name" };
 
-        var sut = new CosmosMongoCollection<string, BsonVectorStoreTestModel>(fixture.MongoDatabase, fixture.TestCollection);
+        using var sut = new CosmosMongoCollection<string, BsonVectorStoreTestModel>(fixture.MongoDatabase, fixture.TestCollection);
 
         // Act
         await sut.UpsertAsync(model);
@@ -308,7 +308,7 @@ public class CosmosMongoCollectionTests(CosmosMongoVectorStoreFixture fixture)
         // Arrange
         var model = new BsonVectorStoreWithNameTestModel { Id = "key", HotelName = "Test Name" };
 
-        var sut = new CosmosMongoCollection<string, BsonVectorStoreWithNameTestModel>(fixture.MongoDatabase, fixture.TestCollection);
+        using var sut = new CosmosMongoCollection<string, BsonVectorStoreWithNameTestModel>(fixture.MongoDatabase, fixture.TestCollection);
 
         // Act
         await sut.UpsertAsync(model);
@@ -329,7 +329,7 @@ public class CosmosMongoCollectionTests(CosmosMongoVectorStoreFixture fixture)
         var hotel3 = this.CreateTestHotel(hotelId: "key3", embedding: new[] { 20f, 20f, 20f, 20f });
         var hotel4 = this.CreateTestHotel(hotelId: "key4", embedding: new[] { -1000f, -1000f, -1000f, -1000f });
 
-        var sut = new CosmosMongoCollection<string, CosmosMongoHotel>(fixture.MongoDatabase, "TestVectorizedSearch");
+        using var sut = new CosmosMongoCollection<string, CosmosMongoHotel>(fixture.MongoDatabase, "TestVectorizedSearch");
 
         await sut.EnsureCollectionExistsAsync();
 
@@ -359,7 +359,7 @@ public class CosmosMongoCollectionTests(CosmosMongoVectorStoreFixture fixture)
         var hotel3 = this.CreateTestHotel(hotelId: "key3", embedding: new[] { 20f, 20f, 20f, 20f });
         var hotel4 = this.CreateTestHotel(hotelId: "key4", embedding: new[] { -1000f, -1000f, -1000f, -1000f });
 
-        var sut = new CosmosMongoCollection<string, CosmosMongoHotel>(fixture.MongoDatabase, "TestVectorizedSearchWithOffset");
+        using var sut = new CosmosMongoCollection<string, CosmosMongoHotel>(fixture.MongoDatabase, "TestVectorizedSearchWithOffset");
 
         await sut.EnsureCollectionExistsAsync();
 
@@ -390,7 +390,7 @@ public class CosmosMongoCollectionTests(CosmosMongoVectorStoreFixture fixture)
         var hotel3 = this.CreateTestHotel(hotelId: "key3", embedding: new[] { 20f, 20f, 20f, 20f });
         var hotel4 = this.CreateTestHotel(hotelId: "key4", embedding: new[] { -1000f, -1000f, -1000f, -1000f });
 
-        var sut = new CosmosMongoCollection<string, CosmosMongoHotel>(fixture.MongoDatabase, "TestVectorizedSearchWithOffset");
+        using var sut = new CosmosMongoCollection<string, CosmosMongoHotel>(fixture.MongoDatabase, "TestVectorizedSearchWithOffset");
 
         await sut.EnsureCollectionExistsAsync();
 
@@ -421,7 +421,7 @@ public class CosmosMongoCollectionTests(CosmosMongoVectorStoreFixture fixture)
             VectorStoreRecordDefinition = fixture.HotelVectorStoreRecordDefinition
         };
 
-        var sut = new CosmosMongoCollection<object, Dictionary<string, object?>>(fixture.MongoDatabase, fixture.TestCollection, options);
+        using var sut = new CosmosMongoCollection<object, Dictionary<string, object?>>(fixture.MongoDatabase, fixture.TestCollection, options);
 
         // Act
         await sut.UpsertAsync(new Dictionary<string, object?>

--- a/dotnet/src/IntegrationTests/Connectors/Memory/CosmosMongoDB/CosmosMongoVectorStoreTests.cs
+++ b/dotnet/src/IntegrationTests/Connectors/Memory/CosmosMongoDB/CosmosMongoVectorStoreTests.cs
@@ -10,6 +10,8 @@ namespace SemanticKernel.IntegrationTests.Connectors.CosmosMongoDB;
 [Collection("CosmosMongoCollection")]
 [DisableVectorStoreTests(Skip = "Azure CosmosDB MongoDB cluster is required")]
 public class CosmosMongoVectorStoreTests(CosmosMongoVectorStoreFixture fixture)
+#pragma warning disable CA2000 // Dispose objects before losing scope
     : BaseVectorStoreTests<string, CosmosMongoHotel>(new CosmosMongoVectorStore(fixture.MongoDatabase))
+#pragma warning restore CA2000 // Dispose objects before losing scope
 {
 }

--- a/dotnet/src/IntegrationTests/Connectors/Memory/CosmosNoSql/CosmosNoSqlCollectionTests.cs
+++ b/dotnet/src/IntegrationTests/Connectors/Memory/CosmosNoSql/CosmosNoSqlCollectionTests.cs
@@ -28,7 +28,7 @@ public sealed class CosmosNoSqlCollectionTests(CosmosNoSqlVectorStoreFixture fix
     public async Task ItCanEnsureCollectionExistsAsync()
     {
         // Arrange
-        var sut = new CosmosNoSqlCollection<string, CosmosNoSqlHotel>(fixture.Database!, "test-create-collection");
+        using var sut = new CosmosNoSqlCollection<string, CosmosNoSqlHotel>(fixture.Database!, "test-create-collection");
 
         // Act
         await sut.EnsureCollectionExistsAsync();
@@ -43,7 +43,7 @@ public sealed class CosmosNoSqlCollectionTests(CosmosNoSqlVectorStoreFixture fix
     public async Task CollectionExistsReturnsCollectionStateAsync(string collectionName, bool expectedExists)
     {
         // Arrange
-        var sut = new CosmosNoSqlCollection<string, CosmosNoSqlHotel>(fixture.Database!, collectionName);
+        using var sut = new CosmosNoSqlCollection<string, CosmosNoSqlHotel>(fixture.Database!, collectionName);
 
         if (expectedExists)
         {
@@ -76,7 +76,7 @@ public sealed class CosmosNoSqlCollectionTests(CosmosNoSqlVectorStoreFixture fix
             VectorStoreRecordDefinition = useRecordDefinition ? this.GetTestHotelRecordDefinition() : null
         };
 
-        var sut = new CosmosNoSqlCollection<string, CosmosNoSqlHotel>(fixture.Database!, collectionName);
+        using var sut = new CosmosNoSqlCollection<string, CosmosNoSqlHotel>(fixture.Database!, collectionName);
 
         var record = this.CreateTestHotel(HotelId);
 
@@ -118,7 +118,7 @@ public sealed class CosmosNoSqlCollectionTests(CosmosNoSqlVectorStoreFixture fix
         const string TempCollectionName = "test-delete-collection";
         await fixture.Database!.CreateContainerAsync(new ContainerProperties(TempCollectionName, "/id"));
 
-        var sut = new CosmosNoSqlCollection<string, CosmosNoSqlHotel>(fixture.Database!, TempCollectionName);
+        using var sut = new CosmosNoSqlCollection<string, CosmosNoSqlHotel>(fixture.Database!, TempCollectionName);
 
         Assert.True(await sut.CollectionExistsAsync());
 
@@ -137,7 +137,7 @@ public sealed class CosmosNoSqlCollectionTests(CosmosNoSqlVectorStoreFixture fix
     {
         // Arrange
         const string HotelId = "55555555-5555-5555-5555-555555555555";
-        var sut = new CosmosNoSqlCollection<string, CosmosNoSqlHotel>(
+        using var sut = new CosmosNoSqlCollection<string, CosmosNoSqlHotel>(
             fixture.Database!,
             collectionName,
             new() { IndexingMode = indexingMode, Automatic = indexingMode != IndexingMode.None });
@@ -167,7 +167,7 @@ public sealed class CosmosNoSqlCollectionTests(CosmosNoSqlVectorStoreFixture fix
         const string HotelId = "55555555-5555-5555-5555-555555555555";
         const string HotelName = "Test Hotel Name";
 
-        VectorStoreCollection<CosmosNoSqlCompositeKey, CosmosNoSqlHotel> sut =
+        using VectorStoreCollection<CosmosNoSqlCompositeKey, CosmosNoSqlHotel> sut =
             new CosmosNoSqlCollection<CosmosNoSqlCompositeKey, CosmosNoSqlHotel>(
                 fixture.Database!,
                 "delete-with-partition-key",
@@ -201,7 +201,7 @@ public sealed class CosmosNoSqlCollectionTests(CosmosNoSqlVectorStoreFixture fix
         const string HotelId2 = "22222222-2222-2222-2222-222222222222";
         const string HotelId3 = "33333333-3333-3333-3333-333333333333";
 
-        var sut = new CosmosNoSqlCollection<string, CosmosNoSqlHotel>(fixture.Database!, "get-and-delete-batch");
+        using var sut = new CosmosNoSqlCollection<string, CosmosNoSqlHotel>(fixture.Database!, "get-and-delete-batch");
 
         await sut.EnsureCollectionExistsAsync();
 
@@ -230,7 +230,7 @@ public sealed class CosmosNoSqlCollectionTests(CosmosNoSqlVectorStoreFixture fix
     {
         // Arrange
         const string HotelId = "55555555-5555-5555-5555-555555555555";
-        var sut = new CosmosNoSqlCollection<string, CosmosNoSqlHotel>(fixture.Database!, "upsert-record");
+        using var sut = new CosmosNoSqlCollection<string, CosmosNoSqlHotel>(fixture.Database!, "upsert-record");
 
         await sut.EnsureCollectionExistsAsync();
 
@@ -262,7 +262,7 @@ public sealed class CosmosNoSqlCollectionTests(CosmosNoSqlVectorStoreFixture fix
         var hotel3 = this.CreateTestHotel(hotelId: "key3", embedding: new[] { 20f, 20f, 20f, 20f });
         var hotel4 = this.CreateTestHotel(hotelId: "key4", embedding: new[] { -1000f, -1000f, -1000f, -1000f });
 
-        var sut = new CosmosNoSqlCollection<string, CosmosNoSqlHotel>(fixture.Database!, "vector-search-default");
+        using var sut = new CosmosNoSqlCollection<string, CosmosNoSqlHotel>(fixture.Database!, "vector-search-default");
 
         await sut.EnsureCollectionExistsAsync();
 
@@ -292,7 +292,7 @@ public sealed class CosmosNoSqlCollectionTests(CosmosNoSqlVectorStoreFixture fix
         var hotel3 = this.CreateTestHotel(hotelId: "key3", embedding: new[] { 20f, 20f, 20f, 20f });
         var hotel4 = this.CreateTestHotel(hotelId: "key4", embedding: new[] { -1000f, -1000f, -1000f, -1000f });
 
-        var sut = new CosmosNoSqlCollection<string, CosmosNoSqlHotel>(fixture.Database!, "vector-search-with-offset");
+        using var sut = new CosmosNoSqlCollection<string, CosmosNoSqlHotel>(fixture.Database!, "vector-search-with-offset");
 
         await sut.EnsureCollectionExistsAsync();
 
@@ -324,7 +324,7 @@ public sealed class CosmosNoSqlCollectionTests(CosmosNoSqlVectorStoreFixture fix
         var hotel3 = this.CreateTestHotel(hotelId: "key3", embedding: new[] { 20f, 20f, 20f, 20f });
         var hotel4 = this.CreateTestHotel(hotelId: "key4", embedding: new[] { -1000f, -1000f, -1000f, -1000f });
 
-        var sut = new CosmosNoSqlCollection<string, CosmosNoSqlHotel>(fixture.Database!, "vector-search-with-filter");
+        using var sut = new CosmosNoSqlCollection<string, CosmosNoSqlHotel>(fixture.Database!, "vector-search-with-filter");
 
         await sut.EnsureCollectionExistsAsync();
 
@@ -352,7 +352,7 @@ public sealed class CosmosNoSqlCollectionTests(CosmosNoSqlVectorStoreFixture fix
             VectorStoreRecordDefinition = this.GetTestHotelRecordDefinition()
         };
 
-        var sut = new CosmosNoSqlCollection<object, Dictionary<string, object?>>(fixture.Database!, "dynamic-mapper", options);
+        using var sut = new CosmosNoSqlCollection<object, Dictionary<string, object?>>(fixture.Database!, "dynamic-mapper", options);
 
         await sut.EnsureCollectionExistsAsync();
 

--- a/dotnet/src/IntegrationTests/Connectors/Memory/CosmosNoSql/CosmosNoSqlVectorStoreTests.cs
+++ b/dotnet/src/IntegrationTests/Connectors/Memory/CosmosNoSql/CosmosNoSqlVectorStoreTests.cs
@@ -11,6 +11,8 @@ namespace SemanticKernel.IntegrationTests.Connectors.Memory.CosmosNoSql;
 [Collection("CosmosNoSqlVectorStoreCollection")]
 [CosmosNoSqlConnectionStringSetCondition]
 public sealed class CosmosNoSqlVectorStoreTests(CosmosNoSqlVectorStoreFixture fixture)
+#pragma warning disable CA2000 // Dispose objects before losing scope
     : BaseVectorStoreTests<string, CosmosNoSqlHotel>(new CosmosNoSqlVectorStore(fixture.Database!))
+#pragma warning restore CA2000 // Dispose objects before losing scope
 {
 }

--- a/dotnet/src/IntegrationTests/Connectors/Memory/MongoDB/MongoDBVectorStoreRecordCollectionTests.cs
+++ b/dotnet/src/IntegrationTests/Connectors/Memory/MongoDB/MongoDBVectorStoreRecordCollectionTests.cs
@@ -28,7 +28,7 @@ public class MongoDBVectorStoreRecordCollectionTests(MongoDBVectorStoreFixture f
     public async Task CollectionExistsReturnsCollectionStateAsync(string collectionName, bool expectedExists)
     {
         // Arrange
-        var sut = new MongoCollection<string, MongoDBHotel>(fixture.MongoDatabase, collectionName);
+        using var sut = new MongoCollection<string, MongoDBHotel>(fixture.MongoDatabase, collectionName);
 
         // Act
         var actual = await sut.CollectionExistsAsync();
@@ -42,7 +42,7 @@ public class MongoDBVectorStoreRecordCollectionTests(MongoDBVectorStoreFixture f
     {
         // Arrange
         var newCollection = Guid.NewGuid().ToString();
-        var sut = new MongoCollection<string, MongoDBHotel>(fixture.MongoDatabase, newCollection);
+        using var sut = new MongoCollection<string, MongoDBHotel>(fixture.MongoDatabase, newCollection);
 
         // Act
         await sut.EnsureCollectionExistsAsync();
@@ -71,7 +71,7 @@ public class MongoDBVectorStoreRecordCollectionTests(MongoDBVectorStoreFixture f
             VectorStoreRecordDefinition = useRecordDefinition ? fixture.HotelVectorStoreRecordDefinition : null
         };
 
-        var sut = new MongoCollection<string, MongoDBHotel>(fixture.MongoDatabase, collectionName, options);
+        using var sut = new MongoCollection<string, MongoDBHotel>(fixture.MongoDatabase, collectionName, options);
 
         var record = this.CreateTestHotel(HotelId);
 
@@ -113,7 +113,7 @@ public class MongoDBVectorStoreRecordCollectionTests(MongoDBVectorStoreFixture f
         const string TempCollectionName = "temp-test";
         await fixture.MongoDatabase.CreateCollectionAsync(TempCollectionName);
 
-        var sut = new MongoCollection<string, MongoDBHotel>(fixture.MongoDatabase, TempCollectionName);
+        using var sut = new MongoCollection<string, MongoDBHotel>(fixture.MongoDatabase, TempCollectionName);
 
         Assert.True(await sut.CollectionExistsAsync());
 
@@ -129,7 +129,7 @@ public class MongoDBVectorStoreRecordCollectionTests(MongoDBVectorStoreFixture f
     {
         // Arrange
         const string HotelId = "55555555-5555-5555-5555-555555555555";
-        var sut = new MongoCollection<string, MongoDBHotel>(fixture.MongoDatabase, fixture.TestCollection);
+        using var sut = new MongoCollection<string, MongoDBHotel>(fixture.MongoDatabase, fixture.TestCollection);
 
         var record = this.CreateTestHotel(HotelId);
 
@@ -155,7 +155,7 @@ public class MongoDBVectorStoreRecordCollectionTests(MongoDBVectorStoreFixture f
         const string HotelId2 = "22222222-2222-2222-2222-222222222222";
         const string HotelId3 = "33333333-3333-3333-3333-333333333333";
 
-        var sut = new MongoCollection<string, MongoDBHotel>(fixture.MongoDatabase, fixture.TestCollection);
+        using var sut = new MongoCollection<string, MongoDBHotel>(fixture.MongoDatabase, fixture.TestCollection);
 
         var record1 = this.CreateTestHotel(HotelId1);
         var record2 = this.CreateTestHotel(HotelId2);
@@ -183,7 +183,7 @@ public class MongoDBVectorStoreRecordCollectionTests(MongoDBVectorStoreFixture f
     {
         // Arrange
         const string HotelId = "55555555-5555-5555-5555-555555555555";
-        var sut = new MongoCollection<string, MongoDBHotel>(fixture.MongoDatabase, fixture.TestCollection);
+        using var sut = new MongoCollection<string, MongoDBHotel>(fixture.MongoDatabase, fixture.TestCollection);
 
         var record = this.CreateTestHotel(HotelId);
 
@@ -220,7 +220,7 @@ public class MongoDBVectorStoreRecordCollectionTests(MongoDBVectorStoreFixture f
 
         var model = new TestModel { Id = "key", HotelName = "Test Name" };
 
-        var sut = new MongoCollection<string, TestModel>(
+        using var sut = new MongoCollection<string, TestModel>(
             fixture.MongoDatabase,
             fixture.TestCollection,
             new() { VectorStoreRecordDefinition = definition });
@@ -241,7 +241,7 @@ public class MongoDBVectorStoreRecordCollectionTests(MongoDBVectorStoreFixture f
         // Arrange
         var model = new VectorStoreTestModel { HotelId = "key", HotelName = "Test Name" };
 
-        var sut = new MongoCollection<string, VectorStoreTestModel>(fixture.MongoDatabase, fixture.TestCollection);
+        using var sut = new MongoCollection<string, VectorStoreTestModel>(fixture.MongoDatabase, fixture.TestCollection);
 
         // Act
         await sut.UpsertAsync(model);
@@ -268,7 +268,7 @@ public class MongoDBVectorStoreRecordCollectionTests(MongoDBVectorStoreFixture f
 
         var model = new BsonTestModel { Id = "key", HotelName = "Test Name" };
 
-        var sut = new MongoCollection<string, BsonTestModel>(
+        using var sut = new MongoCollection<string, BsonTestModel>(
             fixture.MongoDatabase,
             fixture.TestCollection,
             new() { VectorStoreRecordDefinition = definition });
@@ -289,7 +289,7 @@ public class MongoDBVectorStoreRecordCollectionTests(MongoDBVectorStoreFixture f
         // Arrange
         var model = new BsonVectorStoreTestModel { HotelId = "key", HotelName = "Test Name" };
 
-        var sut = new MongoCollection<string, BsonVectorStoreTestModel>(fixture.MongoDatabase, fixture.TestCollection);
+        using var sut = new MongoCollection<string, BsonVectorStoreTestModel>(fixture.MongoDatabase, fixture.TestCollection);
 
         // Act
         await sut.UpsertAsync(model);
@@ -307,7 +307,7 @@ public class MongoDBVectorStoreRecordCollectionTests(MongoDBVectorStoreFixture f
         // Arrange
         var model = new BsonVectorStoreWithNameTestModel { Id = "key", HotelName = "Test Name" };
 
-        var sut = new MongoCollection<string, BsonVectorStoreWithNameTestModel>(fixture.MongoDatabase, fixture.TestCollection);
+        using var sut = new MongoCollection<string, BsonVectorStoreWithNameTestModel>(fixture.MongoDatabase, fixture.TestCollection);
 
         // Act
         await sut.UpsertAsync(model);
@@ -328,7 +328,7 @@ public class MongoDBVectorStoreRecordCollectionTests(MongoDBVectorStoreFixture f
         var hotel3 = this.CreateTestHotel(hotelId: "key3", embedding: new[] { 20f, 20f, 20f, 20f });
         var hotel4 = this.CreateTestHotel(hotelId: "key4", embedding: new[] { -1000f, -1000f, -1000f, -1000f });
 
-        var sut = new MongoCollection<string, MongoDBHotel>(fixture.MongoDatabase, "TestVectorizedSearch");
+        using var sut = new MongoCollection<string, MongoDBHotel>(fixture.MongoDatabase, "TestVectorizedSearch");
 
         await sut.EnsureCollectionExistsAsync();
 
@@ -358,7 +358,7 @@ public class MongoDBVectorStoreRecordCollectionTests(MongoDBVectorStoreFixture f
         var hotel3 = this.CreateTestHotel(hotelId: "key3", embedding: new[] { 20f, 20f, 20f, 20f });
         var hotel4 = this.CreateTestHotel(hotelId: "key4", embedding: new[] { -1000f, -1000f, -1000f, -1000f });
 
-        var sut = new MongoCollection<string, MongoDBHotel>(fixture.MongoDatabase, "TestVectorizedSearchWithOffset");
+        using var sut = new MongoCollection<string, MongoDBHotel>(fixture.MongoDatabase, "TestVectorizedSearchWithOffset");
 
         await sut.EnsureCollectionExistsAsync();
 
@@ -389,7 +389,7 @@ public class MongoDBVectorStoreRecordCollectionTests(MongoDBVectorStoreFixture f
         var hotel3 = this.CreateTestHotel(hotelId: "key3", embedding: new[] { 20f, 20f, 20f, 20f });
         var hotel4 = this.CreateTestHotel(hotelId: "key4", embedding: new[] { -1000f, -1000f, -1000f, -1000f });
 
-        var sut = new MongoCollection<string, MongoDBHotel>(fixture.MongoDatabase, "TestVectorizedSearchWithOffset");
+        using var sut = new MongoCollection<string, MongoDBHotel>(fixture.MongoDatabase, "TestVectorizedSearchWithOffset");
 
         await sut.EnsureCollectionExistsAsync();
 
@@ -420,7 +420,7 @@ public class MongoDBVectorStoreRecordCollectionTests(MongoDBVectorStoreFixture f
             VectorStoreRecordDefinition = fixture.HotelVectorStoreRecordDefinition
         };
 
-        var sut = new MongoCollection<object, Dictionary<string, object?>>(fixture.MongoDatabase, fixture.TestCollection, options);
+        using var sut = new MongoCollection<object, Dictionary<string, object?>>(fixture.MongoDatabase, fixture.TestCollection, options);
 
         // Act
         await sut.UpsertAsync(new Dictionary<string, object?>

--- a/dotnet/src/IntegrationTests/Connectors/Memory/MongoDB/MongoDBVectorStoreTests.cs
+++ b/dotnet/src/IntegrationTests/Connectors/Memory/MongoDB/MongoDBVectorStoreTests.cs
@@ -10,6 +10,8 @@ namespace SemanticKernel.IntegrationTests.Connectors.MongoDB;
 [Collection("MongoDBVectorStoreCollection")]
 [DisableVectorStoreTests(Skip = "The MongoDB container is intermittently timing out at startup time blocking prs, so these test should be run manually.")]
 public class MongoDBVectorStoreTests(MongoDBVectorStoreFixture fixture)
+#pragma warning disable CA2000 // Dispose objects before losing scope
     : BaseVectorStoreTests<string, MongoDBHotel>(new MongoVectorStore(fixture.MongoDatabase))
+#pragma warning restore CA2000 // Dispose objects before losing scope
 {
 }

--- a/dotnet/src/IntegrationTests/Connectors/Memory/PgVector/CommonPostgresVectorStoreRecordCollectionTests.cs
+++ b/dotnet/src/IntegrationTests/Connectors/Memory/PgVector/CommonPostgresVectorStoreRecordCollectionTests.cs
@@ -21,9 +21,10 @@ public class CommonPostgresVectorStoreRecordCollectionTests(PostgresVectorStoreF
 
     protected override VectorStoreCollection<string, TRecord> GetTargetRecordCollection<TRecord>(string recordCollectionName, VectorStoreRecordDefinition? vectorStoreRecordDefinition)
     {
-        return new PostgresCollection<string, TRecord>(fixture.DataSource!, recordCollectionName, ownsDataSource: false, new()
+        return new PostgresCollection<string, TRecord>(fixture.DataSource!, recordCollectionName, new()
         {
-            VectorStoreRecordDefinition = vectorStoreRecordDefinition
+            VectorStoreRecordDefinition = vectorStoreRecordDefinition,
+            OwnsDataSource = false,
         });
     }
 

--- a/dotnet/src/IntegrationTests/Connectors/Memory/PgVector/PostgresVectorStoreFixture.cs
+++ b/dotnet/src/IntegrationTests/Connectors/Memory/PgVector/PostgresVectorStoreFixture.cs
@@ -42,7 +42,7 @@ public class PostgresVectorStoreFixture : IAsyncLifetime
     /// <summary>
     /// Gets a vector store to use for tests.
     /// </summary>
-    public VectorStore VectorStore => new PostgresVectorStore(this.DataSource!, ownsDataSource: false);
+    public VectorStore VectorStore => new PostgresVectorStore(this.DataSource!, new() { OwnsDataSource = false });
 
     /// <summary>
     /// Get a database connection

--- a/dotnet/src/IntegrationTests/Connectors/Memory/Qdrant/QdrantTextSearchTests.cs
+++ b/dotnet/src/IntegrationTests/Connectors/Memory/Qdrant/QdrantTextSearchTests.cs
@@ -30,7 +30,7 @@ public class QdrantTextSearchTests(QdrantVectorStoreFixture fixture) : BaseVecto
             HasNamedVectors = true,
             VectorStoreRecordDefinition = fixture.HotelVectorStoreRecordDefinition,
         };
-        var vectorSearch = new QdrantCollection<ulong, HotelInfo>(fixture.QdrantClient, "namedVectorsHotels", options);
+        using var vectorSearch = new QdrantCollection<ulong, HotelInfo>(fixture.QdrantClient, "namedVectorsHotels", options);
         var stringMapper = new HotelInfoTextSearchStringMapper();
         var resultMapper = new HotelInfoTextSearchResultMapper();
 

--- a/dotnet/src/IntegrationTests/Connectors/Memory/Qdrant/QdrantVectorStoreRecordCollectionTests.cs
+++ b/dotnet/src/IntegrationTests/Connectors/Memory/Qdrant/QdrantVectorStoreRecordCollectionTests.cs
@@ -31,7 +31,7 @@ public sealed class QdrantVectorStoreRecordCollectionTests(ITestOutputHelper out
     public async Task CollectionExistsReturnsCollectionStateAsync(string collectionName, bool expectedExists)
     {
         // Arrange.
-        var sut = new QdrantCollection<ulong, HotelInfo>(fixture.QdrantClient, collectionName);
+        using var sut = new QdrantCollection<ulong, HotelInfo>(fixture.QdrantClient, collectionName);
 
         // Act.
         var actual = await sut.CollectionExistsAsync();
@@ -57,7 +57,7 @@ public sealed class QdrantVectorStoreRecordCollectionTests(ITestOutputHelper out
             HasNamedVectors = hasNamedVectors,
             VectorStoreRecordDefinition = useRecordDefinition ? fixture.HotelVectorStoreRecordDefinition : null
         };
-        var sut = new QdrantCollection<ulong, HotelInfo>(fixture.QdrantClient, testCollectionName, options);
+        using var sut = new QdrantCollection<ulong, HotelInfo>(fixture.QdrantClient, testCollectionName, options);
 
         var record = await this.CreateTestHotelAsync(30, fixture.EmbeddingGenerator);
 
@@ -110,7 +110,7 @@ public sealed class QdrantVectorStoreRecordCollectionTests(ITestOutputHelper out
             tempCollectionName,
             new VectorParams { Size = 4, Distance = Distance.Cosine });
 
-        var sut = new QdrantCollection<ulong, HotelInfo>(fixture.QdrantClient, tempCollectionName);
+        using var sut = new QdrantCollection<ulong, HotelInfo>(fixture.QdrantClient, tempCollectionName);
 
         // Act
         await sut.DeleteCollectionAsync();
@@ -132,7 +132,7 @@ public sealed class QdrantVectorStoreRecordCollectionTests(ITestOutputHelper out
             HasNamedVectors = hasNamedVectors,
             VectorStoreRecordDefinition = useRecordDefinition ? fixture.HotelVectorStoreRecordDefinition : null
         };
-        var sut = new QdrantCollection<ulong, HotelInfo>(fixture.QdrantClient, collectionName, options);
+        using var sut = new QdrantCollection<ulong, HotelInfo>(fixture.QdrantClient, collectionName, options);
 
         var record = await this.CreateTestHotelAsync(20, fixture.EmbeddingGenerator);
 
@@ -161,7 +161,7 @@ public sealed class QdrantVectorStoreRecordCollectionTests(ITestOutputHelper out
     {
         // Arrange.
         var options = new QdrantCollectionOptions { HasNamedVectors = false };
-        VectorStoreCollection<Guid, HotelInfoWithGuidId> sut = new QdrantCollection<Guid, HotelInfoWithGuidId>(fixture.QdrantClient, "singleVectorGuidIdHotels", options);
+        using VectorStoreCollection<Guid, HotelInfoWithGuidId> sut = new QdrantCollection<Guid, HotelInfoWithGuidId>(fixture.QdrantClient, "singleVectorGuidIdHotels", options);
 
         var record = new HotelInfoWithGuidId
         {
@@ -207,7 +207,7 @@ public sealed class QdrantVectorStoreRecordCollectionTests(ITestOutputHelper out
             HasNamedVectors = hasNamedVectors,
             VectorStoreRecordDefinition = useRecordDefinition ? fixture.HotelVectorStoreRecordDefinition : null
         };
-        var sut = new QdrantCollection<ulong, HotelInfo>(fixture.QdrantClient, collectionName, options);
+        using var sut = new QdrantCollection<ulong, HotelInfo>(fixture.QdrantClient, collectionName, options);
 
         // Act.
         var getResult = await sut.GetAsync(11, new RecordRetrievalOptions { IncludeVectors = withEmbeddings });
@@ -249,7 +249,7 @@ public sealed class QdrantVectorStoreRecordCollectionTests(ITestOutputHelper out
             HasNamedVectors = false,
             VectorStoreRecordDefinition = useRecordDefinition ? fixture.HotelWithGuidIdVectorStoreRecordDefinition : null
         };
-        var sut = new QdrantCollection<Guid, HotelInfoWithGuidId>(fixture.QdrantClient, "singleVectorGuidIdHotels", options);
+        using var sut = new QdrantCollection<Guid, HotelInfoWithGuidId>(fixture.QdrantClient, "singleVectorGuidIdHotels", options);
 
         // Act.
         var getResult = await sut.GetAsync(Guid.Parse("11111111-1111-1111-1111-111111111111"), new RecordRetrievalOptions { IncludeVectors = withEmbeddings });
@@ -276,7 +276,7 @@ public sealed class QdrantVectorStoreRecordCollectionTests(ITestOutputHelper out
     {
         // Arrange
         var options = new QdrantCollectionOptions { HasNamedVectors = true };
-        var sut = new QdrantCollection<ulong, HotelInfo>(fixture.QdrantClient, "namedVectorsHotels", options);
+        using var sut = new QdrantCollection<ulong, HotelInfo>(fixture.QdrantClient, "namedVectorsHotels", options);
 
         // Act
         // Also include one non-existing key to test that the operation does not fail for these and returns only the found ones.
@@ -307,7 +307,7 @@ public sealed class QdrantVectorStoreRecordCollectionTests(ITestOutputHelper out
             HasNamedVectors = hasNamedVectors,
             VectorStoreRecordDefinition = useRecordDefinition ? fixture.HotelVectorStoreRecordDefinition : null
         };
-        var sut = new QdrantCollection<ulong, HotelInfo>(fixture.QdrantClient, collectionName, options);
+        using var sut = new QdrantCollection<ulong, HotelInfo>(fixture.QdrantClient, collectionName, options);
 
         await sut.UpsertAsync(await this.CreateTestHotelAsync(20, fixture.EmbeddingGenerator));
 
@@ -333,7 +333,7 @@ public sealed class QdrantVectorStoreRecordCollectionTests(ITestOutputHelper out
             HasNamedVectors = hasNamedVectors,
             VectorStoreRecordDefinition = useRecordDefinition ? fixture.HotelVectorStoreRecordDefinition : null
         };
-        var sut = new QdrantCollection<ulong, HotelInfo>(fixture.QdrantClient, collectionName, options);
+        using var sut = new QdrantCollection<ulong, HotelInfo>(fixture.QdrantClient, collectionName, options);
 
         await sut.UpsertAsync(await this.CreateTestHotelAsync(20, fixture.EmbeddingGenerator));
 
@@ -350,7 +350,7 @@ public sealed class QdrantVectorStoreRecordCollectionTests(ITestOutputHelper out
     {
         // Arrange
         var options = new QdrantCollectionOptions { HasNamedVectors = false };
-        var sut = new QdrantCollection<ulong, HotelInfo>(fixture.QdrantClient, "singleVectorHotels", options);
+        using var sut = new QdrantCollection<ulong, HotelInfo>(fixture.QdrantClient, "singleVectorHotels", options);
 
         // Act & Assert
         Assert.Null(await sut.GetAsync(15, new RecordRetrievalOptions { IncludeVectors = true }));
@@ -373,7 +373,7 @@ public sealed class QdrantVectorStoreRecordCollectionTests(ITestOutputHelper out
             HasNamedVectors = hasNamedVectors,
             VectorStoreRecordDefinition = useRecordDefinition ? fixture.HotelVectorStoreRecordDefinition : null
         };
-        var sut = new QdrantCollection<ulong, HotelInfo>(fixture.QdrantClient, collectionName, options);
+        using var sut = new QdrantCollection<ulong, HotelInfo>(fixture.QdrantClient, collectionName, options);
 
         // Act.
         var vector = await fixture.EmbeddingGenerator.GenerateEmbeddingAsync("A great hotel");
@@ -406,7 +406,7 @@ public sealed class QdrantVectorStoreRecordCollectionTests(ITestOutputHelper out
         {
             VectorStoreRecordDefinition = fixture.HotelVectorStoreRecordDefinition
         };
-        var sut = new QdrantCollection<object, Dictionary<string, object?>>(fixture.QdrantClient, "singleVectorHotels", options);
+        using var sut = new QdrantCollection<object, Dictionary<string, object?>>(fixture.QdrantClient, "singleVectorHotels", options);
 
         // Act
         var baseSetGetResult = await sut.GetAsync(11ul, new RecordRetrievalOptions { IncludeVectors = true });

--- a/dotnet/src/IntegrationTests/Connectors/Memory/Qdrant/QdrantVectorStoreTests.cs
+++ b/dotnet/src/IntegrationTests/Connectors/Memory/Qdrant/QdrantVectorStoreTests.cs
@@ -8,19 +8,24 @@ namespace SemanticKernel.IntegrationTests.Connectors.Memory.Qdrant;
 
 [Collection("QdrantVectorStoreCollection")]
 public class QdrantVectorStoreTests(QdrantVectorStoreFixture fixture)
+#pragma warning disable CA2000 // Dispose objects before losing scope
     : BaseVectorStoreTests<ulong, QdrantVectorStoreFixture.HotelInfo>(new QdrantVectorStore(fixture.QdrantClient))
+#pragma warning restore CA2000 // Dispose objects before losing scope
 {
     [Fact]
     public async Task ItPassesSettingsFromVectorStoreToCollectionAsync()
     {
+        // The client is shared with base class tests.
+        const bool OwnsClient = false;
         // Arrange
-        var sut = new QdrantVectorStore(fixture.QdrantClient, new() { HasNamedVectors = true });
+        using QdrantVectorStore sut = new(fixture.QdrantClient, new() { HasNamedVectors = true, OwnsClient = OwnsClient });
 
         // Act
         var collectionFromVS = sut.GetCollection<ulong, QdrantVectorStoreFixture.HotelInfo>("SettingsPassedCollection");
         await collectionFromVS.EnsureCollectionExistsAsync();
 
-        var directCollection = new QdrantCollection<ulong, QdrantVectorStoreFixture.HotelInfo>(fixture.QdrantClient, "SettingsPassedCollection", new() { HasNamedVectors = true });
+        using QdrantCollection<ulong, QdrantVectorStoreFixture.HotelInfo> directCollection = new(
+            fixture.QdrantClient, "SettingsPassedCollection", new() { HasNamedVectors = true, OwnsClient = OwnsClient });
         await directCollection.UpsertAsync(new QdrantVectorStoreFixture.HotelInfo
         {
             HotelId = 1ul,

--- a/dotnet/src/IntegrationTests/Connectors/Memory/Redis/RedisHashSetVectorStoreRecordCollectionTests.cs
+++ b/dotnet/src/IntegrationTests/Connectors/Memory/Redis/RedisHashSetVectorStoreRecordCollectionTests.cs
@@ -34,7 +34,7 @@ public sealed class RedisHashSetVectorStoreRecordCollectionTests(ITestOutputHelp
     public async Task CollectionExistsReturnsCollectionStateAsync(string collectionName, bool expectedExists)
     {
         // Arrange.
-        var sut = new RedisHashSetCollection<string, RedisBasicFloat32Hotel>(fixture.Database, collectionName);
+        using var sut = new RedisHashSetCollection<string, RedisBasicFloat32Hotel>(fixture.Database, collectionName);
 
         // Act.
         var actual = await sut.CollectionExistsAsync();
@@ -58,7 +58,7 @@ public sealed class RedisHashSetVectorStoreRecordCollectionTests(ITestOutputHelp
             PrefixCollectionNameToKeyNames = true,
             VectorStoreRecordDefinition = useRecordDefinition ? fixture.BasicVectorStoreRecordDefinition : null
         };
-        var sut = new RedisHashSetCollection<string, RedisBasicFloat32Hotel>(fixture.Database, testCollectionName, options);
+        using var sut = new RedisHashSetCollection<string, RedisBasicFloat32Hotel>(fixture.Database, testCollectionName, options);
 
         // Act
         await sut.EnsureCollectionExistsAsync();
@@ -110,7 +110,7 @@ public sealed class RedisHashSetVectorStoreRecordCollectionTests(ITestOutputHelp
         createParams.AddPrefix(tempCollectionName);
         await fixture.Database.FT().CreateAsync(tempCollectionName, createParams, schema);
 
-        var sut = new RedisHashSetCollection<string, RedisBasicFloat32Hotel>(fixture.Database, tempCollectionName);
+        using var sut = new RedisHashSetCollection<string, RedisBasicFloat32Hotel>(fixture.Database, tempCollectionName);
 
         // Act
         await sut.DeleteCollectionAsync();
@@ -130,7 +130,7 @@ public sealed class RedisHashSetVectorStoreRecordCollectionTests(ITestOutputHelp
             PrefixCollectionNameToKeyNames = true,
             VectorStoreRecordDefinition = useRecordDefinition ? fixture.BasicVectorStoreRecordDefinition : null
         };
-        var sut = new RedisHashSetCollection<string, RedisBasicFloat32Hotel>(fixture.Database, TestCollectionName, options);
+        using var sut = new RedisHashSetCollection<string, RedisBasicFloat32Hotel>(fixture.Database, TestCollectionName, options);
         var record = CreateTestHotel("HUpsert-2", 2);
 
         // Act.
@@ -161,7 +161,7 @@ public sealed class RedisHashSetVectorStoreRecordCollectionTests(ITestOutputHelp
             PrefixCollectionNameToKeyNames = true,
             VectorStoreRecordDefinition = useRecordDefinition ? fixture.BasicVectorStoreRecordDefinition : null
         };
-        var sut = new RedisHashSetCollection<string, RedisBasicFloat32Hotel>(fixture.Database, TestCollectionName, options);
+        using var sut = new RedisHashSetCollection<string, RedisBasicFloat32Hotel>(fixture.Database, TestCollectionName, options);
 
         // Act.
         await sut.UpsertAsync(
@@ -185,7 +185,7 @@ public sealed class RedisHashSetVectorStoreRecordCollectionTests(ITestOutputHelp
             PrefixCollectionNameToKeyNames = true,
             VectorStoreRecordDefinition = useRecordDefinition ? fixture.BasicVectorStoreRecordDefinition : null
         };
-        var sut = new RedisHashSetCollection<string, RedisBasicFloat32Hotel>(fixture.Database, TestCollectionName, options);
+        using var sut = new RedisHashSetCollection<string, RedisBasicFloat32Hotel>(fixture.Database, TestCollectionName, options);
 
         // Act.
         var getResult = await sut.GetAsync("HBaseSet-1", new RecordRetrievalOptions { IncludeVectors = includeVectors });
@@ -215,7 +215,7 @@ public sealed class RedisHashSetVectorStoreRecordCollectionTests(ITestOutputHelp
     {
         // Arrange
         var options = new RedisHashSetCollectionOptions { PrefixCollectionNameToKeyNames = true };
-        var sut = new RedisHashSetCollection<string, RedisBasicFloat32Hotel>(fixture.Database, TestCollectionName, options);
+        using var sut = new RedisHashSetCollection<string, RedisBasicFloat32Hotel>(fixture.Database, TestCollectionName, options);
 
         // Act
         // Also include one non-existing key to test that the operation does not fail for these and returns only the found ones.
@@ -244,7 +244,7 @@ public sealed class RedisHashSetVectorStoreRecordCollectionTests(ITestOutputHelp
             PrefixCollectionNameToKeyNames = true,
             VectorStoreRecordDefinition = useRecordDefinition ? fixture.BasicVectorStoreRecordDefinition : null
         };
-        var sut = new RedisHashSetCollection<string, RedisBasicFloat32Hotel>(fixture.Database, TestCollectionName, options);
+        using var sut = new RedisHashSetCollection<string, RedisBasicFloat32Hotel>(fixture.Database, TestCollectionName, options);
         var record = new RedisBasicFloat32Hotel
         {
             HotelId = "HRemove-1",
@@ -270,7 +270,7 @@ public sealed class RedisHashSetVectorStoreRecordCollectionTests(ITestOutputHelp
     {
         // Arrange
         var options = new RedisHashSetCollectionOptions { PrefixCollectionNameToKeyNames = true };
-        var sut = new RedisHashSetCollection<string, RedisBasicFloat32Hotel>(fixture.Database, TestCollectionName, options);
+        using var sut = new RedisHashSetCollection<string, RedisBasicFloat32Hotel>(fixture.Database, TestCollectionName, options);
         await sut.UpsertAsync(CreateTestHotel("HRemoveMany-1", 1));
         await sut.UpsertAsync(CreateTestHotel("HRemoveMany-2", 2));
         await sut.UpsertAsync(CreateTestHotel("HRemoveMany-3", 3));
@@ -293,7 +293,7 @@ public sealed class RedisHashSetVectorStoreRecordCollectionTests(ITestOutputHelp
         // Arrange
         var options = new RedisHashSetCollectionOptions { PrefixCollectionNameToKeyNames = true }
         ;
-        var sut = new RedisHashSetCollection<string, RedisBasicFloat32Hotel>(fixture.Database, TestCollectionName, options);
+        using var sut = new RedisHashSetCollection<string, RedisBasicFloat32Hotel>(fixture.Database, TestCollectionName, options);
         var vector = new ReadOnlyMemory<float>(new[] { 30f, 31f, 32f, 33f });
         var filter = filterType == "equality" ? new VectorSearchFilter().EqualTo("HotelCode", 1) : new VectorSearchFilter().EqualTo("HotelName", "My Hotel 1");
 
@@ -332,7 +332,7 @@ public sealed class RedisHashSetVectorStoreRecordCollectionTests(ITestOutputHelp
     {
         // Arrange
         var options = new RedisHashSetCollectionOptions { PrefixCollectionNameToKeyNames = true };
-        var sut = new RedisHashSetCollection<string, RedisBasicFloat32Hotel>(fixture.Database, TestCollectionName + "TopSkip", options);
+        using var sut = new RedisHashSetCollection<string, RedisBasicFloat32Hotel>(fixture.Database, TestCollectionName + "TopSkip", options);
         await sut.EnsureCollectionExistsAsync();
         await sut.UpsertAsync(new RedisBasicFloat32Hotel { HotelId = "HTopSkip_1", HotelName = "1", Description = "Nice hotel", DescriptionEmbedding = new ReadOnlyMemory<float>([1.0f, 1.0f, 1.0f, 1.0f]) });
         await sut.UpsertAsync(new RedisBasicFloat32Hotel { HotelId = "HTopSkip_2", HotelName = "2", Description = "Nice hotel", DescriptionEmbedding = new ReadOnlyMemory<float>([1.0f, 1.0f, 1.0f, 2.0f]) });
@@ -362,7 +362,7 @@ public sealed class RedisHashSetVectorStoreRecordCollectionTests(ITestOutputHelp
     {
         // Arrange
         var options = new RedisHashSetCollectionOptions { PrefixCollectionNameToKeyNames = true };
-        var sut = new RedisHashSetCollection<string, RedisBasicFloat64Hotel>(fixture.Database, TestCollectionName + "Float64", options);
+        using var sut = new RedisHashSetCollection<string, RedisBasicFloat64Hotel>(fixture.Database, TestCollectionName + "Float64", options);
         await sut.EnsureCollectionExistsAsync();
         await sut.UpsertAsync(new RedisBasicFloat64Hotel { HotelId = "HFloat64_1", HotelName = "1", Description = "Nice hotel", DescriptionEmbedding = new ReadOnlyMemory<double>([1.0d, 1.1d, 1.2d, 1.3d]) });
         await sut.UpsertAsync(new RedisBasicFloat64Hotel { HotelId = "HFloat64_2", HotelName = "2", Description = "Nice hotel", DescriptionEmbedding = new ReadOnlyMemory<double>([2.0d, 2.1d, 2.2d, 2.3d]) });
@@ -400,7 +400,7 @@ public sealed class RedisHashSetVectorStoreRecordCollectionTests(ITestOutputHelp
     {
         // Arrange
         var options = new RedisHashSetCollectionOptions { PrefixCollectionNameToKeyNames = true };
-        var sut = new RedisHashSetCollection<string, RedisBasicFloat32Hotel>(fixture.Database, TestCollectionName, options);
+        using var sut = new RedisHashSetCollection<string, RedisBasicFloat32Hotel>(fixture.Database, TestCollectionName, options);
 
         // Act & Assert
         Assert.Null(await sut.GetAsync("HBaseSet-5", new RecordRetrievalOptions { IncludeVectors = true }));
@@ -415,7 +415,7 @@ public sealed class RedisHashSetVectorStoreRecordCollectionTests(ITestOutputHelp
             PrefixCollectionNameToKeyNames = true,
             VectorStoreRecordDefinition = fixture.BasicVectorStoreRecordDefinition
         };
-        var sut = new RedisHashSetCollection<object, Dictionary<string, object?>>(fixture.Database, TestCollectionName, options);
+        using var sut = new RedisHashSetCollection<object, Dictionary<string, object?>>(fixture.Database, TestCollectionName, options);
 
         // Act
         var baseSetGetResult = await sut.GetAsync("HBaseSet-1", new RecordRetrievalOptions { IncludeVectors = true });

--- a/dotnet/src/IntegrationTests/Connectors/Memory/Redis/RedisJsonVectorStoreRecordCollectionTests.cs
+++ b/dotnet/src/IntegrationTests/Connectors/Memory/Redis/RedisJsonVectorStoreRecordCollectionTests.cs
@@ -34,7 +34,7 @@ public sealed class RedisJsonVectorStoreRecordCollectionTests(ITestOutputHelper 
     public async Task CollectionExistsReturnsCollectionStateAsync(string collectionName, bool expectedExists)
     {
         // Arrange.
-        var sut = new RedisJsonCollection<string, RedisHotel>(fixture.Database, collectionName);
+        using var sut = new RedisJsonCollection<string, RedisHotel>(fixture.Database, collectionName);
 
         // Act.
         var actual = await sut.CollectionExistsAsync();
@@ -58,7 +58,7 @@ public sealed class RedisJsonVectorStoreRecordCollectionTests(ITestOutputHelper 
             PrefixCollectionNameToKeyNames = true,
             VectorStoreRecordDefinition = useRecordDefinition ? fixture.VectorStoreRecordDefinition : null
         };
-        var sut = new RedisJsonCollection<string, RedisHotel>(fixture.Database, testCollectionName, options);
+        using var sut = new RedisJsonCollection<string, RedisHotel>(fixture.Database, testCollectionName, options);
 
         // Act
         await sut.EnsureCollectionExistsAsync();
@@ -119,7 +119,7 @@ public sealed class RedisJsonVectorStoreRecordCollectionTests(ITestOutputHelper 
         createParams.AddPrefix(tempCollectionName);
         await fixture.Database.FT().CreateAsync(tempCollectionName, createParams, schema);
 
-        var sut = new RedisJsonCollection<string, RedisHotel>(fixture.Database, tempCollectionName);
+        using var sut = new RedisJsonCollection<string, RedisHotel>(fixture.Database, tempCollectionName);
 
         // Act
         await sut.DeleteCollectionAsync();
@@ -139,7 +139,7 @@ public sealed class RedisJsonVectorStoreRecordCollectionTests(ITestOutputHelper 
             PrefixCollectionNameToKeyNames = true,
             VectorStoreRecordDefinition = useRecordDefinition ? fixture.VectorStoreRecordDefinition : null
         };
-        var sut = new RedisJsonCollection<string, RedisHotel>(fixture.Database, TestCollectionName, options);
+        using var sut = new RedisJsonCollection<string, RedisHotel>(fixture.Database, TestCollectionName, options);
         RedisHotel record = CreateTestHotel("Upsert-2", 2);
 
         // Act.
@@ -175,7 +175,7 @@ public sealed class RedisJsonVectorStoreRecordCollectionTests(ITestOutputHelper 
             PrefixCollectionNameToKeyNames = true,
             VectorStoreRecordDefinition = useRecordDefinition ? fixture.VectorStoreRecordDefinition : null
         };
-        var sut = new RedisJsonCollection<string, RedisHotel>(fixture.Database, TestCollectionName, options);
+        using var sut = new RedisJsonCollection<string, RedisHotel>(fixture.Database, TestCollectionName, options);
 
         // Act.
         await sut.UpsertAsync(
@@ -199,7 +199,7 @@ public sealed class RedisJsonVectorStoreRecordCollectionTests(ITestOutputHelper 
             PrefixCollectionNameToKeyNames = true,
             VectorStoreRecordDefinition = useRecordDefinition ? fixture.VectorStoreRecordDefinition : null
         };
-        var sut = new RedisJsonCollection<string, RedisHotel>(fixture.Database, TestCollectionName, options);
+        using var sut = new RedisJsonCollection<string, RedisHotel>(fixture.Database, TestCollectionName, options);
 
         // Act.
         var getResult = await sut.GetAsync("BaseSet-1", new RecordRetrievalOptions { IncludeVectors = includeVectors });
@@ -233,7 +233,7 @@ public sealed class RedisJsonVectorStoreRecordCollectionTests(ITestOutputHelper 
     {
         // Arrange
         var options = new RedisJsonCollectionOptions { PrefixCollectionNameToKeyNames = true };
-        var sut = new RedisJsonCollection<string, RedisHotel>(fixture.Database, TestCollectionName, options);
+        using var sut = new RedisJsonCollection<string, RedisHotel>(fixture.Database, TestCollectionName, options);
 
         // Act
         // Also include one non-existing key to test that the operation does not fail for these and returns only the found ones.
@@ -256,7 +256,7 @@ public sealed class RedisJsonVectorStoreRecordCollectionTests(ITestOutputHelper 
     {
         // Arrange.
         var options = new RedisJsonCollectionOptions { PrefixCollectionNameToKeyNames = true };
-        var sut = new RedisJsonCollection<string, RedisHotel>(fixture.Database, TestCollectionName, options);
+        using var sut = new RedisJsonCollection<string, RedisHotel>(fixture.Database, TestCollectionName, options);
 
         // Act & Assert.
         await Assert.ThrowsAsync<InvalidOperationException>(async () => await sut.GetAsync("BaseSet-4-Invalid", new RecordRetrievalOptions { IncludeVectors = true }));
@@ -273,7 +273,7 @@ public sealed class RedisJsonVectorStoreRecordCollectionTests(ITestOutputHelper 
             PrefixCollectionNameToKeyNames = true,
             VectorStoreRecordDefinition = useRecordDefinition ? fixture.VectorStoreRecordDefinition : null
         };
-        var sut = new RedisJsonCollection<string, RedisHotel>(fixture.Database, TestCollectionName, options);
+        using var sut = new RedisJsonCollection<string, RedisHotel>(fixture.Database, TestCollectionName, options);
         var address = new RedisHotelAddress { City = "Seattle", Country = "USA" };
         var record = new RedisHotel
         {
@@ -300,7 +300,7 @@ public sealed class RedisJsonVectorStoreRecordCollectionTests(ITestOutputHelper 
     {
         // Arrange
         var options = new RedisJsonCollectionOptions { PrefixCollectionNameToKeyNames = true };
-        var sut = new RedisJsonCollection<string, RedisHotel>(fixture.Database, TestCollectionName, options);
+        using var sut = new RedisJsonCollection<string, RedisHotel>(fixture.Database, TestCollectionName, options);
         await sut.UpsertAsync(CreateTestHotel("RemoveMany-1", 1));
         await sut.UpsertAsync(CreateTestHotel("RemoveMany-2", 2));
         await sut.UpsertAsync(CreateTestHotel("RemoveMany-3", 3));
@@ -322,7 +322,7 @@ public sealed class RedisJsonVectorStoreRecordCollectionTests(ITestOutputHelper 
     {
         // Arrange
         var options = new RedisJsonCollectionOptions { PrefixCollectionNameToKeyNames = true };
-        var sut = new RedisJsonCollection<string, RedisHotel>(fixture.Database, TestCollectionName, options);
+        using var sut = new RedisJsonCollection<string, RedisHotel>(fixture.Database, TestCollectionName, options);
         var vector = new ReadOnlyMemory<float>(new[] { 30f, 31f, 32f, 33f });
         var filter = filterType == "equality" ? new VectorSearchFilter().EqualTo("HotelCode", 1) : new VectorSearchFilter().AnyTagEqualTo("Tags", "pool");
 
@@ -355,7 +355,7 @@ public sealed class RedisJsonVectorStoreRecordCollectionTests(ITestOutputHelper 
     {
         // Arrange
         var options = new RedisJsonCollectionOptions { PrefixCollectionNameToKeyNames = true };
-        var sut = new RedisJsonCollection<string, RedisBasicFloat32Hotel>(fixture.Database, TestCollectionName + "TopSkip", options);
+        using var sut = new RedisJsonCollection<string, RedisBasicFloat32Hotel>(fixture.Database, TestCollectionName + "TopSkip", options);
         await sut.EnsureCollectionExistsAsync();
         await sut.UpsertAsync(new RedisBasicFloat32Hotel { HotelId = "TopSkip_1", HotelName = "1", Description = "Nice hotel", DescriptionEmbedding = new ReadOnlyMemory<float>([1.0f, 1.0f, 1.0f, 1.0f]) });
         await sut.UpsertAsync(new RedisBasicFloat32Hotel { HotelId = "TopSkip_2", HotelName = "2", Description = "Nice hotel", DescriptionEmbedding = new ReadOnlyMemory<float>([1.0f, 1.0f, 1.0f, 2.0f]) });
@@ -385,7 +385,7 @@ public sealed class RedisJsonVectorStoreRecordCollectionTests(ITestOutputHelper 
     {
         // Arrange
         var options = new RedisJsonCollectionOptions { PrefixCollectionNameToKeyNames = true };
-        var sut = new RedisJsonCollection<string, RedisBasicFloat64Hotel>(fixture.Database, TestCollectionName + "Float64", options);
+        using var sut = new RedisJsonCollection<string, RedisBasicFloat64Hotel>(fixture.Database, TestCollectionName + "Float64", options);
         await sut.EnsureCollectionExistsAsync();
         await sut.UpsertAsync(new RedisBasicFloat64Hotel { HotelId = "Float64_1", HotelName = "1", Description = "Nice hotel", DescriptionEmbedding = new ReadOnlyMemory<double>([1.0d, 1.1d, 1.2d, 1.3d]) });
         await sut.UpsertAsync(new RedisBasicFloat64Hotel { HotelId = "Float64_2", HotelName = "2", Description = "Nice hotel", DescriptionEmbedding = new ReadOnlyMemory<double>([2.0d, 2.1d, 2.2d, 2.3d]) });
@@ -419,7 +419,7 @@ public sealed class RedisJsonVectorStoreRecordCollectionTests(ITestOutputHelper 
     {
         // Arrange
         var options = new RedisJsonCollectionOptions { PrefixCollectionNameToKeyNames = true };
-        var sut = new RedisJsonCollection<string, RedisHotel>(fixture.Database, TestCollectionName, options);
+        using var sut = new RedisJsonCollection<string, RedisHotel>(fixture.Database, TestCollectionName, options);
 
         // Act & Assert
         Assert.Null(await sut.GetAsync("BaseSet-5", new RecordRetrievalOptions { IncludeVectors = true }));
@@ -434,7 +434,7 @@ public sealed class RedisJsonVectorStoreRecordCollectionTests(ITestOutputHelper 
             PrefixCollectionNameToKeyNames = true,
             VectorStoreRecordDefinition = fixture.VectorStoreRecordDefinition
         };
-        var sut = new RedisJsonCollection<object, Dictionary<string, object?>>(fixture.Database, TestCollectionName, options);
+        using var sut = new RedisJsonCollection<object, Dictionary<string, object?>>(fixture.Database, TestCollectionName, options);
 
         // Act
         var baseSetGetResult = await sut.GetAsync("BaseSet-1", new RecordRetrievalOptions { IncludeVectors = true });

--- a/dotnet/src/IntegrationTests/Connectors/Memory/Redis/RedisVectorStoreTests.cs
+++ b/dotnet/src/IntegrationTests/Connectors/Memory/Redis/RedisVectorStoreTests.cs
@@ -13,6 +13,8 @@ namespace SemanticKernel.IntegrationTests.Connectors.Memory.Redis;
 [Collection("RedisVectorStoreCollection")]
 [DisableVectorStoreTests(Skip = "Redis tests fail intermittently on build server")]
 public class RedisVectorStoreTests(RedisVectorStoreFixture fixture)
+#pragma warning disable CA2000 // Dispose objects before losing scope
     : BaseVectorStoreTests<string, RedisHotel>(new RedisVectorStore(fixture.Database))
+#pragma warning restore CA2000 // Dispose objects before losing scope
 {
 }

--- a/dotnet/src/IntegrationTests/Connectors/Memory/SqliteVec/SqliteVectorStoreRecordCollectionTests.cs
+++ b/dotnet/src/IntegrationTests/Connectors/Memory/SqliteVec/SqliteVectorStoreRecordCollectionTests.cs
@@ -29,7 +29,7 @@ public sealed class SqliteVectorStoreRecordCollectionTests(SqliteVectorStoreFixt
     public async Task CollectionExistsReturnsCollectionStateAsync(bool createCollection)
     {
         // Arrange
-        var sut = fixture.GetCollection<ulong, SqliteHotel<ulong>>("CollectionExists");
+        using var sut = fixture.GetCollection<ulong, SqliteHotel<ulong>>("CollectionExists");
 
         if (createCollection)
         {
@@ -47,7 +47,7 @@ public sealed class SqliteVectorStoreRecordCollectionTests(SqliteVectorStoreFixt
     public async Task ItCanEnsureCollectionExistsAsync()
     {
         // Arrange
-        var sut = fixture.GetCollection<ulong, SqliteHotel<ulong>>("CreateCollection");
+        using var sut = fixture.GetCollection<ulong, SqliteHotel<ulong>>("CreateCollection");
 
         // Act
         await sut.EnsureCollectionExistsAsync();
@@ -60,7 +60,7 @@ public sealed class SqliteVectorStoreRecordCollectionTests(SqliteVectorStoreFixt
     public async Task ItCanCreateCollectionForSupportedDistanceFunctionsAsync()
     {
         // Arrange
-        var sut = fixture.GetCollection<ulong, RecordWithSupportedDistanceFunctions>("CreateCollectionForSupportedDistanceFunctions");
+        using var sut = fixture.GetCollection<ulong, RecordWithSupportedDistanceFunctions>("CreateCollectionForSupportedDistanceFunctions");
 
         // Act
         await sut.EnsureCollectionExistsAsync();
@@ -73,7 +73,7 @@ public sealed class SqliteVectorStoreRecordCollectionTests(SqliteVectorStoreFixt
     public async Task ItCanDeleteCollectionAsync()
     {
         // Arrange
-        var sut = fixture.GetCollection<ulong, SqliteHotel<ulong>>("DeleteCollection");
+        using var sut = fixture.GetCollection<ulong, SqliteHotel<ulong>>("DeleteCollection");
 
         await sut.EnsureCollectionExistsAsync();
 
@@ -104,7 +104,7 @@ public sealed class SqliteVectorStoreRecordCollectionTests(SqliteVectorStoreFixt
             VectorStoreRecordDefinition = useRecordDefinition ? GetVectorStoreRecordDefinition<ulong>() : null
         };
 
-        var sut = fixture.GetCollection<ulong, SqliteHotel<ulong>>("DeleteCollection", options);
+        using var sut = fixture.GetCollection<ulong, SqliteHotel<ulong>>("DeleteCollection", options);
 
         var record = CreateTestHotel(HotelId);
 
@@ -142,7 +142,7 @@ public sealed class SqliteVectorStoreRecordCollectionTests(SqliteVectorStoreFixt
     {
         // Arrange
         const ulong HotelId = 5;
-        var sut = fixture.GetCollection<ulong, SqliteHotel<ulong>>("DeleteRecord");
+        using var sut = fixture.GetCollection<ulong, SqliteHotel<ulong>>("DeleteRecord");
 
         await sut.EnsureCollectionExistsAsync();
 
@@ -170,7 +170,7 @@ public sealed class SqliteVectorStoreRecordCollectionTests(SqliteVectorStoreFixt
         const ulong HotelId2 = 2;
         const ulong HotelId3 = 3;
 
-        var sut = fixture.GetCollection<ulong, SqliteHotel<ulong>>("GetUpsertDeleteBatchWithNumericKey");
+        using var sut = fixture.GetCollection<ulong, SqliteHotel<ulong>>("GetUpsertDeleteBatchWithNumericKey");
 
         await sut.EnsureCollectionExistsAsync();
 
@@ -202,7 +202,7 @@ public sealed class SqliteVectorStoreRecordCollectionTests(SqliteVectorStoreFixt
         const string HotelId2 = "22222222-2222-2222-2222-222222222222";
         const string HotelId3 = "33333333-3333-3333-3333-333333333333";
 
-        var sut = fixture.GetCollection<string, SqliteHotel<string>>("GetUpsertDeleteBatchWithStringKey") as VectorStoreCollection<string, SqliteHotel<string>>;
+        using var sut = fixture.GetCollection<string, SqliteHotel<string>>("GetUpsertDeleteBatchWithStringKey") as VectorStoreCollection<string, SqliteHotel<string>>;
 
         await sut.EnsureCollectionExistsAsync();
 
@@ -236,7 +236,7 @@ public sealed class SqliteVectorStoreRecordCollectionTests(SqliteVectorStoreFixt
         var collectionName = $"Collection{collectionNamePostfix}";
 
         const ulong HotelId = 5;
-        var sut = fixture.GetCollection<ulong, SqliteHotel<ulong>>(collectionName);
+        using var sut = fixture.GetCollection<ulong, SqliteHotel<ulong>>(collectionName);
 
         await sut.EnsureCollectionExistsAsync();
 
@@ -302,7 +302,7 @@ public sealed class SqliteVectorStoreRecordCollectionTests(SqliteVectorStoreFixt
     {
         // Arrange
         const ulong HotelId = 5;
-        var sut = fixture.GetCollection<ulong, SqliteHotel<ulong>>("UpsertRecord");
+        using var sut = fixture.GetCollection<ulong, SqliteHotel<ulong>>("UpsertRecord");
 
         await sut.EnsureCollectionExistsAsync();
 
@@ -341,7 +341,7 @@ public sealed class SqliteVectorStoreRecordCollectionTests(SqliteVectorStoreFixt
         var hotel3 = CreateTestHotel(hotelId: "key3", embedding: new[] { 20f, 20f, 20f, 20f });
         var hotel4 = CreateTestHotel(hotelId: "key4", embedding: new[] { -1000f, -1000f, -1000f, -1000f });
 
-        var sut = fixture.GetCollection<string, SqliteHotel<string>>("VectorizedSearch");
+        using var sut = fixture.GetCollection<string, SqliteHotel<string>>("VectorizedSearch");
 
         await sut.EnsureCollectionExistsAsync();
 
@@ -376,7 +376,7 @@ public sealed class SqliteVectorStoreRecordCollectionTests(SqliteVectorStoreFixt
         var hotel3 = CreateTestHotel(hotelId: "key3", embedding: new[] { 20f, 20f, 20f, 20f });
         var hotel4 = CreateTestHotel(hotelId: "key4", embedding: new[] { -1000f, -1000f, -1000f, -1000f });
 
-        var sut = fixture.GetCollection<string, SqliteHotel<string>>("SearchEmbeddingWithOffset");
+        using var sut = fixture.GetCollection<string, SqliteHotel<string>>("SearchEmbeddingWithOffset");
 
         await sut.EnsureCollectionExistsAsync();
 
@@ -407,7 +407,7 @@ public sealed class SqliteVectorStoreRecordCollectionTests(SqliteVectorStoreFixt
         var hotel3 = CreateTestHotel(hotelId: "key3", embedding: new[] { 20f, 20f, 20f, 20f });
         var hotel4 = CreateTestHotel(hotelId: "key4", embedding: new[] { -1000f, -1000f, -1000f, -1000f });
 
-        var sut = fixture.GetCollection<string, SqliteHotel<string>>("SearchEmbeddingWithFilter");
+        using var sut = fixture.GetCollection<string, SqliteHotel<string>>("SearchEmbeddingWithFilter");
 
         await sut.EnsureCollectionExistsAsync();
 
@@ -439,7 +439,7 @@ public sealed class SqliteVectorStoreRecordCollectionTests(SqliteVectorStoreFixt
             VectorStoreRecordDefinition = GetVectorStoreRecordDefinition<ulong>()
         };
 
-        var sut = fixture.GetCollection<object, Dictionary<string, object?>>("DynamicMapperWithNumericKey", options);
+        using var sut = fixture.GetCollection<object, Dictionary<string, object?>>("DynamicMapperWithNumericKey", options);
 
         await sut.EnsureCollectionExistsAsync();
 
@@ -479,7 +479,7 @@ public sealed class SqliteVectorStoreRecordCollectionTests(SqliteVectorStoreFixt
             VectorStoreRecordDefinition = GetVectorStoreRecordDefinition<string>()
         };
 
-        var sut = fixture.GetCollection<object, Dictionary<string, object?>>("DynamicMapperWithStringKey", options)
+        using var sut = fixture.GetCollection<object, Dictionary<string, object?>>("DynamicMapperWithStringKey", options)
             as VectorStoreCollection<object, Dictionary<string, object?>>;
 
         await sut.EnsureCollectionExistsAsync();

--- a/dotnet/src/IntegrationTests/Connectors/Memory/SqliteVec/SqliteVectorStoreTests.cs
+++ b/dotnet/src/IntegrationTests/Connectors/Memory/SqliteVec/SqliteVectorStoreTests.cs
@@ -17,7 +17,9 @@ namespace SemanticKernel.IntegrationTests.Connectors.Memory.SqliteVec;
 [Collection("SqliteVectorStoreCollection")]
 [DisableVectorStoreTests(Skip = "SQLite vector search extension is required")]
 public sealed class SqliteVectorStoreTests(SqliteVectorStoreFixture fixture)
+#pragma warning disable CA2000 // Dispose objects before losing scope
     : BaseVectorStoreTests<string, SqliteHotel<string>>(new SqliteVectorStore(fixture.ConnectionString))
+#pragma warning restore CA2000 // Dispose objects before losing scope
 {
     [VectorStoreFact]
     public async Task ItCanGetAListOfExistingCollectionNamesWhenRegisteredWithDIAsync()

--- a/dotnet/src/IntegrationTests/Connectors/Memory/Weaviate/WeaviateVectorStoreRecordCollectionTests.cs
+++ b/dotnet/src/IntegrationTests/Connectors/Memory/Weaviate/WeaviateVectorStoreRecordCollectionTests.cs
@@ -21,7 +21,7 @@ public sealed class WeaviateVectorStoreRecordCollectionTests(WeaviateVectorStore
     public async Task ItCanEnsureCollectionExistsAsync()
     {
         // Arrange
-        var sut = new WeaviateCollection<Guid, WeaviateHotel>(fixture.HttpClient!, "TestCreateCollection");
+        using var sut = new WeaviateCollection<Guid, WeaviateHotel>(fixture.HttpClient!, "TestCreateCollection");
 
         // Act
         await sut.EnsureCollectionExistsAsync();
@@ -36,7 +36,7 @@ public sealed class WeaviateVectorStoreRecordCollectionTests(WeaviateVectorStore
     public async Task ItCanCheckIfCollectionExistsAsync(string collectionName, bool collectionExists)
     {
         // Arrange
-        var sut = new WeaviateCollection<Guid, WeaviateHotel>(fixture.HttpClient!, collectionName);
+        using var sut = new WeaviateCollection<Guid, WeaviateHotel>(fixture.HttpClient!, collectionName);
 
         if (collectionExists)
         {
@@ -65,7 +65,7 @@ public sealed class WeaviateVectorStoreRecordCollectionTests(WeaviateVectorStore
             VectorStoreRecordDefinition = useRecordDefinition ? this.GetTestHotelRecordDefinition() : null
         };
 
-        var sut = new WeaviateCollection<Guid, WeaviateHotel>(fixture.HttpClient!, collectionName, options);
+        using var sut = new WeaviateCollection<Guid, WeaviateHotel>(fixture.HttpClient!, collectionName, options);
 
         var record = this.CreateTestHotel(hotelId);
 
@@ -104,7 +104,7 @@ public sealed class WeaviateVectorStoreRecordCollectionTests(WeaviateVectorStore
         // Arrange
         const string CollectionName = "TestDeleteCollection";
 
-        var sut = new WeaviateCollection<Guid, WeaviateHotel>(fixture.HttpClient!, CollectionName);
+        using var sut = new WeaviateCollection<Guid, WeaviateHotel>(fixture.HttpClient!, CollectionName);
 
         await sut.EnsureCollectionExistsAsync();
 
@@ -123,7 +123,7 @@ public sealed class WeaviateVectorStoreRecordCollectionTests(WeaviateVectorStore
         // Arrange
         var hotelId = new Guid("55555555-5555-5555-5555-555555555555");
 
-        var sut = new WeaviateCollection<Guid, WeaviateHotel>(fixture.HttpClient!, "TestDeleteRecord");
+        using var sut = new WeaviateCollection<Guid, WeaviateHotel>(fixture.HttpClient!, "TestDeleteRecord");
 
         await sut.EnsureCollectionExistsAsync();
 
@@ -151,7 +151,7 @@ public sealed class WeaviateVectorStoreRecordCollectionTests(WeaviateVectorStore
         var hotelId2 = new Guid("22222222-2222-2222-2222-222222222222");
         var hotelId3 = new Guid("33333333-3333-3333-3333-333333333333");
 
-        var sut = new WeaviateCollection<Guid, WeaviateHotel>(fixture.HttpClient!, "TestBatch");
+        using var sut = new WeaviateCollection<Guid, WeaviateHotel>(fixture.HttpClient!, "TestBatch");
 
         await sut.EnsureCollectionExistsAsync();
 
@@ -180,7 +180,7 @@ public sealed class WeaviateVectorStoreRecordCollectionTests(WeaviateVectorStore
     {
         // Arrange
         var hotelId = new Guid("55555555-5555-5555-5555-555555555555");
-        var sut = new WeaviateCollection<Guid, WeaviateHotel>(fixture.HttpClient!, "TestUpsert");
+        using var sut = new WeaviateCollection<Guid, WeaviateHotel>(fixture.HttpClient!, "TestUpsert");
 
         await sut.EnsureCollectionExistsAsync();
 
@@ -215,7 +215,7 @@ public sealed class WeaviateVectorStoreRecordCollectionTests(WeaviateVectorStore
         var hotel3 = this.CreateTestHotel(hotelId: new Guid("33333333-3333-3333-3333-333333333333"), embedding: new[] { 20f, 20f, 20f, 20f });
         var hotel4 = this.CreateTestHotel(hotelId: new Guid("44444444-4444-4444-4444-444444444444"), embedding: new[] { -1000f, -1000f, -1000f, -1000f });
 
-        var sut = new WeaviateCollection<Guid, WeaviateHotel>(fixture.HttpClient!, "VectorSearchDefault");
+        using var sut = new WeaviateCollection<Guid, WeaviateHotel>(fixture.HttpClient!, "VectorSearchDefault");
 
         await sut.EnsureCollectionExistsAsync();
 
@@ -252,7 +252,7 @@ public sealed class WeaviateVectorStoreRecordCollectionTests(WeaviateVectorStore
         var hotel3 = this.CreateTestHotel(hotelId: new Guid("33333333-3333-3333-3333-333333333333"), embedding: new[] { 20f, 20f, 20f, 20f });
         var hotel4 = this.CreateTestHotel(hotelId: new Guid("44444444-4444-4444-4444-444444444444"), embedding: new[] { -1000f, -1000f, -1000f, -1000f });
 
-        var sut = new WeaviateCollection<Guid, WeaviateHotel>(fixture.HttpClient!, "VectorSearchWithOffset");
+        using var sut = new WeaviateCollection<Guid, WeaviateHotel>(fixture.HttpClient!, "VectorSearchWithOffset");
 
         await sut.EnsureCollectionExistsAsync();
 
@@ -284,7 +284,7 @@ public sealed class WeaviateVectorStoreRecordCollectionTests(WeaviateVectorStore
         var hotel3 = this.CreateTestHotel(hotelId: new Guid("33333333-3333-3333-3333-333333333333"), embedding: new[] { 20f, 20f, 20f, 20f });
         var hotel4 = this.CreateTestHotel(hotelId: new Guid("44444444-4444-4444-4444-444444444444"), embedding: new[] { -1000f, -1000f, -1000f, -1000f });
 
-        var sut = new WeaviateCollection<Guid, WeaviateHotel>(fixture.HttpClient!, "VectorSearchWithFilter");
+        using var sut = new WeaviateCollection<Guid, WeaviateHotel>(fixture.HttpClient!, "VectorSearchWithFilter");
 
         await sut.EnsureCollectionExistsAsync();
 
@@ -327,7 +327,7 @@ public sealed class WeaviateVectorStoreRecordCollectionTests(WeaviateVectorStore
             Timestamp = new DateTime(2024, 9, 22, 15, 59, 42)
         };
 
-        var sut = new WeaviateCollection<Guid, WeaviateHotel>(fixture.HttpClient!, "VectorSearchWithFilterAndDataTypes");
+        using var sut = new WeaviateCollection<Guid, WeaviateHotel>(fixture.HttpClient!, "VectorSearchWithFilterAndDataTypes");
 
         await sut.EnsureCollectionExistsAsync();
 
@@ -357,7 +357,7 @@ public sealed class WeaviateVectorStoreRecordCollectionTests(WeaviateVectorStore
             VectorStoreRecordDefinition = this.GetTestHotelRecordDefinition()
         };
 
-        var sut = new WeaviateCollection<object, Dictionary<string, object?>>(fixture.HttpClient!, "TestDynamicMapper", options);
+        using var sut = new WeaviateCollection<object, Dictionary<string, object?>>(fixture.HttpClient!, "TestDynamicMapper", options);
 
         await sut.EnsureCollectionExistsAsync();
 

--- a/dotnet/src/IntegrationTests/Connectors/Memory/Weaviate/WeaviateVectorStoreTests.cs
+++ b/dotnet/src/IntegrationTests/Connectors/Memory/Weaviate/WeaviateVectorStoreTests.cs
@@ -11,7 +11,9 @@ namespace SemanticKernel.IntegrationTests.Connectors.Memory.Weaviate;
 [Collection("WeaviateVectorStoreCollection")]
 [DisableVectorStoreTests(Skip = "Weaviate tests are failing on the build server with connection reset errors, but passing locally.")]
 public sealed class WeaviateVectorStoreTests(WeaviateVectorStoreFixture fixture)
+#pragma warning disable CA2000 // Dispose objects before losing scope
     : BaseVectorStoreTests<Guid, WeaviateHotel>(new WeaviateVectorStore(fixture.HttpClient!))
+#pragma warning restore CA2000 // Dispose objects before losing scope
 {
     // Weaviate requires each collection name to start with uppercase ASCII letter.
     protected override IEnumerable<string> CollectionNames => ["Listcollectionnames1", "Listcollectionnames2", "Listcollectionnames3"];

--- a/dotnet/src/SemanticKernel.UnitTests/Data/TextSearchServiceCollectionExtensionsTests.cs
+++ b/dotnet/src/SemanticKernel.UnitTests/Data/TextSearchServiceCollectionExtensionsTests.cs
@@ -20,7 +20,7 @@ public class TextSearchServiceCollectionExtensionsTests : VectorStoreTextSearchT
         using var embeddingGenerator = new MockTextEmbeddingGenerator();
 
         var services = new ServiceCollection();
-        var vectorStore = new InMemoryVectorStore(new() { EmbeddingGenerator = embeddingGenerator });
+        using var vectorStore = new InMemoryVectorStore(new() { EmbeddingGenerator = embeddingGenerator });
         var collection = vectorStore.GetCollection<Guid, DataModel>("records");
         var stringMapper = new DataModelTextSearchStringMapper();
         var resultMapper = new DataModelTextSearchResultMapper();
@@ -44,7 +44,7 @@ public class TextSearchServiceCollectionExtensionsTests : VectorStoreTextSearchT
         using var embeddingGenerator = new MockTextEmbeddingGenerator();
 
         var services = new ServiceCollection();
-        var vectorStore = new InMemoryVectorStore(new() { EmbeddingGenerator = embeddingGenerator });
+        using var vectorStore = new InMemoryVectorStore(new() { EmbeddingGenerator = embeddingGenerator });
         var collection = vectorStore.GetCollection<Guid, DataModel>("records");
 
         // Act
@@ -64,7 +64,7 @@ public class TextSearchServiceCollectionExtensionsTests : VectorStoreTextSearchT
         using var embeddingGenerator = new MockTextEmbeddingGenerator();
 
         var services = new ServiceCollection();
-        var vectorStore = new InMemoryVectorStore(new() { EmbeddingGenerator = embeddingGenerator });
+        using var vectorStore = new InMemoryVectorStore(new() { EmbeddingGenerator = embeddingGenerator });
         var collection = vectorStore.GetCollection<Guid, DataModel>("records");
 
         // Act
@@ -84,7 +84,7 @@ public class TextSearchServiceCollectionExtensionsTests : VectorStoreTextSearchT
         using var embeddingGenerator = new MockTextEmbeddingGenerator();
 
         var services = new ServiceCollection();
-        var vectorStore = new InMemoryVectorStore(new() { EmbeddingGenerator = embeddingGenerator });
+        using var vectorStore = new InMemoryVectorStore(new() { EmbeddingGenerator = embeddingGenerator });
         var collection = vectorStore.GetCollection<Guid, DataModel>("records");
 
         // Act
@@ -102,7 +102,7 @@ public class TextSearchServiceCollectionExtensionsTests : VectorStoreTextSearchT
     {
         // Arrange
         var services = new ServiceCollection();
-        var vectorStore = new InMemoryVectorStore();
+        using var vectorStore = new InMemoryVectorStore();
         var collection = vectorStore.GetCollection<Guid, DataModelWithRawEmbedding>("records");
         using var generator = new MockTextEmbeddingGenerator();
 
@@ -123,7 +123,7 @@ public class TextSearchServiceCollectionExtensionsTests : VectorStoreTextSearchT
     {
         // Arrange
         var services = new ServiceCollection();
-        var vectorStore = new InMemoryVectorStore();
+        using var vectorStore = new InMemoryVectorStore();
         var collection = vectorStore.GetCollection<Guid, DataModelWithRawEmbedding>("records");
         using var textGeneration = new MockTextEmbeddingGenerator();
 
@@ -143,7 +143,7 @@ public class TextSearchServiceCollectionExtensionsTests : VectorStoreTextSearchT
     {
         // Arrange
         var services = new ServiceCollection();
-        var vectorStore = new InMemoryVectorStore();
+        using var vectorStore = new InMemoryVectorStore();
         var vectorSearch = vectorStore.GetCollection<Guid, DataModelWithRawEmbedding>("records");
         using var textGeneration = new MockTextEmbeddingGenerator();
 

--- a/dotnet/src/SemanticKernel.UnitTests/Data/VectorStoreTextSearchTestBase.cs
+++ b/dotnet/src/SemanticKernel.UnitTests/Data/VectorStoreTextSearchTestBase.cs
@@ -26,7 +26,7 @@ public class VectorStoreTextSearchTestBase
     [Obsolete("VectorStoreTextSearch with ITextEmbeddingGenerationService is obsolete")]
     public static async Task<VectorStoreTextSearch<DataModelWithRawEmbedding>> CreateVectorStoreTextSearchWithEmbeddingGenerationServiceAsync()
     {
-        var vectorStore = new InMemoryVectorStore();
+        using var vectorStore = new InMemoryVectorStore();
         var vectorSearchable = vectorStore.GetCollection<Guid, DataModelWithRawEmbedding>("records");
         var stringMapper = new DataModelTextSearchStringMapper();
         var resultMapper = new DataModelTextSearchResultMapper();
@@ -42,7 +42,7 @@ public class VectorStoreTextSearchTestBase
     public static async Task<VectorStoreTextSearch<DataModel>> CreateVectorStoreTextSearchAsync()
     {
         using var embeddingGenerator = new MockTextEmbeddingGenerator();
-        var vectorStore = new InMemoryVectorStore(new() { EmbeddingGenerator = embeddingGenerator });
+        using var vectorStore = new InMemoryVectorStore(new() { EmbeddingGenerator = embeddingGenerator });
         var vectorSearch = vectorStore.GetCollection<Guid, DataModel>("records");
         var stringMapper = new DataModelTextSearchStringMapper();
         var resultMapper = new DataModelTextSearchResultMapper();

--- a/dotnet/src/SemanticKernel.UnitTests/Data/VectorStoreTextSearchTests.cs
+++ b/dotnet/src/SemanticKernel.UnitTests/Data/VectorStoreTextSearchTests.cs
@@ -15,7 +15,7 @@ public class VectorStoreTextSearchTests : VectorStoreTextSearchTestBase
     public void CanCreateVectorStoreTextSearchWithEmbeddingGenerationService()
     {
         // Arrange.
-        var vectorStore = new InMemoryVectorStore();
+        using var vectorStore = new InMemoryVectorStore();
         var vectorSearch = vectorStore.GetCollection<Guid, DataModelWithRawEmbedding>("records");
         var stringMapper = new DataModelTextSearchStringMapper();
         var resultMapper = new DataModelTextSearchResultMapper();
@@ -33,7 +33,7 @@ public class VectorStoreTextSearchTests : VectorStoreTextSearchTestBase
     public void CanCreateVectorStoreTextSearchWithIVectorSearch()
     {
         // Arrange.
-        var vectorStore = new InMemoryVectorStore(new() { EmbeddingGenerator = new MockTextEmbeddingGenerator() });
+        using var vectorStore = new InMemoryVectorStore(new() { EmbeddingGenerator = new MockTextEmbeddingGenerator() });
         var vectorSearch = vectorStore.GetCollection<Guid, DataModel>("records");
         var stringMapper = new DataModelTextSearchStringMapper();
         var resultMapper = new DataModelTextSearchResultMapper();

--- a/dotnet/src/VectorDataIntegrationTests/AzureAISearchIntegrationTests/Support/AzureAISearchTestStore.cs
+++ b/dotnet/src/VectorDataIntegrationTests/AzureAISearchIntegrationTests/Support/AzureAISearchTestStore.cs
@@ -15,13 +15,9 @@ internal sealed class AzureAISearchTestStore : TestStore
     public static AzureAISearchTestStore Instance { get; } = new();
 
     private SearchIndexClient? _client;
-    private AzureAISearchVectorStore? _defaultVectorStore;
 
     public SearchIndexClient Client
         => this._client ?? throw new InvalidOperationException("Call InitializeAsync() first");
-
-    public override VectorStore DefaultVectorStore
-        => this._defaultVectorStore ?? throw new InvalidOperationException("Call InitializeAsync() first");
 
     public AzureAISearchVectorStore GetVectorStore(AzureAISearchVectorStoreOptions options)
         => new(this.Client, options);
@@ -43,7 +39,7 @@ internal sealed class AzureAISearchTestStore : TestStore
             ? new SearchIndexClient(new Uri(serviceUrl), new DefaultAzureCredential())
             : new SearchIndexClient(new Uri(serviceUrl), new AzureKeyCredential(apiKey));
 
-        this._defaultVectorStore = new(this._client);
+        this.DefaultVectorStore = new AzureAISearchVectorStore(this._client);
 
         return Task.CompletedTask;
     }

--- a/dotnet/src/VectorDataIntegrationTests/CosmosMongoDBIntegrationTests/Support/CosmosMongoTestStore.cs
+++ b/dotnet/src/VectorDataIntegrationTests/CosmosMongoDBIntegrationTests/Support/CosmosMongoTestStore.cs
@@ -1,6 +1,5 @@
 ﻿// Copyright (c) Microsoft. All rights reserved.
 
-using Microsoft.Extensions.VectorData;
 using Microsoft.SemanticKernel.Connectors.CosmosMongoDB;
 using MongoDB.Driver;
 using VectorDataSpecificationTests.Support;
@@ -13,13 +12,9 @@ public sealed class CosmosMongoTestStore : TestStore
 
     private MongoClient? _client;
     private IMongoDatabase? _database;
-    private CosmosMongoVectorStore? _defaultVectorStore;
 
     public MongoClient Client => this._client ?? throw new InvalidOperationException("Not initialized");
     public IMongoDatabase Database => this._database ?? throw new InvalidOperationException("Not initialized");
-
-    public override VectorStore DefaultVectorStore
-        => this._defaultVectorStore ?? throw new InvalidOperationException("Call InitializeAsync() first");
 
     public override string DefaultIndexKind => Microsoft.Extensions.VectorData.IndexKind.IvfFlat;
 
@@ -41,7 +36,7 @@ public sealed class CosmosMongoTestStore : TestStore
 
         this._client = new MongoClient(CosmosMongoTestEnvironment.ConnectionString);
         this._database = this._client.GetDatabase("VectorSearchTests");
-        this._defaultVectorStore = new(this._database);
+        this.DefaultVectorStore = new CosmosMongoVectorStore(this._database);
 
         return Task.CompletedTask;
     }

--- a/dotnet/src/VectorDataIntegrationTests/InMemoryIntegrationTests/Support/InMemoryTestStore.cs
+++ b/dotnet/src/VectorDataIntegrationTests/InMemoryIntegrationTests/Support/InMemoryTestStore.cs
@@ -1,6 +1,5 @@
 ﻿// Copyright (c) Microsoft. All rights reserved.
 
-using Microsoft.Extensions.VectorData;
 using Microsoft.SemanticKernel.Connectors.InMemory;
 using VectorDataSpecificationTests.Support;
 
@@ -9,10 +8,6 @@ namespace InMemoryIntegrationTests.Support;
 internal sealed class InMemoryTestStore : TestStore
 {
     public static InMemoryTestStore Instance { get; } = new();
-
-    private InMemoryVectorStore _defaultVectorStore = new();
-
-    public override VectorStore DefaultVectorStore => this._defaultVectorStore;
 
     public InMemoryVectorStore GetVectorStore(InMemoryVectorStoreOptions options)
         => new(new() { EmbeddingGenerator = options.EmbeddingGenerator });
@@ -23,7 +18,7 @@ internal sealed class InMemoryTestStore : TestStore
 
     protected override Task StartAsync()
     {
-        this._defaultVectorStore = new InMemoryVectorStore();
+        this.DefaultVectorStore = new InMemoryVectorStore();
 
         return Task.CompletedTask;
     }

--- a/dotnet/src/VectorDataIntegrationTests/MongoDBIntegrationTests/Support/MongoDBTestStore.cs
+++ b/dotnet/src/VectorDataIntegrationTests/MongoDBIntegrationTests/Support/MongoDBTestStore.cs
@@ -1,6 +1,5 @@
 ﻿// Copyright (c) Microsoft. All rights reserved.
 
-using Microsoft.Extensions.VectorData;
 using Microsoft.SemanticKernel.Connectors.MongoDB;
 using MongoDB.Driver;
 using Testcontainers.MongoDb;
@@ -12,18 +11,17 @@ internal sealed class MongoDBTestStore : TestStore
 {
     public static MongoDBTestStore Instance { get; } = new();
 
+#pragma warning disable CA2213 // Disposable fields should be disposed
     private readonly MongoDbContainer _container = new MongoDbBuilder()
+#pragma warning restore CA2213 // Disposable fields should be disposed
         .WithImage("mongodb/mongodb-atlas-local:7.0.6")
         .Build();
 
     public MongoClient? _client { get; private set; }
     public IMongoDatabase? _database { get; private set; }
-    private MongoVectorStore? _defaultVectorStore;
 
     public MongoClient Client => this._client ?? throw new InvalidOperationException("Not initialized");
     public IMongoDatabase Database => this._database ?? throw new InvalidOperationException("Not initialized");
-
-    public override VectorStore DefaultVectorStore => this._defaultVectorStore ?? throw new InvalidOperationException("Not initialized");
 
     public MongoVectorStore GetVectorStore(MongoVectorStoreOptions options)
         => new(this.Database, options);
@@ -46,7 +44,7 @@ internal sealed class MongoDBTestStore : TestStore
             // WriteConcern = WriteConcern.WMajority
         });
         this._database = this._client.GetDatabase("VectorSearchTests");
-        this._defaultVectorStore = new(this._database);
+        this.DefaultVectorStore = new MongoVectorStore(this._database);
     }
 
     protected override Task StopAsync()

--- a/dotnet/src/VectorDataIntegrationTests/PgVectorIntegrationTests/Support/PostgresTestStore.cs
+++ b/dotnet/src/VectorDataIntegrationTests/PgVectorIntegrationTests/Support/PostgresTestStore.cs
@@ -28,8 +28,8 @@ internal sealed class PostgresTestStore : TestStore
     public PostgresVectorStore GetVectorStore(PostgresVectorStoreOptions options)
     {
         // The DataSource is shared with the static instance, we don't want any of the tests to dispose it.
-        bool ownsDataSource = false;
-        return new(this.DataSource, ownsDataSource, options);
+        options.OwnsDataSource = false;
+        return new(this.DataSource, options);
     }
 
     private PostgresTestStore()
@@ -63,8 +63,7 @@ internal sealed class PostgresTestStore : TestStore
         await connection.ReloadTypesAsync();
 
         // It's a shared static instance, we don't want any of the tests to dispose it.
-        bool ownsDataSource = false;
-        this._defaultVectorStore = new(this._dataSource, ownsDataSource);
+        this._defaultVectorStore = new(this._dataSource, new() { OwnsDataSource = false });
     }
 
     protected override async Task StopAsync()

--- a/dotnet/src/VectorDataIntegrationTests/PineconeIntegrationTests/Support/PineconeTestStore.cs
+++ b/dotnet/src/VectorDataIntegrationTests/PineconeIntegrationTests/Support/PineconeTestStore.cs
@@ -5,7 +5,6 @@ using System.Net.Http;
 #pragma warning restore IDE0005 // Using directive is unnecessary.
 using DotNet.Testcontainers.Builders;
 using DotNet.Testcontainers.Containers;
-using Microsoft.Extensions.VectorData;
 using Microsoft.SemanticKernel.Connectors.Pinecone;
 using Pinecone;
 using VectorDataSpecificationTests.Support;
@@ -29,11 +28,8 @@ internal sealed class PineconeTestStore : TestStore
 
     private IContainer? _container;
     private Pinecone.PineconeClient? _client;
-    private PineconeVectorStore? _defaultVectorStore;
 
     public Pinecone.PineconeClient Client => this._client ?? throw new InvalidOperationException("Not initialized");
-
-    public override VectorStore DefaultVectorStore => this._defaultVectorStore ?? throw new InvalidOperationException("Not initialized");
 
     public PineconeVectorStore GetVectorStore(PineconeVectorStoreOptions options)
         => new(this.Client, options);
@@ -77,7 +73,7 @@ internal sealed class PineconeTestStore : TestStore
             apiKey: "ForPineconeLocalTheApiKeysAreIgnored",
             clientOptions: clientOptions);
 
-        this._defaultVectorStore = new(this._client);
+        this.DefaultVectorStore = new PineconeVectorStore(this._client);
     }
 
     protected override async Task StopAsync()

--- a/dotnet/src/VectorDataIntegrationTests/SqlServerIntegrationTests/Support/SqlServerTestStore.cs
+++ b/dotnet/src/VectorDataIntegrationTests/SqlServerIntegrationTests/Support/SqlServerTestStore.cs
@@ -13,15 +13,10 @@ public sealed class SqlServerTestStore : TestStore
 
     public static readonly SqlServerTestStore Instance = new();
 
-    public override VectorStore DefaultVectorStore
-        => this._defaultVectorStore ?? throw new InvalidOperationException("Not initialized");
-
     public SqlServerVectorStore GetVectorStore(SqlServerVectorStoreOptions options)
         => new(this.ConnectionString, options);
 
     public override string DefaultDistanceFunction => DistanceFunction.CosineDistance;
-
-    private SqlServerVectorStore? _defaultVectorStore;
 
     protected override Task StartAsync()
     {
@@ -32,7 +27,7 @@ public sealed class SqlServerTestStore : TestStore
             throw new InvalidOperationException("Connection string is not configured, set the SqlServer:ConnectionString environment variable");
         }
 
-        this._defaultVectorStore = new(this._connectionString);
+        this.DefaultVectorStore = new SqlServerVectorStore(this._connectionString);
 
         return Task.CompletedTask;
     }

--- a/dotnet/src/VectorDataIntegrationTests/SqliteVecIntegrationTests/Support/SqliteTestStore.cs
+++ b/dotnet/src/VectorDataIntegrationTests/SqliteVecIntegrationTests/Support/SqliteTestStore.cs
@@ -1,6 +1,5 @@
 ﻿// Copyright (c) Microsoft. All rights reserved.
 
-using Microsoft.Extensions.VectorData;
 using Microsoft.SemanticKernel.Connectors.SqliteVec;
 using VectorDataSpecificationTests.Support;
 
@@ -15,10 +14,6 @@ internal sealed class SqliteTestStore : TestStore
 
     public static SqliteTestStore Instance { get; } = new();
 
-    private SqliteVectorStore? _defaultVectorStore;
-    public override VectorStore DefaultVectorStore
-        => this._defaultVectorStore ?? throw new InvalidOperationException("Call InitializeAsync() first");
-
     public override string DefaultDistanceFunction => Microsoft.Extensions.VectorData.DistanceFunction.CosineDistance;
 
     public SqliteVectorStore GetVectorStore(SqliteVectorStoreOptions options)
@@ -32,7 +27,7 @@ internal sealed class SqliteTestStore : TestStore
     {
         this._databasePath = Path.GetTempFileName();
         this._connectionString = $"Data Source={this._databasePath}";
-        this._defaultVectorStore = new SqliteVectorStore(this._connectionString);
+        this.DefaultVectorStore = new SqliteVectorStore(this._connectionString);
         return Task.CompletedTask;
     }
 

--- a/dotnet/src/VectorDataIntegrationTests/WeaviateIntegrationTests/Support/WeaviateTestStore.cs
+++ b/dotnet/src/VectorDataIntegrationTests/WeaviateIntegrationTests/Support/WeaviateTestStore.cs
@@ -3,7 +3,6 @@
 #if NET472
 using System.Net.Http;
 #endif
-using Microsoft.Extensions.VectorData;
 using Microsoft.SemanticKernel.Connectors.Weaviate;
 using VectorDataSpecificationTests.Support;
 using WeaviateIntegrationTests.Support.TestContainer;
@@ -17,14 +16,13 @@ public sealed class WeaviateTestStore : TestStore
 
     public override string DefaultDistanceFunction => Microsoft.Extensions.VectorData.DistanceFunction.CosineDistance;
 
+#pragma warning disable CA2213 // Disposable fields should be disposed
     private readonly WeaviateContainer _container = new WeaviateBuilder().Build();
+#pragma warning restore CA2213 // Disposable fields should be disposed
     private readonly bool _hasNamedVectors;
     public HttpClient? _httpClient { get; private set; }
-    private WeaviateVectorStore? _defaultVectorStore;
 
     public HttpClient Client => this._httpClient ?? throw new InvalidOperationException("Not initialized");
-
-    public override VectorStore DefaultVectorStore => this._defaultVectorStore ?? throw new InvalidOperationException("Not initialized");
 
     public WeaviateVectorStore GetVectorStore(WeaviateVectorStoreOptions options)
         => new(this.Client, options);
@@ -35,7 +33,7 @@ public sealed class WeaviateTestStore : TestStore
     {
         await this._container.StartAsync();
         this._httpClient = new HttpClient { BaseAddress = new Uri($"http://localhost:{this._container.GetMappedPublicPort(WeaviateBuilder.WeaviateHttpPort)}/v1/") };
-        this._defaultVectorStore = new(this._httpClient, new() { HasNamedVectors = this._hasNamedVectors });
+        this.DefaultVectorStore = new WeaviateVectorStore(this._httpClient, new() { HasNamedVectors = this._hasNamedVectors });
     }
 
     protected override Task StopAsync()


### PR DESCRIPTION
The PR is not ready for final review, I am opening it first to use CI to verify if I have found all the places that required an update.

Connectors that do override `Dispose(bool)` and provide actual implementation:
- Postgres
- Qdrant

Tricky things:
- Weaviate accepts a `HttpClient` that implements `IDisposable`. The best thing to do would be to use `IHttpClientFactor` instead (https://stackoverflow.com/a/56928757). The problem is that it does not support .NET Standard 2.0
- The `MongoVectorStore` accepts `IMongoDatabase` that does not implement `IDisposable`, but in order to create it, we need `MongoClient` which implements `IDisposable` and `IMongoDatabase` exposes the client via a public property. So in theory, there is a resource that our customers will need to dispose and we could do it, but it's not obvious whether we should.
https://github.com/microsoft/semantic-kernel/blob/aa7f10bbe4f9e974c53fc2a3999922badbe80c65/dotnet/src/VectorDataIntegrationTests/CosmosMongoDBIntegrationTests/Support/CosmosMongoTestStore.cs#L42-L44