### PR TITLE
.Net: Rename DeleteCollection -> EnsureCollectionDeleted

### DIFF
--- a/dotnet/samples/Concepts/Memory/VectorStoreLangchainInterop/PineconeFactory.cs
+++ b/dotnet/samples/Concepts/Memory/VectorStoreLangchainInterop/PineconeFactory.cs
@@ -82,6 +82,6 @@ public static class PineconeFactory
 
         public override Task<bool> CollectionExistsAsync(string name, CancellationToken cancellationToken = default) => innerStore.CollectionExistsAsync(name, cancellationToken);
 
-        public override Task DeleteCollectionAsync(string name, CancellationToken cancellationToken = default) => innerStore.DeleteCollectionAsync(name, cancellationToken);
+        public override Task EnsureCollectionDeletedAsync(string name, CancellationToken cancellationToken = default) => innerStore.EnsureCollectionDeletedAsync(name, cancellationToken);
     }
 }

--- a/dotnet/samples/Concepts/Memory/VectorStoreLangchainInterop/RedisFactory.cs
+++ b/dotnet/samples/Concepts/Memory/VectorStoreLangchainInterop/RedisFactory.cs
@@ -84,6 +84,6 @@ public static class RedisFactory
 
         public override Task<bool> CollectionExistsAsync(string name, CancellationToken cancellationToken = default) => innerStore.CollectionExistsAsync(name, cancellationToken);
 
-        public override Task DeleteCollectionAsync(string name, CancellationToken cancellationToken = default) => innerStore.DeleteCollectionAsync(name, cancellationToken);
+        public override Task EnsureCollectionDeletedAsync(string name, CancellationToken cancellationToken = default) => innerStore.EnsureCollectionDeletedAsync(name, cancellationToken);
     }
 }

--- a/dotnet/samples/GettingStartedWithTextSearch/InMemoryVectorStoreFixture.cs
+++ b/dotnet/samples/GettingStartedWithTextSearch/InMemoryVectorStoreFixture.cs
@@ -47,7 +47,7 @@ public class InMemoryVectorStoreFixture : IAsyncLifetime
     /// <inheritdoc/>
     public async Task DisposeAsync()
     {
-        await this.VectorStoreRecordCollection.DeleteCollectionAsync().ConfigureAwait(false);
+        await this.VectorStoreRecordCollection.EnsureCollectionDeletedAsync().ConfigureAwait(false);
     }
 
     /// <inheritdoc/>

--- a/dotnet/src/Connectors/Connectors.AzureAISearch.UnitTests/AzureAISearchCollectionTests.cs
+++ b/dotnet/src/Connectors/Connectors.AzureAISearch.UnitTests/AzureAISearchCollectionTests.cs
@@ -136,7 +136,7 @@ public class AzureAISearchCollectionTests
         using var sut = this.CreateRecordCollection(false);
 
         // Act.
-        await sut.DeleteCollectionAsync(this._testCancellationToken);
+        await sut.EnsureCollectionDeletedAsync(this._testCancellationToken);
 
         // Assert.
         this._searchIndexClientMock.Verify(x => x.DeleteIndexAsync(TestCollectionName, this._testCancellationToken), Times.Once);

--- a/dotnet/src/Connectors/Connectors.CosmosMongoDB.UnitTests/CosmosMongoCollectionTests.cs
+++ b/dotnet/src/Connectors/Connectors.CosmosMongoDB.UnitTests/CosmosMongoCollectionTests.cs
@@ -216,7 +216,7 @@ public sealed class CosmosMongoCollectionTests
             CollectionName);
 
         // Act
-        await sut.DeleteCollectionAsync();
+        await sut.EnsureCollectionDeletedAsync();
 
         // Assert
         this._mockMongoDatabase.Verify(l => l.DropCollectionAsync(

--- a/dotnet/src/Connectors/Connectors.CosmosNoSql.UnitTests/CosmosNoSqlCollectionTests.cs
+++ b/dotnet/src/Connectors/Connectors.CosmosNoSql.UnitTests/CosmosNoSqlCollectionTests.cs
@@ -349,7 +349,7 @@ public sealed class CosmosNoSqlCollectionTests
             "collection");
 
         // Act
-        await sut.DeleteCollectionAsync();
+        await sut.EnsureCollectionDeletedAsync();
 
         // Assert
         this._mockContainer.Verify(l => l.DeleteContainerAsync(

--- a/dotnet/src/Connectors/Connectors.Memory.AzureAISearch/AzureAISearchCollection.cs
+++ b/dotnet/src/Connectors/Connectors.Memory.AzureAISearch/AzureAISearchCollection.cs
@@ -211,7 +211,7 @@ public class AzureAISearchCollection<TKey, TRecord> : VectorStoreCollection<TKey
     }
 
     /// <inheritdoc />
-    public override Task DeleteCollectionAsync(CancellationToken cancellationToken = default)
+    public override Task EnsureCollectionDeletedAsync(CancellationToken cancellationToken = default)
     {
         return this.RunOperationAsync<Response>(
             "DeleteIndex",

--- a/dotnet/src/Connectors/Connectors.Memory.AzureAISearch/AzureAISearchVectorStore.cs
+++ b/dotnet/src/Connectors/Connectors.Memory.AzureAISearch/AzureAISearchVectorStore.cs
@@ -123,10 +123,10 @@ public sealed class AzureAISearchVectorStore : VectorStore
     }
 
     /// <inheritdoc />
-    public override Task DeleteCollectionAsync(string name, CancellationToken cancellationToken = default)
+    public override Task EnsureCollectionDeletedAsync(string name, CancellationToken cancellationToken = default)
     {
         var collection = this.GetDynamicCollection(name, s_generalPurposeDefinition);
-        return collection.DeleteCollectionAsync(cancellationToken);
+        return collection.EnsureCollectionDeletedAsync(cancellationToken);
     }
 
     /// <inheritdoc />

--- a/dotnet/src/Connectors/Connectors.Memory.CosmosMongoDB/CosmosMongoCollection.cs
+++ b/dotnet/src/Connectors/Connectors.Memory.CosmosMongoDB/CosmosMongoCollection.cs
@@ -157,7 +157,7 @@ public class CosmosMongoCollection<TKey, TRecord> : VectorStoreCollection<TKey, 
     }
 
     /// <inheritdoc />
-    public override Task DeleteCollectionAsync(CancellationToken cancellationToken = default)
+    public override Task EnsureCollectionDeletedAsync(CancellationToken cancellationToken = default)
         => this.RunOperationAsync("DropCollection", () => this._mongoDatabase.DropCollectionAsync(this.Name, cancellationToken));
 
     /// <inheritdoc />

--- a/dotnet/src/Connectors/Connectors.Memory.CosmosMongoDB/CosmosMongoVectorStore.cs
+++ b/dotnet/src/Connectors/Connectors.Memory.CosmosMongoDB/CosmosMongoVectorStore.cs
@@ -117,10 +117,10 @@ public sealed class CosmosMongoVectorStore : VectorStore
     }
 
     /// <inheritdoc />
-    public override Task DeleteCollectionAsync(string name, CancellationToken cancellationToken = default)
+    public override Task EnsureCollectionDeletedAsync(string name, CancellationToken cancellationToken = default)
     {
         var collection = this.GetDynamicCollection(name, s_generalPurposeDefinition);
-        return collection.DeleteCollectionAsync(cancellationToken);
+        return collection.EnsureCollectionDeletedAsync(cancellationToken);
     }
 
     /// <inheritdoc />

--- a/dotnet/src/Connectors/Connectors.Memory.CosmosNoSql/CosmosNoSqlCollection.cs
+++ b/dotnet/src/Connectors/Connectors.Memory.CosmosNoSql/CosmosNoSqlCollection.cs
@@ -265,7 +265,7 @@ public class CosmosNoSqlCollection<TKey, TRecord> : VectorStoreCollection<TKey, 
     }
 
     /// <inheritdoc />
