### PR TITLE
.Net: [Feature Branch] Improvements and tests for declarative processes

### DIFF
--- a/dotnet/src/Experimental/Process.Abstractions/Serialization/WorkflowSerializer.cs
+++ b/dotnet/src/Experimental/Process.Abstractions/Serialization/WorkflowSerializer.cs
@@ -33,13 +33,27 @@ public static class WorkflowSerializer
                 .IgnoreUnmatchedProperties()
                 .Build();
 
-        //var wrapper = deserializer.Deserialize<WorkflowWrapper>(yaml);
-        var workflow = deserializer.Deserialize<Workflow>(yaml);
-        return workflow;
+        Workflow? workflow = null;
 
-        //return wrapper?.Workflow == null
-        //    ? throw new KernelException("Failed to deserialize provided YAML to a Processes.")
-        //    : wrapper.Workflow;
+        try
+        {
+            // Try to deserialize workflow wrapper version first.
+            var wrapper = deserializer.Deserialize<WorkflowWrapper>(yaml);
+            workflow = wrapper?.Workflow;
+        }
+#pragma warning disable CA1031 // Do not catch general exception types
+        catch
+#pragma warning restore CA1031 // Do not catch general exception types
+        {
+            // If it's not a workflow wrapper version, continue with parsing non-wrapper version.
+        }
+
+        if (workflow is null)
+        {
+            workflow = deserializer.Deserialize<Workflow>(yaml);
+        }
+
+        return workflow;
     }
 
     /// <summary>

--- a/dotnet/src/Experimental/Process.Core/FoundryProcessBuilder.cs
+++ b/dotnet/src/Experimental/Process.Core/FoundryProcessBuilder.cs
@@ -40,11 +40,10 @@ public class FoundryProcessBuilder
     /// Adds a step to the process from a declarative agent.
     /// </summary>
     /// <param name="agentDefinition">The <see cref="AgentDefinition"/></param>
+    /// <param name="id">The unique Id of the step. If not provided, the name of the step Type will be used.</param>
+    /// <param name="aliases">Aliases that have been used by previous versions of the step, used for supporting backward compatibility when reading old version Process States</param>
     /// <param name="threadName">Specifies the thread reference to be used by the agent. If not provided, the agent will create a new thread for each invocation.</param>
-    /// <param name="aliases"></param>
-    /// <returns></returns>
-    /// <exception cref="ArgumentException"></exception>
-    public ProcessAgentBuilder AddStepFromAgent(AgentDefinition agentDefinition, string? threadName = null, IReadOnlyList<string>? aliases = null)
+    public ProcessAgentBuilder AddStepFromAgent(AgentDefinition agentDefinition, string? id = null, IReadOnlyList<string>? aliases = null, string? threadName = null)
     {
         Verify.NotNull(agentDefinition);
         if (agentDefinition.Type != AzureAIAgentFactory.AzureAIAgentType)
@@ -52,7 +51,7 @@ public class FoundryProcessBuilder
             throw new ArgumentException($"The agent type '{agentDefinition.Type}' is not supported. Only '{AzureAIAgentFactory.AzureAIAgentType}' is supported.");
         }
 
-        return this._processBuilder.AddStepFromAgent(agentDefinition, threadName, aliases);
+        return this._processBuilder.AddStepFromAgent(agentDefinition, id, aliases, threadName);
     }
 
     /// <summary>

--- a/dotnet/src/Experimental/Process.Core/FoundryProcessBuilder.cs
+++ b/dotnet/src/Experimental/Process.Core/FoundryProcessBuilder.cs
@@ -44,7 +44,7 @@ public class FoundryProcessBuilder<TProcessState> where TProcessState : class, n
     /// <param name="aliases">Aliases that have been used by previous versions of the step, used for supporting backward compatibility when reading old version Process States</param>
     /// <param name="defaultThread">Specifies the thread reference to be used by the agent. If not provided, the agent will create a new thread for each invocation.</param>
     /// <param name="humanInLoopMode">Specifies the human-in-the-loop mode for the agent. If not provided, the default is <see cref="HITLMode.Never"/>.</param>
