### PR TITLE
.Net: Rename RecordSearchOptions -> VectorSearchOptions

### DIFF
--- a/dotnet/src/Connectors/Connectors.CosmosMongoDB.UnitTests/CosmosMongoCollectionTests.cs
+++ b/dotnet/src/Connectors/Connectors.CosmosMongoDB.UnitTests/CosmosMongoCollectionTests.cs
@@ -14,6 +14,7 @@ using MongoDB.Bson.Serialization.Attributes;
 using MongoDB.Driver;
 using Moq;
 using Xunit;
+using MEVD = Microsoft.Extensions.VectorData;
 
 namespace SemanticKernel.Connectors.CosmosMongoDB.UnitTests;
 
@@ -513,7 +514,7 @@ public sealed class CosmosMongoCollectionTests
             this._mockMongoDatabase.Object,
             "collection");
 
-        var options = new RecordSearchOptions<CosmosMongoHotelModel> { VectorProperty = r => "non-existent-property" };
+        var options = new MEVD.VectorSearchOptions<CosmosMongoHotelModel> { VectorProperty = r => "non-existent-property" };
 
         // Act & Assert
         await Assert.ThrowsAsync<InvalidOperationException>(async () => await sut.SearchAsync(new ReadOnlyMemory<float>([1f, 2f, 3f]), top: 3, options).FirstOrDefaultAsync());

--- a/dotnet/src/Connectors/Connectors.CosmosNoSql.UnitTests/CosmosNoSqlCollectionTests.cs
+++ b/dotnet/src/Connectors/Connectors.CosmosNoSql.UnitTests/CosmosNoSqlCollectionTests.cs
@@ -564,7 +564,7 @@ public sealed class CosmosNoSqlCollectionTests
             this._mockDatabase.Object,
             "collection");
 