-    public override async Task DeleteCollectionAsync(CancellationToken cancellationToken = default)
+    public override async Task EnsureCollectionDeletedAsync(CancellationToken cancellationToken = default)
     {
         try
         {

--- a/dotnet/src/Connectors/Connectors.Memory.CosmosNoSql/CosmosNoSqlVectorStore.cs
+++ b/dotnet/src/Connectors/Connectors.Memory.CosmosNoSql/CosmosNoSqlVectorStore.cs
@@ -171,10 +171,10 @@ public sealed class CosmosNoSqlVectorStore : VectorStore
     }
 
     /// <inheritdoc />
-    public override Task DeleteCollectionAsync(string name, CancellationToken cancellationToken = default)
+    public override Task EnsureCollectionDeletedAsync(string name, CancellationToken cancellationToken = default)
     {
         var collection = this.GetDynamicCollection(name, s_generalPurposeDefinition);
-        return collection.DeleteCollectionAsync(cancellationToken);
+        return collection.EnsureCollectionDeletedAsync(cancellationToken);
     }
 
     /// <inheritdoc />

--- a/dotnet/src/Connectors/Connectors.Memory.InMemory/InMemoryCollection.cs
+++ b/dotnet/src/Connectors/Connectors.Memory.InMemory/InMemoryCollection.cs
@@ -129,7 +129,7 @@ public class InMemoryCollection<TKey, TRecord> : VectorStoreCollection<TKey, TRe
     }
 
     /// <inheritdoc />
-    public override Task DeleteCollectionAsync(CancellationToken cancellationToken = default)
+    public override Task EnsureCollectionDeletedAsync(CancellationToken cancellationToken = default)
     {
         this._internalCollections.TryRemove(this.Name, out _);
         this._internalCollectionTypes.TryRemove(this.Name, out _);

--- a/dotnet/src/Connectors/Connectors.Memory.InMemory/InMemoryVectorStore.cs
+++ b/dotnet/src/Connectors/Connectors.Memory.InMemory/InMemoryVectorStore.cs
@@ -109,7 +109,7 @@ public sealed class InMemoryVectorStore : VectorStore
     }
 
     /// <inheritdoc />
-    public override Task DeleteCollectionAsync(string name, CancellationToken cancellationToken = default)
+    public override Task EnsureCollectionDeletedAsync(string name, CancellationToken cancellationToken = default)
     {
         this._internalCollections.TryRemove(name, out _);
         this._internalCollectionTypes.TryRemove(name, out _);

--- a/dotnet/src/Connectors/Connectors.Memory.MongoDB/MongoCollection.cs
+++ b/dotnet/src/Connectors/Connectors.Memory.MongoDB/MongoCollection.cs
@@ -174,7 +174,7 @@ public class MongoCollection<TKey, TRecord> : VectorStoreCollection<TKey, TRecor
     }
 
     /// <inheritdoc />
-    public override Task DeleteCollectionAsync(CancellationToken cancellationToken = default)
+    public override Task EnsureCollectionDeletedAsync(CancellationToken cancellationToken = default)
         => this.RunOperationAsync("DropCollection", () => this._mongoDatabase.DropCollectionAsync(this.Name, cancellationToken));
 
     /// <inheritdoc />

--- a/dotnet/src/Connectors/Connectors.Memory.MongoDB/MongoVectorStore.cs
+++ b/dotnet/src/Connectors/Connectors.Memory.MongoDB/MongoVectorStore.cs
@@ -116,10 +116,10 @@ public sealed class MongoVectorStore : VectorStore
     }
 
     /// <inheritdoc />
-    public override Task DeleteCollectionAsync(string name, CancellationToken cancellationToken = default)
+    public override Task EnsureCollectionDeletedAsync(string name, CancellationToken cancellationToken = default)
     {
         var collection = this.GetDynamicCollection(name, s_generalPurposeDefinition);
-        return collection.DeleteCollectionAsync(cancellationToken);
+        return collection.EnsureCollectionDeletedAsync(cancellationToken);
     }
 
     /// <inheritdoc />

--- a/dotnet/src/Connectors/Connectors.Memory.PgVector/PostgresCollection.cs
+++ b/dotnet/src/Connectors/Connectors.Memory.PgVector/PostgresCollection.cs
@@ -144,7 +144,7 @@ public class PostgresCollection<TKey, TRecord> : VectorStoreCollection<TKey, TRe
     }
 
     /// <inheritdoc/>
-    public override Task DeleteCollectionAsync(CancellationToken cancellationToken = default)
+    public override Task EnsureCollectionDeletedAsync(CancellationToken cancellationToken = default)
     {
         const string OperationName = "DeleteCollection";
         return this.RunOperationAsync(OperationName, () =>

--- a/dotnet/src/Connectors/Connectors.Memory.PgVector/PostgresVectorStore.cs
+++ b/dotnet/src/Connectors/Connectors.Memory.PgVector/PostgresVectorStore.cs
@@ -128,10 +128,10 @@ public sealed class PostgresVectorStore : VectorStore
     }
 
     /// <inheritdoc />
-    public override Task DeleteCollectionAsync(string name, CancellationToken cancellationToken = default)
+    public override Task EnsureCollectionDeletedAsync(string name, CancellationToken cancellationToken = default)
     {
         var collection = this.GetDynamicCollection(name, s_generalPurposeDefinition);
-        return collection.DeleteCollectionAsync(cancellationToken);
+        return collection.EnsureCollectionDeletedAsync(cancellationToken);
     }
 
     /// <inheritdoc />

--- a/dotnet/src/Connectors/Connectors.Memory.Pinecone/PineconeCollection.cs
+++ b/dotnet/src/Connectors/Connectors.Memory.Pinecone/PineconeCollection.cs
@@ -165,7 +165,7 @@ public class PineconeCollection<TKey, TRecord> : VectorStoreCollection<TKey, TRe
     }
 
     /// <inheritdoc />