-    public ProcessAgentBuilder AddStepFromAgent(AgentDefinition agentDefinition, string? id = null, IReadOnlyList<string>? aliases = null, string? defaultThread = null, HITLMode humanInLoopMode = HITLMode.Never)
+    public ProcessAgentBuilder<TProcessState> AddStepFromAgent(AgentDefinition agentDefinition, string? id = null, IReadOnlyList<string>? aliases = null, string? defaultThread = null, HITLMode humanInLoopMode = HITLMode.Never)
     {
         Verify.NotNull(agentDefinition);
         if (agentDefinition.Type != AzureAIAgentFactory.AzureAIAgentType)
@@ -52,7 +52,7 @@ public class FoundryProcessBuilder<TProcessState> where TProcessState : class, n
             throw new ArgumentException($"The agent type '{agentDefinition.Type}' is not supported. Only '{AzureAIAgentFactory.AzureAIAgentType}' is supported.");
         }
 
-        return this._processBuilder.AddStepFromAgent(agentDefinition, id, aliases, defaultThread, humanInLoopMode);
+        return this._processBuilder.AddStepFromAgent<TProcessState>(agentDefinition, id, aliases, defaultThread, humanInLoopMode);
     }
 
     /// <summary>

--- a/dotnet/src/Experimental/Process.Core/ProcessBuilder.cs
+++ b/dotnet/src/Experimental/Process.Core/ProcessBuilder.cs
@@ -279,7 +279,7 @@ public sealed partial class ProcessBuilder : ProcessStepBuilder
             threadName = agentDefinition.Name;
         }
 
-        var stepBuilder = new ProcessAgentBuilder(agentDefinition, threadName: threadName, [], this.ProcessBuilder) { HumanInLoopMode = humanInLoopMode }; // TODO: Add inputs to the agent
+        var stepBuilder = new ProcessAgentBuilder(agentDefinition, threadName: threadName, [], this.ProcessBuilder, id) { HumanInLoopMode = humanInLoopMode }; // TODO: Add inputs to the agent
         return this.AddStep(stepBuilder, aliases);
     }
 

--- a/dotnet/src/Experimental/Process.Core/ProcessBuilder.cs
+++ b/dotnet/src/Experimental/Process.Core/ProcessBuilder.cs
@@ -222,11 +222,10 @@ public sealed partial class ProcessBuilder : ProcessStepBuilder
     /// Adds a step to the process from a declarative agent.
     /// </summary>
     /// <param name="agentDefinition">The <see cref="AgentDefinition"/></param>
+    /// <param name="id">The unique Id of the step. If not provided, the name of the step Type will be used.</param>
+    /// <param name="aliases">Aliases that have been used by previous versions of the step, used for supporting backward compatibility when reading old version Process States</param>
     /// <param name="threadName">Specifies the thread reference to be used by the agent. If not provided, the agent will create a new thread for each invocation.</param>
-    /// <param name="aliases"></param>
-    /// <returns></returns>
-    /// <exception cref="ArgumentException"></exception>
-    public ProcessAgentBuilder AddStepFromAgent(AgentDefinition agentDefinition, string? threadName = null, IReadOnlyList<string>? aliases = null)
+    public ProcessAgentBuilder AddStepFromAgent(AgentDefinition agentDefinition, string? id = null, IReadOnlyList<string>? aliases = null, string? threadName = null)
     {
         Verify.NotNull(agentDefinition, nameof(agentDefinition));
 
@@ -242,7 +241,7 @@ public sealed partial class ProcessBuilder : ProcessStepBuilder
             threadName = agentDefinition.Name;
         }
 
-        ProcessAgentBuilder stepBuilder = new(agentDefinition, threadName: threadName, new NodeInputs()); // TODO: Add inputs to the agent
+        ProcessAgentBuilder stepBuilder = new(agentDefinition, threadName: threadName, new NodeInputs(), id); // TODO: Add inputs to the agent
         return this.AddStep(stepBuilder, aliases);
     }
 

