### PR TITLE
.Net: Stop setting dimensions when generating embeddings in SearchAsync 

### DIFF
--- a/dotnet/src/Connectors/Connectors.Memory.AzureAISearch/AzureAISearchCollection.cs
+++ b/dotnet/src/Connectors/Connectors.Memory.AzureAISearch/AzureAISearchCollection.cs
@@ -400,7 +400,7 @@ public class AzureAISearchCollection<TKey, TRecord> : VectorStoreCollection<TKey
             float[] f => new ReadOnlyMemory<float>(f),
             Embedding<float> e => e.Vector,
             _ when vectorProperty.EmbeddingGenerator is IEmbeddingGenerator<TInput, Embedding<float>> generator
-                => await generator.GenerateVectorAsync(searchValue, new() { Dimensions = vectorProperty.Dimensions }, cancellationToken).ConfigureAwait(false),
+                => await generator.GenerateVectorAsync(searchValue, cancellationToken: cancellationToken).ConfigureAwait(false),
 
             // A string was passed without an embedding generator being configured; send the string to Azure AI Search for backend embedding generation.
             string when vectorProperty.EmbeddingGenerator is null => (ReadOnlyMemory<float>?)null,

--- a/dotnet/src/Connectors/Connectors.Memory.CosmosMongoDB/CosmosMongoCollection.cs
+++ b/dotnet/src/Connectors/Connectors.Memory.CosmosMongoDB/CosmosMongoCollection.cs
@@ -333,8 +333,9 @@ public class CosmosMongoCollection<TKey, TRecord> : VectorStoreCollection<TKey, 
             ReadOnlyMemory<float> r => Unwrap(r),
             float[] f => f,
             Embedding<float> e => Unwrap(e.Vector),
+
             _ when vectorProperty.EmbeddingGenerator is IEmbeddingGenerator<TInput, Embedding<float>> generator
-                => Unwrap(await generator.GenerateVectorAsync(searchValue, new() { Dimensions = vectorProperty.Dimensions }, cancellationToken).ConfigureAwait(false)),
+                => Unwrap(await generator.GenerateVectorAsync(searchValue, cancellationToken: cancellationToken).ConfigureAwait(false)),
 
             _ => vectorProperty.EmbeddingGenerator is null
                 ? throw new NotSupportedException(VectorDataStrings.InvalidSearchInputAndNoEmbeddingGeneratorWasConfigured(searchValue.GetType(), MongoModelBuilder.SupportedVectorTypes))

--- a/dotnet/src/Connectors/Connectors.Memory.CosmosNoSql/CosmosNoSqlCollection.cs
+++ b/dotnet/src/Connectors/Connectors.Memory.CosmosNoSql/CosmosNoSqlCollection.cs
@@ -492,21 +492,21 @@ public class CosmosNoSqlCollection<TKey, TRecord> : VectorStoreCollection<TKey, 
             float[] a => new ReadOnlyMemory<float>(a),
             Embedding<float> e => e.Vector,
             _ when vectorProperty.EmbeddingGenerator is IEmbeddingGenerator<TInput, Embedding<float>> generator
-                => await generator.GenerateVectorAsync(searchValue, new() { Dimensions = vectorProperty.Dimensions }, cancellationToken).ConfigureAwait(false),
+                => await generator.GenerateVectorAsync(searchValue, cancellationToken: cancellationToken).ConfigureAwait(false),
 
             // int8
             ReadOnlyMemory<sbyte> m => m,
             sbyte[] a => new ReadOnlyMemory<sbyte>(a),
             Embedding<sbyte> e => e.Vector,
             _ when vectorProperty.EmbeddingGenerator is IEmbeddingGenerator<TInput, Embedding<sbyte>> generator
-                => await generator.GenerateVectorAsync(searchValue, new() { Dimensions = vectorProperty.Dimensions }, cancellationToken).ConfigureAwait(false),
+                => await generator.GenerateVectorAsync(searchValue, cancellationToken: cancellationToken).ConfigureAwait(false),
 
             // uint8
             ReadOnlyMemory<byte> m => m,
             byte[] a => new ReadOnlyMemory<byte>(a),
             Embedding<byte> e => e.Vector,
             _ when vectorProperty.EmbeddingGenerator is IEmbeddingGenerator<TInput, Embedding<byte>> generator
-                => await generator.GenerateVectorAsync(searchValue, new() { Dimensions = vectorProperty.Dimensions }, cancellationToken).ConfigureAwait(false),
+                => await generator.GenerateVectorAsync(searchValue, cancellationToken: cancellationToken).ConfigureAwait(false),
 
             _ => vectorProperty.EmbeddingGenerator is null
                 ? throw new NotSupportedException(VectorDataStrings.InvalidSearchInputAndNoEmbeddingGeneratorWasConfigured(searchValue.GetType(), CosmosNoSqlModelBuilder.SupportedVectorTypes))