-    public override async Task DeleteCollectionAsync(CancellationToken cancellationToken = default)
+    public override async Task EnsureCollectionDeletedAsync(CancellationToken cancellationToken = default)
     {
         try
         {

--- a/dotnet/src/Connectors/Connectors.Memory.Pinecone/PineconeVectorStore.cs
+++ b/dotnet/src/Connectors/Connectors.Memory.Pinecone/PineconeVectorStore.cs
@@ -111,10 +111,10 @@ public sealed class PineconeVectorStore : VectorStore
     }
 
     /// <inheritdoc />
-    public override Task DeleteCollectionAsync(string name, CancellationToken cancellationToken = default)
+    public override Task EnsureCollectionDeletedAsync(string name, CancellationToken cancellationToken = default)
     {
         var collection = this.GetDynamicCollection(name, s_generalPurposeDefinition);
-        return collection.DeleteCollectionAsync(cancellationToken);
+        return collection.EnsureCollectionDeletedAsync(cancellationToken);
     }
 
     /// <inheritdoc />

--- a/dotnet/src/Connectors/Connectors.Memory.Qdrant/QdrantCollection.cs
+++ b/dotnet/src/Connectors/Connectors.Memory.Qdrant/QdrantCollection.cs
@@ -243,7 +243,7 @@ public class QdrantCollection<TKey, TRecord> : VectorStoreCollection<TKey, TReco
     }
 
     /// <inheritdoc />
-    public override Task DeleteCollectionAsync(CancellationToken cancellationToken = default)
+    public override Task EnsureCollectionDeletedAsync(CancellationToken cancellationToken = default)
         => this.RunOperationAsync("DeleteCollection",
             async () =>
             {

--- a/dotnet/src/Connectors/Connectors.Memory.Qdrant/QdrantVectorStore.cs
+++ b/dotnet/src/Connectors/Connectors.Memory.Qdrant/QdrantVectorStore.cs
@@ -129,10 +129,10 @@ public sealed class QdrantVectorStore : VectorStore
     }
 
     /// <inheritdoc />
-    public override Task DeleteCollectionAsync(string name, CancellationToken cancellationToken = default)
+    public override Task EnsureCollectionDeletedAsync(string name, CancellationToken cancellationToken = default)
     {
         var collection = this.GetDynamicCollection(name, s_generalPurposeDefinition);
-        return collection.DeleteCollectionAsync(cancellationToken);
+        return collection.EnsureCollectionDeletedAsync(cancellationToken);
     }
 
     /// <inheritdoc />

--- a/dotnet/src/Connectors/Connectors.Memory.Redis/RedisHashSetCollection.cs
+++ b/dotnet/src/Connectors/Connectors.Memory.Redis/RedisHashSetCollection.cs
@@ -197,7 +197,7 @@ public class RedisHashSetCollection<TKey, TRecord> : VectorStoreCollection<TKey,
     }
 
     /// <inheritdoc />
-    public override async Task DeleteCollectionAsync(CancellationToken cancellationToken = default)
+    public override async Task EnsureCollectionDeletedAsync(CancellationToken cancellationToken = default)
     {
         try
         {

--- a/dotnet/src/Connectors/Connectors.Memory.Redis/RedisJsonCollection.cs
+++ b/dotnet/src/Connectors/Connectors.Memory.Redis/RedisJsonCollection.cs
@@ -210,7 +210,7 @@ public class RedisJsonCollection<TKey, TRecord> : VectorStoreCollection<TKey, TR
     }
 
     /// <inheritdoc />
-    public override async Task DeleteCollectionAsync(CancellationToken cancellationToken = default)
+    public override async Task EnsureCollectionDeletedAsync(CancellationToken cancellationToken = default)
     {
         try
         {

--- a/dotnet/src/Connectors/Connectors.Memory.Redis/RedisVectorStore.cs
+++ b/dotnet/src/Connectors/Connectors.Memory.Redis/RedisVectorStore.cs
@@ -140,10 +140,10 @@ public sealed class RedisVectorStore : VectorStore
     }
 
     /// <inheritdoc />
-    public override Task DeleteCollectionAsync(string name, CancellationToken cancellationToken = default)
+    public override Task EnsureCollectionDeletedAsync(string name, CancellationToken cancellationToken = default)
     {
         var collection = this.GetDynamicCollection(name, s_generalPurposeDefinition);
-        return collection.DeleteCollectionAsync(cancellationToken);
+        return collection.EnsureCollectionDeletedAsync(cancellationToken);
     }
 
     /// <inheritdoc />

--- a/dotnet/src/Connectors/Connectors.Memory.SqlServer/SqlServerCollection.cs
+++ b/dotnet/src/Connectors/Connectors.Memory.SqlServer/SqlServerCollection.cs
@@ -127,7 +127,7 @@ public class SqlServerCollection<TKey, TRecord>
     }
 
     /// <inheritdoc/>
-    public override async Task DeleteCollectionAsync(CancellationToken cancellationToken = default)
+    public override async Task EnsureCollectionDeletedAsync(CancellationToken cancellationToken = default)
     {
         using SqlConnection connection = new(this._connectionString);
         using SqlCommand command = SqlServerCommandBuilder.DropTableIfExists(

--- a/dotnet/src/Connectors/Connectors.Memory.SqlServer/SqlServerVectorStore.cs
+++ b/dotnet/src/Connectors/Connectors.Memory.SqlServer/SqlServerVectorStore.cs
@@ -128,10 +128,10 @@ public sealed class SqlServerVectorStore : VectorStore
     }
 
     /// <inheritdoc />
-    public override Task DeleteCollectionAsync(string name, CancellationToken cancellationToken = default)
+    public override Task EnsureCollectionDeletedAsync(string name, CancellationToken cancellationToken = default)
     {
         var collection = this.GetDynamicCollection(name, s_generalPurposeDefinition);
-        return collection.DeleteCollectionAsync(cancellationToken);
+        return collection.EnsureCollectionDeletedAsync(cancellationToken);
     }
 
     /// <inheritdoc />

--- a/dotnet/src/Connectors/Connectors.Memory.SqliteVec/SqliteCollection.cs
+++ b/dotnet/src/Connectors/Connectors.Memory.SqliteVec/SqliteCollection.cs
@@ -145,7 +145,7 @@ public class SqliteCollection<TKey, TRecord> : VectorStoreCollection<TKey, TReco
     }
 
     /// <inheritdoc />
-    public override async Task DeleteCollectionAsync(CancellationToken cancellationToken = default)
+    public override async Task EnsureCollectionDeletedAsync(CancellationToken cancellationToken = default)
     {
         using var connection = await this.GetConnectionAsync(cancellationToken).ConfigureAwait(false);
 

--- a/dotnet/src/Connectors/Connectors.Memory.SqliteVec/SqliteVectorStore.cs
+++ b/dotnet/src/Connectors/Connectors.Memory.SqliteVec/SqliteVectorStore.cs
@@ -135,10 +135,10 @@ public sealed class SqliteVectorStore : VectorStore
     }
 
     /// <inheritdoc />
-    public override Task DeleteCollectionAsync(string name, CancellationToken cancellationToken = default)
+    public override Task EnsureCollectionDeletedAsync(string name, CancellationToken cancellationToken = default)
     {
         var collection = this.GetDynamicCollection(name, s_generalPurposeDefinition);
-        return collection.DeleteCollectionAsync(cancellationToken);
+        return collection.EnsureCollectionDeletedAsync(cancellationToken);
     }
 
     /// <inheritdoc />

--- a/dotnet/src/Connectors/Connectors.Memory.Weaviate/WeaviateCollection.cs
+++ b/dotnet/src/Connectors/Connectors.Memory.Weaviate/WeaviateCollection.cs
@@ -176,7 +176,7 @@ public class WeaviateCollection<TKey, TRecord> : VectorStoreCollection<TKey, TRe
     }
 
     /// <inheritdoc />