--- a/dotnet/src/Experimental/Process.Core/ProcessExporter.cs
+++ b/dotnet/src/Experimental/Process.Core/ProcessExporter.cs
@@ -1,9 +1,9 @@
 ﻿// Copyright (c) Microsoft. All rights reserved.
 
 using System.Linq;
-using YamlDotNet.Serialization.NamingConventions;
-using YamlDotNet.Serialization;
 using System.Text.Json;
+using YamlDotNet.Serialization;
+using YamlDotNet.Serialization.NamingConventions;
 
 namespace Microsoft.SemanticKernel.Process;
 

--- a/dotnet/src/Experimental/Process.Core/Workflow/WorkflowBuilder.cs
+++ b/dotnet/src/Experimental/Process.Core/Workflow/WorkflowBuilder.cs
@@ -185,7 +185,7 @@ public class WorkflowBuilder
     {
         Verify.NotNull(node);
 
-        if (node.Agent is null || string.IsNullOrEmpty(node.Agent.Type) || string.IsNullOrEmpty(node.Agent.Id))
+        if (node.Agent is null || string.IsNullOrEmpty(node.Agent.Type))
         {
             throw new ArgumentException($"The agent specified in the Node with id {node.Id} is not fully specified.");
         }

--- a/dotnet/src/Experimental/Process.Core/Workflow/WorkflowBuilder.cs
+++ b/dotnet/src/Experimental/Process.Core/Workflow/WorkflowBuilder.cs
@@ -136,7 +136,7 @@ public class WorkflowBuilder
         }
 
         AgentDefinition? agentDefinition = node.Agent ?? throw new KernelException("Declarative steps must have an agent defined.");
-        var stepBuilder = processBuilder.AddStepFromAgent(agentDefinition);
+        var stepBuilder = processBuilder.AddStepFromAgent(agentDefinition, node.Id);
         if (stepBuilder is not ProcessAgentBuilder agentBuilder)
         {
             throw new KernelException($"Failed to build step from agent definition: {node.Id}");
@@ -206,7 +206,7 @@ public class WorkflowBuilder
             throw new KernelException("The agent type specified in the node is not found.");
         }
 
-        var stepBuilder = processBuilder.AddStepFromType(dotnetAgentType, id: node.Agent.Id);
+        var stepBuilder = processBuilder.AddStepFromType(dotnetAgentType, id: node.Id);
         this._stepBuilders[node.Id] = stepBuilder;
         return Task.CompletedTask;
     }

--- a/dotnet/src/Experimental/Process.UnitTests/.editorconfig
+++ b/dotnet/src/Experimental/Process.UnitTests/.editorconfig
@@ -1,0 +1,6 @@
+# Suppressing errors for Test projects under dotnet folder
+[*.cs]
+dotnet_diagnostic.CA2007.severity = none # Do not directly await a Task
+dotnet_diagnostic.CS1591.severity = none # Missing XML comment for publicly visible type or member
+dotnet_diagnostic.IDE1006.severity = warning # Naming rule violations
+dotnet_diagnostic.VSTHRD111.severity = none # Use .ConfigureAwait(bool) is hidden by default, set to none to prevent IDE from changing on autosave

--- a/dotnet/src/Experimental/Process.UnitTests/Process.UnitTests.csproj
+++ b/dotnet/src/Experimental/Process.UnitTests/Process.UnitTests.csproj
@@ -8,16 +8,20 @@
     <IsTestProject>true</IsTestProject>
     <IsPackable>false</IsPackable>
     <LangVersion>12</LangVersion>
-    <NoWarn>$(NoWarn);CA2007,CA1812,CA1861,CA1063,VSTHRD111,SKEXP0001,SKEXP0050,SKEXP0080,SKEXP0110;OPENAI001</NoWarn>
+    <NoWarn>$(NoWarn);CA2007,CA1812,CA1861,CA1063,VSTHRD111,SKEXP0001,SKEXP0050,SKEXP0080,SKEXP0110;OPENAI001,CA1024</NoWarn>
   </PropertyGroup>
 
   <ItemGroup>