--- a/dotnet/src/Connectors/Connectors.Memory.InMemory/InMemoryCollection.cs
+++ b/dotnet/src/Connectors/Connectors.Memory.InMemory/InMemoryCollection.cs
@@ -272,7 +272,7 @@ public class InMemoryCollection<TKey, TRecord> : VectorStoreCollection<TKey, TRe
             float[] f => new ReadOnlyMemory<float>(f),
             Embedding<float> e => e.Vector,
             _ when vectorProperty.EmbeddingGenerator is IEmbeddingGenerator<TInput, Embedding<float>> generator
-                => await generator.GenerateVectorAsync(searchValue, new() { Dimensions = vectorProperty.Dimensions }, cancellationToken).ConfigureAwait(false),
+                => await generator.GenerateVectorAsync(searchValue, cancellationToken: cancellationToken).ConfigureAwait(false),
 
             _ => vectorProperty.EmbeddingGenerator is null
                 ? throw new NotSupportedException(VectorDataStrings.InvalidSearchInputAndNoEmbeddingGeneratorWasConfigured(searchValue.GetType(), InMemoryModelBuilder.SupportedVectorTypes))

--- a/dotnet/src/Connectors/Connectors.Memory.MongoDB/MongoCollection.cs
+++ b/dotnet/src/Connectors/Connectors.Memory.MongoDB/MongoCollection.cs
@@ -351,7 +351,7 @@ public class MongoCollection<TKey, TRecord> : VectorStoreCollection<TKey, TRecor
             float[] f => new ReadOnlyMemory<float>(f),
             Embedding<float> e => e.Vector,
             _ when vectorProperty.EmbeddingGenerator is IEmbeddingGenerator<TInput, Embedding<float>> generator
-                => await generator.GenerateVectorAsync(searchValue, new() { Dimensions = vectorProperty.Dimensions }, cancellationToken).ConfigureAwait(false),
+                => await generator.GenerateVectorAsync(searchValue, cancellationToken: cancellationToken).ConfigureAwait(false),
 
             _ => vectorProperty.EmbeddingGenerator is null
                 ? throw new NotSupportedException(VectorDataStrings.InvalidSearchInputAndNoEmbeddingGeneratorWasConfigured(searchValue.GetType(), MongoModelBuilder.SupportedVectorTypes))

--- a/dotnet/src/Connectors/Connectors.Memory.PgVector/PostgresCollection.cs
+++ b/dotnet/src/Connectors/Connectors.Memory.PgVector/PostgresCollection.cs
@@ -369,7 +369,7 @@ public class PostgresCollection<TKey, TRecord> : VectorStoreCollection<TKey, TRe
             float[] f => new ReadOnlyMemory<float>(f),
             Embedding<float> e => e.Vector,
             _ when vectorProperty.EmbeddingGenerator is IEmbeddingGenerator<TInput, Embedding<float>> generator
-                => await generator.GenerateVectorAsync(searchValue, new() { Dimensions = vectorProperty.Dimensions }, cancellationToken).ConfigureAwait(false),
+                => await generator.GenerateVectorAsync(searchValue, cancellationToken: cancellationToken).ConfigureAwait(false),
 
 #if NET8_0_OR_GREATER
             // Dense float16
@@ -377,7 +377,7 @@ public class PostgresCollection<TKey, TRecord> : VectorStoreCollection<TKey, TRe
             Half[] f => new ReadOnlyMemory<Half>(f),
             Embedding<Half> e => e.Vector,
             _ when vectorProperty.EmbeddingGenerator is IEmbeddingGenerator<TInput, Embedding<Half>> generator
-                => await generator.GenerateVectorAsync(searchValue, new() { Dimensions = vectorProperty.Dimensions }, cancellationToken).ConfigureAwait(false),
+                => await generator.GenerateVectorAsync(searchValue, cancellationToken: cancellationToken).ConfigureAwait(false),
 #endif
 
             // Dense Binary
@@ -385,7 +385,7 @@ public class PostgresCollection<TKey, TRecord> : VectorStoreCollection<TKey, TRe
             // TODO: Uncomment once we sync to the latest MEAI
             // BinaryEmbedding e => e.Vector,
             // _ when vectorProperty.EmbeddingGenerator is IEmbeddingGenerator<TVector, BinaryEmbedding> generator
-            //     => (await generator.GenerateEmbeddingAsync(value, new() { Dimensions = vectorProperty.Dimensions }, cancellationToken).ConfigureAwait(false)).Vector,
+            //     => (await generator.GenerateEmbeddingAsync(value, cancellationToken: cancellationToken).ConfigureAwait(false)).Vector,
 
             // Sparse
             SparseVector sv => sv,