-    public override async Task DeleteCollectionAsync(CancellationToken cancellationToken = default)
+    public override async Task EnsureCollectionDeletedAsync(CancellationToken cancellationToken = default)
     {
         using var request = new WeaviateDeleteCollectionSchemaRequest(this.Name).Build();
 

--- a/dotnet/src/Connectors/Connectors.Memory.Weaviate/WeaviateVectorStore.cs
+++ b/dotnet/src/Connectors/Connectors.Memory.Weaviate/WeaviateVectorStore.cs
@@ -160,10 +160,10 @@ public sealed class WeaviateVectorStore : VectorStore
     }
 
     /// <inheritdoc />
-    public override Task DeleteCollectionAsync(string name, CancellationToken cancellationToken = default)
+    public override Task EnsureCollectionDeletedAsync(string name, CancellationToken cancellationToken = default)
     {
         var collection = this.GetDynamicCollection(name, s_generalPurposeDefinition);
-        return collection.DeleteCollectionAsync(cancellationToken);
+        return collection.EnsureCollectionDeletedAsync(cancellationToken);
     }
 
     /// <inheritdoc />

--- a/dotnet/src/Connectors/Connectors.MongoDB.UnitTests/MongoCollectionTests.cs
+++ b/dotnet/src/Connectors/Connectors.MongoDB.UnitTests/MongoCollectionTests.cs
@@ -216,7 +216,7 @@ public sealed class MongoCollectionTests
             CollectionName);
 
         // Act