+    <None Remove="Resources\combined-workflow.yaml" />
     <None Remove="Resources\dotnetOnlyWorkflow1.yaml" />
     <None Remove="Resources\scenario1.yaml" />
     <None Remove="Resources\workflow1.yaml" />
   </ItemGroup>
 
   <ItemGroup>
+    <EmbeddedResource Include="Resources\combined-workflow.yaml">
+      <CopyToOutputDirectory>Always</CopyToOutputDirectory>
+    </EmbeddedResource>
     <EmbeddedResource Include="Resources\dotnetOnlyWorkflow1.yaml">
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </EmbeddedResource>

--- a/dotnet/src/Experimental/Process.UnitTests/ProcessSerializationTests.cs
+++ b/dotnet/src/Experimental/Process.UnitTests/ProcessSerializationTests.cs
@@ -4,8 +4,8 @@ using System;
 using System.IO;
 using System.Linq;
 using System.Reflection;
-using System.Runtime.Serialization;
 using System.Threading.Tasks;
+using Microsoft.SemanticKernel.Process.UnitTests.Steps;
 using Xunit;
 
 namespace Microsoft.SemanticKernel.Process.UnitTests;
@@ -139,7 +139,7 @@ public class ProcessSerializationTests
         // For demonstration purposes, we add the CStep and configure its initial state with a CurrentCycle of 1.
         // Initializing state in a step can be useful for when you need a step to start out with a predetermines
         // configuration that is not easily accomplished with dependency injection.
-        var myCStep = processBuilder.AddStepFromType<CStep, CStepState>(initialState: new() { CurrentCycle = 1 });
+        var myCStep = processBuilder.AddStepFromType<CStep, CStep.CStepState>(initialState: new() { CurrentCycle = 1 });
 
         // Setup the input event that can trigger the process to run and specify which step and function it should be routed to.
         processBuilder
@@ -210,116 +210,4 @@ public class ProcessSerializationTests
             }
         }
     }
