### PR TITLE
.Net: Support search-only embedding generation

### DIFF
--- a/dotnet/src/Connectors/Connectors.Memory.AzureAISearch/AzureAISearchCollection.cs
+++ b/dotnet/src/Connectors/Connectors.Memory.AzureAISearch/AzureAISearchCollection.cs
@@ -234,8 +234,7 @@ public class AzureAISearchCollection<TKey, TRecord> : VectorStoreCollection<TKey
         // Create Options.
         var innerOptions = this.ConvertGetDocumentOptions(options);
         var includeVectors = options?.IncludeVectors ?? false;
-
-        if (includeVectors && this._model.VectorProperties.Any(p => p.EmbeddingGenerator is not null))
+        if (includeVectors && this._model.EmbeddingGenerationRequired)
         {
             throw new NotSupportedException(VectorDataStrings.IncludeVectorsNotSupportedWithEmbeddingGeneration);
         }
@@ -252,8 +251,7 @@ public class AzureAISearchCollection<TKey, TRecord> : VectorStoreCollection<TKey
         // Create Options
         var innerOptions = this.ConvertGetDocumentOptions(options);
         var includeVectors = options?.IncludeVectors ?? false;
-
-        if (includeVectors && this._model.VectorProperties.Any(p => p.EmbeddingGenerator is not null))
+        if (includeVectors && this._model.EmbeddingGenerationRequired)
         {
             throw new NotSupportedException(VectorDataStrings.IncludeVectorsNotSupportedWithEmbeddingGeneration);
         }
@@ -335,7 +333,7 @@ public class AzureAISearchCollection<TKey, TRecord> : VectorStoreCollection<TKey
         options ??= new();
 
         var includeVectors = options.IncludeVectors;
-        if (includeVectors && this._model.VectorProperties.Any(p => p.EmbeddingGenerator is not null))
+        if (includeVectors && this._model.EmbeddingGenerationRequired)
         {
             throw new NotSupportedException(VectorDataStrings.IncludeVectorsNotSupportedWithEmbeddingGeneration);
         }
@@ -630,7 +628,7 @@ public class AzureAISearchCollection<TKey, TRecord> : VectorStoreCollection<TKey
             throw new InvalidOperationException("The collection does not have any vector fields, so vector search is not possible.");
         }
 
-        if (options.IncludeVectors && model.VectorProperties.Any(p => p.EmbeddingGenerator is not null))
+        if (options.IncludeVectors && model.EmbeddingGenerationRequired)
         {
             throw new NotSupportedException(VectorDataStrings.IncludeVectorsNotSupportedWithEmbeddingGeneration);
         }