--- a/dotnet/src/Connectors/Connectors.Memory.Pinecone/PineconeCollection.cs
+++ b/dotnet/src/Connectors/Connectors.Memory.Pinecone/PineconeCollection.cs
@@ -418,7 +418,7 @@ public class PineconeCollection<TKey, TRecord> : VectorStoreCollection<TKey, TRe
             float[] f => new ReadOnlyMemory<float>(f),
             Embedding<float> e => e.Vector,
             _ when vectorProperty.EmbeddingGenerator is IEmbeddingGenerator<TInput, Embedding<float>> generator
-                => await generator.GenerateVectorAsync(searchValue, new() { Dimensions = vectorProperty.Dimensions }, cancellationToken).ConfigureAwait(false),
+                => await generator.GenerateVectorAsync(searchValue, cancellationToken: cancellationToken).ConfigureAwait(false),
 
             _ => vectorProperty.EmbeddingGenerator is null
                 ? throw new NotSupportedException(VectorDataStrings.InvalidSearchInputAndNoEmbeddingGeneratorWasConfigured(searchValue.GetType(), PineconeModelBuilder.SupportedVectorTypes))

--- a/dotnet/src/Connectors/Connectors.Memory.Qdrant/QdrantCollection.cs
+++ b/dotnet/src/Connectors/Connectors.Memory.Qdrant/QdrantCollection.cs
@@ -540,7 +540,7 @@ public class QdrantCollection<TKey, TRecord> : VectorStoreCollection<TKey, TReco
             float[] f => new ReadOnlyMemory<float>(f),
             Embedding<float> e => e.Vector,
             _ when vectorProperty.EmbeddingGenerator is IEmbeddingGenerator<TInput, Embedding<float>> generator
-                => await generator.GenerateVectorAsync(searchValue, new() { Dimensions = vectorProperty.Dimensions }, cancellationToken).ConfigureAwait(false),
+                => await generator.GenerateVectorAsync(searchValue, cancellationToken: cancellationToken).ConfigureAwait(false),
 
             _ => vectorProperty.EmbeddingGenerator is null
                 ? throw new NotSupportedException(VectorDataStrings.InvalidSearchInputAndNoEmbeddingGeneratorWasConfigured(searchValue.GetType(), QdrantModelBuilder.SupportedVectorTypes))

--- a/dotnet/src/Connectors/Connectors.Memory.Redis/RedisHashSetCollection.cs
+++ b/dotnet/src/Connectors/Connectors.Memory.Redis/RedisHashSetCollection.cs
@@ -344,14 +344,14 @@ public class RedisHashSetCollection<TKey, TRecord> : VectorStoreCollection<TKey,
             float[] f => new ReadOnlyMemory<float>(f),
             Embedding<float> e => e.Vector,
             _ when vectorProperty.EmbeddingGenerator is IEmbeddingGenerator<TInput, Embedding<float>> generator
-                => await generator.GenerateVectorAsync(searchValue, new() { Dimensions = vectorProperty.Dimensions }, cancellationToken).ConfigureAwait(false),
+                => await generator.GenerateVectorAsync(searchValue, cancellationToken: cancellationToken).ConfigureAwait(false),
 
             // float64
             ReadOnlyMemory<double> r => r,
             double[] f => new ReadOnlyMemory<double>(f),
             Embedding<double> e => e.Vector,
             _ when vectorProperty.EmbeddingGenerator is IEmbeddingGenerator<TInput, Embedding<double>> generator
-                => await generator.GenerateVectorAsync(searchValue, new() { Dimensions = vectorProperty.Dimensions }, cancellationToken).ConfigureAwait(false),
+                => await generator.GenerateVectorAsync(searchValue, cancellationToken: cancellationToken).ConfigureAwait(false),
 
             _ => vectorProperty.EmbeddingGenerator is null
                 ? throw new NotSupportedException(VectorDataStrings.InvalidSearchInputAndNoEmbeddingGeneratorWasConfigured(searchValue.GetType(), RedisModelBuilder.SupportedVectorTypes))

--- a/dotnet/src/Connectors/Connectors.Memory.Redis/RedisJsonCollection.cs
+++ b/dotnet/src/Connectors/Connectors.Memory.Redis/RedisJsonCollection.cs
@@ -427,14 +427,14 @@ public class RedisJsonCollection<TKey, TRecord> : VectorStoreCollection<TKey, TR
             float[] f => new ReadOnlyMemory<float>(f),
             Embedding<float> e => e.Vector,
             _ when vectorProperty.EmbeddingGenerator is IEmbeddingGenerator<TInput, Embedding<float>> generator