-
-    /// <summary>
-    /// Kick off step for the process.
-    /// </summary>
-    private sealed class KickoffStep : KernelProcessStep
-    {
-        public static class ProcessFunctions
-        {
-            public const string KickOff = nameof(KickOff);
-        }
-
-        [KernelFunction(ProcessFunctions.KickOff)]
-        public async ValueTask PrintWelcomeMessageAsync(KernelProcessStepContext context)
-        {
-            Console.WriteLine("##### Kickoff ran.");
-            await context.EmitEventAsync(new() { Id = CommonEvents.StartARequested, Data = "Get Going" });
-        }
-    }
-
-    /// <summary>
-    /// A step in the process.
-    /// </summary>
-    private sealed class AStep : KernelProcessStep
-    {
-        [KernelFunction]
-        public async ValueTask DoItAsync(KernelProcessStepContext context)
-        {
-            Console.WriteLine("##### AStep ran.");
-            await Task.Delay(TimeSpan.FromSeconds(1));
-            await context.EmitEventAsync(CommonEvents.AStepDone, "I did A");
-        }
-    }
-
-    /// <summary>
-    /// A step in the process.
-    /// </summary>
-    private sealed class BStep : KernelProcessStep
-    {
-        [KernelFunction]
-        public async ValueTask DoItAsync(KernelProcessStepContext context)
-        {
-            Console.WriteLine("##### BStep ran.");
-            await Task.Delay(TimeSpan.FromSeconds(2));
-            await context.EmitEventAsync(new() { Id = CommonEvents.BStepDone, Data = "I did B" });
-        }
-    }
-
-    /// <summary>
-    /// A stateful step in the process. This step uses <see cref="CStepState"/> as the persisted
-    /// state object and overrides the ActivateAsync method to initialize the state when activated.
-    /// </summary>
-    private sealed class CStep : KernelProcessStep<CStepState>
-    {
-        private CStepState? _state;
-
-        // ################ Using persisted state #################
-        // CStep has state that we want to be persisted in the process. To ensure that the step always
-        // starts with the previously persisted or configured state, we need to override the ActivateAsync
-        // method and use the state object it provides.
-        public override ValueTask ActivateAsync(KernelProcessStepState<CStepState> state)
-        {
-            this._state = state.State!;
-            Console.WriteLine($"##### CStep activated with Cycle = '{state.State?.CurrentCycle}'.");
-            return base.ActivateAsync(state);
-        }
-
-        [KernelFunction]
-        public async ValueTask DoItAsync(KernelProcessStepContext context, string astepdata, string bstepdata)
-        {
-            // ########### This method will restart the process in a loop until CurrentCycle >= 3 ###########
-            this._state!.CurrentCycle++;
-            if (this._state.CurrentCycle >= 3)
-            {
-                // Exit the processes
-                Console.WriteLine("##### CStep run cycle 3 - exiting.");
-                await context.EmitEventAsync(new() { Id = CommonEvents.ExitRequested });
-                return;
-            }
-
-            // Cycle back to the start
-            Console.WriteLine($"##### CStep run cycle {this._state.CurrentCycle}.");
-            await context.EmitEventAsync(new() { Id = CommonEvents.CStepDone });
-        }
-    }
-
-    /// <summary>
-    /// A state object for the CStep.
-    /// </summary>
-    [DataContract]
-    private sealed record CStepState
-    {
-        [DataMember]
-        public int CurrentCycle { get; set; }
-    }
-
-    /// <summary>
-    /// Common Events used in the process.
-    /// </summary>
-    private static class CommonEvents
-    {
-        public const string UserInputReceived = nameof(UserInputReceived);
-        public const string CompletionResponseGenerated = nameof(CompletionResponseGenerated);
-        public const string WelcomeDone = nameof(WelcomeDone);
-        public const string AStepDone = nameof(AStepDone);
-        public const string BStepDone = nameof(BStepDone);
-        public const string CStepDone = nameof(CStepDone);
-        public const string StartARequested = nameof(StartARequested);
-        public const string StartBRequested = nameof(StartBRequested);
-        public const string ExitRequested = nameof(ExitRequested);
-        public const string StartProcess = nameof(StartProcess);
-    }
-#pragma warning restore CA1812 // Avoid uninstantiated internal classes
 }

--- a/dotnet/src/Experimental/Process.UnitTests/Resources/combined-workflow.yaml
+++ b/dotnet/src/Experimental/Process.UnitTests/Resources/combined-workflow.yaml
@@ -1,7 +1,11 @@
 workflow:
   name: ProductSummarization
   inputs:
-    messages: {}
+    events:
+      cloud_events:
+        - type: input_message_received
+          data_schema: 
+            type: string
   nodes:
     - id: GetProductInfo
       type: dotnet
@@ -28,8 +32,8 @@ workflow:
               - event_type: ProcessCompleted
   orchestration:
     - listen_for:
-        from: $.inputs.events
-        event: input_message_received
+        event: input_message_received    
+        from: _workflow_
       then:
         - node: GetProductInfo
     - listen_for:

--- a/dotnet/src/Experimental/Process.UnitTests/Resources/combined-workflow.yaml
+++ b/dotnet/src/Experimental/Process.UnitTests/Resources/combined-workflow.yaml
@@ -1,0 +1,40 @@
+workflow:
+  name: ProductSummarization
+  inputs:
+    messages: {}
+  nodes:
+    - id: GetProductInfo
+      type: dotnet
+      description: Gets product information
+      agent:
+        type: SemanticKernel.Process.UnitTests.Steps.ProductInfoProvider, SemanticKernel.Process.UnitTests
+        id: GetProductInfoAgent
+      on_complete:
+        - on_condition:
+            type: default
+            emits:
+              - event_type: GetProductInfo.OnResult
+    - id: Summarize
+      type: declarative
+      description: Summarizes the information
+      agent:
+        type: chat_completion_agent
+        name: SummarizationAgent
+        description: Summarizes the information
+        instructions: Summarize the provided information in 3 sentences
+      on_complete:
+        - on_condition:
+            type: default
+            emits:
+              - event_type: ProcessCompleted
+  orchestration:
+    - listen_for:
+        from: $.inputs.events
+        event: input_message_received
+      then:
+        - node: GetProductInfo
+    - listen_for:
+        from: GetProductInfo
+        event: GetProductInfo.OnResult
+      then:
+        - node: Summarize

