### PR TITLE
.Net: Remove unsigned type support from SqliteVec provider

### DIFF
--- a/.github/workflows/dotnet-format.yml
+++ b/.github/workflows/dotnet-format.yml
@@ -25,7 +25,6 @@ jobs:
       fail-fast: false
       matrix:
         include:
-          - { dotnet: "8.0", configuration: Release, os: ubuntu-latest }
           - { dotnet: "9.0", configuration: Release, os: ubuntu-latest }
 
     runs-on: ${{ matrix.os }}

--- a/dotnet/src/Connectors/Connectors.Memory.AzureAISearch/AzureAISearchCollection.cs
+++ b/dotnet/src/Connectors/Connectors.Memory.AzureAISearch/AzureAISearchCollection.cs
@@ -26,7 +26,7 @@ namespace Microsoft.SemanticKernel.Connectors.AzureAISearch;
 /// <summary>
 /// Service for storing and retrieving vector records, that uses Azure AI Search as the underlying storage.
 /// </summary>
-/// <typeparam name="TKey">The data type of the record key. Can be either <see cref="string"/>, or <see cref="object"/> for dynamic mapping.</typeparam>
+/// <typeparam name="TKey">The data type of the record key. Must be <see cref="string"/>.</typeparam>
 /// <typeparam name="TRecord">The data model to use for adding, updating and retrieving data from storage.</typeparam>
 #pragma warning disable CA1711 // Identifiers should not have incorrect suffix
 public class AzureAISearchCollection<TKey, TRecord> : VectorStoreCollection<TKey, TRecord>, IKeywordHybridSearchable<TRecord>
@@ -85,7 +85,7 @@ public class AzureAISearchCollection<TKey, TRecord> : VectorStoreCollection<TKey
 
         if (typeof(TKey) != typeof(string) && typeof(TKey) != typeof(object))
         {
-            throw new NotSupportedException("Only string keys are supported (and object for dynamic mapping)");
+            throw new NotSupportedException("Only string keys are supported.");
         }
 
         options ??= AzureAISearchCollectionOptions.Default;

--- a/dotnet/src/Connectors/Connectors.Memory.CosmosMongoDB/CosmosMongoCollection.cs
+++ b/dotnet/src/Connectors/Connectors.Memory.CosmosMongoDB/CosmosMongoCollection.cs
@@ -23,7 +23,7 @@ namespace Microsoft.SemanticKernel.Connectors.CosmosMongoDB;
 /// <summary>
 /// Service for storing and retrieving vector records, that uses Azure CosmosDB MongoDB as the underlying storage.
 /// </summary>
-/// <typeparam name="TKey">The data type of the record key. Can be either <see cref="string"/>, or <see cref="object"/> for dynamic mapping.</typeparam>
+/// <typeparam name="TKey">The data type of the record key. Must be either <see cref="string"/>.</typeparam>
 /// <typeparam name="TRecord">The data model to use for adding, updating and retrieving data from storage.</typeparam>
 #pragma warning disable CA1711 // Identifiers should not have incorrect suffix
 public class CosmosMongoCollection<TKey, TRecord> : VectorStoreCollection<TKey, TRecord>
@@ -97,7 +97,7 @@ public class CosmosMongoCollection<TKey, TRecord> : VectorStoreCollection<TKey, 
 
         if (typeof(TKey) != typeof(string) && typeof(TKey) != typeof(object))
         {
-            throw new NotSupportedException("Only string keys are supported (and object for dynamic mapping)");
+            throw new NotSupportedException("Only string keys are supported.");
         }
 
         options ??= CosmosMongoCollectionOptions.Default;

--- a/dotnet/src/Connectors/Connectors.Memory.CosmosNoSql/CosmosNoSqlCollection.cs
+++ b/dotnet/src/Connectors/Connectors.Memory.CosmosNoSql/CosmosNoSqlCollection.cs
@@ -26,7 +26,7 @@ namespace Microsoft.SemanticKernel.Connectors.CosmosNoSql;
 /// <summary>
 /// Service for storing and retrieving vector records, that uses Azure CosmosDB NoSQL as the underlying storage.
 /// </summary>
-/// <typeparam name="TKey">The data type of the record key. Can be either <see cref="string"/>, or <see cref="object"/> for dynamic mapping.</typeparam>
+/// <typeparam name="TKey">The data type of the record key. Must be <see cref="string"/>.</typeparam>
 /// <typeparam name="TRecord">The data model to use for adding, updating and retrieving data from storage.</typeparam>
 #pragma warning disable CA1711 // Identifiers should not have incorrect suffix
 public class CosmosNoSqlCollection<TKey, TRecord> : VectorStoreCollection<TKey, TRecord>, IKeywordHybridSearchable<TRecord>