-        var searchOptions = new RecordSearchOptions<CosmosNoSqlHotel> { VectorProperty = r => "non-existent-property" };
+        var searchOptions = new VectorSearchOptions<CosmosNoSqlHotel> { VectorProperty = r => "non-existent-property" };
 
         // Act & Assert
         await Assert.ThrowsAsync<InvalidOperationException>(async () =>

--- a/dotnet/src/Connectors/Connectors.Memory.AzureAISearch/AzureAISearchCollection.cs
+++ b/dotnet/src/Connectors/Connectors.Memory.AzureAISearch/AzureAISearchCollection.cs
@@ -38,7 +38,7 @@ public class AzureAISearchCollection<TKey, TRecord> : VectorStoreCollection<TKey
     private readonly VectorStoreCollectionMetadata _collectionMetadata;
 
     /// <summary>The default options for vector search.</summary>
-    private static readonly RecordSearchOptions<TRecord> s_defaultVectorSearchOptions = new();
+    private static readonly VectorSearchOptions<TRecord> s_defaultVectorSearchOptions = new();
 
     /// <summary>The default options for hybrid vector search.</summary>
     private static readonly HybridSearchOptions<TRecord> s_defaultKeywordVectorizedHybridSearchOptions = new();
@@ -387,7 +387,7 @@ public class AzureAISearchCollection<TKey, TRecord> : VectorStoreCollection<TKey
     public override async IAsyncEnumerable<VectorSearchResult<TRecord>> SearchAsync<TInput>(
         TInput searchValue,
         int top,
-        RecordSearchOptions<TRecord>? options = null,
+        VectorSearchOptions<TRecord>? options = null,
         [EnumeratorCancellation] CancellationToken cancellationToken = default)
     {
         Verify.NotNull(searchValue);
@@ -623,7 +623,7 @@ public class AzureAISearchCollection<TKey, TRecord> : VectorStoreCollection<TKey
     /// Build the search options for a vector search, where the type of vector search can be provided as input.
     /// E.g. VectorizedQuery or VectorizableTextQuery.
     /// </summary>
-    private static SearchOptions BuildSearchOptions(CollectionModel model, RecordSearchOptions<TRecord> options, int top, VectorQuery? vectorQuery)
+    private static SearchOptions BuildSearchOptions(CollectionModel model, VectorSearchOptions<TRecord> options, int top, VectorQuery? vectorQuery)
     {
         if (model.VectorProperties.Count == 0)
         {

--- a/dotnet/src/Connectors/Connectors.Memory.CosmosMongoDB/CosmosMongoCollection.cs
+++ b/dotnet/src/Connectors/Connectors.Memory.CosmosMongoDB/CosmosMongoCollection.cs
@@ -16,6 +16,7 @@ using Microsoft.Extensions.VectorData.ProviderServices;
 using Microsoft.SemanticKernel.Connectors.MongoDB;
 using MongoDB.Bson;
 using MongoDB.Driver;
+using MEVD = Microsoft.Extensions.VectorData;
 
 namespace Microsoft.SemanticKernel.Connectors.CosmosMongoDB;
 
@@ -40,7 +41,7 @@ public class CosmosMongoCollection<TKey, TRecord> : VectorStoreCollection<TKey, 
     private const string DocumentPropertyName = "document";
 
     /// <summary>The default options for vector search.</summary>
-    private static readonly RecordSearchOptions<TRecord> s_defaultVectorSearchOptions = new();
+    private static readonly MEVD.VectorSearchOptions<TRecord> s_defaultVectorSearchOptions = new();
 
     /// <summary><see cref="IMongoDatabase"/> that can be used to manage the collections in Azure CosmosDB MongoDB.</summary>
     private readonly IMongoDatabase _mongoDatabase;
@@ -314,7 +315,7 @@ public class CosmosMongoCollection<TKey, TRecord> : VectorStoreCollection<TKey, 
     public override async IAsyncEnumerable<VectorSearchResult<TRecord>> SearchAsync<TInput>(
         TInput searchValue,
         int top,
-        RecordSearchOptions<TRecord>? options = null,
+        MEVD.VectorSearchOptions<TRecord>? options = null,
         [EnumeratorCancellation] CancellationToken cancellationToken = default)
     {
         Verify.NotNull(searchValue);
@@ -534,7 +535,7 @@ public class CosmosMongoCollection<TKey, TRecord> : VectorStoreCollection<TKey, 
 
     private async IAsyncEnumerable<VectorSearchResult<TRecord>> EnumerateAndMapSearchResultsAsync(
         ErrorHandlingAsyncCursor<BsonDocument> cursor,
-        RecordSearchOptions<TRecord> searchOptions,
+        MEVD.VectorSearchOptions<TRecord> searchOptions,
         [EnumeratorCancellation] CancellationToken cancellationToken)
     {
         var skipCounter = 0;

--- a/dotnet/src/Connectors/Connectors.Memory.CosmosNoSql/CosmosNoSqlCollection.cs
+++ b/dotnet/src/Connectors/Connectors.Memory.CosmosNoSql/CosmosNoSqlCollection.cs
@@ -38,7 +38,7 @@ public class CosmosNoSqlCollection<TKey, TRecord> : VectorStoreCollection<TKey, 
     private readonly VectorStoreCollectionMetadata _collectionMetadata;
 
     /// <summary>The default options for vector search.</summary>
-    private static readonly RecordSearchOptions<TRecord> s_defaultVectorSearchOptions = new();
+    private static readonly VectorSearchOptions<TRecord> s_defaultVectorSearchOptions = new();
 
     /// <summary>The default options for hybrid vector search.</summary>
     private static readonly HybridSearchOptions<TRecord> s_defaultKeywordVectorizedHybridSearchOptions = new();
@@ -468,7 +468,7 @@ public class CosmosNoSqlCollection<TKey, TRecord> : VectorStoreCollection<TKey, 
     public override async IAsyncEnumerable<VectorSearchResult<TRecord>> SearchAsync<TInput>(
         TInput searchValue,
         int top,
-        RecordSearchOptions<TRecord>? options = null,
+        VectorSearchOptions<TRecord>? options = null,
         [EnumeratorCancellation] CancellationToken cancellationToken = default)
     {
         Verify.NotNull(searchValue);

--- a/dotnet/src/Connectors/Connectors.Memory.InMemory/InMemoryCollection.cs
+++ b/dotnet/src/Connectors/Connectors.Memory.InMemory/InMemoryCollection.cs
@@ -31,7 +31,7 @@ public class InMemoryCollection<TKey, TRecord> : VectorStoreCollection<TKey, TRe
     private readonly VectorStoreCollectionMetadata _collectionMetadata;
 
     /// <summary>The default options for vector search.</summary>
-    private static readonly RecordSearchOptions<TRecord> s_defaultVectorSearchOptions = new();
+    private static readonly VectorSearchOptions<TRecord> s_defaultVectorSearchOptions = new();
 
     /// <summary>Internal storage for all of the record collections.</summary>
     private readonly ConcurrentDictionary<string, ConcurrentDictionary<object, object>> _internalCollections;
@@ -252,7 +252,7 @@ public class InMemoryCollection<TKey, TRecord> : VectorStoreCollection<TKey, TRe
     public override async IAsyncEnumerable<VectorSearchResult<TRecord>> SearchAsync<TInput>(
         TInput searchValue,
         int top,
-        RecordSearchOptions<TRecord>? options = null,
+        VectorSearchOptions<TRecord>? options = null,
         [EnumeratorCancellation] CancellationToken cancellationToken = default)
     {
         Verify.NotNull(searchValue);

--- a/dotnet/src/Connectors/Connectors.Memory.MongoDB/MongoCollection.cs
+++ b/dotnet/src/Connectors/Connectors.Memory.MongoDB/MongoCollection.cs
@@ -15,6 +15,7 @@ using Microsoft.Extensions.VectorData;
 using Microsoft.Extensions.VectorData.ProviderServices;
 using MongoDB.Bson;
 using MongoDB.Driver;
+using MEVD = Microsoft.Extensions.VectorData;
 
 namespace Microsoft.SemanticKernel.Connectors.MongoDB;
 
@@ -39,7 +40,7 @@ public class MongoCollection<TKey, TRecord> : VectorStoreCollection<TKey, TRecor
     private const string DocumentPropertyName = "document";
 
     /// <summary>The default options for vector search.</summary>
-    private static readonly RecordSearchOptions<TRecord> s_defaultVectorSearchOptions = new();
+    private static readonly MEVD.VectorSearchOptions<TRecord> s_defaultVectorSearchOptions = new();
 
     /// <summary>The default options for hybrid vector search.</summary>
     private static readonly HybridSearchOptions<TRecord> s_defaultKeywordVectorizedHybridSearchOptions = new();
@@ -331,7 +332,7 @@ public class MongoCollection<TKey, TRecord> : VectorStoreCollection<TKey, TRecor
     public override async IAsyncEnumerable<VectorSearchResult<TRecord>> SearchAsync<TInput>(
         TInput searchValue,
         int top,
-        RecordSearchOptions<TRecord>? options = null,
+        MEVD.VectorSearchOptions<TRecord>? options = null,
         [EnumeratorCancellation] CancellationToken cancellationToken = default)
     {
         Verify.NotNull(searchValue);

--- a/dotnet/src/Connectors/Connectors.Memory.PgVector/PostgresCollection.cs
+++ b/dotnet/src/Connectors/Connectors.Memory.PgVector/PostgresCollection.cs
@@ -44,7 +44,7 @@ public class PostgresCollection<TKey, TRecord> : VectorStoreCollection<TKey, TRe
     private readonly PostgresMapper<TRecord> _mapper;
 
     /// <summary>The default options for vector search.</summary>
-    private static readonly RecordSearchOptions<TRecord> s_defaultVectorSearchOptions = new();
+    private static readonly VectorSearchOptions<TRecord> s_defaultVectorSearchOptions = new();
 
     /// <summary>
     /// Initializes a new instance of the <see cref="PostgresCollection{TKey, TRecord}"/> class.
@@ -348,7 +348,7 @@ public class PostgresCollection<TKey, TRecord> : VectorStoreCollection<TKey, TRe
     public override async IAsyncEnumerable<VectorSearchResult<TRecord>> SearchAsync<TInput>(
         TInput searchValue,
         int top,
-        RecordSearchOptions<TRecord>? options = null,
+        VectorSearchOptions<TRecord>? options = null,
         [EnumeratorCancellation] CancellationToken cancellationToken = default)
     {
         Verify.NotNull(searchValue);

--- a/dotnet/src/Connectors/Connectors.Memory.PgVector/PostgresDbClient.cs
+++ b/dotnet/src/Connectors/Connectors.Memory.PgVector/PostgresDbClient.cs
@@ -212,7 +212,7 @@ internal sealed class PostgresDbClient(NpgsqlDataSource dataSource, string? sche
     /// <inheritdoc />
     public async IAsyncEnumerable<(Dictionary<string, object?> Row, double Distance)> GetNearestMatchesAsync<TRecord>(
         string tableName, CollectionModel model, VectorPropertyModel vectorProperty, object vectorValue, int limit,
-        RecordSearchOptions<TRecord> options, [EnumeratorCancellation] CancellationToken cancellationToken = default)
+        VectorSearchOptions<TRecord> options, [EnumeratorCancellation] CancellationToken cancellationToken = default)
     {
         NpgsqlConnection connection = await this.DataSource.OpenConnectionAsync(cancellationToken).ConfigureAwait(false);
 

--- a/dotnet/src/Connectors/Connectors.Memory.Pinecone/PineconeCollection.cs
+++ b/dotnet/src/Connectors/Connectors.Memory.Pinecone/PineconeCollection.cs
@@ -28,7 +28,7 @@ public class PineconeCollection<TKey, TRecord> : VectorStoreCollection<TKey, TRe
     where TRecord : class
 #pragma warning restore CA1711 // Identifiers should not have incorrect suffix
 {
-    private static readonly RecordSearchOptions<TRecord> s_defaultVectorSearchOptions = new();
+    private static readonly VectorSearchOptions<TRecord> s_defaultVectorSearchOptions = new();
 
     /// <summary>Metadata about vector store record collection.</summary>
     private readonly VectorStoreCollectionMetadata _collectionMetadata;
@@ -398,7 +398,7 @@ public class PineconeCollection<TKey, TRecord> : VectorStoreCollection<TKey, TRe
     public override async IAsyncEnumerable<VectorSearchResult<TRecord>> SearchAsync<TInput>(
         TInput searchValue,
         int top,
-        RecordSearchOptions<TRecord>? options = null,
+        VectorSearchOptions<TRecord>? options = null,
         [EnumeratorCancellation] CancellationToken cancellationToken = default)
     {
         Verify.NotNull(searchValue);

--- a/dotnet/src/Connectors/Connectors.Memory.Qdrant/QdrantCollection.cs
+++ b/dotnet/src/Connectors/Connectors.Memory.Qdrant/QdrantCollection.cs
@@ -35,7 +35,7 @@ public class QdrantCollection<TKey, TRecord> : VectorStoreCollection<TKey, TReco
     private readonly VectorStoreCollectionMetadata _collectionMetadata;
 
     /// <summary>The default options for vector search.</summary>
-    private static readonly RecordSearchOptions<TRecord> s_defaultVectorSearchOptions = new();
+    private static readonly VectorSearchOptions<TRecord> s_defaultVectorSearchOptions = new();
 
     /// <summary>The default options for hybrid vector search.</summary>
     private static readonly HybridSearchOptions<TRecord> s_defaultKeywordVectorizedHybridSearchOptions = new();
@@ -520,7 +520,7 @@ public class QdrantCollection<TKey, TRecord> : VectorStoreCollection<TKey, TReco
     public override async IAsyncEnumerable<VectorSearchResult<TRecord>> SearchAsync<TInput>(
         TInput searchValue,
         int top,
-        RecordSearchOptions<TRecord>? options = null,
+        VectorSearchOptions<TRecord>? options = null,
         [EnumeratorCancellation] CancellationToken cancellationToken = default)
     {
         Verify.NotNull(searchValue);

--- a/dotnet/src/Connectors/Connectors.Memory.Redis/RedisCollectionSearchMapping.cs
+++ b/dotnet/src/Connectors/Connectors.Memory.Redis/RedisCollectionSearchMapping.cs
@@ -48,7 +48,7 @@ internal static class RedisCollectionSearchMapping
     /// <param name="vectorProperty">The vector property.</param>
     /// <param name="selectFields">The set of fields to limit the results to. Null for all.</param>
     /// <returns>The <see cref="Query"/>.</returns>
-    public static Query BuildQuery<TRecord>(byte[] vectorBytes, int top, RecordSearchOptions<TRecord> options, CollectionModel model, VectorPropertyModel vectorProperty, string[]? selectFields)
+    public static Query BuildQuery<TRecord>(byte[] vectorBytes, int top, VectorSearchOptions<TRecord> options, CollectionModel model, VectorPropertyModel vectorProperty, string[]? selectFields)
     {
         // Build search query.
         var redisLimit = top + options.Skip;

--- a/dotnet/src/Connectors/Connectors.Memory.Redis/RedisHashSetCollection.cs
+++ b/dotnet/src/Connectors/Connectors.Memory.Redis/RedisHashSetCollection.cs
@@ -41,7 +41,7 @@ public class RedisHashSetCollection<TKey, TRecord> : VectorStoreCollection<TKey,
     };
 
     /// <summary>The default options for vector search.</summary>
-    private static readonly RecordSearchOptions<TRecord> s_defaultVectorSearchOptions = new();
+    private static readonly VectorSearchOptions<TRecord> s_defaultVectorSearchOptions = new();
 
     /// <summary>The Redis database to read/write records from.</summary>
     private readonly IDatabase _database;
@@ -323,7 +323,7 @@ public class RedisHashSetCollection<TKey, TRecord> : VectorStoreCollection<TKey,
     public override async IAsyncEnumerable<VectorSearchResult<TRecord>> SearchAsync<TInput>(
         TInput searchValue,
         int top,
-        RecordSearchOptions<TRecord>? options = null,
+        VectorSearchOptions<TRecord>? options = null,
         [EnumeratorCancellation] CancellationToken cancellationToken = default)
     {
         Verify.NotNull(searchValue);

--- a/dotnet/src/Connectors/Connectors.Memory.Redis/RedisJsonCollection.cs
+++ b/dotnet/src/Connectors/Connectors.Memory.Redis/RedisJsonCollection.cs
@@ -45,7 +45,7 @@ public class RedisJsonCollection<TKey, TRecord> : VectorStoreCollection<TKey, TR
     };
 
     /// <summary>The default options for vector search.</summary>
-    private static readonly RecordSearchOptions<TRecord> s_defaultVectorSearchOptions = new();
+    private static readonly VectorSearchOptions<TRecord> s_defaultVectorSearchOptions = new();
 
     /// <summary>The Redis database to read/write records from.</summary>
     private readonly IDatabase _database;
@@ -406,7 +406,7 @@ public class RedisJsonCollection<TKey, TRecord> : VectorStoreCollection<TKey, TR
     public override async IAsyncEnumerable<VectorSearchResult<TRecord>> SearchAsync<TInput>(
         TInput searchValue,
         int top,
-        RecordSearchOptions<TRecord>? options = null,
+        VectorSearchOptions<TRecord>? options = null,
         [EnumeratorCancellation] CancellationToken cancellationToken = default)
     {
         Verify.NotNull(searchValue);

--- a/dotnet/src/Connectors/Connectors.Memory.SqlServer/SqlServerCollection.cs
+++ b/dotnet/src/Connectors/Connectors.Memory.SqlServer/SqlServerCollection.cs
@@ -29,7 +29,7 @@ public class SqlServerCollection<TKey, TRecord>
     /// <summary>Metadata about vector store record collection.</summary>
     private readonly VectorStoreCollectionMetadata _collectionMetadata;
 
-    private static readonly RecordSearchOptions<TRecord> s_defaultVectorSearchOptions = new();
+    private static readonly VectorSearchOptions<TRecord> s_defaultVectorSearchOptions = new();
 
     private readonly string _connectionString;
     private readonly CollectionModel _model;
@@ -512,7 +512,7 @@ public class SqlServerCollection<TKey, TRecord>
     public override async IAsyncEnumerable<VectorSearchResult<TRecord>> SearchAsync<TInput>(
         TInput searchValue,
         int top,
-        RecordSearchOptions<TRecord>? options = null,
+        VectorSearchOptions<TRecord>? options = null,
         [EnumeratorCancellation] CancellationToken cancellationToken = default)
     {
         Verify.NotNull(searchValue);

--- a/dotnet/src/Connectors/Connectors.Memory.SqlServer/SqlServerCommandBuilder.cs
+++ b/dotnet/src/Connectors/Connectors.Memory.SqlServer/SqlServerCommandBuilder.cs
@@ -332,7 +332,7 @@ internal static class SqlServerCommandBuilder
         VectorPropertyModel vectorProperty,
         CollectionModel model,
         int top,
-        RecordSearchOptions<TRecord> options,
+        VectorSearchOptions<TRecord> options,
         ReadOnlyMemory<float> vector)
     {
         string distanceFunction = vectorProperty.DistanceFunction ?? DistanceFunction.CosineDistance;

--- a/dotnet/src/Connectors/Connectors.Memory.SqliteVec/SqliteCollection.cs
+++ b/dotnet/src/Connectors/Connectors.Memory.SqliteVec/SqliteCollection.cs
@@ -37,7 +37,7 @@ public class SqliteCollection<TKey, TRecord> : VectorStoreCollection<TKey, TReco
     private readonly SqliteMapper<TRecord> _mapper;
 
     /// <summary>The default options for vector search.</summary>
-    private static readonly RecordSearchOptions<TRecord> s_defaultVectorSearchOptions = new();
+    private static readonly VectorSearchOptions<TRecord> s_defaultVectorSearchOptions = new();
 
     /// <summary>The model for this collection.</summary>
     private readonly CollectionModel _model;
@@ -163,7 +163,7 @@ public class SqliteCollection<TKey, TRecord> : VectorStoreCollection<TKey, TReco
     public override async IAsyncEnumerable<VectorSearchResult<TRecord>> SearchAsync<TInput>(
         TInput searchValue,
         int top,
-        RecordSearchOptions<TRecord>? options = null,
+        VectorSearchOptions<TRecord>? options = null,
         [EnumeratorCancellation] CancellationToken cancellationToken = default)
     {
         Verify.NotNull(searchValue);
@@ -523,7 +523,7 @@ public class SqliteCollection<TKey, TRecord> : VectorStoreCollection<TKey, TReco
         List<SqliteWhereCondition> conditions,
         string? extraWhereFilter,
         Dictionary<string, object>? extraParameters,
-        RecordSearchOptions<TRecord> searchOptions,
+        VectorSearchOptions<TRecord> searchOptions,
         [EnumeratorCancellation] CancellationToken cancellationToken)
     {
         const string OperationName = "VectorizedSearch";

--- a/dotnet/src/Connectors/Connectors.Memory.Weaviate/WeaviateCollection.cs
+++ b/dotnet/src/Connectors/Connectors.Memory.Weaviate/WeaviateCollection.cs
@@ -35,7 +35,7 @@ public class WeaviateCollection<TKey, TRecord> : VectorStoreCollection<TKey, TRe
     private readonly VectorStoreCollectionMetadata _collectionMetadata;
 
     /// <summary>The default options for vector search.</summary>
-    private static readonly RecordSearchOptions<TRecord> s_defaultVectorSearchOptions = new();
+    private static readonly VectorSearchOptions<TRecord> s_defaultVectorSearchOptions = new();
 
     /// <summary>The default options for hybrid vector search.</summary>
     private static readonly HybridSearchOptions<TRecord> s_defaultKeywordVectorizedHybridSearchOptions = new();
@@ -319,7 +319,7 @@ public class WeaviateCollection<TKey, TRecord> : VectorStoreCollection<TKey, TRe
     public override async IAsyncEnumerable<VectorSearchResult<TRecord>> SearchAsync<TInput>(
         TInput searchValue,
         int top,
-        RecordSearchOptions<TRecord>? options = null,
+        VectorSearchOptions<TRecord>? options = null,
         [EnumeratorCancellation] CancellationToken cancellationToken = default)
     {
         Verify.NotNull(searchValue);

--- a/dotnet/src/Connectors/Connectors.Memory.Weaviate/WeaviateQueryBuilder.cs
+++ b/dotnet/src/Connectors/Connectors.Memory.Weaviate/WeaviateQueryBuilder.cs
@@ -25,7 +25,7 @@ internal static class WeaviateQueryBuilder
         string vectorPropertyName,
         JsonSerializerOptions jsonSerializerOptions,
         int top,
-        RecordSearchOptions<TRecord> searchOptions,
+        VectorSearchOptions<TRecord> searchOptions,
         CollectionModel model,
         bool hasNamedVectors)
     {

--- a/dotnet/src/Connectors/Connectors.MongoDB.UnitTests/MongoCollectionTests.cs
+++ b/dotnet/src/Connectors/Connectors.MongoDB.UnitTests/MongoCollectionTests.cs
@@ -14,6 +14,7 @@ using MongoDB.Bson.Serialization.Attributes;
 using MongoDB.Driver;
 using Moq;
 using Xunit;
+using MEVD = Microsoft.Extensions.VectorData;
 
 namespace SemanticKernel.Connectors.MongoDB.UnitTests;
 
@@ -509,7 +510,7 @@ public sealed class MongoCollectionTests
             this._mockMongoDatabase.Object,
             "collection");
 
-        var options = new RecordSearchOptions<MongoHotelModel> { VectorProperty = r => "non-existent-property" };
+        var options = new MEVD.VectorSearchOptions<MongoHotelModel> { VectorProperty = r => "non-existent-property" };
 
         // Act & Assert
         await Assert.ThrowsAsync<InvalidOperationException>(async () => await sut.SearchAsync(new ReadOnlyMemory<float>([1f, 2f, 3f]), top: 3, options).FirstOrDefaultAsync());

--- a/dotnet/src/Connectors/Connectors.Redis.UnitTests/RedisCollectionSearchMappingTests.cs
+++ b/dotnet/src/Connectors/Connectors.Redis.UnitTests/RedisCollectionSearchMappingTests.cs
@@ -73,7 +73,7 @@ public class RedisCollectionSearchMappingTests
         ]);
 
         // Act.
-        var query = RedisCollectionSearchMapping.BuildQuery(byteArray, top: 3, new RecordSearchOptions<DummyType>(), model, model.VectorProperty, null);
+        var query = RedisCollectionSearchMapping.BuildQuery(byteArray, top: 3, new VectorSearchOptions<DummyType>(), model, model.VectorProperty, null);
 
         // Assert.
         Assert.NotNull(query);
@@ -89,7 +89,7 @@ public class RedisCollectionSearchMappingTests
         // Arrange.
         var floatVector = new ReadOnlyMemory<float>(new float[] { 1.0f, 2.0f, 3.0f });
         var byteArray = MemoryMarshal.AsBytes(floatVector.Span).ToArray();
-        var vectorSearchOptions = new RecordSearchOptions<DummyType> { Skip = 3 };
+        var vectorSearchOptions = new VectorSearchOptions<DummyType> { Skip = 3 };
         var model = BuildModel(
         [
             new VectorStoreKeyProperty("Key", typeof(string)),

--- a/dotnet/src/Connectors/Connectors.Weaviate.UnitTests/WeaviateQueryBuilderTests.cs
+++ b/dotnet/src/Connectors/Connectors.Weaviate.UnitTests/WeaviateQueryBuilderTests.cs
@@ -77,7 +77,7 @@ public sealed class WeaviateQueryBuilderTests
         }
         """;
 
-        var searchOptions = new RecordSearchOptions<DummyType>
+        var searchOptions = new VectorSearchOptions<DummyType>
         {
             Skip = 2,
         };
@@ -106,7 +106,7 @@ public sealed class WeaviateQueryBuilderTests
     public void BuildSearchQueryWithIncludedVectorsReturnsValidQuery(bool hasNamedVectors)
     {
         // Arrange
-        var searchOptions = new RecordSearchOptions<DummyType>
+        var searchOptions = new VectorSearchOptions<DummyType>
         {
             Skip = 2,
             IncludeVectors = true
@@ -136,7 +136,7 @@ public sealed class WeaviateQueryBuilderTests
         const string ExpectedFirstSubquery = """{ path: ["HotelName"], operator: Equal, valueText: "Test Name" }""";
         const string ExpectedSecondSubquery = """{ path: ["Tags"], operator: ContainsAny, valueText: ["t1"] }""";
 
-        var searchOptions = new RecordSearchOptions<DummyType>
+        var searchOptions = new VectorSearchOptions<DummyType>
         {
             Skip = 2,
             OldFilter = new VectorSearchFilter()
@@ -164,7 +164,7 @@ public sealed class WeaviateQueryBuilderTests
     public void BuildSearchQueryWithInvalidFilterValueThrowsException()
     {
         // Arrange
-        var searchOptions = new RecordSearchOptions<DummyType>
+        var searchOptions = new VectorSearchOptions<DummyType>
         {
             Skip = 2,
             OldFilter = new VectorSearchFilter().EqualTo("HotelName", new TestFilterValue())
@@ -186,7 +186,7 @@ public sealed class WeaviateQueryBuilderTests
     public void BuildSearchQueryWithNonExistentPropertyInFilterThrowsException()
     {
         // Arrange
-        var searchOptions = new RecordSearchOptions<DummyType>
+        var searchOptions = new VectorSearchOptions<DummyType>
         {
             Skip = 2,
             OldFilter = new VectorSearchFilter().EqualTo("NonExistentProperty", "value")

--- a/dotnet/src/Connectors/VectorData.Abstractions/ProviderServices/CollectionModel.cs
+++ b/dotnet/src/Connectors/VectorData.Abstractions/ProviderServices/CollectionModel.cs
@@ -101,7 +101,7 @@ public sealed class CollectionModel
     /// </summary>
     /// <param name="searchOptions">The search options.</param>
     /// <exception cref="InvalidOperationException">Thrown if the provided property name is not a valid vector property name.</exception>
-    public VectorPropertyModel GetVectorPropertyOrSingle<TRecord>(RecordSearchOptions<TRecord> searchOptions)
+    public VectorPropertyModel GetVectorPropertyOrSingle<TRecord>(VectorSearchOptions<TRecord> searchOptions)
     {
         if (searchOptions.VectorProperty is not null)
         {

--- a/dotnet/src/Connectors/VectorData.Abstractions/VectorSearch/IVectorSearchable.cs
+++ b/dotnet/src/Connectors/VectorData.Abstractions/VectorSearch/IVectorSearchable.cs
@@ -54,7 +54,7 @@ public interface IVectorSearchable<TRecord>
     IAsyncEnumerable<VectorSearchResult<TRecord>> SearchAsync<TInput>(
         TInput searchValue,
         int top,
-        RecordSearchOptions<TRecord>? options = default,
+        VectorSearchOptions<TRecord>? options = default,
         CancellationToken cancellationToken = default)
         where TInput : notnull;
 

--- a/dotnet/src/Connectors/VectorData.Abstractions/VectorSearch/RecordSearchOptions.cs
+++ b/dotnet/src/Connectors/VectorData.Abstractions/VectorSearch/RecordSearchOptions.cs
@@ -7,9 +7,9 @@ using System.Threading;
 namespace Microsoft.Extensions.VectorData;
 
 /// <summary>
-/// Defines options for vector search via <see cref="VectorStoreCollection{TKey, TRecord}.SearchAsync{TInput}(TInput, int, RecordSearchOptions{TRecord}, CancellationToken)"/>.
+/// Defines options for vector search via <see cref="VectorStoreCollection{TKey, TRecord}.SearchAsync{TInput}(TInput, int, VectorSearchOptions{TRecord}, CancellationToken)"/>.
 /// </summary>
-public class RecordSearchOptions<TRecord>
+public class VectorSearchOptions<TRecord>
 {
     private int _skip = 0;
 

--- a/dotnet/src/Connectors/VectorData.Abstractions/VectorStorage/VectorStoreCollection.cs
+++ b/dotnet/src/Connectors/VectorData.Abstractions/VectorStorage/VectorStoreCollection.cs
@@ -179,7 +179,7 @@ public abstract class VectorStoreCollection<TKey, TRecord> : IVectorSearchable<T
     public abstract IAsyncEnumerable<TRecord> GetAsync(Expression<Func<TRecord, bool>> filter, int top, FilteredRecordRetrievalOptions<TRecord>? options = null, CancellationToken cancellationToken = default);
 
     /// <inheritdoc />
-    public abstract IAsyncEnumerable<VectorSearchResult<TRecord>> SearchAsync<TInput>(TInput searchValue, int top, RecordSearchOptions<TRecord>? options = null, CancellationToken cancellationToken = default)
+    public abstract IAsyncEnumerable<VectorSearchResult<TRecord>> SearchAsync<TInput>(TInput searchValue, int top, VectorSearchOptions<TRecord>? options = null, CancellationToken cancellationToken = default)
         where TInput : notnull;
 
     /// <inheritdoc />

--- a/dotnet/src/SemanticKernel.AotTests/UnitTests/Search/MockVectorizableTextSearch.cs
+++ b/dotnet/src/SemanticKernel.AotTests/UnitTests/Search/MockVectorizableTextSearch.cs
@@ -16,7 +16,7 @@ internal sealed class MockVectorizableTextSearch<TRecord> : IVectorSearchable<TR
     public IAsyncEnumerable<VectorSearchResult<TRecord>> SearchAsync<TInput>(
         TInput searchValue,
         int top,
-        RecordSearchOptions<TRecord>? options = default,
+        VectorSearchOptions<TRecord>? options = default,
         CancellationToken cancellationToken = default)
         where TInput : notnull
     {
@@ -26,7 +26,7 @@ internal sealed class MockVectorizableTextSearch<TRecord> : IVectorSearchable<TR
     public IAsyncEnumerable<VectorSearchResult<TRecord>> SearchEmbeddingAsync<TVector>(
         TVector vector,
         int top,
-        RecordSearchOptions<TRecord>? options = default,
+        VectorSearchOptions<TRecord>? options = default,
         CancellationToken cancellationToken = default)
         where TVector : notnull
     {

--- a/dotnet/src/SemanticKernel.Core/Data/TextSearch/VectorStoreTextSearch.cs
+++ b/dotnet/src/SemanticKernel.Core/Data/TextSearch/VectorStoreTextSearch.cs
@@ -251,7 +251,7 @@ public sealed class VectorStoreTextSearch<[DynamicallyAccessedMembers(Dynamicall
     private async IAsyncEnumerable<VectorSearchResult<TRecord>> ExecuteVectorSearchAsync(string query, TextSearchOptions? searchOptions, [EnumeratorCancellation] CancellationToken cancellationToken)
     {
         searchOptions ??= new TextSearchOptions();
-        var vectorSearchOptions = new RecordSearchOptions<TRecord>
+        var vectorSearchOptions = new VectorSearchOptions<TRecord>
         {
 #pragma warning disable CS0618 // VectorSearchFilter is obsolete
             OldFilter = searchOptions.Filter?.FilterClauses is not null ? new VectorSearchFilter(searchOptions.Filter.FilterClauses) : null,

--- a/dotnet/src/VectorDataIntegrationTests/VectorDataIntegrationTests/DependencyInjectionTests.cs
+++ b/dotnet/src/VectorDataIntegrationTests/VectorDataIntegrationTests/DependencyInjectionTests.cs
@@ -253,7 +253,7 @@ public abstract class DependencyInjectionTests<TVectorStore, TCollection, TKey, 
         public override Task<TRecord?> GetAsync(TKey key, RecordRetrievalOptions? options = null, CancellationToken cancellationToken = default) => throw new NotImplementedException();
         public override IAsyncEnumerable<TRecord> GetAsync(Expression<Func<TRecord, bool>> filter, int top, FilteredRecordRetrievalOptions<TRecord>? options = null, CancellationToken cancellationToken = default) => throw new NotImplementedException();
         public override object? GetService(Type serviceType, object? serviceKey = null) => throw new NotImplementedException();
-        public override IAsyncEnumerable<VectorSearchResult<TRecord>> SearchAsync<TInput>(TInput searchValue, int top, RecordSearchOptions<TRecord>? options = null, CancellationToken cancellationToken = default) => throw new NotImplementedException();
+        public override IAsyncEnumerable<VectorSearchResult<TRecord>> SearchAsync<TInput>(TInput searchValue, int top, VectorSearchOptions<TRecord>? options = null, CancellationToken cancellationToken = default) => throw new NotImplementedException();
         public override Task UpsertAsync(TRecord record, CancellationToken cancellationToken = default) => throw new NotImplementedException();
         public override Task UpsertAsync(IEnumerable<TRecord> records, CancellationToken cancellationToken = default) => throw new NotImplementedException();
     }


### PR DESCRIPTION
We currently have:

* RecordRetrievalOptions and FilteredRecordRetrievalOptions (for the GetAsync methods)
* RecordSearchOptions (for SearchAsync)
* HybridSearchOptions (for HybridSearchAsync)

As we're a bit inconsistent, we discussed several options:

* Add Record to the hybrid options (RecordHybridSearchOptions), this way all the options have Record in them
* @dmytrostruk suggested just removing Record altogether and have RetrievalOptions, SearchOptions and HybridSearchOptions. While I really like this, I kinda can't bring myself to have a type called SearchOptions (it just feels too short/general, too much potential of confusion/conflict).
* So I'm proposing here to keep HybridSearchOptions, and simply replace RecordSearchOptions with VectorSearchOptions, which seems very clear and unambiguous. It's slightly inconsistent in that the Get-related types have Record and the Search-related ones don't, though all of them deal with records (though all also deal with "retrieval"). This seems to be a good compromise between keeping the names short and at the same time specific/unambiguous/clear.

If anyone has anyone strong feelings here, I'm fully OK doing something else here.