--- a/dotnet/src/Experimental/Process.UnitTests/Resources/combined-workflow.yaml
+++ b/dotnet/src/Experimental/Process.UnitTests/Resources/combined-workflow.yaml
@@ -8,7 +8,6 @@ workflow:
       description: Gets product information
       agent:
         type: SemanticKernel.Process.UnitTests.Steps.ProductInfoProvider, SemanticKernel.Process.UnitTests
-        id: GetProductInfoAgent
       on_complete:
         - on_condition:
             type: default

--- a/dotnet/src/Experimental/Process.UnitTests/Resources/dotnetOnlyWorkflow1.yaml
+++ b/dotnet/src/Experimental/Process.UnitTests/Resources/dotnetOnlyWorkflow1.yaml
@@ -60,7 +60,7 @@ nodes:
     version: "1.0"
     description: "Kickoff the workflow"
     agent:
-      type: "Microsoft.SemanticKernel.Process.UnitTests.ProcessSerializationTests+KickoffStep, SemanticKernel.Process.UnitTests, Version=1.0.0.0, Culture=neutral, PublicKeyToken=null"
+      type: "Microsoft.SemanticKernel.Process.UnitTests.Steps.KickoffStep, SemanticKernel.Process.UnitTests"
       id: kickoff_agent
     inputs:
       input:
@@ -92,7 +92,7 @@ nodes:
       last_feedback: 
         type: string
     agent:
-      type: "Microsoft.SemanticKernel.Process.UnitTests.ProcessSerializationTests+AStep, SemanticKernel.Process.UnitTests, Version=1.0.0.0, Culture=neutral, PublicKeyToken=null"
+      type: "Microsoft.SemanticKernel.Process.UnitTests.Steps.AStep, SemanticKernel.Process.UnitTests"
       id: a_step_agent
     on_complete:
       - on_condition:
@@ -108,7 +108,7 @@ nodes:
     version: "1.0"
     description: "B Step"
     agent:
-      type: "Microsoft.SemanticKernel.Process.UnitTests.ProcessSerializationTests+BStep, SemanticKernel.Process.UnitTests, Version=1.0.0.0, Culture=neutral, PublicKeyToken=null"
+      type: "Microsoft.SemanticKernel.Process.UnitTests.Steps.BStep, SemanticKernel.Process.UnitTests"
       id: b_step_agent
     on_complete:
       - on_condition:
@@ -142,7 +142,7 @@ nodes:
     version: "1.0"
     description: "C Step"
     agent: 
-      type: "Microsoft.SemanticKernel.Process.UnitTests.ProcessSerializationTests+CStep, SemanticKernel.Process.UnitTests, Version=1.0.0.0, Culture=neutral, PublicKeyToken=null"
+      type: "Microsoft.SemanticKernel.Process.UnitTests.Steps.CStep, SemanticKernel.Process.UnitTests"
       id: c_step_agent
     # inputs:
     #   type: string

--- a/dotnet/src/Experimental/Process.UnitTests/Steps/AStep.cs
+++ b/dotnet/src/Experimental/Process.UnitTests/Steps/AStep.cs
@@ -1,0 +1,20 @@
+﻿// Copyright (c) Microsoft. All rights reserved.
+
+using System;
+using System.Threading.Tasks;
+
+namespace Microsoft.SemanticKernel.Process.UnitTests.Steps;
+
+/// <summary>
+/// A step in the process.
+/// </summary>
+public sealed class AStep : KernelProcessStep
+{
+    [KernelFunction]
+    public async ValueTask DoItAsync(KernelProcessStepContext context)
+    {
+        Console.WriteLine("##### AStep ran.");
+        await Task.Delay(TimeSpan.FromSeconds(1));
+        await context.EmitEventAsync(CommonEvents.AStepDone, "I did A");
+    }
+}