-        await sut.DeleteCollectionAsync();
+        await sut.EnsureCollectionDeletedAsync();
 
         // Assert
         this._mockMongoDatabase.Verify(l => l.DropCollectionAsync(

--- a/dotnet/src/Connectors/Connectors.Qdrant.UnitTests/QdrantCollectionTests.cs
+++ b/dotnet/src/Connectors/Connectors.Qdrant.UnitTests/QdrantCollectionTests.cs
@@ -135,7 +135,7 @@ public class QdrantCollectionTests
             .Returns(Task.CompletedTask);
 
         // Act.
-        await sut.DeleteCollectionAsync(this._testCancellationToken);
+        await sut.EnsureCollectionDeletedAsync(this._testCancellationToken);
 
         // Assert.
         this._qdrantClientMock

--- a/dotnet/src/Connectors/Connectors.Redis.UnitTests/RedisHashSetCollectionTests.cs
+++ b/dotnet/src/Connectors/Connectors.Redis.UnitTests/RedisHashSetCollectionTests.cs
@@ -120,7 +120,7 @@ public class RedisHashSetCollectionTests
         using var sut = this.CreateRecordCollection(false);
 
         // Act
-        await sut.DeleteCollectionAsync();
+        await sut.EnsureCollectionDeletedAsync();
 
         // Assert
         var expectedArgs = new object[] { TestCollectionName };

--- a/dotnet/src/Connectors/Connectors.Redis.UnitTests/RedisJsonCollectionTests.cs
+++ b/dotnet/src/Connectors/Connectors.Redis.UnitTests/RedisJsonCollectionTests.cs
@@ -141,7 +141,7 @@ public class RedisJsonCollectionTests
         using var sut = this.CreateRecordCollection(false);
 
         // Act
-        await sut.DeleteCollectionAsync();
+        await sut.EnsureCollectionDeletedAsync();
 
         // Assert
         var expectedArgs = new object[] { TestCollectionName };

--- a/dotnet/src/Connectors/Connectors.Weaviate.UnitTests/WeaviateCollectionTests.cs
+++ b/dotnet/src/Connectors/Connectors.Weaviate.UnitTests/WeaviateCollectionTests.cs
@@ -166,7 +166,7 @@ public sealed class WeaviateCollectionTests : IDisposable
         using var sut = new WeaviateCollection<Guid, WeaviateHotel>(this._mockHttpClient, CollectionName);
 
         // Act
-        await sut.DeleteCollectionAsync();
+        await sut.EnsureCollectionDeletedAsync();
 
         // Assert
         Assert.Equal("http://default-endpoint/schema/Collection", this._messageHandlerStub.RequestUri?.AbsoluteUri);

--- a/dotnet/src/Connectors/VectorData.Abstractions/VectorStorage/VectorStore.cs
+++ b/dotnet/src/Connectors/VectorData.Abstractions/VectorStorage/VectorStore.cs
@@ -67,7 +67,7 @@ public abstract class VectorStore : IDisposable
     /// <param name="name">The name of the collection.</param>
     /// <param name="cancellationToken">The <see cref="CancellationToken"/> to monitor for cancellation requests. The default is <see cref="CancellationToken.None"/>.</param>
     /// <returns>A <see cref="Task"/> that completes when the collection has been deleted.</returns>
-    public abstract Task DeleteCollectionAsync(string name, CancellationToken cancellationToken = default);
+    public abstract Task EnsureCollectionDeletedAsync(string name, CancellationToken cancellationToken = default);
 
     /// <summary>Asks the <see cref="VectorStore"/> for an object of the specified type <paramref name="serviceType"/>.</summary>
     /// <param name="serviceType">The type of object being requested.</param>

--- a/dotnet/src/Connectors/VectorData.Abstractions/VectorStorage/VectorStoreCollection.cs
+++ b/dotnet/src/Connectors/VectorData.Abstractions/VectorStorage/VectorStoreCollection.cs
@@ -44,11 +44,11 @@ public abstract class VectorStoreCollection<TKey, TRecord> : IVectorSearchable<T
     public abstract Task EnsureCollectionExistsAsync(CancellationToken cancellationToken = default);
 
     /// <summary>
-    /// Deletes the collection from the vector store.
+    /// Deletes the collection from the vector store if it exists.
     /// </summary>
     /// <param name="cancellationToken">The <see cref="CancellationToken"/> to monitor for cancellation requests. The default is <see cref="CancellationToken.None"/>.</param>
     /// <returns>A <see cref="Task"/> that completes when the collection has been deleted.</returns>
-    public abstract Task DeleteCollectionAsync(CancellationToken cancellationToken = default);
+    public abstract Task EnsureCollectionDeletedAsync(CancellationToken cancellationToken = default);
 
     /// <summary>
     /// Gets a record from the vector store. Does not guarantee that the collection exists.

--- a/dotnet/src/IntegrationTests/Connectors/Memory/AzureAISearch/AzureAISearchVectorStoreRecordCollectionTests.cs
+++ b/dotnet/src/IntegrationTests/Connectors/Memory/AzureAISearch/AzureAISearchVectorStoreRecordCollectionTests.cs
@@ -55,7 +55,7 @@ public sealed class AzureAISearchVectorStoreRecordCollectionTests(ITestOutputHel
         };
         using var sut = new AzureAISearchCollection<string, AzureAISearchHotel>(fixture.SearchIndexClient, testCollectionName, options);
 
-        await sut.DeleteCollectionAsync();
+        await sut.EnsureCollectionDeletedAsync();
 
         // Act
         await sut.EnsureCollectionExistsAsync();
@@ -74,7 +74,7 @@ public sealed class AzureAISearchVectorStoreRecordCollectionTests(ITestOutputHel
         // Assert
         var collectionExistResult = await sut.CollectionExistsAsync();
         Assert.True(collectionExistResult);
-        await sut.DeleteCollectionAsync();
+        await sut.EnsureCollectionDeletedAsync();
 
         Assert.NotNull(getResult);
         Assert.Equal(hotel.HotelName, getResult.HotelName);
@@ -111,7 +111,7 @@ public sealed class AzureAISearchVectorStoreRecordCollectionTests(ITestOutputHel
         using var sut = new AzureAISearchCollection<string, AzureAISearchHotel>(fixture.SearchIndexClient, tempCollectionName);
 
         // Act
-        await sut.DeleteCollectionAsync();
+        await sut.EnsureCollectionDeletedAsync();
 
         // Assert
         Assert.False(await sut.CollectionExistsAsync());

--- a/dotnet/src/IntegrationTests/Connectors/Memory/BaseVectorStoreRecordCollectionTests.cs
+++ b/dotnet/src/IntegrationTests/Connectors/Memory/BaseVectorStoreRecordCollectionTests.cs
@@ -112,7 +112,7 @@ public abstract class BaseVectorStoreRecordCollectionTests<TKey>
         Assert.Equal(Math.Round(scoreDictionary[resultOrder[2]], 2), Math.Round(results[2].Score!.Value, 2));
 
         // Cleanup
-        await sut.DeleteCollectionAsync();
+        await sut.EnsureCollectionDeletedAsync();
     }
 
     private static VectorStoreRecordDefinition CreateKeyWithVectorRecordDefinition(int vectorDimensions, string distanceFunction)

--- a/dotnet/src/IntegrationTests/Connectors/Memory/BaseVectorStoreTests.cs
+++ b/dotnet/src/IntegrationTests/Connectors/Memory/BaseVectorStoreTests.cs
@@ -45,7 +45,7 @@ public abstract class BaseVectorStoreTests<TKey, TRecord>(VectorStore vectorStor
         {
             var collection = vectorStore.GetCollection<TKey, TRecord>(collectionName);
 
-            await collection.DeleteCollectionAsync();
+            await collection.EnsureCollectionDeletedAsync();
         }
     }
 }

--- a/dotnet/src/IntegrationTests/Connectors/Memory/CosmosMongoDB/CosmosMongoCollectionTests.cs
+++ b/dotnet/src/IntegrationTests/Connectors/Memory/CosmosMongoDB/CosmosMongoCollectionTests.cs
@@ -51,7 +51,7 @@ public class CosmosMongoCollectionTests(CosmosMongoVectorStoreFixture fixture)
         finally
         {
             // Clean up
-            await sut.DeleteCollectionAsync();
+            await sut.EnsureCollectionDeletedAsync();
         }
     }
 
@@ -84,7 +84,7 @@ public class CosmosMongoCollectionTests(CosmosMongoVectorStoreFixture fixture)
 
         // Assert
         Assert.True(await sut.CollectionExistsAsync());
-        await sut.DeleteCollectionAsync();
+        await sut.EnsureCollectionDeletedAsync();
 
         Assert.NotNull(getResult);
 
@@ -120,7 +120,7 @@ public class CosmosMongoCollectionTests(CosmosMongoVectorStoreFixture fixture)
         Assert.True(await sut.CollectionExistsAsync());
 
         // Act
-        await sut.DeleteCollectionAsync();
+        await sut.EnsureCollectionDeletedAsync();
 
         // Assert
         Assert.False(await sut.CollectionExistsAsync());

--- a/dotnet/src/IntegrationTests/Connectors/Memory/CosmosNoSql/CosmosNoSqlCollectionTests.cs
+++ b/dotnet/src/IntegrationTests/Connectors/Memory/CosmosNoSql/CosmosNoSqlCollectionTests.cs
@@ -87,7 +87,7 @@ public sealed class CosmosNoSqlCollectionTests(CosmosNoSqlVectorStoreFixture fix
 
         // Assert
         Assert.True(await sut.CollectionExistsAsync());
-        await sut.DeleteCollectionAsync();
+        await sut.EnsureCollectionDeletedAsync();
 
         Assert.NotNull(getResult);
 
@@ -123,7 +123,7 @@ public sealed class CosmosNoSqlCollectionTests(CosmosNoSqlVectorStoreFixture fix
         Assert.True(await sut.CollectionExistsAsync());
 
         // Act
-        await sut.DeleteCollectionAsync();
+        await sut.EnsureCollectionDeletedAsync();
 
         // Assert
         Assert.False(await sut.CollectionExistsAsync());

--- a/dotnet/src/IntegrationTests/Connectors/Memory/MongoDB/MongoDBVectorStoreRecordCollectionTests.cs
+++ b/dotnet/src/IntegrationTests/Connectors/Memory/MongoDB/MongoDBVectorStoreRecordCollectionTests.cs
@@ -49,7 +49,7 @@ public class MongoDBVectorStoreRecordCollectionTests(MongoDBVectorStoreFixture f
 
         // Assert
         Assert.True(await sut.CollectionExistsAsync());
-        await sut.DeleteCollectionAsync();
+        await sut.EnsureCollectionDeletedAsync();
     }
 
     [RetryTheory(typeof(MongoCommandException), Skip = SkipReason)]
@@ -82,7 +82,7 @@ public class MongoDBVectorStoreRecordCollectionTests(MongoDBVectorStoreFixture f
 
         // Assert
         Assert.True(await sut.CollectionExistsAsync());
-        await sut.DeleteCollectionAsync();
+        await sut.EnsureCollectionDeletedAsync();
 
         Assert.NotNull(getResult);
 
@@ -118,7 +118,7 @@ public class MongoDBVectorStoreRecordCollectionTests(MongoDBVectorStoreFixture f
         Assert.True(await sut.CollectionExistsAsync());
 
         // Act
-        await sut.DeleteCollectionAsync();
+        await sut.EnsureCollectionDeletedAsync();
 
         // Assert
         Assert.False(await sut.CollectionExistsAsync());

--- a/dotnet/src/IntegrationTests/Connectors/Memory/PgVector/PostgresVectorStoreRecordCollectionTests.cs
+++ b/dotnet/src/IntegrationTests/Connectors/Memory/PgVector/PostgresVectorStoreRecordCollectionTests.cs
@@ -41,7 +41,7 @@ public sealed class PostgresVectorStoreRecordCollectionTests(PostgresVectorStore
             // Cleanup
             if (createCollection)
             {
-                await sut.DeleteCollectionAsync();
+                await sut.EnsureCollectionDeletedAsync();
             }
         }
     }
@@ -60,7 +60,7 @@ public sealed class PostgresVectorStoreRecordCollectionTests(PostgresVectorStore
         finally
         {
             // Cleanup
-            await sut.DeleteCollectionAsync();
+            await sut.EnsureCollectionDeletedAsync();
         }
     }
 
@@ -71,7 +71,7 @@ public sealed class PostgresVectorStoreRecordCollectionTests(PostgresVectorStore
         var sut = fixture.GetCollection<int, PostgresHotel<int>>("CollectionCanUpsertAndGet");
         if (await sut.CollectionExistsAsync())
         {
-            await sut.DeleteCollectionAsync();
+            await sut.EnsureCollectionDeletedAsync();
         }
 
         await sut.EnsureCollectionExistsAsync();
@@ -127,7 +127,7 @@ public sealed class PostgresVectorStoreRecordCollectionTests(PostgresVectorStore
         finally
         {
             // Cleanup
-            await sut.DeleteCollectionAsync();
+            await sut.EnsureCollectionDeletedAsync();
         }
     }
 

--- a/dotnet/src/IntegrationTests/Connectors/Memory/Qdrant/QdrantVectorStoreRecordCollectionTests.cs
+++ b/dotnet/src/IntegrationTests/Connectors/Memory/Qdrant/QdrantVectorStoreRecordCollectionTests.cs
@@ -74,7 +74,7 @@ public sealed class QdrantVectorStoreRecordCollectionTests(ITestOutputHelper out
         // Assert
         var collectionExistResult = await sut.CollectionExistsAsync();
         Assert.True(collectionExistResult);
-        await sut.DeleteCollectionAsync();
+        await sut.EnsureCollectionDeletedAsync();
 
         Assert.Equal(record.HotelId, getResult?.HotelId);
         Assert.Equal(record.HotelName, getResult?.HotelName);
@@ -113,7 +113,7 @@ public sealed class QdrantVectorStoreRecordCollectionTests(ITestOutputHelper out
         using var sut = new QdrantCollection<ulong, HotelInfo>(fixture.QdrantClient, tempCollectionName, ownsClient: false);
 
         // Act
-        await sut.DeleteCollectionAsync();
+        await sut.EnsureCollectionDeletedAsync();
 
         // Assert
         Assert.False(await sut.CollectionExistsAsync());

--- a/dotnet/src/IntegrationTests/Connectors/Memory/Redis/RedisHashSetVectorStoreRecordCollectionTests.cs
+++ b/dotnet/src/IntegrationTests/Connectors/Memory/Redis/RedisHashSetVectorStoreRecordCollectionTests.cs
@@ -73,7 +73,7 @@ public sealed class RedisHashSetVectorStoreRecordCollectionTests(ITestOutputHelp
         // Assert
         var collectionExistResult = await sut.CollectionExistsAsync();
         Assert.True(collectionExistResult);
-        await sut.DeleteCollectionAsync();
+        await sut.EnsureCollectionDeletedAsync();
 
         Assert.Equal(record.HotelId, getResult?.HotelId);
         Assert.Equal(record.HotelName, getResult?.HotelName);
@@ -113,7 +113,7 @@ public sealed class RedisHashSetVectorStoreRecordCollectionTests(ITestOutputHelp
         using var sut = new RedisHashSetCollection<string, RedisBasicFloat32Hotel>(fixture.Database, tempCollectionName);
 
         // Act
-        await sut.DeleteCollectionAsync();
+        await sut.EnsureCollectionDeletedAsync();
 
         // Assert
         Assert.False(await sut.CollectionExistsAsync());

--- a/dotnet/src/IntegrationTests/Connectors/Memory/Redis/RedisJsonVectorStoreRecordCollectionTests.cs
+++ b/dotnet/src/IntegrationTests/Connectors/Memory/Redis/RedisJsonVectorStoreRecordCollectionTests.cs
@@ -72,7 +72,7 @@ public sealed class RedisJsonVectorStoreRecordCollectionTests(ITestOutputHelper 
         // Assert
         var collectionExistResult = await sut.CollectionExistsAsync();
         Assert.True(collectionExistResult);
-        await sut.DeleteCollectionAsync();
+        await sut.EnsureCollectionDeletedAsync();
 
         Assert.Equal(record.HotelId, getResult?.HotelId);
         Assert.Equal(record.HotelName, getResult?.HotelName);
@@ -122,7 +122,7 @@ public sealed class RedisJsonVectorStoreRecordCollectionTests(ITestOutputHelper 
         using var sut = new RedisJsonCollection<string, RedisHotel>(fixture.Database, tempCollectionName);
 
         // Act
-        await sut.DeleteCollectionAsync();
+        await sut.EnsureCollectionDeletedAsync();
 
         // Assert
         Assert.False(await sut.CollectionExistsAsync());

--- a/dotnet/src/IntegrationTests/Connectors/Memory/SqliteVec/SqliteVectorStoreRecordCollectionTests.cs
+++ b/dotnet/src/IntegrationTests/Connectors/Memory/SqliteVec/SqliteVectorStoreRecordCollectionTests.cs
@@ -80,7 +80,7 @@ public sealed class SqliteVectorStoreRecordCollectionTests(SqliteVectorStoreFixt
         Assert.True(await sut.CollectionExistsAsync());
 
         // Act
-        await sut.DeleteCollectionAsync();
+        await sut.EnsureCollectionDeletedAsync();
 
         // Assert
         Assert.False(await sut.CollectionExistsAsync());
@@ -115,7 +115,7 @@ public sealed class SqliteVectorStoreRecordCollectionTests(SqliteVectorStoreFixt
 
         // Assert
         Assert.True(await sut.CollectionExistsAsync());
-        await sut.DeleteCollectionAsync();
+        await sut.EnsureCollectionDeletedAsync();
 
         Assert.NotNull(getResult);
 

--- a/dotnet/src/IntegrationTests/Connectors/Memory/Weaviate/WeaviateVectorStoreRecordCollectionTests.cs
+++ b/dotnet/src/IntegrationTests/Connectors/Memory/Weaviate/WeaviateVectorStoreRecordCollectionTests.cs
@@ -111,7 +111,7 @@ public sealed class WeaviateVectorStoreRecordCollectionTests(WeaviateVectorStore
         Assert.True(await sut.CollectionExistsAsync());
 
         // Act
-        await sut.DeleteCollectionAsync();
+        await sut.EnsureCollectionDeletedAsync();
 
         // Assert
         Assert.False(await sut.CollectionExistsAsync());

--- a/dotnet/src/VectorDataIntegrationTests/SqlServerIntegrationTests/SqlServerVectorStoreTests.cs
+++ b/dotnet/src/VectorDataIntegrationTests/SqlServerIntegrationTests/SqlServerVectorStoreTests.cs
@@ -35,14 +35,14 @@ public class SqlServerVectorStoreTests(SqlServerFixture fixture) : IClassFixture
 
             Assert.True(await collection.CollectionExistsAsync());
 
-            await collection.DeleteCollectionAsync();
+            await collection.EnsureCollectionDeletedAsync();
 
             Assert.False(await collection.CollectionExistsAsync());
             Assert.False(await testStore.DefaultVectorStore.ListCollectionNamesAsync().ContainsAsync(collectionName));
         }
         finally
         {
-            await collection.DeleteCollectionAsync();
+            await collection.EnsureCollectionDeletedAsync();
         }
     }
 
@@ -100,7 +100,7 @@ public class SqlServerVectorStoreTests(SqlServerFixture fixture) : IClassFixture
         }
         finally
         {
-            await collection.DeleteCollectionAsync();
+            await collection.EnsureCollectionDeletedAsync();
         }
     }
 
@@ -143,7 +143,7 @@ public class SqlServerVectorStoreTests(SqlServerFixture fixture) : IClassFixture
         }
         finally
         {
-            await collection.DeleteCollectionAsync();
+            await collection.EnsureCollectionDeletedAsync();
         }
     }
 
@@ -195,7 +195,7 @@ public class SqlServerVectorStoreTests(SqlServerFixture fixture) : IClassFixture
         }
         finally
         {
-            await collection.DeleteCollectionAsync();
+            await collection.EnsureCollectionDeletedAsync();
         }
     }
 
@@ -291,7 +291,7 @@ public class SqlServerVectorStoreTests(SqlServerFixture fixture) : IClassFixture
         }
         finally
         {
-            await collection.DeleteCollectionAsync();
+            await collection.EnsureCollectionDeletedAsync();
         }
     }
 #endif
@@ -361,7 +361,7 @@ public class SqlServerVectorStoreTests(SqlServerFixture fixture) : IClassFixture
         }
         finally
         {
-            await collection.DeleteCollectionAsync();
+            await collection.EnsureCollectionDeletedAsync();
         }
 
         void AssertEquality(FancyTestModel<TKey> expected, FancyTestModel<TKey>? received, TKey expectedKey)

--- a/dotnet/src/VectorDataIntegrationTests/VectorDataIntegrationTests/Collections/CollectionConformanceTests.cs
+++ b/dotnet/src/VectorDataIntegrationTests/VectorDataIntegrationTests/Collections/CollectionConformanceTests.cs
@@ -12,7 +12,7 @@ public abstract class CollectionConformanceTests<TKey>(VectorStoreFixture fixtur
     where TKey : notnull
 {
     public Task InitializeAsync()
-        => fixture.VectorStore.DeleteCollectionAsync(this.CollectionName);
+        => fixture.VectorStore.EnsureCollectionDeletedAsync(this.CollectionName);
 
     [ConditionalFact]
     public async Task Collection_Ensure_Exists_Delete()
@@ -22,11 +22,11 @@ public abstract class CollectionConformanceTests<TKey>(VectorStoreFixture fixtur
         Assert.False(await collection.CollectionExistsAsync());
         await collection.EnsureCollectionExistsAsync();
         Assert.True(await collection.CollectionExistsAsync());
-        await collection.DeleteCollectionAsync();
+        await collection.EnsureCollectionDeletedAsync();
         Assert.False(await collection.CollectionExistsAsync());
 
         // Deleting a non-existing collection does not throw
-        await fixture.TestStore.DefaultVectorStore.DeleteCollectionAsync(collection.Name);
+        await fixture.TestStore.DefaultVectorStore.EnsureCollectionDeletedAsync(collection.Name);
     }
 
     [ConditionalFact]
@@ -57,7 +57,7 @@ public abstract class CollectionConformanceTests<TKey>(VectorStoreFixture fixtur
         var collection = this.GetCollection();
 
         await collection.EnsureCollectionExistsAsync();
-        await fixture.TestStore.DefaultVectorStore.DeleteCollectionAsync(collection.Name);
+        await fixture.TestStore.DefaultVectorStore.EnsureCollectionDeletedAsync(collection.Name);
         Assert.False(await collection.CollectionExistsAsync());
     }
 

--- a/dotnet/src/VectorDataIntegrationTests/VectorDataIntegrationTests/DependencyInjectionTests.cs
+++ b/dotnet/src/VectorDataIntegrationTests/VectorDataIntegrationTests/DependencyInjectionTests.cs
@@ -236,7 +236,7 @@ public abstract class DependencyInjectionTests<TVectorStore, TCollection, TKey, 
     private sealed class FakeVectorStore : VectorStore
     {
         public override Task<bool> CollectionExistsAsync(string name, CancellationToken cancellationToken = default) => throw new NotImplementedException();
-        public override Task DeleteCollectionAsync(string name, CancellationToken cancellationToken = default) => throw new NotImplementedException();
+        public override Task EnsureCollectionDeletedAsync(string name, CancellationToken cancellationToken = default) => throw new NotImplementedException();
         public override VectorStoreCollection<TKey1, TRecord1> GetCollection<TKey1, TRecord1>(string name, VectorStoreRecordDefinition? vectorStoreRecordDefinition = null) => throw new NotImplementedException();
         public override VectorStoreCollection<object, Dictionary<string, object?>> GetDynamicCollection(string name, VectorStoreRecordDefinition? vectorStoreRecordDefinition = null) => throw new NotImplementedException();
         public override object? GetService(Type serviceType, object? serviceKey = null) => throw new NotImplementedException();
@@ -249,7 +249,7 @@ public abstract class DependencyInjectionTests<TVectorStore, TCollection, TKey, 
         public override Task<bool> CollectionExistsAsync(CancellationToken cancellationToken = default) => throw new NotImplementedException();
         public override Task EnsureCollectionExistsAsync(CancellationToken cancellationToken = default) => throw new NotImplementedException();
         public override Task DeleteAsync(TKey key, CancellationToken cancellationToken = default) => throw new NotImplementedException();
-        public override Task DeleteCollectionAsync(CancellationToken cancellationToken = default) => throw new NotImplementedException();
+        public override Task EnsureCollectionDeletedAsync(CancellationToken cancellationToken = default) => throw new NotImplementedException();
         public override Task<TRecord?> GetAsync(TKey key, RecordRetrievalOptions? options = null, CancellationToken cancellationToken = default) => throw new NotImplementedException();
         public override IAsyncEnumerable<TRecord> GetAsync(Expression<Func<TRecord, bool>> filter, int top, FilteredRecordRetrievalOptions<TRecord>? options = null, CancellationToken cancellationToken = default) => throw new NotImplementedException();
         public override object? GetService(Type serviceType, object? serviceKey = null) => throw new NotImplementedException();

--- a/dotnet/src/VectorDataIntegrationTests/VectorDataIntegrationTests/EmbeddingTypeTests.cs
+++ b/dotnet/src/VectorDataIntegrationTests/VectorDataIntegrationTests/EmbeddingTypeTests.cs
@@ -42,7 +42,7 @@ public abstract class EmbeddingTypeTests<TKey>(EmbeddingTypeTests<TKey>.Fixture 
     {
         vectorEqualityAsserter ??= (e, a) => Assert.Equal(e, a);
 
-        await fixture.VectorStore.DeleteCollectionAsync(fixture.CollectionName);
+        await fixture.VectorStore.EnsureCollectionDeletedAsync(fixture.CollectionName);
 
         var collection = fixture.VectorStore.GetCollection<TKey, Record<TVector>>(fixture.CollectionName, fixture.CreateRecordDefinition<TVector>(embeddingGenerator: null, distanceFunction, dimensions));
         await collection.EnsureCollectionExistsAsync();
@@ -80,7 +80,7 @@ public abstract class EmbeddingTypeTests<TKey>(EmbeddingTypeTests<TKey>.Fixture 
         ///////////////////////
         if (fixture.RecreateCollection)
         {
-            await collection.DeleteCollectionAsync();
+            await collection.EnsureCollectionDeletedAsync();
         }
         else
         {
@@ -129,7 +129,7 @@ public abstract class EmbeddingTypeTests<TKey>(EmbeddingTypeTests<TKey>.Fixture 
         {
             if (fixture.RecreateCollection)
             {
-                await collection.DeleteCollectionAsync();
+                await collection.EnsureCollectionDeletedAsync();
             }
             else
             {

--- a/dotnet/src/VectorDataIntegrationTests/VectorDataIntegrationTests/Support/VectorStoreCollectionFixture.cs
+++ b/dotnet/src/VectorDataIntegrationTests/VectorDataIntegrationTests/Support/VectorStoreCollectionFixture.cs
@@ -34,7 +34,7 @@ public abstract class VectorStoreCollectionFixture<TKey, TRecord> : VectorStoreF
 
         if (await this.Collection.CollectionExistsAsync())
         {
-            await this.Collection.DeleteCollectionAsync();
+            await this.Collection.EnsureCollectionDeletedAsync();
         }
 
         await this.Collection.EnsureCollectionExistsAsync();

--- a/dotnet/src/VectorDataIntegrationTests/VectorDataIntegrationTests/VectorSearch/VectorSearchDistanceFunctionComplianceTests.cs
+++ b/dotnet/src/VectorDataIntegrationTests/VectorDataIntegrationTests/VectorSearch/VectorSearchDistanceFunctionComplianceTests.cs
@@ -131,7 +131,7 @@ public abstract class VectorSearchDistanceFunctionComplianceTests<TKey>(VectorSt
         }
         finally
         {
-            await collection.DeleteCollectionAsync();
+            await collection.EnsureCollectionDeletedAsync();
         }
 
         static void VerifySearchResults(SearchRecord[] expectedRecords, double[] expectedScores,

--- a/dotnet/src/VectorDataIntegrationTests/VectorDataIntegrationTests/VectorSearch/VectorSearchWithFilterConformanceTests.cs
+++ b/dotnet/src/VectorDataIntegrationTests/VectorDataIntegrationTests/VectorSearch/VectorSearchWithFilterConformanceTests.cs
@@ -52,7 +52,7 @@ public abstract class VectorSearchWithFilterConformanceTests<TKey>(VectorStoreFi
         }
         finally
         {
-            await collection.DeleteCollectionAsync();
+            await collection.EnsureCollectionDeletedAsync();
         }
 
         // Assert


### PR DESCRIPTION
I'm mainly proposing this rename to align with colleciton creation, which has been renamed to EnsureCollectionCreatedAsync (next to which we'd have EnsureCollectionDeletedAsync). It's slightly longer than DeleteCollectionAsync, but the consistency here seem to be worth it.

I'm also noting that EF also has an EnsureDeleted/EnsureCreated pair ([docs](https://learn.microsoft.com/en-us/ef/core/managing-schemas/ensure-created)).

Note that this changes both the method on VectorStoreCollection and on VectorStore (where there's no EnsureCreated).