-                => await generator.GenerateVectorAsync(searchValue, new() { Dimensions = vectorProperty.Dimensions }, cancellationToken).ConfigureAwait(false),
+                => await generator.GenerateVectorAsync(searchValue, cancellationToken: cancellationToken).ConfigureAwait(false),
 
             // float64
             ReadOnlyMemory<double> r => r,
             double[] f => new ReadOnlyMemory<double>(f),
             Embedding<double> e => e.Vector,
             _ when vectorProperty.EmbeddingGenerator is IEmbeddingGenerator<TInput, Embedding<double>> generator
-                => await generator.GenerateVectorAsync(searchValue, new() { Dimensions = vectorProperty.Dimensions }, cancellationToken).ConfigureAwait(false),
+                => await generator.GenerateVectorAsync(searchValue, cancellationToken: cancellationToken).ConfigureAwait(false),
 
             _ => vectorProperty.EmbeddingGenerator is null
                 ? throw new NotSupportedException(VectorDataStrings.InvalidSearchInputAndNoEmbeddingGeneratorWasConfigured(searchValue.GetType(), RedisModelBuilder.SupportedVectorTypes))

--- a/dotnet/src/Connectors/Connectors.Memory.SqlServer/SqlServerCollection.cs
+++ b/dotnet/src/Connectors/Connectors.Memory.SqlServer/SqlServerCollection.cs
@@ -538,7 +538,7 @@ public class SqlServerCollection<TKey, TRecord>
             float[] f => new ReadOnlyMemory<float>(f),
             Embedding<float> e => e.Vector,
             _ when vectorProperty.EmbeddingGenerator is IEmbeddingGenerator<TInput, Embedding<float>> generator
-                => await generator.GenerateVectorAsync(searchValue, new() { Dimensions = vectorProperty.Dimensions }, cancellationToken).ConfigureAwait(false),
+                => await generator.GenerateVectorAsync(searchValue, cancellationToken: cancellationToken).ConfigureAwait(false),
 
             _ => vectorProperty.EmbeddingGenerator is null
                 ? throw new NotSupportedException(VectorDataStrings.InvalidSearchInputAndNoEmbeddingGeneratorWasConfigured(searchValue.GetType(), SqlServerModelBuilder.SupportedVectorTypes))

--- a/dotnet/src/Connectors/Connectors.Memory.SqliteVec/SqliteCollection.cs
+++ b/dotnet/src/Connectors/Connectors.Memory.SqliteVec/SqliteCollection.cs
@@ -185,7 +185,7 @@ public class SqliteCollection<TKey, TRecord> : VectorStoreCollection<TKey, TReco
             float[] f => new ReadOnlyMemory<float>(f),
             Embedding<float> e => e.Vector,
             _ when vectorProperty.EmbeddingGenerator is IEmbeddingGenerator<TInput, Embedding<float>> generator
-                => await generator.GenerateVectorAsync(searchValue, new() { Dimensions = vectorProperty.Dimensions }, cancellationToken).ConfigureAwait(false),
+                => await generator.GenerateVectorAsync(searchValue, cancellationToken: cancellationToken).ConfigureAwait(false),
 
             _ => vectorProperty.EmbeddingGenerator is null
                 ? throw new NotSupportedException(VectorDataStrings.InvalidSearchInputAndNoEmbeddingGeneratorWasConfigured(searchValue.GetType(), SqliteModelBuilder.SupportedVectorTypes))

--- a/dotnet/src/Connectors/Connectors.Memory.Weaviate/WeaviateCollection.cs
+++ b/dotnet/src/Connectors/Connectors.Memory.Weaviate/WeaviateCollection.cs
@@ -339,7 +339,7 @@ public class WeaviateCollection<TKey, TRecord> : VectorStoreCollection<TKey, TRe
             float[] f => new ReadOnlyMemory<float>(f),
             Embedding<float> e => e.Vector,
             _ when vectorProperty.EmbeddingGenerator is IEmbeddingGenerator<TInput, Embedding<float>> generator
-                => await generator.GenerateVectorAsync(searchValue, new() { Dimensions = vectorProperty.Dimensions }, cancellationToken).ConfigureAwait(false),
+                => await generator.GenerateVectorAsync(searchValue, cancellationToken: cancellationToken).ConfigureAwait(false),
 
             _ => vectorProperty.EmbeddingGenerator is null
                 ? throw new NotSupportedException(VectorDataStrings.InvalidSearchInputAndNoEmbeddingGeneratorWasConfigured(searchValue.GetType(), WeaviateModelBuilder.SupportedVectorTypes))


### PR DESCRIPTION
~**NOTE: This is based on top of #12081, review last commit only.**~

#11908 stopped passing dimensions to embedding generation (since that causes failures in some models), but left out SearchAsync. This PR completes that work.

Closes #11902