--- a/dotnet/src/Experimental/Process.UnitTests/Steps/BStep.cs
+++ b/dotnet/src/Experimental/Process.UnitTests/Steps/BStep.cs
@@ -1,0 +1,20 @@
+﻿// Copyright (c) Microsoft. All rights reserved.
+
+using System;
+using System.Threading.Tasks;
+
+namespace Microsoft.SemanticKernel.Process.UnitTests.Steps;
+
+/// <summary>
+/// A step in the process.
+/// </summary>
+public sealed class BStep : KernelProcessStep
+{
+    [KernelFunction]
+    public async ValueTask DoItAsync(KernelProcessStepContext context)
+    {
+        Console.WriteLine("##### BStep ran.");
+        await Task.Delay(TimeSpan.FromSeconds(2));
+        await context.EmitEventAsync(new() { Id = CommonEvents.BStepDone, Data = "I did B" });
+    }
+}

--- a/dotnet/src/Experimental/Process.UnitTests/Steps/CStep.cs
+++ b/dotnet/src/Experimental/Process.UnitTests/Steps/CStep.cs
@@ -1,0 +1,55 @@
+﻿// Copyright (c) Microsoft. All rights reserved.
+
+using System;
+using System.Runtime.Serialization;
+using System.Threading.Tasks;
+
+namespace Microsoft.SemanticKernel.Process.UnitTests.Steps;
+
+/// <summary>
+/// A stateful step in the process. This step uses <see cref="CStepState"/> as the persisted
+/// state object and overrides the ActivateAsync method to initialize the state when activated.
+/// </summary>
+public sealed class CStep : KernelProcessStep<CStep.CStepState>
+{
+    private CStepState? _state;
+
+    // ################ Using persisted state #################
+    // CStep has state that we want to be persisted in the process. To ensure that the step always
+    // starts with the previously persisted or configured state, we need to override the ActivateAsync
+    // method and use the state object it provides.
+    public override ValueTask ActivateAsync(KernelProcessStepState<CStepState> state)
+    {
+        this._state = state.State!;
+        Console.WriteLine($"##### CStep activated with Cycle = '{state.State?.CurrentCycle}'.");
+        return base.ActivateAsync(state);
+    }
+
+    [KernelFunction]
+    public async ValueTask DoItAsync(KernelProcessStepContext context, string astepdata, string bstepdata)
+    {
+        // ########### This method will restart the process in a loop until CurrentCycle >= 3 ###########
+        this._state!.CurrentCycle++;
+        if (this._state.CurrentCycle >= 3)
+        {
+            // Exit the processes
+            Console.WriteLine("##### CStep run cycle 3 - exiting.");
+            await context.EmitEventAsync(new() { Id = CommonEvents.ExitRequested });
+            return;
+        }
+
+        // Cycle back to the start
+        Console.WriteLine($"##### CStep run cycle {this._state.CurrentCycle}.");
+        await context.EmitEventAsync(new() { Id = CommonEvents.CStepDone });
+    }
+
+    /// <summary>
+    /// A state object for the CStep.
+    /// </summary>
+    [DataContract]
+    public sealed record CStepState
+    {
+        [DataMember]
+        public int CurrentCycle { get; set; }
+    }
+}

--- a/dotnet/src/Experimental/Process.UnitTests/Steps/CommonEvents.cs
+++ b/dotnet/src/Experimental/Process.UnitTests/Steps/CommonEvents.cs
@@ -1,0 +1,20 @@
+﻿// Copyright (c) Microsoft. All rights reserved.
+
+namespace Microsoft.SemanticKernel.Process.UnitTests.Steps;
+
+/// <summary>
+/// Common Events used in the process.
+/// </summary>
+public static class CommonEvents
+{
+    public const string UserInputReceived = nameof(UserInputReceived);
+    public const string CompletionResponseGenerated = nameof(CompletionResponseGenerated);
+    public const string WelcomeDone = nameof(WelcomeDone);
+    public const string AStepDone = nameof(AStepDone);
+    public const string BStepDone = nameof(BStepDone);
+    public const string CStepDone = nameof(CStepDone);
+    public const string StartARequested = nameof(StartARequested);
+    public const string StartBRequested = nameof(StartBRequested);
+    public const string ExitRequested = nameof(ExitRequested);
+    public const string StartProcess = nameof(StartProcess);
+}