@@ -136,7 +136,7 @@ public class CosmosNoSqlCollection<TKey, TRecord> : VectorStoreCollection<TKey, 
         {
             if (typeof(TKey) != typeof(string) && typeof(TKey) != typeof(CosmosNoSqlCompositeKey) && typeof(TKey) != typeof(object))
             {
-                throw new NotSupportedException($"Only {nameof(String)} and {nameof(CosmosNoSqlCompositeKey)} keys are supported (and object for dynamic mapping).");
+                throw new NotSupportedException($"Only {nameof(String)} and {nameof(CosmosNoSqlCompositeKey)} keys are supported.");
             }
 
             this._database = databaseProvider(clientWrapper.Client);

--- a/dotnet/src/Connectors/Connectors.Memory.MongoDB/MongoCollection.cs
+++ b/dotnet/src/Connectors/Connectors.Memory.MongoDB/MongoCollection.cs
@@ -22,7 +22,7 @@ namespace Microsoft.SemanticKernel.Connectors.MongoDB;
 /// <summary>
 /// Service for storing and retrieving vector records, that uses MongoDB as the underlying storage.
 /// </summary>
-/// <typeparam name="TKey">The data type of the record key. Can be either <see cref="string"/>, or <see cref="object"/> for dynamic mapping.</typeparam>
+/// <typeparam name="TKey">The data type of the record key. Must be <see cref="string"/>.</typeparam>
 /// <typeparam name="TRecord">The data model to use for adding, updating and retrieving data from storage.</typeparam>
 #pragma warning disable CA1711 // Identifiers should not have incorrect suffix
 public class MongoCollection<TKey, TRecord> : VectorStoreCollection<TKey, TRecord>, IKeywordHybridSearchable<TRecord>
@@ -105,7 +105,7 @@ public class MongoCollection<TKey, TRecord> : VectorStoreCollection<TKey, TRecor
 
         if (typeof(TKey) != typeof(string) && typeof(TKey) != typeof(object))
         {
-            throw new NotSupportedException("Only string keys are supported (and object for dynamic mapping)");
+            throw new NotSupportedException("Only string keys are supported.");
         }
 
         options ??= MongoCollectionOptions.Default;

--- a/dotnet/src/Connectors/Connectors.Memory.Pinecone/PineconeCollection.cs
+++ b/dotnet/src/Connectors/Connectors.Memory.Pinecone/PineconeCollection.cs
@@ -20,7 +20,7 @@ namespace Microsoft.SemanticKernel.Connectors.Pinecone;
 /// <summary>
 /// Service for storing and retrieving vector records, that uses Pinecone as the underlying storage.
 /// </summary>
-/// <typeparam name="TKey">The data type of the record key. Can be either <see cref="string"/>, or <see cref="object"/> for dynamic mapping.</typeparam>
+/// <typeparam name="TKey">The data type of the record key. Must be <see cref="string"/>.</typeparam>
 /// <typeparam name="TRecord">The data model to use for adding, updating and retrieving data from storage.</typeparam>
 #pragma warning disable CA1711 // Identifiers should not have incorrect suffix
 public class PineconeCollection<TKey, TRecord> : VectorStoreCollection<TKey, TRecord>
@@ -78,7 +78,7 @@ public class PineconeCollection<TKey, TRecord> : VectorStoreCollection<TKey, TRe
 
         if (typeof(TKey) != typeof(string) && typeof(TKey) != typeof(object))
         {
-            throw new NotSupportedException("Only string keys are supported (and object for dynamic mapping)");
+            throw new NotSupportedException("Only string keys are supported.");
         }
 
         options ??= PineconeCollectionOptions.Default;

--- a/dotnet/src/Connectors/Connectors.Memory.Qdrant/QdrantCollection.cs
+++ b/dotnet/src/Connectors/Connectors.Memory.Qdrant/QdrantCollection.cs
@@ -23,7 +23,7 @@ namespace Microsoft.SemanticKernel.Connectors.Qdrant;
 /// <summary>
 /// Service for storing and retrieving vector records, that uses Qdrant as the underlying storage.
 /// </summary>
-/// <typeparam name="TKey">The data type of the record key. Can be either <see cref="Guid"/> or <see cref="ulong"/>, or <see cref="object"/> for dynamic mapping.</typeparam>
+/// <typeparam name="TKey">The data type of the record key. Can be either <see cref="Guid"/> or <see cref="ulong"/>.</typeparam>
 /// <typeparam name="TRecord">The data model to use for adding, updating and retrieving data from storage.</typeparam>
 #pragma warning disable CA1711 // Identifiers should not have incorrect suffix
 public class QdrantCollection<TKey, TRecord> : VectorStoreCollection<TKey, TRecord>, IKeywordHybridSearchable<TRecord>
@@ -103,7 +103,7 @@ public class QdrantCollection<TKey, TRecord> : VectorStoreCollection<TKey, TReco
 
         if (typeof(TKey) != typeof(ulong) && typeof(TKey) != typeof(Guid) && typeof(TKey) != typeof(object))
         {
-            throw new NotSupportedException("Only ulong and Guid keys are supported (and object for dynamic mapping).");
+            throw new NotSupportedException("Only ulong and Guid keys are supported.");
         }
 
         options ??= QdrantCollectionOptions.Default;

--- a/dotnet/src/Connectors/Connectors.Memory.Redis/RedisHashSetCollection.cs
+++ b/dotnet/src/Connectors/Connectors.Memory.Redis/RedisHashSetCollection.cs
@@ -22,7 +22,7 @@ namespace Microsoft.SemanticKernel.Connectors.Redis;
 /// <summary>
 /// Service for storing and retrieving vector records, that uses Redis HashSets as the underlying storage.
 /// </summary>
-/// <typeparam name="TKey">The data type of the record key. Can be either <see cref="string"/>, or <see cref="object"/> for dynamic mapping.</typeparam>
+/// <typeparam name="TKey">The data type of the record key. Must be <see cref="string"/>.</typeparam>
 /// <typeparam name="TRecord">The data model to use for adding, updating and retrieving data from storage.</typeparam>
 #pragma warning disable CA1711 // Identifiers should not have incorrect suffix
 public class RedisHashSetCollection<TKey, TRecord> : VectorStoreCollection<TKey, TRecord>
@@ -90,7 +90,7 @@ public class RedisHashSetCollection<TKey, TRecord> : VectorStoreCollection<TKey,
 
         if (typeof(TKey) != typeof(string) && typeof(TKey) != typeof(object))
         {
-            throw new NotSupportedException("Only string keys are supported (and object for dynamic mapping).");
+            throw new NotSupportedException("Only string keys are supported.");
         }
 
         options ??= RedisHashSetCollectionOptions.Default;

--- a/dotnet/src/Connectors/Connectors.Memory.Redis/RedisJsonCollection.cs
+++ b/dotnet/src/Connectors/Connectors.Memory.Redis/RedisJsonCollection.cs
@@ -25,7 +25,7 @@ namespace Microsoft.SemanticKernel.Connectors.Redis;
 /// <summary>
 /// Service for storing and retrieving vector records, that uses Redis JSON as the underlying storage.
 /// </summary>
-/// <typeparam name="TKey">The data type of the record key. Can be either <see cref="string"/>, or <see cref="object"/> for dynamic mapping.</typeparam>
+/// <typeparam name="TKey">The data type of the record key. Must be <see cref="string"/>.</typeparam>
 /// <typeparam name="TRecord">The data model to use for adding, updating and retrieving data from storage.</typeparam>
 #pragma warning disable CA1711 // Identifiers should not have incorrect suffix
 public class RedisJsonCollection<TKey, TRecord> : VectorStoreCollection<TKey, TRecord>
@@ -99,7 +99,7 @@ public class RedisJsonCollection<TKey, TRecord> : VectorStoreCollection<TKey, TR
 
         if (typeof(TKey) != typeof(string) && typeof(TKey) != typeof(object))
         {
-            throw new NotSupportedException("Only string keys are supported (and object for dynamic mapping).");
+            throw new NotSupportedException("Only string keys are supported.");
         }
 
         var isDynamic = typeof(TRecord) == typeof(Dictionary<string, object?>);

--- a/dotnet/src/Connectors/Connectors.Memory.SqliteVec/SqliteCollection.cs
+++ b/dotnet/src/Connectors/Connectors.Memory.SqliteVec/SqliteCollection.cs
@@ -19,7 +19,7 @@ namespace Microsoft.SemanticKernel.Connectors.SqliteVec;
 /// <summary>
 /// Service for storing and retrieving vector records, that uses SQLite as the underlying storage.
 /// </summary>
-/// <typeparam name="TKey">The data type of the record key. Can be <see cref="string"/> or <see cref="ulong"/>, or <see cref="object"/> for dynamic mapping.</typeparam>
+/// <typeparam name="TKey">The data type of the record key. Can be <see cref="string"/>, <see cref="int"/> or <see cref="long"/>.</typeparam>
 /// <typeparam name="TRecord">The data model to use for adding, updating and retrieving data from storage.</typeparam>
 #pragma warning disable CA1711 // Identifiers should not have incorrect suffix
 public class SqliteCollection<TKey, TRecord> : VectorStoreCollection<TKey, TRecord>
@@ -85,9 +85,9 @@ public class SqliteCollection<TKey, TRecord> : VectorStoreCollection<TKey, TReco
         Verify.NotNull(connectionString);
         Verify.NotNullOrWhiteSpace(name);
 
-        if (typeof(TKey) != typeof(string) && typeof(TKey) != typeof(ulong) && typeof(TKey) != typeof(object))
+        if (typeof(TKey) != typeof(string) && typeof(TKey) != typeof(int) && typeof(TKey) != typeof(long) && typeof(TKey) != typeof(object))
         {
-            throw new NotSupportedException($"Only {nameof(String)} and {nameof(UInt64)} keys are supported (and object for dynamic mapping).");
+            throw new NotSupportedException("Only string, int and long keys are supported.");
         }
 
         options ??= SqliteCollectionOptions.Default;

--- a/dotnet/src/Connectors/Connectors.Memory.SqliteVec/SqliteModelBuilder.cs
+++ b/dotnet/src/Connectors/Connectors.Memory.SqliteVec/SqliteModelBuilder.cs
@@ -21,14 +21,14 @@ internal class SqliteModelBuilder() : CollectionModelBuilder(s_modelBuildingOpti
 
     protected override bool IsKeyPropertyTypeValid(Type type, [NotNullWhen(false)] out string? supportedTypes)
     {
-        supportedTypes = "ulong, string";
+        supportedTypes = "int, long, string";
 
-        return type == typeof(ulong) || type == typeof(string);
+        return type == typeof(int) || type == typeof(long) || type == typeof(string);
     }
 
     protected override bool IsDataPropertyTypeValid(Type type, [NotNullWhen(false)] out string? supportedTypes)
     {
-        supportedTypes = "int, long, ulong, short, ushort, string, bool, float, double, decimal, byte[]";
+        supportedTypes = "int, long, short, string, bool, float, double, byte[]";
 
         if (Nullable.GetUnderlyingType(type) is Type underlyingType)
         {
@@ -37,14 +37,11 @@ internal class SqliteModelBuilder() : CollectionModelBuilder(s_modelBuildingOpti
 
         return type == typeof(int)
             || type == typeof(long)
-            || type == typeof(ulong)
             || type == typeof(short)
-            || type == typeof(ushort)
             || type == typeof(string)
             || type == typeof(bool)
             || type == typeof(float)
             || type == typeof(double)
-            || type == typeof(decimal)
             || type == typeof(byte[]);
     }
 

--- a/dotnet/src/Connectors/Connectors.Memory.SqliteVec/SqlitePropertyMapping.cs
+++ b/dotnet/src/Connectors/Connectors.Memory.SqliteVec/SqlitePropertyMapping.cs
@@ -112,13 +112,10 @@ internal static class SqlitePropertyMapping
         {
             Type t when t == typeof(int) => reader.GetInt32(propertyIndex),
             Type t when t == typeof(long) => reader.GetInt64(propertyIndex),
-            Type t when t == typeof(ulong) => (ulong)reader.GetInt64(propertyIndex),
             Type t when t == typeof(short) => reader.GetInt16(propertyIndex),
-            Type t when t == typeof(ushort) => (ushort)reader.GetInt16(propertyIndex),
             Type t when t == typeof(bool) => reader.GetBoolean(propertyIndex),
             Type t when t == typeof(float) => reader.GetFloat(propertyIndex),
             Type t when t == typeof(double) => reader.GetDouble(propertyIndex),
-            Type t when t == typeof(decimal) => reader.GetDecimal(propertyIndex),
             Type t when t == typeof(string) => reader.GetString(propertyIndex),
             Type t when t == typeof(byte[]) => (byte[])reader[propertyIndex],
             Type t when t == typeof(ReadOnlyMemory<float>) => (byte[])reader[propertyIndex],
@@ -137,14 +134,11 @@ internal static class SqlitePropertyMapping
             // Integer types
             Type t when t == typeof(int) || t == typeof(int?) => "INTEGER",
             Type t when t == typeof(long) || t == typeof(long?) => "INTEGER",
-            Type t when t == typeof(ulong) || t == typeof(ulong?) => "INTEGER",
             Type t when t == typeof(short) || t == typeof(short?) => "INTEGER",
-            Type t when t == typeof(ushort) || t == typeof(ushort?) => "INTEGER",
 
             // Floating-point types
             Type t when t == typeof(float) || t == typeof(float?) => "REAL",
             Type t when t == typeof(double) || t == typeof(double?) => "REAL",
-            Type t when t == typeof(decimal) || t == typeof(decimal?) => "REAL",
 
             // String type
             Type t when t == typeof(string) => "TEXT",

--- a/dotnet/src/Connectors/Connectors.Memory.Weaviate/WeaviateCollection.cs
+++ b/dotnet/src/Connectors/Connectors.Memory.Weaviate/WeaviateCollection.cs
@@ -23,7 +23,7 @@ namespace Microsoft.SemanticKernel.Connectors.Weaviate;
 /// <summary>
 /// Service for storing and retrieving vector records, that uses Weaviate as the underlying storage.
 /// </summary>
-/// <typeparam name="TKey">The data type of the record key. Can be either <see cref="Guid"/>, or <see cref="object"/> for dynamic mapping.</typeparam>
+/// <typeparam name="TKey">The data type of the record key. Must be <see cref="Guid"/>.</typeparam>
 /// <typeparam name="TRecord">The data model to use for adding, updating and retrieving data from storage.</typeparam>
 #pragma warning disable CA1711 // Identifiers should not have incorrect suffix
 public class WeaviateCollection<TKey, TRecord> : VectorStoreCollection<TKey, TRecord>, IKeywordHybridSearchable<TRecord>
@@ -97,7 +97,7 @@ public class WeaviateCollection<TKey, TRecord> : VectorStoreCollection<TKey, TRe
 
         if (typeof(TKey) != typeof(Guid) && typeof(TKey) != typeof(object))
         {
-            throw new NotSupportedException($"Only {nameof(Guid)} key is supported (and object for dynamic mapping).");
+            throw new NotSupportedException($"Only {nameof(Guid)} key is supported.");
         }
 
         var endpoint = (options?.Endpoint ?? httpClient.BaseAddress) ?? throw new ArgumentException($"Weaviate endpoint should be provided via HttpClient.BaseAddress property or {nameof(WeaviateCollectionOptions)} options parameter.");

--- a/dotnet/src/Connectors/Connectors.SqliteVec.UnitTests/SqliteCollectionTests.cs
+++ b/dotnet/src/Connectors/Connectors.SqliteVec.UnitTests/SqliteCollectionTests.cs
@@ -33,7 +33,7 @@ public sealed class SqliteCollectionTests
         using var fakeCommand = new FakeDbCommand(scalarResult: tableCount);
         using var fakeConnection = new FakeDBConnection(fakeCommand);
 
-        var sut = new SqliteVectorStoreRecordCollection<TestRecord<ulong>>(fakeConnection, TableName);
+        var sut = new SqliteVectorStoreRecordCollection<TestRecord<long>>(fakeConnection, TableName);
 
         // Act
         var result = await sut.CollectionExistsAsync();
@@ -50,7 +50,7 @@ public sealed class SqliteCollectionTests
         using var fakeCommand = new FakeDbCommand();
         using var fakeConnection = new FakeDBConnection(fakeCommand);
 
-        var sut = new SqliteVectorStoreRecordCollection<TestRecord<ulong>>(fakeConnection, TableName);
+        var sut = new SqliteVectorStoreRecordCollection<TestRecord<long>>(fakeConnection, TableName);
 
         // Act
         await sut.CreateCollectionAsync();
@@ -68,7 +68,7 @@ public sealed class SqliteCollectionTests
         using var fakeCommand = new FakeDbCommand();
         using var fakeConnection = new FakeDBConnection(fakeCommand);
 
-        var sut = new SqliteVectorStoreRecordCollection<TestRecord<ulong>>(fakeConnection, TableName);
+        var sut = new SqliteVectorStoreRecordCollection<TestRecord<long>>(fakeConnection, TableName);
 
         // Act
         await sut.EnsureCollectionExistsAsync();
@@ -87,8 +87,8 @@ public sealed class SqliteCollectionTests
         using var fakeCommandWithoutVectorProperty = new FakeDbCommand();
         using var fakeConnectionWithoutVectorProperty = new FakeDBConnection(fakeCommandWithoutVectorProperty);
 
-        var collectionWithVectorProperty = new SqliteVectorStoreRecordCollection<TestRecord<ulong>>(fakeConnectionWithVectorProperty, "WithVectorProperty");
-        var collectionWithoutVectorProperty = new SqliteVectorStoreRecordCollection<TestRecordWithoutVectorProperty<ulong>>(fakeConnectionWithoutVectorProperty, "WithoutVectorProperty");
+        var collectionWithVectorProperty = new SqliteVectorStoreRecordCollection<TestRecord<long>>(fakeConnectionWithVectorProperty, "WithVectorProperty");
+        var collectionWithoutVectorProperty = new SqliteVectorStoreRecordCollection<TestRecordWithoutVectorProperty<long>>(fakeConnectionWithoutVectorProperty, "WithoutVectorProperty");
 
         // Act
         await collectionWithVectorProperty.DeleteCollectionAsync();
@@ -105,7 +105,7 @@ public sealed class SqliteCollectionTests
     public async Task VectorizedSearchReturnsRecordAsync(bool includeVectors)
     {
         // Arrange
-        var expectedRecord = new TestRecord<ulong> { Key = 1, Data = "Test data", Vector = new ReadOnlyMemory<float>([1f, 2f, 3f, 4f]) };
+        var expectedRecord = new TestRecord<long> { Key = 1, Data = "Test data", Vector = new ReadOnlyMemory<float>([1f, 2f, 3f, 4f]) };
 
         var mockReader = new Mock<DbDataReader>();
 
@@ -117,7 +117,7 @@ public sealed class SqliteCollectionTests
         using var fakeCommand = new FakeDbCommand(mockReader.Object);
         using var fakeConnection = new FakeDBConnection(fakeCommand);
 
-        var sut = new SqliteVectorStoreRecordCollection<TestRecord<ulong>>(fakeConnection, "VectorizedSearch");
+        var sut = new SqliteVectorStoreRecordCollection<TestRecord<long>>(fakeConnection, "VectorizedSearch");
 
         // Act
         var result = await sut.VectorizedSearchAsync(expectedRecord.Vector, new() { IncludeVectors = includeVectors }).FirstOrDefaultAsync();
@@ -136,7 +136,7 @@ public sealed class SqliteCollectionTests
     public async Task GetReturnsValidRecordAsync(bool includeVectors)
     {
         // Arrange
-        var expectedRecord = new TestRecord<ulong> { Key = 1, Data = "Test data", Vector = new ReadOnlyMemory<float>([1f, 2f, 3f, 4f]) };
+        var expectedRecord = new TestRecord<long> { Key = 1, Data = "Test data", Vector = new ReadOnlyMemory<float>([1f, 2f, 3f, 4f]) };
 
         var mockReader = new Mock<DbDataReader>();
 
@@ -145,7 +145,7 @@ public sealed class SqliteCollectionTests
         using var fakeCommand = new FakeDbCommand(mockReader.Object);
         using var fakeConnection = new FakeDBConnection(fakeCommand);
 
-        var sut = new SqliteVectorStoreRecordCollection<TestRecord<ulong>>(fakeConnection, "Get");
+        var sut = new SqliteVectorStoreRecordCollection<TestRecord<long>>(fakeConnection, "Get");
 
         // Act
         var actualRecord = await sut.GetAsync(expectedRecord.Key, new() { IncludeVectors = includeVectors });
@@ -160,11 +160,11 @@ public sealed class SqliteCollectionTests
     public async Task GetBatchReturnsValidRecordsAsync(bool includeVectors)
     {
         // Arrange
-        var expectedRecord1 = new TestRecord<ulong> { Key = 1, Data = "Test data", Vector = new ReadOnlyMemory<float>([1f, 2f, 3f, 4f]) };
-        var expectedRecord2 = new TestRecord<ulong> { Key = 2, Data = "Test data", Vector = new ReadOnlyMemory<float>([1f, 2f, 3f, 4f]) };
-        var expectedRecord3 = new TestRecord<ulong> { Key = 3, Data = "Test data", Vector = new ReadOnlyMemory<float>([1f, 2f, 3f, 4f]) };
+        var expectedRecord1 = new TestRecord<long> { Key = 1, Data = "Test data", Vector = new ReadOnlyMemory<float>([1f, 2f, 3f, 4f]) };
+        var expectedRecord2 = new TestRecord<long> { Key = 2, Data = "Test data", Vector = new ReadOnlyMemory<float>([1f, 2f, 3f, 4f]) };
+        var expectedRecord3 = new TestRecord<long> { Key = 3, Data = "Test data", Vector = new ReadOnlyMemory<float>([1f, 2f, 3f, 4f]) };
 
-        var expectedRecords = new List<TestRecord<ulong>> { expectedRecord1, expectedRecord2, expectedRecord3 };
+        var expectedRecords = new List<TestRecord<long>> { expectedRecord1, expectedRecord2, expectedRecord3 };
 
         var mockReader = new Mock<DbDataReader>();
 
@@ -173,7 +173,7 @@ public sealed class SqliteCollectionTests
         using var fakeCommand = new FakeDbCommand(mockReader.Object);
         using var fakeConnection = new FakeDBConnection(fakeCommand);
 
-        var sut = new SqliteVectorStoreRecordCollection<TestRecord<ulong>>(fakeConnection, "GetBatch");
+        var sut = new SqliteVectorStoreRecordCollection<TestRecord<long>>(fakeConnection, "GetBatch");
 
         // Act
         var actualRecords = await sut
@@ -191,7 +191,7 @@ public sealed class SqliteCollectionTests
     public async Task UpsertReturnsKeyAsync()
     {
         // Arrange
-        var expectedRecord = new TestRecord<ulong> { Key = 1, Data = "Test data", Vector = new ReadOnlyMemory<float>([1f, 2f, 3f, 4f]) };
+        var expectedRecord = new TestRecord<long> { Key = 1, Data = "Test data", Vector = new ReadOnlyMemory<float>([1f, 2f, 3f, 4f]) };
 
         var mockReader = new Mock<DbDataReader>();
 
@@ -200,7 +200,7 @@ public sealed class SqliteCollectionTests
         using var fakeCommand = new FakeDbCommand(mockReader.Object);
         using var fakeConnection = new FakeDBConnection(fakeCommand);
 
-        var sut = new SqliteVectorStoreRecordCollection<TestRecord<ulong>>(fakeConnection, "Upsert");
+        var sut = new SqliteVectorStoreRecordCollection<TestRecord<long>>(fakeConnection, "Upsert");
 
         // Act
         var actualKey = await sut.UpsertAsync(expectedRecord);
@@ -215,7 +215,7 @@ public sealed class SqliteCollectionTests
     public async Task UpsertWithoutVectorPropertyReturnsKeyAsync()
     {
         // Arrange
-        var expectedRecord = new TestRecordWithoutVectorProperty<ulong> { Key = 1, Data = "Test data" };
+        var expectedRecord = new TestRecordWithoutVectorProperty<long> { Key = 1, Data = "Test data" };
 
         var mockReader = new Mock<DbDataReader>();
 
@@ -224,7 +224,7 @@ public sealed class SqliteCollectionTests
         using var fakeCommand = new FakeDbCommand(mockReader.Object);
         using var fakeConnection = new FakeDBConnection(fakeCommand);
 
-        var sut = new SqliteVectorStoreRecordCollection<TestRecordWithoutVectorProperty<ulong>>(fakeConnection, "UpsertWithoutVectorProperty");
+        var sut = new SqliteVectorStoreRecordCollection<TestRecordWithoutVectorProperty<long>>(fakeConnection, "UpsertWithoutVectorProperty");
 
         // Act
         var actualKey = await sut.UpsertAsync(expectedRecord);
@@ -239,11 +239,11 @@ public sealed class SqliteCollectionTests
     public async Task UpsertBatchReturnsKeysAsync()
     {
         // Arrange
-        var expectedRecord1 = new TestRecord<ulong> { Key = 1, Data = "Test data", Vector = new ReadOnlyMemory<float>([1f, 2f, 3f, 4f]) };
-        var expectedRecord2 = new TestRecord<ulong> { Key = 2, Data = "Test data", Vector = new ReadOnlyMemory<float>([1f, 2f, 3f, 4f]) };
-        var expectedRecord3 = new TestRecord<ulong> { Key = 3, Data = "Test data", Vector = new ReadOnlyMemory<float>([1f, 2f, 3f, 4f]) };
+        var expectedRecord1 = new TestRecord<long> { Key = 1, Data = "Test data", Vector = new ReadOnlyMemory<float>([1f, 2f, 3f, 4f]) };
+        var expectedRecord2 = new TestRecord<long> { Key = 2, Data = "Test data", Vector = new ReadOnlyMemory<float>([1f, 2f, 3f, 4f]) };
+        var expectedRecord3 = new TestRecord<long> { Key = 3, Data = "Test data", Vector = new ReadOnlyMemory<float>([1f, 2f, 3f, 4f]) };
 
-        var expectedRecords = new List<TestRecord<ulong>> { expectedRecord1, expectedRecord2, expectedRecord3 };
+        var expectedRecords = new List<TestRecord<long>> { expectedRecord1, expectedRecord2, expectedRecord3 };
 
         var mockReader = new Mock<DbDataReader>();
 
@@ -252,7 +252,7 @@ public sealed class SqliteCollectionTests
         using var fakeCommand = new FakeDbCommand(mockReader.Object);
         using var fakeConnection = new FakeDBConnection(fakeCommand);
 
-        var sut = new SqliteVectorStoreRecordCollection<TestRecord<ulong>>(fakeConnection, "UpsertBatch");
+        var sut = new SqliteVectorStoreRecordCollection<TestRecord<long>>(fakeConnection, "UpsertBatch");
 
         // Act
         var actualKeys = await sut.UpsertBatchAsync(expectedRecords).ToListAsync();
@@ -272,8 +272,8 @@ public sealed class SqliteCollectionTests
         using var fakeCommandWithoutVectorProperty = new FakeDbCommand();
         using var fakeConnectionWithoutVectorProperty = new FakeDBConnection(fakeCommandWithoutVectorProperty);
 
-        var collectionWithVectorProperty = new SqliteVectorStoreRecordCollection<TestRecord<ulong>>(fakeConnectionWithVectorProperty, "WithVectorProperty");
-        var collectionWithoutVectorProperty = new SqliteVectorStoreRecordCollection<TestRecordWithoutVectorProperty<ulong>>(fakeConnectionWithoutVectorProperty, "WithoutVectorProperty");
+        var collectionWithVectorProperty = new SqliteVectorStoreRecordCollection<TestRecord<long>>(fakeConnectionWithVectorProperty, "WithVectorProperty");
+        var collectionWithoutVectorProperty = new SqliteVectorStoreRecordCollection<TestRecordWithoutVectorProperty<long>>(fakeConnectionWithoutVectorProperty, "WithoutVectorProperty");
 
         // Act
         await collectionWithVectorProperty.DeleteAsync(key: 1);
@@ -293,8 +293,8 @@ public sealed class SqliteCollectionTests
         using var fakeCommandWithoutVectorProperty = new FakeDbCommand();
         using var fakeConnectionWithoutVectorProperty = new FakeDBConnection(fakeCommandWithoutVectorProperty);
 
-        var collectionWithVectorProperty = new SqliteVectorStoreRecordCollection<TestRecord<ulong>>(fakeConnectionWithVectorProperty, "WithVectorProperty");
-        var collectionWithoutVectorProperty = new SqliteVectorStoreRecordCollection<TestRecordWithoutVectorProperty<ulong>>(fakeConnectionWithoutVectorProperty, "WithoutVectorProperty");
+        var collectionWithVectorProperty = new SqliteVectorStoreRecordCollection<TestRecord<long>>(fakeConnectionWithVectorProperty, "WithVectorProperty");
+        var collectionWithoutVectorProperty = new SqliteVectorStoreRecordCollection<TestRecordWithoutVectorProperty<long>>(fakeConnectionWithoutVectorProperty, "WithoutVectorProperty");
 
         // Act
         await collectionWithVectorProperty.DeleteBatchAsync(keys: [1, 2, 3]);
@@ -327,9 +327,9 @@ public sealed class SqliteCollectionTests
         {
             var vectorBytes = SqliteVectorStoreRecordPropertyMapping.MapVectorForStorageModel(record.Vector);
 
-            if (record.Key is ulong numericKey)
+            if (record.Key is long numericKey)
             {
-                numericKeySequence.Returns((long)numericKey);
+                numericKeySequence.Returns(numericKey);
             }
 
             if (record.Key is string stringKey)

--- a/dotnet/src/Connectors/Connectors.SqliteVec.UnitTests/SqliteMapperTests.cs
+++ b/dotnet/src/Connectors/Connectors.SqliteVec.UnitTests/SqliteMapperTests.cs
@@ -42,17 +42,17 @@ public sealed class SqliteMapperTests
     public void MapFromDataToStorageModelWithNumericKeyReturnsValidStorageModel()
     {
         // Arrange
-        var definition = GetRecordDefinition<ulong>();
-        var model = BuildModel(typeof(TestRecord<ulong>), definition);
-        var dataModel = GetDataModel<ulong>(1);
+        var definition = GetRecordDefinition<long>();
+        var model = BuildModel(typeof(TestRecord<long>), definition);
+        var dataModel = GetDataModel<long>(1);
 
-        var mapper = new SqliteMapper<TestRecord<ulong>>(model);
+        var mapper = new SqliteMapper<TestRecord<long>>(model);
 
         // Act
         var result = mapper.MapFromDataToStorageModel(dataModel, recordIndex: 0, generatedEmbeddings: null);
 
         // Assert
-        Assert.Equal((ulong)1, result["Key"]);
+        Assert.Equal((long)1, result["Key"]);
         Assert.Equal("Value1", result["StringProperty"]);
         Assert.Equal(5, result["IntProperty"]);
 
@@ -114,22 +114,22 @@ public sealed class SqliteMapperTests
 
         var storageModel = new Dictionary<string, object?>
         {
-            ["Key"] = (ulong)1,
+            ["Key"] = (long)1,
             ["StringProperty"] = "Value1",
             ["IntProperty"] = 5,
             ["FloatVector"] = storageVector
         };
 
-        var definition = GetRecordDefinition<ulong>();
-        var model = BuildModel(typeof(TestRecord<ulong>), definition);
+        var definition = GetRecordDefinition<long>();
+        var model = BuildModel(typeof(TestRecord<long>), definition);
 
-        var mapper = new SqliteMapper<TestRecord<ulong>>(model);
+        var mapper = new SqliteMapper<TestRecord<long>>(model);
 
         // Act
         var result = mapper.MapFromStorageToDataModel(storageModel, includeVectors);
 
         // Assert
-        Assert.Equal((ulong)1, result.Key);
+        Assert.Equal((long)1, result.Key);
         Assert.Equal("Value1", result.StringProperty);
         Assert.Equal(5, result.IntProperty);
 

--- a/dotnet/src/Connectors/Connectors.SqliteVec.UnitTests/SqliteVectorStoreTests.cs
+++ b/dotnet/src/Connectors/Connectors.SqliteVec.UnitTests/SqliteVectorStoreTests.cs
@@ -39,7 +39,7 @@ public sealed class SqliteVectorStoreTests
         var sut = new SqliteVectorStore(Mock.Of<SqliteConnection>());
 
         // Act
-        var collectionWithNumericKey = sut.GetCollection<ulong, SqliteHotel<ulong>>("collection1");
+        var collectionWithNumericKey = sut.GetCollection<long, SqliteHotel<long>>("collection1");
         var collectionWithStringKey = sut.GetCollection<string, SqliteHotel<string>>("collection2");
 
         // Assert

--- a/dotnet/src/IntegrationTests/Connectors/Memory/SqliteVec/SqliteVectorStoreRecordCollectionTests.cs
+++ b/dotnet/src/IntegrationTests/Connectors/Memory/SqliteVec/SqliteVectorStoreRecordCollectionTests.cs
@@ -29,7 +29,7 @@ public sealed class SqliteVectorStoreRecordCollectionTests(SqliteVectorStoreFixt
     public async Task CollectionExistsReturnsCollectionStateAsync(bool createCollection)
     {
         // Arrange
-        using var sut = fixture.GetCollection<ulong, SqliteHotel<ulong>>("CollectionExists");
+        using var sut = fixture.GetCollection<long, SqliteHotel<long>>("CollectionExists");
 
         if (createCollection)
         {
@@ -47,7 +47,7 @@ public sealed class SqliteVectorStoreRecordCollectionTests(SqliteVectorStoreFixt
     public async Task ItCanEnsureCollectionExistsAsync()
     {
         // Arrange
-        using var sut = fixture.GetCollection<ulong, SqliteHotel<ulong>>("CreateCollection");
+        using var sut = fixture.GetCollection<long, SqliteHotel<long>>("CreateCollection");
 
         // Act
         await sut.EnsureCollectionExistsAsync();
@@ -60,7 +60,7 @@ public sealed class SqliteVectorStoreRecordCollectionTests(SqliteVectorStoreFixt
     public async Task ItCanCreateCollectionForSupportedDistanceFunctionsAsync()
     {
         // Arrange
-        using var sut = fixture.GetCollection<ulong, RecordWithSupportedDistanceFunctions>("CreateCollectionForSupportedDistanceFunctions");
+        using var sut = fixture.GetCollection<long, RecordWithSupportedDistanceFunctions>("CreateCollectionForSupportedDistanceFunctions");
 
         // Act
         await sut.EnsureCollectionExistsAsync();
@@ -73,7 +73,7 @@ public sealed class SqliteVectorStoreRecordCollectionTests(SqliteVectorStoreFixt
     public async Task ItCanDeleteCollectionAsync()
     {
         // Arrange
-        using var sut = fixture.GetCollection<ulong, SqliteHotel<ulong>>("DeleteCollection");
+        using var sut = fixture.GetCollection<long, SqliteHotel<long>>("DeleteCollection");
 
         await sut.EnsureCollectionExistsAsync();
 
@@ -94,17 +94,17 @@ public sealed class SqliteVectorStoreRecordCollectionTests(SqliteVectorStoreFixt
     public async Task ItCanCreateCollectionUpsertAndGetAsync(bool includeVectors, bool useRecordDefinition)
     {
         // Arrange
-        const ulong HotelId = 5;
+        const long HotelId = 5;
 
         var collectionNamePostfix = useRecordDefinition ? "WithDefinition" : "WithType";
         var collectionName = $"Collection{collectionNamePostfix}";
 
         var options = new SqliteCollectionOptions
         {
-            Definition = useRecordDefinition ? GetVectorStoreRecordDefinition<ulong>() : null
+            Definition = useRecordDefinition ? GetVectorStoreRecordDefinition<long>() : null
         };
 
-        using var sut = fixture.GetCollection<ulong, SqliteHotel<ulong>>("DeleteCollection", options);
+        using var sut = fixture.GetCollection<long, SqliteHotel<long>>("DeleteCollection", options);
 
         var record = CreateTestHotel(HotelId);
 
@@ -141,8 +141,8 @@ public sealed class SqliteVectorStoreRecordCollectionTests(SqliteVectorStoreFixt
     public async Task ItCanGetAndDeleteRecordAsync()
     {
         // Arrange
-        const ulong HotelId = 5;
-        using var sut = fixture.GetCollection<ulong, SqliteHotel<ulong>>("DeleteRecord");
+        const long HotelId = 5;
+        using var sut = fixture.GetCollection<long, SqliteHotel<long>>("DeleteRecord");
 
         await sut.EnsureCollectionExistsAsync();
 
@@ -166,11 +166,11 @@ public sealed class SqliteVectorStoreRecordCollectionTests(SqliteVectorStoreFixt
     public async Task ItCanGetUpsertDeleteBatchWithNumericKeyAsync()
     {
         // Arrange
-        const ulong HotelId1 = 1;
-        const ulong HotelId2 = 2;
-        const ulong HotelId3 = 3;
+        const long HotelId1 = 1;
+        const long HotelId2 = 2;
+        const long HotelId3 = 3;
 
-        using var sut = fixture.GetCollection<ulong, SqliteHotel<ulong>>("GetUpsertDeleteBatchWithNumericKey");
+        using var sut = fixture.GetCollection<long, SqliteHotel<long>>("GetUpsertDeleteBatchWithNumericKey");
 
         await sut.EnsureCollectionExistsAsync();
 
@@ -235,8 +235,8 @@ public sealed class SqliteVectorStoreRecordCollectionTests(SqliteVectorStoreFixt
         var collectionNamePostfix = includeVectors ? "WithVectors" : "WithoutVectors";
         var collectionName = $"Collection{collectionNamePostfix}";
 
-        const ulong HotelId = 5;
-        using var sut = fixture.GetCollection<ulong, SqliteHotel<ulong>>(collectionName);
+        const long HotelId = 5;
+        using var sut = fixture.GetCollection<long, SqliteHotel<long>>(collectionName);
 
         await sut.EnsureCollectionExistsAsync();
 
@@ -301,8 +301,8 @@ public sealed class SqliteVectorStoreRecordCollectionTests(SqliteVectorStoreFixt
     public async Task ItCanUpsertExistingRecordAsync()
     {
         // Arrange
-        const ulong HotelId = 5;
-        using var sut = fixture.GetCollection<ulong, SqliteHotel<ulong>>("UpsertRecord");
+        const long HotelId = 5;
+        using var sut = fixture.GetCollection<long, SqliteHotel<long>>("UpsertRecord");
 
         await sut.EnsureCollectionExistsAsync();
 
@@ -436,7 +436,7 @@ public sealed class SqliteVectorStoreRecordCollectionTests(SqliteVectorStoreFixt
 
         var options = new SqliteCollectionOptions
         {
-            Definition = GetVectorStoreRecordDefinition<ulong>()
+            Definition = GetVectorStoreRecordDefinition<long>()
         };
 
         using var sut = fixture.GetCollection<object, Dictionary<string, object?>>("DynamicMapperWithNumericKey", options);
@@ -555,7 +555,7 @@ public sealed class SqliteVectorStoreRecordCollectionTests(SqliteVectorStoreFixt
     private sealed class RecordWithSupportedDistanceFunctions
     {
         [VectorStoreKey]
-        public ulong Id { get; set; }
+        public long Id { get; set; }
 
         [VectorStoreVector(Dimensions: 4, DistanceFunction = DistanceFunction.CosineDistance)]
         public ReadOnlyMemory<float>? Embedding1 { get; set; }

--- a/dotnet/src/VectorDataIntegrationTests/SqliteVecIntegrationTests/CRUD/SqliteBatchConformanceTests.cs
+++ b/dotnet/src/VectorDataIntegrationTests/SqliteVecIntegrationTests/CRUD/SqliteBatchConformanceTests.cs
@@ -11,7 +11,7 @@ public class SqliteBatchConformanceTests_string(SqliteSimpleModelFixture<string>
 {
 }
 
-public class SqliteBatchConformanceTests_ulong(SqliteSimpleModelFixture<ulong> fixture)
-    : BatchConformanceTests<ulong>(fixture), IClassFixture<SqliteSimpleModelFixture<ulong>>
+public class SqliteBatchConformanceTests_long(SqliteSimpleModelFixture<long> fixture)
+    : BatchConformanceTests<long>(fixture), IClassFixture<SqliteSimpleModelFixture<long>>
 {
 }

--- a/dotnet/src/VectorDataIntegrationTests/SqliteVecIntegrationTests/CRUD/SqliteRecordConformanceTests.cs
+++ b/dotnet/src/VectorDataIntegrationTests/SqliteVecIntegrationTests/CRUD/SqliteRecordConformanceTests.cs
@@ -11,7 +11,7 @@ public class SqliteRecordConformanceTests_string(SqliteSimpleModelFixture<string
 {
 }
 
-public class SqliteRecordConformanceTests_ulong(SqliteSimpleModelFixture<ulong> fixture)
-    : RecordConformanceTests<ulong>(fixture), IClassFixture<SqliteSimpleModelFixture<ulong>>
+public class SqliteRecordConformanceTests_long(SqliteSimpleModelFixture<long> fixture)
+    : RecordConformanceTests<long>(fixture), IClassFixture<SqliteSimpleModelFixture<long>>
 {
 }

--- a/dotnet/src/VectorDataIntegrationTests/SqliteVecIntegrationTests/Filter/SqliteBasicFilterTests.cs
+++ b/dotnet/src/VectorDataIntegrationTests/SqliteVecIntegrationTests/Filter/SqliteBasicFilterTests.cs
@@ -12,7 +12,7 @@ namespace SqliteVecIntegrationTests.Filter;
 #pragma warning disable CS0252 // Possible unintended reference comparison; left hand side needs cast
 
 public class SqliteBasicFilterTests(SqliteBasicFilterTests.Fixture fixture)
-    : BasicFilterTests<ulong>(fixture), IClassFixture<SqliteBasicFilterTests.Fixture>
+    : BasicFilterTests<long>(fixture), IClassFixture<SqliteBasicFilterTests.Fixture>
 {
     public override async Task Not_over_Or()
     {
@@ -53,7 +53,7 @@ public class SqliteBasicFilterTests(SqliteBasicFilterTests.Fixture fixture)
     public override Task Legacy_AnyTagEqualTo_List()
         => Assert.ThrowsAsync<NotSupportedException>(() => base.Legacy_AnyTagEqualTo_List());
 
-    public new class Fixture : BasicFilterTests<ulong>.Fixture
+    public new class Fixture : BasicFilterTests<long>.Fixture
     {
         public override TestStore TestStore => SqliteTestStore.Instance;
 

--- a/dotnet/src/VectorDataIntegrationTests/SqliteVecIntegrationTests/Filter/SqliteBasicQueryTests.cs
+++ b/dotnet/src/VectorDataIntegrationTests/SqliteVecIntegrationTests/Filter/SqliteBasicQueryTests.cs
@@ -12,7 +12,7 @@ namespace SqliteVecIntegrationTests.Filter;
 #pragma warning disable CS0252 // Possible unintended reference comparison; left hand side needs cast
 
 public class SqliteBasicQueryTests(SqliteBasicQueryTests.Fixture fixture)
-    : BasicQueryTests<ulong>(fixture), IClassFixture<SqliteBasicQueryTests.Fixture>
+    : BasicQueryTests<long>(fixture), IClassFixture<SqliteBasicQueryTests.Fixture>
 {
     public override async Task Not_over_Or()
     {
@@ -44,7 +44,7 @@ public class SqliteBasicQueryTests(SqliteBasicQueryTests.Fixture fixture)
     public override Task Contains_over_field_string_List()
         => Assert.ThrowsAsync<InvalidOperationException>(() => base.Contains_over_field_string_List());
 
-    public new class Fixture : BasicQueryTests<ulong>.QueryFixture
+    public new class Fixture : BasicQueryTests<long>.QueryFixture
     {
         public override TestStore TestStore => SqliteTestStore.Instance;
 


### PR DESCRIPTION
Like other relational databases, Sqlite does not support unsigned integer types ([Sqlite docs](https://sqlite.org/datatype3.html)):

> The value is a signed integer, stored in 0, 1, 2, 3, 4, 6, or 8 bytes depending on the magnitude of the value.

However, our Sqlite provider does allow ulong and ushort (but not uint for some reason), and even "supports" ulong as a key type.

This PR removes support for ulong and ushort. It also updates some docs and error messages now that dynamic support has been split out to a separate type (users can no longer e.g. instantiate `SqliteCollection<object, Dictionary<string, object?>>` directly).

Part of #11784