@@ -690,10 +688,13 @@ public class AzureAISearchCollection<TKey, TRecord> : VectorStoreCollection<TKey
         {
             var vectorProperty = model.VectorProperties[i];
 
-            if (vectorProperty.EmbeddingGenerator is null)
+            if (AzureAISearchModelBuilder.IsVectorPropertyTypeValidCore(vectorProperty.Type, out _))
             {
                 continue;
             }
+
+            // We have a vector property whose type isn't natively supported - we need to generate embeddings.
+            Debug.Assert(vectorProperty.EmbeddingGenerator is not null);
 
             // We have a property with embedding generation; materialize the records' enumerable if needed, to
             // prevent multiple enumeration.
@@ -711,7 +712,7 @@ public class AzureAISearchCollection<TKey, TRecord> : VectorStoreCollection<TKey
 
             // TODO: Ideally we'd group together vector properties using the same generator (and with the same input and output properties),
             // and generate embeddings for them in a single batch. That's some more complexity though.
-            if (vectorProperty.TryGenerateEmbeddings<TRecord, Embedding<float>, ReadOnlyMemory<float>>(records, cancellationToken, out var floatTask))
+            if (vectorProperty.TryGenerateEmbeddings<TRecord, Embedding<float>>(records, cancellationToken, out var floatTask))
             {
                 generatedEmbeddings ??= new IReadOnlyList<MEAI.Embedding>?[vectorPropertyCount];
                 generatedEmbeddings[i] = await floatTask.ConfigureAwait(false);

--- a/dotnet/src/Connectors/Connectors.Memory.CosmosMongoDB/CosmosMongoCollection.cs
+++ b/dotnet/src/Connectors/Connectors.Memory.CosmosMongoDB/CosmosMongoCollection.cs
@@ -167,7 +167,7 @@ public class CosmosMongoCollection<TKey, TRecord> : VectorStoreCollection<TKey, 
         var stringKey = this.GetStringKey(key);
 
         var includeVectors = options?.IncludeVectors ?? false;
-        if (includeVectors && this._model.VectorProperties.Any(p => p.EmbeddingGenerator is not null))
+        if (includeVectors && this._model.EmbeddingGenerationRequired)
         {
             throw new NotSupportedException(VectorDataStrings.IncludeVectorsNotSupportedWithEmbeddingGeneration);
         }
@@ -195,7 +195,7 @@ public class CosmosMongoCollection<TKey, TRecord> : VectorStoreCollection<TKey, 
         Verify.NotNull(keys);
 
         var includeVectors = options?.IncludeVectors ?? false;
-        if (includeVectors && this._model.VectorProperties.Any(p => p.EmbeddingGenerator is not null))
+        if (includeVectors && this._model.EmbeddingGenerationRequired)
         {
             throw new NotSupportedException(VectorDataStrings.IncludeVectorsNotSupportedWithEmbeddingGeneration);
         }
@@ -273,10 +273,13 @@ public class CosmosMongoCollection<TKey, TRecord> : VectorStoreCollection<TKey, 
         {
             var vectorProperty = model.VectorProperties[i];
 
-            if (vectorProperty.EmbeddingGenerator is null)
+            if (MongoModelBuilder.IsVectorPropertyTypeValidCore(vectorProperty.Type, out _))
             {
                 continue;
             }
+
+            // We have a vector property whose type isn't natively supported - we need to generate embeddings.
+            Debug.Assert(vectorProperty.EmbeddingGenerator is not null);
 
             // We have a property with embedding generation; materialize the records' enumerable if needed, to
             // prevent multiple enumeration.
@@ -294,7 +297,7 @@ public class CosmosMongoCollection<TKey, TRecord> : VectorStoreCollection<TKey, 
 
             // TODO: Ideally we'd group together vector properties using the same generator (and with the same input and output properties),
             // and generate embeddings for them in a single batch. That's some more complexity though.
-            if (vectorProperty.TryGenerateEmbeddings<TRecord, Embedding<float>, ReadOnlyMemory<float>>(records, cancellationToken, out var floatTask))
+            if (vectorProperty.TryGenerateEmbeddings<TRecord, Embedding<float>>(records, cancellationToken, out var floatTask))
             {
                 generatedEmbeddings ??= new IReadOnlyList<Embedding>?[vectorPropertyCount];
                 generatedEmbeddings[i] = await floatTask.ConfigureAwait(false);
@@ -322,7 +325,7 @@ public class CosmosMongoCollection<TKey, TRecord> : VectorStoreCollection<TKey, 
         Verify.NotLessThan(top, 1);
 
         options ??= s_defaultVectorSearchOptions;
-        if (options.IncludeVectors && this._model.VectorProperties.Any(p => p.EmbeddingGenerator is not null))
+        if (options.IncludeVectors && this._model.EmbeddingGenerationRequired)
         {
             throw new NotSupportedException(VectorDataStrings.IncludeVectorsNotSupportedWithEmbeddingGeneration);
         }

--- a/dotnet/src/Connectors/Connectors.Memory.PgVector/PostgresModelBuilder.cs
+++ b/dotnet/src/Connectors/Connectors.Memory.PgVector/PostgresModelBuilder.cs
@@ -84,28 +84,13 @@ internal class PostgresModelBuilder() : CollectionModelBuilder(PostgresModelBuil
     }
 
     /// <inheritdoc />
-    protected override void SetupEmbeddingGeneration(
+    protected override Type? ResolveEmbeddingType(
         VectorPropertyModel vectorProperty,
         IEmbeddingGenerator embeddingGenerator,
-        Type? embeddingType)
-    {
-        if (!vectorProperty.TrySetupEmbeddingGeneration<Embedding<float>, ReadOnlyMemory<float>>(embeddingGenerator, embeddingType)
+        Type? userRequestedEmbeddingType)
+        => vectorProperty.ResolveEmbeddingType<Embedding<float>>(embeddingGenerator, userRequestedEmbeddingType)
 #if NET8_0_OR_GREATER
-            && !vectorProperty.TrySetupEmbeddingGeneration<Embedding<Half>, ReadOnlyMemory<Half>>(embeddingGenerator, embeddingType)
+        ?? vectorProperty.ResolveEmbeddingType<Embedding<Half>>(embeddingGenerator, userRequestedEmbeddingType)
 #endif
-            )
-        {
-            throw new InvalidOperationException(
-                VectorDataStrings.IncompatibleEmbeddingGenerator(
-                    embeddingGeneratorType: embeddingGenerator.GetType(),
-                    supportedInputTypes: vectorProperty.GetSupportedInputTypes(),
-                    supportedOutputTypes:
-                    [
-                        typeof(ReadOnlyMemory<float>),
-#if NET8_0_OR_GREATER
-                        typeof(ReadOnlyMemory<Half>)
-#endif
-                    ]));
-        }
-    }
+        ;
 }

--- a/dotnet/src/Connectors/Connectors.Memory.Pinecone/PineconeCollection.cs
+++ b/dotnet/src/Connectors/Connectors.Memory.Pinecone/PineconeCollection.cs
@@ -191,7 +191,7 @@ public class PineconeCollection<TKey, TRecord> : VectorStoreCollection<TKey, TRe
     public override async Task<TRecord?> GetAsync(TKey key, RecordRetrievalOptions? options = null, CancellationToken cancellationToken = default)
     {
         var includeVectors = options?.IncludeVectors is true;
-        if (includeVectors && this._model.VectorProperties.Any(p => p.EmbeddingGenerator is not null))
+        if (includeVectors && this._model.EmbeddingGenerationRequired)
         {
             throw new NotSupportedException(VectorDataStrings.IncludeVectorsNotSupportedWithEmbeddingGeneration);
         }
@@ -224,7 +224,7 @@ public class PineconeCollection<TKey, TRecord> : VectorStoreCollection<TKey, TRe
         Verify.NotNull(keys);
 
         var includeVectors = options?.IncludeVectors is true;
-        if (includeVectors && this._model.VectorProperties.Any(p => p.EmbeddingGenerator is not null))
+        if (includeVectors && this._model.EmbeddingGenerationRequired)
         {
             throw new NotSupportedException(VectorDataStrings.IncludeVectorsNotSupportedWithEmbeddingGeneration);
         }
@@ -316,9 +316,12 @@ public class PineconeCollection<TKey, TRecord> : VectorStoreCollection<TKey, TRe
         Embedding<float>? generatedEmbedding = null;
 
         Debug.Assert(this._model.VectorProperties.Count <= 1);
-        if (this._model.VectorProperties is [{ EmbeddingGenerator: not null } vectorProperty])
+        if (this._model.VectorProperties is [var vectorProperty] && !PineconeModelBuilder.IsVectorPropertyTypeValidCore(vectorProperty.Type, out _))
         {
-            if (vectorProperty.TryGenerateEmbedding<TRecord, Embedding<float>, ReadOnlyMemory<float>>(record, cancellationToken, out var task))
+            // We have a vector property whose type isn't natively supported - we need to generate embeddings.
+            Debug.Assert(vectorProperty.EmbeddingGenerator is not null);
+
+            if (vectorProperty.TryGenerateEmbedding<TRecord, Embedding<float>>(record, cancellationToken, out var task))
             {
                 generatedEmbedding = await task.ConfigureAwait(false);
             }
@@ -350,8 +353,11 @@ public class PineconeCollection<TKey, TRecord> : VectorStoreCollection<TKey, TRe
         // If an embedding generator is defined, invoke it once for all records.
         GeneratedEmbeddings<Embedding<float>>? generatedEmbeddings = null;
 
-        if (this._model.VectorProperties is [{ EmbeddingGenerator: not null } vectorProperty])
+        if (this._model.VectorProperties is [var vectorProperty] && !PineconeModelBuilder.IsVectorPropertyTypeValidCore(vectorProperty.Type, out _))
         {
+            // We have a vector property whose type isn't natively supported - we need to generate embeddings.
+            Debug.Assert(vectorProperty.EmbeddingGenerator is not null);
+
             var recordsList = records is IReadOnlyList<TRecord> r ? r : records.ToList();
 
             if (recordsList.Count == 0)
@@ -361,7 +367,7 @@ public class PineconeCollection<TKey, TRecord> : VectorStoreCollection<TKey, TRe
 
             records = recordsList;
 
-            if (vectorProperty.TryGenerateEmbeddings<TRecord, Embedding<float>, ReadOnlyMemory<float>>(records, cancellationToken, out var task))
+            if (vectorProperty.TryGenerateEmbeddings<TRecord, Embedding<float>>(records, cancellationToken, out var task))
             {
                 generatedEmbeddings = await task.ConfigureAwait(false);
 
@@ -405,7 +411,7 @@ public class PineconeCollection<TKey, TRecord> : VectorStoreCollection<TKey, TRe
         Verify.NotLessThan(top, 1);
 
         options ??= s_defaultVectorSearchOptions;
-        if (options.IncludeVectors && this._model.VectorProperties.Any(p => p.EmbeddingGenerator is not null))
+        if (options.IncludeVectors && this._model.EmbeddingGenerationRequired)
         {
             throw new NotSupportedException(VectorDataStrings.IncludeVectorsNotSupportedWithEmbeddingGeneration);
         }
@@ -492,7 +498,7 @@ public class PineconeCollection<TKey, TRecord> : VectorStoreCollection<TKey, TRe
 
         options ??= new();
 
-        if (options.IncludeVectors && this._model.VectorProperties.Any(p => p.EmbeddingGenerator is not null))
+        if (options.IncludeVectors && this._model.EmbeddingGenerationRequired)
         {
             throw new NotSupportedException(VectorDataStrings.IncludeVectorsNotSupportedWithEmbeddingGeneration);
         }

--- a/dotnet/src/Connectors/Connectors.Memory.Redis/RedisHashSetCollection.cs
+++ b/dotnet/src/Connectors/Connectors.Memory.Redis/RedisHashSetCollection.cs
@@ -227,7 +227,7 @@ public class RedisHashSetCollection<TKey, TRecord> : VectorStoreCollection<TKey,
         var maybePrefixedKey = this.PrefixKeyIfNeeded(stringKey);
 
         var includeVectors = options?.IncludeVectors ?? false;
-        if (includeVectors && this._model.VectorProperties.Any(p => p.EmbeddingGenerator is not null))
+        if (includeVectors && this._model.EmbeddingGenerationRequired)
         {
             throw new NotSupportedException(VectorDataStrings.IncludeVectorsNotSupportedWithEmbeddingGeneration);
         }
@@ -330,7 +330,7 @@ public class RedisHashSetCollection<TKey, TRecord> : VectorStoreCollection<TKey,
         Verify.NotLessThan(top, 1);
 
         options ??= s_defaultVectorSearchOptions;
-        if (options.IncludeVectors && this._model.VectorProperties.Any(p => p.EmbeddingGenerator is not null))
+        if (options.IncludeVectors && this._model.EmbeddingGenerationRequired)
         {
             throw new NotSupportedException(VectorDataStrings.IncludeVectorsNotSupportedWithEmbeddingGeneration);
         }
@@ -409,8 +409,7 @@ public class RedisHashSetCollection<TKey, TRecord> : VectorStoreCollection<TKey,
         Verify.NotLessThan(top, 1);
 
         options ??= new();
-
-        if (options.IncludeVectors && this._model.VectorProperties.Any(p => p.EmbeddingGenerator is not null))
+        if (options.IncludeVectors && this._model.EmbeddingGenerationRequired)
         {
             throw new NotSupportedException(VectorDataStrings.IncludeVectorsNotSupportedWithEmbeddingGeneration);
         }

--- a/dotnet/src/Connectors/Connectors.Memory.Redis/RedisJsonCollection.cs
+++ b/dotnet/src/Connectors/Connectors.Memory.Redis/RedisJsonCollection.cs
@@ -239,8 +239,7 @@ public class RedisJsonCollection<TKey, TRecord> : VectorStoreCollection<TKey, TR
         // Create Options
         var maybePrefixedKey = this.PrefixKeyIfNeeded(stringKey);
         var includeVectors = options?.IncludeVectors ?? false;
-
-        if (includeVectors && this._model.VectorProperties.Any(p => p.EmbeddingGenerator is not null))
+        if (includeVectors && this._model.EmbeddingGenerationRequired)
         {
             throw new NotSupportedException(VectorDataStrings.IncludeVectorsNotSupportedWithEmbeddingGeneration);
         }
@@ -292,7 +291,7 @@ public class RedisJsonCollection<TKey, TRecord> : VectorStoreCollection<TKey, TR
         var maybePrefixedKeys = keysList.Select(key => this.PrefixKeyIfNeeded(key));
         var redisKeys = maybePrefixedKeys.Select(x => new RedisKey(x)).ToArray();
         var includeVectors = options?.IncludeVectors ?? false;
-        if (includeVectors && this._model.VectorProperties.Any(p => p.EmbeddingGenerator is not null))
+        if (includeVectors && this._model.EmbeddingGenerationRequired)
         {
             throw new NotSupportedException(VectorDataStrings.IncludeVectorsNotSupportedWithEmbeddingGeneration);
         }
@@ -413,7 +412,7 @@ public class RedisJsonCollection<TKey, TRecord> : VectorStoreCollection<TKey, TR
         Verify.NotLessThan(top, 1);
 
         options ??= s_defaultVectorSearchOptions;
-        if (options.IncludeVectors && this._model.VectorProperties.Any(p => p.EmbeddingGenerator is not null))
+        if (options.IncludeVectors && this._model.EmbeddingGenerationRequired)
         {
             throw new NotSupportedException(VectorDataStrings.IncludeVectorsNotSupportedWithEmbeddingGeneration);
         }
@@ -488,7 +487,7 @@ public class RedisJsonCollection<TKey, TRecord> : VectorStoreCollection<TKey, TR
         Verify.NotNull(filter);
         Verify.NotLessThan(top, 1);
 
-        if (options?.IncludeVectors == true && this._model.VectorProperties.Any(p => p.EmbeddingGenerator is not null))
+        if (options?.IncludeVectors == true && this._model.EmbeddingGenerationRequired)
         {
             throw new NotSupportedException(VectorDataStrings.IncludeVectorsNotSupportedWithEmbeddingGeneration);
         }

--- a/dotnet/src/Connectors/Connectors.Memory.Redis/RedisJsonDynamicModelBuilder.cs
+++ b/dotnet/src/Connectors/Connectors.Memory.Redis/RedisJsonDynamicModelBuilder.cs
@@ -10,25 +10,12 @@ namespace Microsoft.SemanticKernel.Connectors.Redis;
 internal class RedisJsonDynamicModelBuilder(CollectionModelBuildingOptions options) : CollectionModelBuilder(options)
 {
     /// <inheritdoc />
-    protected override void SetupEmbeddingGeneration(
+    protected override Type? ResolveEmbeddingType(
         VectorPropertyModel vectorProperty,
         IEmbeddingGenerator embeddingGenerator,
-        Type? embeddingType)
-    {
-        if (!vectorProperty.TrySetupEmbeddingGeneration<Embedding<float>, ReadOnlyMemory<float>>(embeddingGenerator, embeddingType)
-            && !vectorProperty.TrySetupEmbeddingGeneration<Embedding<double>, ReadOnlyMemory<double>>(embeddingGenerator, embeddingType))
-        {
-            throw new InvalidOperationException(
-                VectorDataStrings.IncompatibleEmbeddingGenerator(
-                    embeddingGeneratorType: embeddingGenerator.GetType(),
-                    supportedInputTypes: vectorProperty.GetSupportedInputTypes(),
-                    supportedOutputTypes:
-                    [
-                        typeof(ReadOnlyMemory<float>),
-                        typeof(ReadOnlyMemory<double>)
-                    ]));
-        }
-    }
+        Type? userRequestedEmbeddingType)
+        => vectorProperty.ResolveEmbeddingType<Embedding<float>>(embeddingGenerator, userRequestedEmbeddingType)
+            ?? vectorProperty.ResolveEmbeddingType<Embedding<double>>(embeddingGenerator, userRequestedEmbeddingType);
 
     protected override bool IsKeyPropertyTypeValid(Type type, [NotNullWhen(false)] out string? supportedTypes)
     {

--- a/dotnet/src/Connectors/Connectors.Memory.Redis/RedisJsonModelBuilder.cs
+++ b/dotnet/src/Connectors/Connectors.Memory.Redis/RedisJsonModelBuilder.cs
@@ -10,26 +10,12 @@ namespace Microsoft.SemanticKernel.Connectors.Redis;
 internal class RedisJsonModelBuilder(CollectionModelBuildingOptions options) : CollectionJsonModelBuilder(options)
 {
     /// <inheritdoc />
-    protected override void SetupEmbeddingGeneration(
+    protected override Type? ResolveEmbeddingType(
         VectorPropertyModel vectorProperty,
         IEmbeddingGenerator embeddingGenerator,
-        Type? embeddingType)
-    {
-        if (!vectorProperty.TrySetupEmbeddingGeneration<Embedding<float>, ReadOnlyMemory<float>>(embeddingGenerator, embeddingType)
-            && !vectorProperty.TrySetupEmbeddingGeneration<Embedding<double>, ReadOnlyMemory<double>>(embeddingGenerator, embeddingType)
-            )
-        {
-            throw new InvalidOperationException(
-                VectorDataStrings.IncompatibleEmbeddingGenerator(
-                    embeddingGeneratorType: embeddingGenerator.GetType(),
-                    supportedInputTypes: vectorProperty.GetSupportedInputTypes(),
-                    supportedOutputTypes:
-                    [
-                        typeof(ReadOnlyMemory<float>),
-                        typeof(ReadOnlyMemory<double>)
-                    ]));
-        }
-    }
+        Type? userRequestedEmbeddingType)
+        => vectorProperty.ResolveEmbeddingType<Embedding<float>>(embeddingGenerator, userRequestedEmbeddingType)
+            ?? vectorProperty.ResolveEmbeddingType<Embedding<double>>(embeddingGenerator, userRequestedEmbeddingType);
 
     protected override bool IsKeyPropertyTypeValid(Type type, [NotNullWhen(false)] out string? supportedTypes)
     {

--- a/dotnet/src/Connectors/Connectors.Memory.Redis/RedisModelBuilder.cs
+++ b/dotnet/src/Connectors/Connectors.Memory.Redis/RedisModelBuilder.cs
@@ -12,26 +12,12 @@ internal class RedisModelBuilder(CollectionModelBuildingOptions options) : Colle
     internal const string SupportedVectorTypes = "ReadOnlyMemory<float>, Embedding<float>, float[], ReadOnlyMemory<double>, Embedding<double>, double[]";
 
     /// <inheritdoc />
-    protected override void SetupEmbeddingGeneration(
+    protected override Type? ResolveEmbeddingType(
         VectorPropertyModel vectorProperty,
         IEmbeddingGenerator embeddingGenerator,
-        Type? embeddingType)
-    {
-        if (!vectorProperty.TrySetupEmbeddingGeneration<Embedding<float>, ReadOnlyMemory<float>>(embeddingGenerator, embeddingType)
-            && !vectorProperty.TrySetupEmbeddingGeneration<Embedding<double>, ReadOnlyMemory<double>>(embeddingGenerator, embeddingType)
-            )
-        {
-            throw new InvalidOperationException(
-                VectorDataStrings.IncompatibleEmbeddingGenerator(
-                    embeddingGeneratorType: embeddingGenerator.GetType(),
-                    supportedInputTypes: vectorProperty.GetSupportedInputTypes(),
-                    supportedOutputTypes:
-                    [
-                        typeof(ReadOnlyMemory<float>),
-                        typeof(ReadOnlyMemory<double>)
-                    ]));
-        }
-    }
+        Type? userRequestedEmbeddingType)
+        => vectorProperty.ResolveEmbeddingType<Embedding<float>>(embeddingGenerator, userRequestedEmbeddingType)
+            ?? vectorProperty.ResolveEmbeddingType<Embedding<double>>(embeddingGenerator, userRequestedEmbeddingType);
 
     protected override bool IsKeyPropertyTypeValid(Type type, [NotNullWhen(false)] out string? supportedTypes)
     {

--- a/dotnet/src/Connectors/Connectors.Memory.SqlServer/SqlServerCollection.cs
+++ b/dotnet/src/Connectors/Connectors.Memory.SqlServer/SqlServerCollection.cs
@@ -3,6 +3,7 @@
 using System;
 using System.Collections.Generic;
 using System.Data.Common;
+using System.Diagnostics;
 using System.Diagnostics.CodeAnalysis;
 using System.Linq;
 using System.Linq.Expressions;
@@ -244,8 +245,7 @@ public class SqlServerCollection<TKey, TRecord>
         Verify.NotNull(key);
 
         bool includeVectors = options?.IncludeVectors is true;
-
-        if (includeVectors && this._model.VectorProperties.Any(p => p.EmbeddingGenerator is not null))
+        if (includeVectors && this._model.EmbeddingGenerationRequired)
         {
             throw new NotSupportedException(VectorDataStrings.IncludeVectorsNotSupportedWithEmbeddingGeneration);
         }
@@ -282,8 +282,7 @@ public class SqlServerCollection<TKey, TRecord>
         Verify.NotNull(keys);
 
         bool includeVectors = options?.IncludeVectors is true;
-
-        if (includeVectors && this._model.VectorProperties.Any(p => p.EmbeddingGenerator is not null))
+        if (includeVectors && this._model.EmbeddingGenerationRequired)
         {
             throw new NotSupportedException(VectorDataStrings.IncludeVectorsNotSupportedWithEmbeddingGeneration);
         }
@@ -343,14 +342,17 @@ public class SqlServerCollection<TKey, TRecord>
         {
             var vectorProperty = this._model.VectorProperties[i];
 
-            if (vectorProperty.EmbeddingGenerator is null)
+            if (SqlServerModelBuilder.IsVectorPropertyTypeValidCore(vectorProperty.Type, out _))
             {
                 continue;
             }
 
+            // We have a vector property whose type isn't natively supported - we need to generate embeddings.
+            Debug.Assert(vectorProperty.EmbeddingGenerator is not null);
+
             // TODO: Ideally we'd group together vector properties using the same generator (and with the same input and output properties),
             // and generate embeddings for them in a single batch. That's some more complexity though.
-            if (vectorProperty.TryGenerateEmbedding<TRecord, Embedding<float>, ReadOnlyMemory<float>>(record, cancellationToken, out var floatTask))
+            if (vectorProperty.TryGenerateEmbedding<TRecord, Embedding<float>>(record, cancellationToken, out var floatTask))
             {
                 generatedEmbeddings ??= new IReadOnlyList<Embedding>?[vectorPropertyCount];
                 generatedEmbeddings[i] = [await floatTask.ConfigureAwait(false)];
@@ -398,10 +400,13 @@ public class SqlServerCollection<TKey, TRecord>
         {
             var vectorProperty = this._model.VectorProperties[i];
 
-            if (vectorProperty.EmbeddingGenerator is null)
+            if (SqlServerModelBuilder.IsVectorPropertyTypeValidCore(vectorProperty.Type, out _))
             {
                 continue;
             }
+
+            // We have a vector property whose type isn't natively supported - we need to generate embeddings.
+            Debug.Assert(vectorProperty.EmbeddingGenerator is not null);
 
             // We have a property with embedding generation; materialize the records' enumerable if needed, to
             // prevent multiple enumeration.
@@ -419,7 +424,7 @@ public class SqlServerCollection<TKey, TRecord>
 
             // TODO: Ideally we'd group together vector properties using the same generator (and with the same input and output properties),
             // and generate embeddings for them in a single batch. That's some more complexity though.
-            if (vectorProperty.TryGenerateEmbeddings<TRecord, Embedding<float>, ReadOnlyMemory<float>>(records, cancellationToken, out var floatTask))
+            if (vectorProperty.TryGenerateEmbeddings<TRecord, Embedding<float>>(records, cancellationToken, out var floatTask))
             {
                 generatedEmbeddings ??= new IReadOnlyList<Embedding>?[vectorPropertyCount];
                 generatedEmbeddings[i] = (IReadOnlyList<Embedding<float>>)await floatTask.ConfigureAwait(false);
@@ -519,7 +524,7 @@ public class SqlServerCollection<TKey, TRecord>
         Verify.NotLessThan(top, 1);
 
         options ??= s_defaultVectorSearchOptions;
-        if (options.IncludeVectors && this._model.VectorProperties.Any(p => p.EmbeddingGenerator is not null))
+        if (options.IncludeVectors && this._model.EmbeddingGenerationRequired)
         {
             throw new NotSupportedException(VectorDataStrings.IncludeVectorsNotSupportedWithEmbeddingGeneration);
         }

--- a/dotnet/src/Connectors/VectorData.Abstractions/ProviderServices/CollectionModel.cs
+++ b/dotnet/src/Connectors/VectorData.Abstractions/ProviderServices/CollectionModel.cs
@@ -50,6 +50,11 @@ public sealed class CollectionModel
     /// </summary>
     public IReadOnlyDictionary<string, PropertyModel> PropertyMap { get; }
 
+    /// <summary>
+    /// Whether any of the vector properties in the model require embedding generation.
+    /// </summary>
+    public bool EmbeddingGenerationRequired { get; }
+
     internal CollectionModel(
         Type recordType,
         IRecordCreator recordCreator,
@@ -66,6 +71,8 @@ public sealed class CollectionModel
         this.VectorProperties = vectorProperties;
         this.PropertyMap = propertyMap;
         this.Properties = propertyMap.Values.ToList();
+
+        this.EmbeddingGenerationRequired = vectorProperties.Any(p => p.EmbeddingType != p.Type);
     }
 
     /// <summary>

--- a/dotnet/src/Connectors/VectorData.Abstractions/ProviderServices/VectorDataStrings.cs
+++ b/dotnet/src/Connectors/VectorData.Abstractions/ProviderServices/VectorDataStrings.cs
@@ -3,6 +3,7 @@
 using System;
 using System.Diagnostics.CodeAnalysis;
 using System.Linq;
+using Microsoft.Extensions.AI;
 
 namespace Microsoft.Extensions.VectorData.ProviderServices;
 
@@ -14,11 +15,20 @@ namespace Microsoft.Extensions.VectorData.ProviderServices;
 [Experimental("MEVD9001")]
 public static class VectorDataStrings
 {
+    public static string ConfiguredEmbeddingTypeIsUnsupportedByTheGenerator(VectorPropertyModel vectorProperty, Type userRequestedEmbeddingType, string supportedVectorTypes)
+        => $"Vector property '{vectorProperty.ModelName}' has embedding type '{TypeName(userRequestedEmbeddingType)}' configured, but that type isn't supported by your embedding generator.";
+
+    public static string ConfiguredEmbeddingTypeIsUnsupportedByTheProvider(VectorPropertyModel vectorProperty, Type userRequestedEmbeddingType, string supportedVectorTypes)
+        => $"Vector property '{vectorProperty.ModelName}' has embedding type '{TypeName(userRequestedEmbeddingType)}' configured, but that type isn't supported by your provider. Supported types are {supportedVectorTypes}.";
+
     public static string EmbeddingGeneratorWithInvalidEmbeddingType(VectorPropertyModel vectorProperty)
         => $"An embedding generator was configured on property '{vectorProperty.ModelName}', but output embedding type '{vectorProperty.EmbeddingType.Name}' isn't supported by the connector.";
 
     public static string EmbeddingPropertyTypeIncompatibleWithEmbeddingGenerator(VectorPropertyModel vectorProperty)
         => $"Property '{vectorProperty.ModelName}' has embedding type '{TypeName(vectorProperty.Type)}', but an embedding generator is configured on the property. Remove the embedding generator or change the property's .NET type to a non-embedding input type to the generator (e.g. string).";
+
+    public static string DifferentEmbeddingTypeSpecifiedForNativelySupportedType(VectorPropertyModel vectorProperty, Type embeddingType)
+        => $"Property '{vectorProperty.ModelName}' has {nameof(VectorStoreVectorProperty.EmbeddingType)} configured to '{TypeName(embeddingType)}', but the property already has natively supported '{TypeName(vectorProperty.Type)}'. {nameof(VectorStoreVectorProperty.EmbeddingType)} only needs to be specified for properties that require embedding generation.";
 
     public static string GetCollectionWithDictionaryNotSupported
         => "Dynamic mapping via Dictionary<string, object?> is not supported via this method, call GetDynamicCollection() instead.";
@@ -26,8 +36,8 @@ public static class VectorDataStrings
     public static string IncludeVectorsNotSupportedWithEmbeddingGeneration
         => "When an embedding generator is configured, `Include Vectors` cannot be enabled.";
 
-    public static string IncompatibleEmbeddingGenerator(Type embeddingGeneratorType, Type[] supportedInputTypes, Type[] supportedOutputTypes)
-        => $"Embedding generator '{embeddingGeneratorType.Name}' is incompatible with the required input and output types. The property input type must be '{string.Join(", ", supportedInputTypes.Select(t => TypeName(t)))}', and the output type must be '{string.Join(", ", supportedOutputTypes.Select(t => TypeName(t)))}'.";
+    public static string IncompatibleEmbeddingGenerator(VectorPropertyModel vectorProperty, IEmbeddingGenerator embeddingGenerator, string supportedOutputTypes)
+        => $"Embedding generator '{TypeName(embeddingGenerator.GetType())}' on vector property '{vectorProperty.ModelName}' cannot convert the input type '{TypeName(vectorProperty.Type)}' to a supported vector type (one of: {supportedOutputTypes}).";
 
     public static string IncompatibleEmbeddingGeneratorWasConfiguredForInputType(Type inputType, Type embeddingGeneratorType)
         => $"An input of type '{TypeName(inputType)}' was provided, but an incompatible embedding generator of type '{TypeName(embeddingGeneratorType)}' was configured.";
@@ -35,8 +45,8 @@ public static class VectorDataStrings
     public static string InvalidSearchInputAndNoEmbeddingGeneratorWasConfigured(Type inputType, string supportedVectorTypes)
         => $"A value of type '{TypeName(inputType)}' was passed to 'SearchAsync', but that isn't a supported vector type by your provider and no embedding generator was configured. The supported vector types are: {supportedVectorTypes}.";
 
-    public static string NonEmbeddingVectorPropertyWithoutEmbeddingGenerator(VectorPropertyModel vectorProperty)
-        => $"Property '{vectorProperty.ModelName}' has non-Embedding type '{TypeName(vectorProperty.EmbeddingType)}', but no embedding generator is configured.";
+    public static string UnsupportedVectorPropertyWithoutEmbeddingGenerator(VectorPropertyModel vectorProperty)
+        => $"Vector property '{vectorProperty.ModelName}' has type '{TypeName(vectorProperty.Type)}' which isn't supported by your provider, and no embedding generator is configured. Configure a generator that supports converting '{TypeName(vectorProperty.Type)}' to vector type supported by your provider.";
 
     public static string NonDynamicCollectionWithDictionaryNotSupported(Type dynamicCollectionType)
         => $"Dynamic mapping via Dictionary<string, object?> is not supported via this class, use '{TypeName(dynamicCollectionType)}' instead.";
@@ -46,7 +56,17 @@ public static class VectorDataStrings
         var i = type.Name.IndexOf('`');
         if (i == -1)
         {
-            return type.Name;
+            return type.Name switch
+            {
+                "Int32" => "int",
+                "Int64" => "long",
+                "Boolean" => "bool",
+                "Double" => "double",
+                "Single" => "float",
+                "String" => "string",
+
+                _ => type.Name
+            };
         }
 
         var genericTypeName = type.Name.Substring(0, i);

--- a/dotnet/src/Connectors/VectorData.UnitTests/CollectionModelBuilderTests.cs
+++ b/dotnet/src/Connectors/VectorData.UnitTests/CollectionModelBuilderTests.cs
@@ -26,7 +26,7 @@ public class CollectionModelBuilderTests
         // The embedding's .NET type (Embedding<float>) is inferred from the embedding generator.
         Assert.Same(embeddingGenerator, model.VectorProperty.EmbeddingGenerator);
         Assert.Same(typeof(string), model.VectorProperty.Type);
-        Assert.Same(typeof(ReadOnlyMemory<float>), model.VectorProperty.EmbeddingType);
+        Assert.Same(typeof(Embedding<float>), model.VectorProperty.EmbeddingType);
     }
 
     [Fact]
@@ -42,8 +42,8 @@ public class CollectionModelBuilderTests
                 new VectorStoreDataProperty(nameof(RecordWithEmbeddingVectorProperty.Name), typeof(string)),
                 new VectorStoreVectorProperty(nameof(RecordWithEmbeddingVectorProperty.Embedding), typeof(string), dimensions: 3)
                 {
-                    // The following configures the property to be ReadOnlyMemory<Half> (non-default embedding type for this connector)
-                    EmbeddingType = typeof(ReadOnlyMemory<Half>)
+                    // The following configures the property to be Embedding<Half> (non-default embedding type for this connector)
+                    EmbeddingType = typeof(Embedding<Half>)
                 }
             ]
         };
@@ -53,7 +53,7 @@ public class CollectionModelBuilderTests
         // The embedding's .NET type (Embedding<float>) is inferred from the embedding generator.
         Assert.Same(embeddingGenerator, model.VectorProperty.EmbeddingGenerator);
         Assert.Same(typeof(string), model.VectorProperty.Type);
-        Assert.Same(typeof(ReadOnlyMemory<Half>), model.VectorProperty.EmbeddingType);
+        Assert.Same(typeof(Embedding<Half>), model.VectorProperty.EmbeddingType);
     }
 
     [Fact]
@@ -76,7 +76,7 @@ public class CollectionModelBuilderTests
         // The embedding's .NET type (Embedding<float>) is inferred from the embedding generator.
         Assert.Same(embeddingGenerator, model.VectorProperty.EmbeddingGenerator);
         Assert.Same(typeof(string), model.VectorProperty.Type);
-        Assert.Same(typeof(ReadOnlyMemory<float>), model.VectorProperty.EmbeddingType);
+        Assert.Same(typeof(Embedding<float>), model.VectorProperty.EmbeddingType);
     }
 
     [Fact]
@@ -92,7 +92,7 @@ public class CollectionModelBuilderTests
                 new VectorStoreDataProperty(nameof(RecordWithEmbeddingVectorProperty.Name), typeof(string)),
                 new VectorStoreVectorProperty(nameof(RecordWithEmbeddingVectorProperty.Embedding), typeof(string), dimensions: 3)
                 {
-                    EmbeddingType = typeof(ReadOnlyMemory<Half>)
+                    EmbeddingType = typeof(Embedding<Half>)
                 }
             ]
         };
@@ -101,7 +101,7 @@ public class CollectionModelBuilderTests
 
         Assert.Same(embeddingGenerator, model.VectorProperty.EmbeddingGenerator);
         Assert.Same(typeof(string), model.VectorProperty.Type);
-        Assert.Same(typeof(ReadOnlyMemory<Half>), model.VectorProperty.EmbeddingType);
+        Assert.Same(typeof(Embedding<Half>), model.VectorProperty.EmbeddingType);
     }
 
     [Fact]
@@ -131,7 +131,7 @@ public class CollectionModelBuilderTests
     [Theory]
     [InlineData(true)]
     [InlineData(false)]
-    public void Embedding_property_type_with_default_embedding_generator_ignores_generator(bool dynamic)
+    public void Embedding_property_type_with_default_embedding_generator(bool dynamic)
     {
         using var embeddingGenerator = new FakeEmbeddingGenerator<string, Embedding<float>>();
 
@@ -149,8 +149,35 @@ public class CollectionModelBuilderTests
                 embeddingGenerator)
             : new CustomModelBuilder().Build(typeof(RecordWithEmbeddingVectorProperty), definition: null, embeddingGenerator);
 
-        Assert.Null(model.VectorProperty.EmbeddingGenerator);
-        Assert.Same(typeof(ReadOnlyMemory<float>), model.VectorProperty.Type);
+        var vectorProperty = model.VectorProperty;
+        Assert.Same(embeddingGenerator, vectorProperty.EmbeddingGenerator);
+        Assert.Same(typeof(ReadOnlyMemory<float>), vectorProperty.Type);
+    }
+
+    [Fact]
+    public void Embedding_property_type_with_property_embedding_generator()
+    {
+        using var embeddingGenerator = new FakeEmbeddingGenerator<int, Embedding<float>>();
+
+        var model = new CustomModelBuilder().Build(
+            typeof(RecordWithEmbeddingVectorProperty),
+            new VectorStoreRecordDefinition
+            {
+                Properties =
+                [
+                    new VectorStoreKeyProperty(nameof(RecordWithEmbeddingVectorProperty.Id), typeof(int)),
+                    new VectorStoreDataProperty(nameof(RecordWithEmbeddingVectorProperty.Name), typeof(string)),
+                    new VectorStoreVectorProperty(nameof(RecordWithEmbeddingVectorProperty.Embedding), typeof(ReadOnlyMemory<float>), dimensions: 3)
+                    {
+                        EmbeddingGenerator = embeddingGenerator
+                    }
+                ]
+            },
+            embeddingGenerator);
+
+        var vectorProperty = model.VectorProperty;
+        Assert.Same(embeddingGenerator, vectorProperty.EmbeddingGenerator);
+        Assert.Same(typeof(ReadOnlyMemory<float>), vectorProperty.EmbeddingType);
     }
 
     [Theory]
@@ -179,7 +206,7 @@ public class CollectionModelBuilderTests
 
         Assert.Same(embeddingGenerator, vectorProperty.EmbeddingGenerator);
         Assert.Same(typeof(Customer), vectorProperty.Type);
-        Assert.Same(typeof(ReadOnlyMemory<float>), vectorProperty.EmbeddingType);
+        Assert.Same(typeof(Embedding<float>), vectorProperty.EmbeddingType);
     }
 
     [Fact]
@@ -191,7 +218,7 @@ public class CollectionModelBuilderTests
         var exception = Assert.Throws<InvalidOperationException>(() =>
             new CustomModelBuilder().Build(typeof(RecordWithStringVectorProperty), definition: null, embeddingGenerator));
 
-        Assert.Equal($"Embedding generator '{typeof(FakeEmbeddingGenerator<,>).Name}' is incompatible with the required input and output types. The property input type must be 'String, DataContent', and the output type must be 'ReadOnlyMemory<Single>, ReadOnlyMemory<Half>'.", exception.Message);
+        Assert.Equal($"Embedding generator 'FakeEmbeddingGenerator<string, Embedding<long>>' on vector property '{nameof(RecordWithStringVectorProperty.Embedding)}' cannot convert the input type 'string' to a supported vector type (one of: ReadOnlyMemory<float>, Embedding<float>, float[], ReadOnlyMemory<Half>, Embedding<Half>, Half[]).", exception.Message);
     }
 
     [Fact]
@@ -203,7 +230,7 @@ public class CollectionModelBuilderTests
         var exception = Assert.Throws<InvalidOperationException>(() =>
             new CustomModelBuilder().Build(typeof(RecordWithStringVectorProperty), definition: null, embeddingGenerator));
 
-        Assert.Equal($"Embedding generator '{typeof(FakeEmbeddingGenerator<,>).Name}' is incompatible with the required input and output types. The property input type must be 'String, DataContent', and the output type must be 'ReadOnlyMemory<Single>, ReadOnlyMemory<Half>'.", exception.Message);
+        Assert.Equal($"Embedding generator 'FakeEmbeddingGenerator<int, Embedding<float>>' on vector property '{nameof(RecordWithStringVectorProperty.Embedding)}' cannot convert the input type 'string' to a supported vector type (one of: ReadOnlyMemory<float>, Embedding<float>, float[], ReadOnlyMemory<Half>, Embedding<Half>, Half[]).", exception.Message);
     }
 
     [Fact]
@@ -212,13 +239,13 @@ public class CollectionModelBuilderTests
         var exception = Assert.Throws<InvalidOperationException>(() =>
             new CustomModelBuilder().Build(typeof(RecordWithStringVectorProperty), definition: null, defaultEmbeddingGenerator: null));
 
-        Assert.Equal($"Property '{nameof(RecordWithStringVectorProperty.Embedding)}' has non-Embedding type 'String', but no embedding generator is configured.", exception.Message);
+        Assert.Equal($"Vector property '{nameof(RecordWithStringVectorProperty.Embedding)}' has type 'string' which isn't supported by your provider, and no embedding generator is configured. Configure a generator that supports converting 'string' to vector type supported by your provider.", exception.Message);
     }
 
     [Fact]
-    public void Embedding_property_type_with_property_embedding_generator_throws()
+    public void EmbeddingType_not_supported_by_provider()
     {
-        using var embeddingGenerator = new FakeEmbeddingGenerator<int, Embedding<float>>();
+        using var embeddingGenerator = new FakeEmbeddingGenerator<string, Embedding<Half>>();
 
         var recordDefinition = new VectorStoreRecordDefinition
         {
@@ -226,19 +253,41 @@ public class CollectionModelBuilderTests
             [
                 new VectorStoreKeyProperty(nameof(RecordWithEmbeddingVectorProperty.Id), typeof(int)),
                 new VectorStoreDataProperty(nameof(RecordWithEmbeddingVectorProperty.Name), typeof(string)),
-                new VectorStoreVectorProperty(nameof(RecordWithEmbeddingVectorProperty.Embedding), typeof(ReadOnlyMemory<float>), dimensions: 3)
+                new VectorStoreVectorProperty(nameof(RecordWithEmbeddingVectorProperty.Embedding), typeof(string), dimensions: 3)
                 {
-                    EmbeddingGenerator = embeddingGenerator
+                    EmbeddingType = typeof(Embedding<byte>) // The provider supports float/Half only, not byte
                 }
             ]
         };
 
         var exception = Assert.Throws<InvalidOperationException>(() =>
-            new CustomModelBuilder().Build(typeof(RecordWithEmbeddingVectorProperty), recordDefinition, embeddingGenerator));
+            new CustomModelBuilder().Build(typeof(RecordWithStringVectorProperty), recordDefinition, embeddingGenerator));
 
-        Assert.Equal(
-            $"Property '{nameof(RecordWithEmbeddingVectorProperty.Embedding)}' has embedding type 'ReadOnlyMemory<Single>', but an embedding generator is configured on the property. Remove the embedding generator or change the property's .NET type to a non-embedding input type to the generator (e.g. string).",
-            exception.Message);
+        Assert.Equal("Vector property 'Embedding' has embedding type 'Embedding<Byte>' configured, but that type isn't supported by your provider. Supported types are ReadOnlyMemory<float>, Embedding<float>, float[], ReadOnlyMemory<Half>, Embedding<Half>, Half[].", exception.Message);
+    }
+
+    [Fact]
+    public void EmbeddingType_not_supported_by_generator()
+    {
+        using var embeddingGenerator = new FakeEmbeddingGenerator<string, Embedding<float>>();
+
+        var recordDefinition = new VectorStoreRecordDefinition
+        {
+            Properties =
+            [
+                new VectorStoreKeyProperty(nameof(RecordWithEmbeddingVectorProperty.Id), typeof(int)),
+                new VectorStoreDataProperty(nameof(RecordWithEmbeddingVectorProperty.Name), typeof(string)),
+                new VectorStoreVectorProperty(nameof(RecordWithEmbeddingVectorProperty.Embedding), typeof(string), dimensions: 3)
+                {
+                    EmbeddingType = typeof(Embedding<Half>) // The generator (instantiated above) supports only Embedding<float>
+                }
+            ]
+        };
+
+        var exception = Assert.Throws<InvalidOperationException>(() =>
+            new CustomModelBuilder().Build(typeof(RecordWithStringVectorProperty), recordDefinition, embeddingGenerator));
+
+        Assert.Equal("Vector property 'Embedding' has embedding type 'Embedding<Half>' configured, but that type isn't supported by your embedding generator.", exception.Message);
     }
 
     public class RecordWithStringVectorProperty
@@ -317,31 +366,27 @@ public class CollectionModelBuilderTests
 
         internal static bool IsVectorPropertyTypeValidCore(Type type, [NotNullWhen(false)] out string? supportedTypes)
         {
-            supportedTypes = "ReadOnlyMemory<float>";
+            supportedTypes = "ReadOnlyMemory<float>, Embedding<float>, float[], ReadOnlyMemory<Half>, Embedding<Half>, Half[]";
 
             if (Nullable.GetUnderlyingType(type) is Type underlyingType)
             {
                 type = underlyingType;
             }
 
-            return type == typeof(ReadOnlyMemory<float>) || type == typeof(ReadOnlyMemory<Half>);
+            return type == typeof(ReadOnlyMemory<float>)
+                || type == typeof(Embedding<float>)
+                || type == typeof(float[])
+                || type == typeof(ReadOnlyMemory<Half>)
+                || type == typeof(Embedding<Half>)
+                || type == typeof(Half[]);
         }
 
-        protected override void SetupEmbeddingGeneration(
+        protected override Type? ResolveEmbeddingType(
             VectorPropertyModel vectorProperty,
             IEmbeddingGenerator embeddingGenerator,
-            Type? embeddingType)
-        {
-            if (!vectorProperty.TrySetupEmbeddingGeneration<Embedding<float>, ReadOnlyMemory<float>>(embeddingGenerator, embeddingType)
-                && !vectorProperty.TrySetupEmbeddingGeneration<Embedding<Half>, ReadOnlyMemory<Half>>(embeddingGenerator, embeddingType))
-            {
-                throw new InvalidOperationException(
-                    VectorDataStrings.IncompatibleEmbeddingGenerator(
-                        embeddingGenerator.GetType(),
-                        vectorProperty.GetSupportedInputTypes(),
-                        [typeof(ReadOnlyMemory<float>), typeof(ReadOnlyMemory<Half>)]));
-            }
-        }
+            Type? userRequestedEmbeddingType)
+            => vectorProperty.ResolveEmbeddingType<Embedding<float>>(embeddingGenerator, userRequestedEmbeddingType)
+                ?? vectorProperty.ResolveEmbeddingType<Embedding<Half>>(embeddingGenerator, userRequestedEmbeddingType);
     }
 
     private sealed class FakeEmbeddingGenerator<TInput, TEmbedding> : IEmbeddingGenerator<TInput, TEmbedding>

--- a/dotnet/src/VectorDataIntegrationTests/VectorDataIntegrationTests/EmbeddingGenerationTests.cs
+++ b/dotnet/src/VectorDataIntegrationTests/VectorDataIntegrationTests/EmbeddingGenerationTests.cs
@@ -152,7 +152,7 @@ public abstract class EmbeddingGenerationTests<TKey>(EmbeddingGenerationTests<TK
         var exception = await Assert.ThrowsAsync<NotSupportedException>(() => collection.SearchAsync("foo", top: 1).ToListAsync().AsTask());
 
         Assert.StartsWith(
-            "A value of type 'String' was passed to 'SearchAsync', but that isn't a supported vector type by your provider and no embedding generator was configured. The supported vector types are:",
+            "A value of type 'string' was passed to 'SearchAsync', but that isn't a supported vector type by your provider and no embedding generator was configured. The supported vector types are:",
             exception.Message);
     }
 
@@ -172,7 +172,7 @@ public abstract class EmbeddingGenerationTests<TKey>(EmbeddingGenerationTests<TK
         // We have a generator configured for string, not int.
         var exception = await Assert.ThrowsAsync<InvalidOperationException>(() => collection.SearchAsync(8, top: 1).ToListAsync().AsTask());
 
-        Assert.Equal($"An input of type 'Int32' was provided, but an incompatible embedding generator of type '{nameof(FakeEmbeddingGenerator)}' was configured.", exception.Message);
+        Assert.Equal($"An input of type 'int' was provided, but an incompatible embedding generator of type '{nameof(FakeEmbeddingGenerator)}' was configured.", exception.Message);
     }
 
     #endregion Search


### PR DESCRIPTION
* An embedding generator now gets configured for all vector properties, including properties with natively supported types like `ReadOnlyMemory<float>`.
* We previously generated embeddings when a generator was configured on a property - that no longer makes sense as generators are always configured on properties (assuming there's a default one). Instead, we now simply check if the property's type is supported as native embedding type or not.
* The IncludeVectors check has also been updated accordingly.

Closes #11842