--- a/dotnet/src/Experimental/Process.UnitTests/Steps/KickoffStep.cs
+++ b/dotnet/src/Experimental/Process.UnitTests/Steps/KickoffStep.cs
@@ -1,0 +1,24 @@
+﻿// Copyright (c) Microsoft. All rights reserved.
+
+using System;
+using System.Threading.Tasks;
+
+namespace Microsoft.SemanticKernel.Process.UnitTests.Steps;
+
+/// <summary>
+/// Kick off step for the process.
+/// </summary>
+public sealed class KickoffStep : KernelProcessStep
+{
+    public static class ProcessFunctions
+    {
+        public const string KickOff = nameof(KickOff);
+    }
+
+    [KernelFunction(ProcessFunctions.KickOff)]
+    public async ValueTask PrintWelcomeMessageAsync(KernelProcessStepContext context)
+    {
+        Console.WriteLine("##### Kickoff ran.");
+        await context.EmitEventAsync(new() { Id = CommonEvents.StartARequested, Data = "Get Going" });
+    }
+}

--- a/dotnet/src/Experimental/Process.UnitTests/Steps/ProductInfoProvider.cs
+++ b/dotnet/src/Experimental/Process.UnitTests/Steps/ProductInfoProvider.cs
@@ -1,0 +1,27 @@
+﻿// Copyright (c) Microsoft. All rights reserved.
+
+using Microsoft.SemanticKernel;
+
+namespace SemanticKernel.Process.UnitTests.Steps;
+
+public class ProductInfoProvider : KernelProcessStep
+{
+    [KernelFunction]
+    public string GetProductInfo()
+    {
+        return
+            """
+            Product Description:
+            GlowBrew is a revolutionary AI driven coffee machine with industry leading number of LEDs and programmable light shows. The machine is also capable of brewing coffee and has a built in grinder.
+
+            Product Features:
+            1. **Luminous Brew Technology**: Customize your morning ambiance with programmable LED lights that sync with your brewing process.
+            2. **AI Taste Assistant**: Learns your taste preferences over time and suggests new brew combinations to explore.
+            3. **Gourmet Aroma Diffusion**: Built-in aroma diffusers enhance your coffee's scent profile, energizing your senses before the first sip.
+
+            Troubleshooting:
+            - **Issue**: LED Lights Malfunctioning
+                - **Solution**: Reset the lighting settings via the app. Ensure the LED connections inside the GlowBrew are secure. Perform a factory reset if necessary.
+            """;
+    }
+}


### PR DESCRIPTION
### Motivation and Context

<!-- Thank you for your contribution to the semantic-kernel repo!
Please help reviewers and future users, providing the following information:
  1. Why is this change required?
  2. What problem does it solve?
  3. What scenario does it contribute to?
  4. If it fixes an open issue, please link to the issue here.
-->

This PR contains a couple of improvements and tests for declarative processes:
1. Added parsing of workflow wrapper on top of non-wrapper declarative format.
2. Added a possibility to specify ID for declarative steps.
3. Fixed the registration of dotnet node by using node ID instead of agent ID.
4. Added unit tests to verify process import from YAML which contains both dotnet and declarative nodes and is compatible with VS Code extension.

### Contribution Checklist

<!-- Before submitting this PR, please make sure: -->

- [x] The code builds clean without any errors or warnings
- [x] The PR follows the [SK Contribution Guidelines](https://github.com/microsoft/semantic-kernel/blob/main/CONTRIBUTING.md) and the [pre-submission formatting script](https://github.com/microsoft/semantic-kernel/blob/main/CONTRIBUTING.md#development-scripts) raises no violations
- [x] All unit tests pass, and I have added new tests where possible
- [x] I didn't break anyone :smile:
