### PR TITLE
.Net: Rename VectorStoreRecordDefinition -> VectorStoreCollectionDefinition

### DIFF
--- a/dotnet/samples/Concepts/Memory/VectorStoreLangchainInterop/PineconeFactory.cs
+++ b/dotnet/samples/Concepts/Memory/VectorStoreLangchainInterop/PineconeFactory.cs
@@ -17,7 +17,7 @@ public static class PineconeFactory
     /// <summary>
     /// Record definition that matches the storage format used by Langchain for Pinecone.
     /// </summary>
-    private static readonly VectorStoreRecordDefinition s_recordDefinition = new()
+    private static readonly VectorStoreCollectionDefinition s_definition = new()
     {
         Properties = new List<VectorStoreProperty>
         {
@@ -43,7 +43,7 @@ public static class PineconeFactory
     {
         private readonly PineconeClient _pineconeClient = pineconeClient;
 
-        public override VectorStoreCollection<TKey, TRecord> GetCollection<TKey, TRecord>(string name, VectorStoreRecordDefinition? vectorStoreRecordDefinition = null)
+        public override VectorStoreCollection<TKey, TRecord> GetCollection<TKey, TRecord>(string name, VectorStoreCollectionDefinition? definition = null)
         {
             if (typeof(TKey) != typeof(string) || typeof(TRecord) != typeof(LangchainDocument<string>))
             {
@@ -58,11 +58,11 @@ public static class PineconeFactory
                 name,
                 new()
                 {
-                    Definition = s_recordDefinition
+                    Definition = s_definition
                 }) as VectorStoreCollection<TKey, TRecord>)!;
         }
 
-        public override VectorStoreCollection<object, Dictionary<string, object?>> GetDynamicCollection(string name, VectorStoreRecordDefinition? vectorStoreRecordDefinition = null)
+        public override VectorStoreCollection<object, Dictionary<string, object?>> GetDynamicCollection(string name, VectorStoreCollectionDefinition? definition = null)
         {
             // Create a Pinecone collection and pass in our custom record definition that matches
             // the schema used by Langchain so that the default mapper can use the storage names
@@ -72,7 +72,7 @@ public static class PineconeFactory
                 name,
                 new()
                 {
-                    Definition = s_recordDefinition
+                    Definition = s_definition
                 });
         }
 

--- a/dotnet/samples/Concepts/Memory/VectorStoreLangchainInterop/RedisFactory.cs
+++ b/dotnet/samples/Concepts/Memory/VectorStoreLangchainInterop/RedisFactory.cs
@@ -17,7 +17,7 @@ public static class RedisFactory
     /// <summary>
     /// Record definition that matches the storage format used by Langchain for Redis.
     /// </summary>
-    private static readonly VectorStoreRecordDefinition s_recordDefinition = new()
+    private static readonly VectorStoreCollectionDefinition s_definition = new()
     {
         Properties = new List<VectorStoreProperty>
         {
@@ -43,7 +43,7 @@ public static class RedisFactory
     {
         private readonly IDatabase _database = database;
 
-        public override VectorStoreCollection<TKey, TRecord> GetCollection<TKey, TRecord>(string name, VectorStoreRecordDefinition? vectorStoreRecordDefinition = null)
+        public override VectorStoreCollection<TKey, TRecord> GetCollection<TKey, TRecord>(string name, VectorStoreCollectionDefinition? definition = null)
         {
             if (typeof(TKey) != typeof(string) || typeof(TRecord) != typeof(LangchainDocument<string>))
             {
@@ -59,11 +59,11 @@ public static class RedisFactory
                 name,
                 new()
                 {
-                    Definition = s_recordDefinition
+                    Definition = s_definition
                 }) as VectorStoreCollection<TKey, TRecord>)!;
         }
 
-        public override VectorStoreCollection<object, Dictionary<string, object?>> GetDynamicCollection(string name, VectorStoreRecordDefinition? vectorStoreRecordDefinition = null)
+        public override VectorStoreCollection<object, Dictionary<string, object?>> GetDynamicCollection(string name, VectorStoreCollectionDefinition? definition = null)
         {
             // Create a hash set collection, since Langchain uses redis hashes for storing records.
             // Also pass in our custom record definition that matches the schema used by Langchain
@@ -74,7 +74,7 @@ public static class RedisFactory
                 name,
                 new()
                 {
-                    Definition = s_recordDefinition
+                    Definition = s_definition
                 });
         }
 

--- a/dotnet/samples/Concepts/Memory/VectorStore_DynamicDataModel_Interop.cs
+++ b/dotnet/samples/Concepts/Memory/VectorStore_DynamicDataModel_Interop.cs
@@ -24,7 +24,7 @@ public class VectorStore_DynamicDataModel_Interop(ITestOutputHelper output, Vect
 {
     private static readonly JsonSerializerOptions s_indentedSerializerOptions = new() { WriteIndented = true };
 
-    private static readonly VectorStoreRecordDefinition s_vectorStoreRecordDefinition = new()
+    private static readonly VectorStoreCollectionDefinition s_definition = new()
     {
         Properties = new List<VectorStoreProperty>
         {
@@ -49,7 +49,7 @@ public class VectorStore_DynamicDataModel_Interop(ITestOutputHelper output, Vect
         var vectorStore = new QdrantVectorStore(new QdrantClient("localhost"), ownsClient: true);
 
         // Get and create collection if it doesn't exist using the dynamic data model and record definition that defines the schema.
-        var dynamicDataModelCollection = vectorStore.GetCollection<object, Dictionary<string, object?>>("skglossary", s_vectorStoreRecordDefinition);
+        var dynamicDataModelCollection = vectorStore.GetCollection<object, Dictionary<string, object?>>("skglossary", s_definition);
         await dynamicDataModelCollection.EnsureCollectionExistsAsync();
 
         // Create glossary entries and generate embeddings for them.
@@ -102,7 +102,7 @@ public class VectorStore_DynamicDataModel_Interop(ITestOutputHelper output, Vect
         await customDataModelCollection.UpsertAsync(glossaryEntries);
 
         // Get the collection using the dynamic data model.
-        var dynamicDataModelCollection = vectorStore.GetCollection<object, Dictionary<string, object?>>("skglossary", s_vectorStoreRecordDefinition);
+        var dynamicDataModelCollection = vectorStore.GetCollection<object, Dictionary<string, object?>>("skglossary", s_definition);
 
         // Retrieve one of the upserted records from the collection.
         var upsertedRecord = await dynamicDataModelCollection.GetAsync(glossaryEntries.First().Key, new() { IncludeVectors = true });

--- a/dotnet/samples/GettingStartedWithVectorStores/Step4_Use_DynamicDataModel.cs
+++ b/dotnet/samples/GettingStartedWithVectorStores/Step4_Use_DynamicDataModel.cs
@@ -36,7 +36,7 @@ public class Step4_Use_DynamicDataModel(ITestOutputHelper output, VectorStoresFi
         // using a record definition. The benefit over a custom data model is that this definition
         // does not have to be known at compile time.
         // E.g. it can be read from a configuration or retrieved from a service.
-        var recordDefinition = new VectorStoreRecordDefinition
+        var recordDefinition = new VectorStoreCollectionDefinition
         {
             Properties = new List<VectorStoreProperty>
             {

--- a/dotnet/src/Connectors/Connectors.AzureAISearch.UnitTests/AzureAISearchCollectionTests.cs
+++ b/dotnet/src/Connectors/Connectors.AzureAISearch.UnitTests/AzureAISearchCollectionTests.cs
@@ -406,7 +406,7 @@ public class AzureAISearchCollectionTests
     public void CanCreateCollectionWithMismatchedDefinitionAndType()
     {
         // Arrange.
-        var definition = new VectorStoreRecordDefinition()
+        var definition = new VectorStoreCollectionDefinition()
         {
             Properties = new List<VectorStoreProperty>
             {
@@ -564,7 +564,7 @@ public class AzureAISearchCollectionTests
         PropertyNamingPolicy = JsonNamingPolicy.CamelCase
     };
 
-    private readonly VectorStoreRecordDefinition _multiPropsDefinition = new()
+    private readonly VectorStoreCollectionDefinition _multiPropsDefinition = new()
     {
         Properties =
         [

--- a/dotnet/src/Connectors/Connectors.CosmosMongoDB.UnitTests/CosmosMongoCollectionTests.cs
+++ b/dotnet/src/Connectors/Connectors.CosmosMongoDB.UnitTests/CosmosMongoCollectionTests.cs
@@ -56,7 +56,7 @@ public sealed class CosmosMongoCollectionTests
     public void ConstructorWithImperativeModelInitializesCollection()
     {
         // Arrange
-        var definition = new VectorStoreRecordDefinition
+        var definition = new VectorStoreCollectionDefinition
         {
             Properties = [new VectorStoreKeyProperty("Id", typeof(string))]
         };
@@ -355,7 +355,7 @@ public sealed class CosmosMongoCollectionTests
     [Fact]
     public async Task UpsertWithModelWorksCorrectlyAsync()
     {
-        var definition = new VectorStoreRecordDefinition
+        var definition = new VectorStoreCollectionDefinition
         {
             Properties = new List<VectorStoreProperty>
             {
@@ -381,7 +381,7 @@ public sealed class CosmosMongoCollectionTests
     [Fact]
     public async Task UpsertWithBsonModelWorksCorrectlyAsync()
     {
-        var definition = new VectorStoreRecordDefinition
+        var definition = new VectorStoreCollectionDefinition
         {
             Properties = new List<VectorStoreProperty>
             {
@@ -601,7 +601,7 @@ public sealed class CosmosMongoCollectionTests
     private async Task TestUpsertWithModelAsync<TDataModel>(
         TDataModel dataModel,
         string expectedPropertyName,
-        VectorStoreRecordDefinition? definition = null)
+        VectorStoreCollectionDefinition? definition = null)
         where TDataModel : class
     {
         // Arrange

--- a/dotnet/src/Connectors/Connectors.CosmosNoSql.UnitTests/CosmosNoSqlCollectionTests.cs
+++ b/dotnet/src/Connectors/Connectors.CosmosNoSql.UnitTests/CosmosNoSqlCollectionTests.cs
@@ -75,7 +75,7 @@ public sealed class CosmosNoSqlCollectionTests
     public void ConstructorWithImperativeModelInitializesCollection()
     {
         // Arrange
-        var definition = new VectorStoreRecordDefinition
+        var definition = new VectorStoreCollectionDefinition
         {
             Properties = [new VectorStoreKeyProperty("Id", typeof(string))]
         };

--- a/dotnet/src/Connectors/Connectors.CosmosNoSql.UnitTests/CosmosNoSqlDynamicMapperTests.cs
+++ b/dotnet/src/Connectors/Connectors.CosmosNoSql.UnitTests/CosmosNoSqlDynamicMapperTests.cs
@@ -21,7 +21,7 @@ public sealed class CosmosNoSqlDynamicMapperTests
 
     private static readonly CollectionModel s_model = new CosmosNoSqlModelBuilder()
         .BuildDynamic(
-            new VectorStoreRecordDefinition
+            new VectorStoreCollectionDefinition
             {
                 Properties = new List<VectorStoreProperty>
                 {
@@ -119,7 +119,7 @@ public sealed class CosmosNoSqlDynamicMapperTests
     public void MapFromDataToStorageModelMapsNullValues()
     {
         // Arrange
-        VectorStoreRecordDefinition vectorStoreRecordDefinition = new()
+        VectorStoreCollectionDefinition definition = new()
         {
             Properties = new List<VectorStoreProperty>
             {
@@ -211,7 +211,7 @@ public sealed class CosmosNoSqlDynamicMapperTests
     public void MapFromStorageToDataModelMapsNullValues()
     {
         // Arrange
-        VectorStoreRecordDefinition vectorStoreRecordDefinition = new()
+        VectorStoreCollectionDefinition definition = new()
         {
             Properties = new List<VectorStoreProperty>
             {
@@ -259,7 +259,7 @@ public sealed class CosmosNoSqlDynamicMapperTests
     public void MapFromDataToStorageModelSkipsMissingProperties()
     {
         // Arrange
-        VectorStoreRecordDefinition vectorStoreRecordDefinition = new()
+        VectorStoreCollectionDefinition definition = new()
         {
             Properties = new List<VectorStoreProperty>
             {
@@ -285,7 +285,7 @@ public sealed class CosmosNoSqlDynamicMapperTests
     public void MapFromStorageToDataModelSkipsMissingProperties()
     {
         // Arrange
-        VectorStoreRecordDefinition vectorStoreRecordDefinition = new()
+        VectorStoreCollectionDefinition definition = new()
         {
             Properties = new List<VectorStoreProperty>
             {

--- a/dotnet/src/Connectors/Connectors.Memory.AzureAISearch/AzureAISearchVectorStore.cs
+++ b/dotnet/src/Connectors/Connectors.Memory.AzureAISearch/AzureAISearchVectorStore.cs
@@ -34,7 +34,7 @@ public sealed class AzureAISearchVectorStore : VectorStore
     private readonly JsonSerializerOptions? _jsonSerializerOptions;
 
     /// <summary>A general purpose definition that can be used to construct a collection when needing to proxy schema agnostic operations.</summary>
-    private static readonly VectorStoreRecordDefinition s_generalPurposeDefinition = new() { Properties = [new VectorStoreKeyProperty("Key", typeof(string))] };
+    private static readonly VectorStoreCollectionDefinition s_generalPurposeDefinition = new() { Properties = [new VectorStoreKeyProperty("Key", typeof(string))] };
 
     /// <summary>
     /// Initializes a new instance of the <see cref="AzureAISearchVectorStore"/> class.
@@ -63,9 +63,9 @@ public sealed class AzureAISearchVectorStore : VectorStore
     [RequiresDynamicCode("This overload of GetCollection() is incompatible with NativeAOT. For dynamic mapping via Dictionary<string, object?>, call GetDynamicCollection() instead.")]
     [RequiresUnreferencedCode("This overload of GetCollecttion() is incompatible with trimming. For dynamic mapping via Dictionary<string, object?>, call GetDynamicCollection() instead.")]
 #if NET8_0_OR_GREATER
-    public override AzureAISearchCollection<TKey, TRecord> GetCollection<TKey, TRecord>(string name, VectorStoreRecordDefinition? vectorStoreRecordDefinition = null)
+    public override AzureAISearchCollection<TKey, TRecord> GetCollection<TKey, TRecord>(string name, VectorStoreCollectionDefinition? definition = null)
 #else
-    public override VectorStoreCollection<TKey, TRecord> GetCollection<TKey, TRecord>(string name, VectorStoreRecordDefinition? vectorStoreRecordDefinition = null)
+    public override VectorStoreCollection<TKey, TRecord> GetCollection<TKey, TRecord>(string name, VectorStoreCollectionDefinition? definition = null)
 #endif
         => typeof(TRecord) == typeof(Dictionary<string, object?>)
             ? throw new ArgumentException(VectorDataStrings.GetCollectionWithDictionaryNotSupported)
@@ -75,7 +75,7 @@ public sealed class AzureAISearchVectorStore : VectorStore
                 new AzureAISearchCollectionOptions()
                 {
                     JsonSerializerOptions = this._jsonSerializerOptions,
-                    Definition = vectorStoreRecordDefinition,
+                    Definition = definition,
                     EmbeddingGenerator = this._embeddingGenerator
                 });
 
@@ -83,9 +83,9 @@ public sealed class AzureAISearchVectorStore : VectorStore
     [RequiresUnreferencedCode("The Azure AI Search provider is currently incompatible with trimming.")]
     [RequiresDynamicCode("The Azure AI Search provider is currently incompatible with NativeAOT.")]
 #if NET8_0_OR_GREATER
-    public override AzureAISearchDynamicCollection GetDynamicCollection(string name, VectorStoreRecordDefinition vectorStoreRecordDefinition)
+    public override AzureAISearchDynamicCollection GetDynamicCollection(string name, VectorStoreCollectionDefinition definition)
 #else
-    public override VectorStoreCollection<object, Dictionary<string, object?>> GetDynamicCollection(string name, VectorStoreRecordDefinition vectorStoreRecordDefinition)
+    public override VectorStoreCollection<object, Dictionary<string, object?>> GetDynamicCollection(string name, VectorStoreCollectionDefinition definition)
 #endif
         => new AzureAISearchDynamicCollection(
             this._searchIndexClient,
@@ -93,7 +93,7 @@ public sealed class AzureAISearchVectorStore : VectorStore
             new()
             {
                 JsonSerializerOptions = this._jsonSerializerOptions,
-                Definition = vectorStoreRecordDefinition,
+                Definition = definition,
                 EmbeddingGenerator = this._embeddingGenerator
             }
         );

--- a/dotnet/src/Connectors/Connectors.Memory.CosmosMongoDB/CosmosMongoVectorStore.cs
+++ b/dotnet/src/Connectors/Connectors.Memory.CosmosMongoDB/CosmosMongoVectorStore.cs
@@ -29,7 +29,7 @@ public sealed class CosmosMongoVectorStore : VectorStore
     private readonly IMongoDatabase _mongoDatabase;
 
     /// <summary>A general purpose definition that can be used to construct a collection when needing to proxy schema agnostic operations.</summary>
-    private static readonly VectorStoreRecordDefinition s_generalPurposeDefinition = new() { Properties = [new VectorStoreKeyProperty("Key", typeof(string))] };
+    private static readonly VectorStoreCollectionDefinition s_generalPurposeDefinition = new() { Properties = [new VectorStoreKeyProperty("Key", typeof(string))] };
 
     private readonly IEmbeddingGenerator? _embeddingGenerator;
 
@@ -57,9 +57,9 @@ public sealed class CosmosMongoVectorStore : VectorStore
     [RequiresDynamicCode("This overload of GetCollection() is incompatible with NativeAOT. For dynamic mapping via Dictionary<string, object?>, call GetDynamicCollection() instead.")]
     [RequiresUnreferencedCode("This overload of GetCollecttion() is incompatible with trimming. For dynamic mapping via Dictionary<string, object?>, call GetDynamicCollection() instead.")]
 #if NET8_0_OR_GREATER
-    public override CosmosMongoCollection<TKey, TRecord> GetCollection<TKey, TRecord>(string name, VectorStoreRecordDefinition? vectorStoreRecordDefinition = null)
+    public override CosmosMongoCollection<TKey, TRecord> GetCollection<TKey, TRecord>(string name, VectorStoreCollectionDefinition? definition = null)
 #else
-    public override VectorStoreCollection<TKey, TRecord> GetCollection<TKey, TRecord>(string name, VectorStoreRecordDefinition? vectorStoreRecordDefinition = null)
+    public override VectorStoreCollection<TKey, TRecord> GetCollection<TKey, TRecord>(string name, VectorStoreCollectionDefinition? definition = null)
 #endif
         => typeof(TRecord) == typeof(Dictionary<string, object?>)
             ? throw new ArgumentException(VectorDataStrings.GetCollectionWithDictionaryNotSupported)
@@ -68,22 +68,22 @@ public sealed class CosmosMongoVectorStore : VectorStore
                 name,
                 new()
                 {
-                    Definition = vectorStoreRecordDefinition,
+                    Definition = definition,
                     EmbeddingGenerator = this._embeddingGenerator
                 });
 
     /// <inheritdoc />
 #if NET8_0_OR_GREATER
-    public override CosmosMongoDynamicCollection GetDynamicCollection(string name, VectorStoreRecordDefinition vectorStoreRecordDefinition)
+    public override CosmosMongoDynamicCollection GetDynamicCollection(string name, VectorStoreCollectionDefinition definition)
 #else
-    public override VectorStoreCollection<object, Dictionary<string, object?>> GetDynamicCollection(string name, VectorStoreRecordDefinition vectorStoreRecordDefinition)
+    public override VectorStoreCollection<object, Dictionary<string, object?>> GetDynamicCollection(string name, VectorStoreCollectionDefinition definition)
 #endif
         => new CosmosMongoDynamicCollection(
             this._mongoDatabase,
             name,
             new()
             {
-                Definition = vectorStoreRecordDefinition,
+                Definition = definition,
                 EmbeddingGenerator = this._embeddingGenerator,
             }
         );

--- a/dotnet/src/Connectors/Connectors.Memory.CosmosNoSql/CosmosNoSqlVectorStore.cs
+++ b/dotnet/src/Connectors/Connectors.Memory.CosmosNoSql/CosmosNoSqlVectorStore.cs
@@ -31,7 +31,7 @@ public sealed class CosmosNoSqlVectorStore : VectorStore
     private readonly ClientWrapper _clientWrapper;
 
     /// <summary>A general purpose definition that can be used to construct a collection when needing to proxy schema agnostic operations.</summary>
-    private static readonly VectorStoreRecordDefinition s_generalPurposeDefinition = new() { Properties = [new VectorStoreKeyProperty("Key", typeof(string))] };
+    private static readonly VectorStoreCollectionDefinition s_generalPurposeDefinition = new() { Properties = [new VectorStoreKeyProperty("Key", typeof(string))] };
 
     private readonly JsonSerializerOptions? _jsonSerializerOptions;
     private readonly IEmbeddingGenerator? _embeddingGenerator;
@@ -102,9 +102,9 @@ public sealed class CosmosNoSqlVectorStore : VectorStore
     [RequiresUnreferencedCode("The Cosmos NoSQL provider is currently incompatible with trimming.")]
     [RequiresDynamicCode("The Cosmos NoSQL provider is currently incompatible with NativeAOT.")]
 #if NET8_0_OR_GREATER
-    public override CosmosNoSqlCollection<TKey, TRecord> GetCollection<TKey, TRecord>(string name, VectorStoreRecordDefinition? vectorStoreRecordDefinition = null)
+    public override CosmosNoSqlCollection<TKey, TRecord> GetCollection<TKey, TRecord>(string name, VectorStoreCollectionDefinition? definition = null)
 #else
-    public override VectorStoreCollection<TKey, TRecord> GetCollection<TKey, TRecord>(string name, VectorStoreRecordDefinition? vectorStoreRecordDefinition = null)
+    public override VectorStoreCollection<TKey, TRecord> GetCollection<TKey, TRecord>(string name, VectorStoreCollectionDefinition? definition = null)
 #endif
         => typeof(TRecord) == typeof(Dictionary<string, object?>)
             ? throw new ArgumentException(VectorDataStrings.GetCollectionWithDictionaryNotSupported)
@@ -114,7 +114,7 @@ public sealed class CosmosNoSqlVectorStore : VectorStore
                 name,
                 new()
                 {
-                    Definition = vectorStoreRecordDefinition,
+                    Definition = definition,
                     JsonSerializerOptions = this._jsonSerializerOptions,
                     EmbeddingGenerator = this._embeddingGenerator
                 });
@@ -123,9 +123,9 @@ public sealed class CosmosNoSqlVectorStore : VectorStore
     [RequiresUnreferencedCode("The Cosmos NoSQL provider is currently incompatible with trimming.")]
     [RequiresDynamicCode("The Cosmos NoSQL provider is currently incompatible with NativeAOT.")]
 #if NET8_0_OR_GREATER
-    public override CosmosNoSqlDynamicCollection GetDynamicCollection(string name, VectorStoreRecordDefinition vectorStoreRecordDefinition)
+    public override CosmosNoSqlDynamicCollection GetDynamicCollection(string name, VectorStoreCollectionDefinition definition)
 #else
-    public override VectorStoreCollection<object, Dictionary<string, object?>> GetDynamicCollection(string name, VectorStoreRecordDefinition vectorStoreRecordDefinition)
+    public override VectorStoreCollection<object, Dictionary<string, object?>> GetDynamicCollection(string name, VectorStoreCollectionDefinition definition)
 #endif
         => new CosmosNoSqlDynamicCollection(
             this._clientWrapper.Share(),
@@ -133,7 +133,7 @@ public sealed class CosmosNoSqlVectorStore : VectorStore
             name,
             new()
             {
-                Definition = vectorStoreRecordDefinition,
+                Definition = definition,
                 JsonSerializerOptions = this._jsonSerializerOptions,
                 EmbeddingGenerator = this._embeddingGenerator
             }

--- a/dotnet/src/Connectors/Connectors.Memory.InMemory/InMemoryVectorStore.cs
+++ b/dotnet/src/Connectors/Connectors.Memory.InMemory/InMemoryVectorStore.cs
@@ -49,9 +49,9 @@ public sealed class InMemoryVectorStore : VectorStore
     [RequiresUnreferencedCode("The InMemory provider is incompatible with trimming.")]
     [RequiresDynamicCode("The InMemory provider is incompatible with NativeAOT.")]
 #if NET8_0_OR_GREATER
-    public override InMemoryCollection<TKey, TRecord> GetCollection<TKey, TRecord>(string name, VectorStoreRecordDefinition? vectorStoreRecordDefinition = null)
+    public override InMemoryCollection<TKey, TRecord> GetCollection<TKey, TRecord>(string name, VectorStoreCollectionDefinition? definition = null)
 #else
-    public override VectorStoreCollection<TKey, TRecord> GetCollection<TKey, TRecord>(string name, VectorStoreRecordDefinition? vectorStoreRecordDefinition = null)
+    public override VectorStoreCollection<TKey, TRecord> GetCollection<TKey, TRecord>(string name, VectorStoreCollectionDefinition? definition = null)
 #endif
     {
         if (typeof(TRecord) == typeof(Dictionary<string, object?>))
@@ -70,7 +70,7 @@ public sealed class InMemoryVectorStore : VectorStore
             name,
             new()
             {
-                Definition = vectorStoreRecordDefinition,
+                Definition = definition,
                 EmbeddingGenerator = this._embeddingGenerator
             });
         return collection!;
@@ -80,9 +80,9 @@ public sealed class InMemoryVectorStore : VectorStore
     [RequiresUnreferencedCode("The InMemory provider is incompatible with trimming.")]
     [RequiresDynamicCode("The InMemory provider is incompatible with NativeAOT.")]
 #if NET8_0_OR_GREATER
-    public override InMemoryDynamicCollection GetDynamicCollection(string name, VectorStoreRecordDefinition vectorStoreRecordDefinition)
+    public override InMemoryDynamicCollection GetDynamicCollection(string name, VectorStoreCollectionDefinition definition)
 #else
-    public override VectorStoreCollection<object, Dictionary<string, object?>> GetDynamicCollection(string name, VectorStoreRecordDefinition vectorStoreRecordDefinition)
+    public override VectorStoreCollection<object, Dictionary<string, object?>> GetDynamicCollection(string name, VectorStoreCollectionDefinition definition)
 #endif
         => new InMemoryDynamicCollection(
             this._internalCollections,
@@ -90,7 +90,7 @@ public sealed class InMemoryVectorStore : VectorStore
             name,
             new()
             {
-                Definition = vectorStoreRecordDefinition,
+                Definition = definition,
                 EmbeddingGenerator = this._embeddingGenerator,
             }
         );

--- a/dotnet/src/Connectors/Connectors.Memory.MongoDB/MongoVectorStore.cs
+++ b/dotnet/src/Connectors/Connectors.Memory.MongoDB/MongoVectorStore.cs
@@ -28,7 +28,7 @@ public sealed class MongoVectorStore : VectorStore
     private readonly IMongoDatabase _mongoDatabase;
 
     /// <summary>A general purpose definition that can be used to construct a collection when needing to proxy schema agnostic operations.</summary>
-    private static readonly VectorStoreRecordDefinition s_generalPurposeDefinition = new() { Properties = [new VectorStoreKeyProperty("Key", typeof(string))] };
+    private static readonly VectorStoreCollectionDefinition s_generalPurposeDefinition = new() { Properties = [new VectorStoreKeyProperty("Key", typeof(string))] };
 
     private readonly IEmbeddingGenerator? _embeddingGenerator;
 
@@ -56,9 +56,9 @@ public sealed class MongoVectorStore : VectorStore
     [RequiresDynamicCode("This overload of GetCollection() is incompatible with NativeAOT. For dynamic mapping via Dictionary<string, object?>, call GetDynamicCollection() instead.")]
     [RequiresUnreferencedCode("This overload of GetCollecttion() is incompatible with trimming. For dynamic mapping via Dictionary<string, object?>, call GetDynamicCollection() instead.")]
 #if NET8_0_OR_GREATER
-    public override MongoCollection<TKey, TRecord> GetCollection<TKey, TRecord>(string name, VectorStoreRecordDefinition? vectorStoreRecordDefinition = null)
+    public override MongoCollection<TKey, TRecord> GetCollection<TKey, TRecord>(string name, VectorStoreCollectionDefinition? definition = null)
 #else
-    public override VectorStoreCollection<TKey, TRecord> GetCollection<TKey, TRecord>(string name, VectorStoreRecordDefinition? vectorStoreRecordDefinition = null)
+    public override VectorStoreCollection<TKey, TRecord> GetCollection<TKey, TRecord>(string name, VectorStoreCollectionDefinition? definition = null)
 #endif
         => typeof(TRecord) == typeof(Dictionary<string, object?>)
             ? throw new ArgumentException(VectorDataStrings.GetCollectionWithDictionaryNotSupported)
@@ -67,22 +67,22 @@ public sealed class MongoVectorStore : VectorStore
                 name,
                 new()
                 {
-                    Definition = vectorStoreRecordDefinition,
+                    Definition = definition,
                     EmbeddingGenerator = this._embeddingGenerator
                 });
 
     /// <inheritdoc />
 #if NET8_0_OR_GREATER
-    public override MongoDynamicCollection GetDynamicCollection(string name, VectorStoreRecordDefinition vectorStoreRecordDefinition)
+    public override MongoDynamicCollection GetDynamicCollection(string name, VectorStoreCollectionDefinition definition)
 #else
-    public override VectorStoreCollection<object, Dictionary<string, object?>> GetDynamicCollection(string name, VectorStoreRecordDefinition vectorStoreRecordDefinition)
+    public override VectorStoreCollection<object, Dictionary<string, object?>> GetDynamicCollection(string name, VectorStoreCollectionDefinition definition)
 #endif
         => new MongoDynamicCollection(
             this._mongoDatabase,
             name,
             new()
             {
-                Definition = vectorStoreRecordDefinition,
+                Definition = definition,
                 EmbeddingGenerator = this._embeddingGenerator,
             }
         );

--- a/dotnet/src/Connectors/Connectors.Memory.PgVector/PostgresVectorStore.cs
+++ b/dotnet/src/Connectors/Connectors.Memory.PgVector/PostgresVectorStore.cs
@@ -23,7 +23,7 @@ public sealed class PostgresVectorStore : VectorStore
     private readonly VectorStoreMetadata _metadata;
 
     /// <summary>A general purpose definition that can be used to construct a collection when needing to proxy schema agnostic operations.</summary>
-    private static readonly VectorStoreRecordDefinition s_generalPurposeDefinition = new() { Properties = [new VectorStoreKeyProperty("Key", typeof(string))] };
+    private static readonly VectorStoreCollectionDefinition s_generalPurposeDefinition = new() { Properties = [new VectorStoreKeyProperty("Key", typeof(string))] };
 
     /// <summary>The database schema.</summary>
     private readonly string _schema;
@@ -85,9 +85,9 @@ public sealed class PostgresVectorStore : VectorStore
     [RequiresDynamicCode("This overload of GetCollection() is incompatible with NativeAOT. For dynamic mapping via Dictionary<string, object?>, call GetDynamicCollection() instead.")]
     [RequiresUnreferencedCode("This overload of GetCollecttion() is incompatible with trimming. For dynamic mapping via Dictionary<string, object?>, call GetDynamicCollection() instead.")]
 #if NET8_0_OR_GREATER
-    public override PostgresCollection<TKey, TRecord> GetCollection<TKey, TRecord>(string name, VectorStoreRecordDefinition? vectorStoreRecordDefinition = null)
+    public override PostgresCollection<TKey, TRecord> GetCollection<TKey, TRecord>(string name, VectorStoreCollectionDefinition? definition = null)
 #else
-    public override VectorStoreCollection<TKey, TRecord> GetCollection<TKey, TRecord>(string name, VectorStoreRecordDefinition? vectorStoreRecordDefinition = null)
+    public override VectorStoreCollection<TKey, TRecord> GetCollection<TKey, TRecord>(string name, VectorStoreCollectionDefinition? definition = null)
 #endif
         => typeof(TRecord) == typeof(Dictionary<string, object?>)
             ? throw new ArgumentException(VectorDataStrings.GetCollectionWithDictionaryNotSupported)
@@ -97,16 +97,16 @@ public sealed class PostgresVectorStore : VectorStore
                 new()
                 {
                     Schema = this._schema,
-                    Definition = vectorStoreRecordDefinition,
+                    Definition = definition,
                     EmbeddingGenerator = this._embeddingGenerator,
                 }
             );
 
     /// <inheritdoc />
 #if NET8_0_OR_GREATER
-    public override PostgresDynamicCollection GetDynamicCollection(string name, VectorStoreRecordDefinition vectorStoreRecordDefinition)
+    public override PostgresDynamicCollection GetDynamicCollection(string name, VectorStoreCollectionDefinition definition)
 #else
-    public override VectorStoreCollection<object, Dictionary<string, object?>> GetDynamicCollection(string name, VectorStoreRecordDefinition vectorStoreRecordDefinition)
+    public override VectorStoreCollection<object, Dictionary<string, object?>> GetDynamicCollection(string name, VectorStoreCollectionDefinition definition)
 #endif
         => new PostgresDynamicCollection(
             () => this._client.Share(),
@@ -114,7 +114,7 @@ public sealed class PostgresVectorStore : VectorStore
             new()
             {
                 Schema = this._schema,
-                Definition = vectorStoreRecordDefinition,
+                Definition = definition,
                 EmbeddingGenerator = this._embeddingGenerator,
             }
         );

--- a/dotnet/src/Connectors/Connectors.Memory.Pinecone/PineconeVectorStore.cs
+++ b/dotnet/src/Connectors/Connectors.Memory.Pinecone/PineconeVectorStore.cs
@@ -27,7 +27,7 @@ public sealed class PineconeVectorStore : VectorStore
     private readonly VectorStoreMetadata _metadata;
 
     /// <summary>A general purpose definition that can be used to construct a collection when needing to proxy schema agnostic operations.</summary>
-    private static readonly VectorStoreRecordDefinition s_generalPurposeDefinition = new() { Properties = [new VectorStoreKeyProperty("Key", typeof(string)), new VectorStoreVectorProperty("Vector", typeof(ReadOnlyMemory<float>), 1)] };
+    private static readonly VectorStoreCollectionDefinition s_generalPurposeDefinition = new() { Properties = [new VectorStoreKeyProperty("Key", typeof(string)), new VectorStoreVectorProperty("Vector", typeof(ReadOnlyMemory<float>), 1)] };
 
     private readonly IEmbeddingGenerator? _embeddingGenerator;
 
@@ -54,9 +54,9 @@ public sealed class PineconeVectorStore : VectorStore
     [RequiresDynamicCode("This overload of GetCollection() is incompatible with NativeAOT. For dynamic mapping via Dictionary<string, object?>, call GetDynamicCollection() instead.")]
     [RequiresUnreferencedCode("This overload of GetCollecttion() is incompatible with trimming. For dynamic mapping via Dictionary<string, object?>, call GetDynamicCollection() instead.")]
 #if NET8_0_OR_GREATER
-    public override PineconeCollection<TKey, TRecord> GetCollection<TKey, TRecord>(string name, VectorStoreRecordDefinition? vectorStoreRecordDefinition = null)
+    public override PineconeCollection<TKey, TRecord> GetCollection<TKey, TRecord>(string name, VectorStoreCollectionDefinition? definition = null)
 #else
-    public override VectorStoreCollection<TKey, TRecord> GetCollection<TKey, TRecord>(string name, VectorStoreRecordDefinition? vectorStoreRecordDefinition = null)
+    public override VectorStoreCollection<TKey, TRecord> GetCollection<TKey, TRecord>(string name, VectorStoreCollectionDefinition? definition = null)
 #endif
         => typeof(TRecord) == typeof(Dictionary<string, object?>)
             ? throw new ArgumentException(VectorDataStrings.GetCollectionWithDictionaryNotSupported)
@@ -65,22 +65,22 @@ public sealed class PineconeVectorStore : VectorStore
                 name,
                 new PineconeCollectionOptions()
                 {
-                    Definition = vectorStoreRecordDefinition,
+                    Definition = definition,
                     EmbeddingGenerator = this._embeddingGenerator
                 });
 
     /// <inheritdoc />
 #if NET8_0_OR_GREATER
-    public override PineconeDynamicCollection GetDynamicCollection(string name, VectorStoreRecordDefinition vectorStoreRecordDefinition)
+    public override PineconeDynamicCollection GetDynamicCollection(string name, VectorStoreCollectionDefinition definition)
 #else
-    public override VectorStoreCollection<object, Dictionary<string, object?>> GetDynamicCollection(string name, VectorStoreRecordDefinition vectorStoreRecordDefinition)
+    public override VectorStoreCollection<object, Dictionary<string, object?>> GetDynamicCollection(string name, VectorStoreCollectionDefinition definition)
 #endif
         => new PineconeDynamicCollection(
             this._pineconeClient,
             name,
             new()
             {
-                Definition = vectorStoreRecordDefinition,
+                Definition = definition,
                 EmbeddingGenerator = this._embeddingGenerator
             }
         );

--- a/dotnet/src/Connectors/Connectors.Memory.Qdrant/QdrantVectorStore.cs
+++ b/dotnet/src/Connectors/Connectors.Memory.Qdrant/QdrantVectorStore.cs
@@ -29,7 +29,7 @@ public sealed class QdrantVectorStore : VectorStore
     private readonly MockableQdrantClient _qdrantClient;
 
     /// <summary>A general purpose definition that can be used to construct a collection when needing to proxy schema agnostic operations.</summary>
-    private static readonly VectorStoreRecordDefinition s_generalPurposeDefinition = new() { Properties = [new VectorStoreKeyProperty("Key", typeof(ulong)), new VectorStoreVectorProperty("Vector", typeof(ReadOnlyMemory<float>), 1)] };
+    private static readonly VectorStoreCollectionDefinition s_generalPurposeDefinition = new() { Properties = [new VectorStoreKeyProperty("Key", typeof(ulong)), new VectorStoreVectorProperty("Vector", typeof(ReadOnlyMemory<float>), 1)] };
 
     /// <summary>Whether the vectors in the store are named and multiple vectors are supported, or whether there is just a single unnamed vector per qdrant point.</summary>
     private readonly bool _hasNamedVectors;
@@ -80,29 +80,29 @@ public sealed class QdrantVectorStore : VectorStore
     [RequiresDynamicCode("This overload of GetCollection() is incompatible with NativeAOT. For dynamic mapping via Dictionary<string, object?>, call GetDynamicCollection() instead.")]
     [RequiresUnreferencedCode("This overload of GetCollecttion() is incompatible with trimming. For dynamic mapping via Dictionary<string, object?>, call GetDynamicCollection() instead.")]
 #if NET8_0_OR_GREATER
-    public override QdrantCollection<TKey, TRecord> GetCollection<TKey, TRecord>(string name, VectorStoreRecordDefinition? vectorStoreRecordDefinition = null)
+    public override QdrantCollection<TKey, TRecord> GetCollection<TKey, TRecord>(string name, VectorStoreCollectionDefinition? definition = null)
 #else
-    public override VectorStoreCollection<TKey, TRecord> GetCollection<TKey, TRecord>(string name, VectorStoreRecordDefinition? vectorStoreRecordDefinition = null)
+    public override VectorStoreCollection<TKey, TRecord> GetCollection<TKey, TRecord>(string name, VectorStoreCollectionDefinition? definition = null)
 #endif
         => typeof(TRecord) == typeof(Dictionary<string, object?>)
             ? throw new ArgumentException(VectorDataStrings.GetCollectionWithDictionaryNotSupported)
             : new QdrantCollection<TKey, TRecord>(this._qdrantClient.Share, name, new()
             {
                 HasNamedVectors = this._hasNamedVectors,
-                Definition = vectorStoreRecordDefinition,
+                Definition = definition,
                 EmbeddingGenerator = this._embeddingGenerator
             });
 
     /// <inheritdoc />
 #if NET8_0_OR_GREATER
-    public override QdrantDynamicCollection GetDynamicCollection(string name, VectorStoreRecordDefinition vectorStoreRecordDefinition)
+    public override QdrantDynamicCollection GetDynamicCollection(string name, VectorStoreCollectionDefinition definition)
 #else
-    public override VectorStoreCollection<object, Dictionary<string, object?>> GetDynamicCollection(string name, VectorStoreRecordDefinition vectorStoreRecordDefinition)
+    public override VectorStoreCollection<object, Dictionary<string, object?>> GetDynamicCollection(string name, VectorStoreCollectionDefinition definition)
 #endif
         => new QdrantDynamicCollection(this._qdrantClient.Share, name, new QdrantCollectionOptions()
         {
             HasNamedVectors = this._hasNamedVectors,
-            Definition = vectorStoreRecordDefinition,
+            Definition = definition,
             EmbeddingGenerator = this._embeddingGenerator
         });
 #pragma warning restore IDE0090

--- a/dotnet/src/Connectors/Connectors.Memory.Redis/RedisVectorStore.cs
+++ b/dotnet/src/Connectors/Connectors.Memory.Redis/RedisVectorStore.cs
@@ -30,7 +30,7 @@ public sealed class RedisVectorStore : VectorStore
     private readonly IDatabase _database;
 
     /// <summary>A general purpose definition that can be used to construct a collection when needing to proxy schema agnostic operations.</summary>
-    private static readonly VectorStoreRecordDefinition s_generalPurposeDefinition = new() { Properties = [new VectorStoreKeyProperty("Key", typeof(string))] };
+    private static readonly VectorStoreCollectionDefinition s_generalPurposeDefinition = new() { Properties = [new VectorStoreKeyProperty("Key", typeof(string))] };
 
     /// <summary>The way in which data should be stored in redis..</summary>
     private readonly RedisStorageType? _storageType;
@@ -65,7 +65,7 @@ public sealed class RedisVectorStore : VectorStore
     // TODO: The provider uses unsafe JSON serialization in many places, #11963
     [RequiresUnreferencedCode("The Weaviate provider is currently incompatible with trimming.")]
     [RequiresDynamicCode("The Weaviate provider is currently incompatible with NativeAOT.")]
-    public override VectorStoreCollection<TKey, TRecord> GetCollection<TKey, TRecord>(string name, VectorStoreRecordDefinition? vectorStoreRecordDefinition = null)
+    public override VectorStoreCollection<TKey, TRecord> GetCollection<TKey, TRecord>(string name, VectorStoreCollectionDefinition? definition = null)
     {
         if (typeof(TRecord) == typeof(Dictionary<string, object?>))
         {
@@ -76,13 +76,13 @@ public sealed class RedisVectorStore : VectorStore
         {
             RedisStorageType.HashSet => new RedisHashSetCollection<TKey, TRecord>(this._database, name, new RedisHashSetCollectionOptions()
             {
-                Definition = vectorStoreRecordDefinition,
+                Definition = definition,
                 EmbeddingGenerator = this._embeddingGenerator
             }),
 
             RedisStorageType.Json => new RedisJsonCollection<TKey, TRecord>(this._database, name, new RedisJsonCollectionOptions()
             {
-                Definition = vectorStoreRecordDefinition,
+                Definition = definition,
                 EmbeddingGenerator = this._embeddingGenerator
             }),
 
@@ -94,18 +94,18 @@ public sealed class RedisVectorStore : VectorStore
     // TODO: The provider uses unsafe JSON serialization in many places, #11963
     [RequiresUnreferencedCode("The Redis provider is currently incompatible with trimming.")]
     [RequiresDynamicCode("The Redis provider is currently incompatible with NativeAOT.")]
-    public override VectorStoreCollection<object, Dictionary<string, object?>> GetDynamicCollection(string name, VectorStoreRecordDefinition vectorStoreRecordDefinition)
+    public override VectorStoreCollection<object, Dictionary<string, object?>> GetDynamicCollection(string name, VectorStoreCollectionDefinition definition)
         => this._storageType switch
         {
             RedisStorageType.HashSet => new RedisHashSetDynamicCollection(this._database, name, new RedisHashSetCollectionOptions()
             {
-                Definition = vectorStoreRecordDefinition,
+                Definition = definition,
                 EmbeddingGenerator = this._embeddingGenerator
             }),
 
             RedisStorageType.Json => new RedisJsonDynamicCollection(this._database, name, new RedisJsonCollectionOptions()
             {
-                Definition = vectorStoreRecordDefinition,
+                Definition = definition,
                 EmbeddingGenerator = this._embeddingGenerator
             }),
 

--- a/dotnet/src/Connectors/Connectors.Memory.SqlServer/SqlServerVectorStore.cs
+++ b/dotnet/src/Connectors/Connectors.Memory.SqlServer/SqlServerVectorStore.cs
@@ -24,7 +24,7 @@ public sealed class SqlServerVectorStore : VectorStore
     private readonly VectorStoreMetadata _metadata;
 
     /// <summary>A general purpose definition that can be used to construct a collection when needing to proxy schema agnostic operations.</summary>
-    private static readonly VectorStoreRecordDefinition s_generalPurposeDefinition = new() { Properties = [new VectorStoreKeyProperty("Key", typeof(string))] };
+    private static readonly VectorStoreCollectionDefinition s_generalPurposeDefinition = new() { Properties = [new VectorStoreKeyProperty("Key", typeof(string))] };
 
     /// <summary>The database schema.</summary>
     private readonly string? _schema;
@@ -62,9 +62,9 @@ public sealed class SqlServerVectorStore : VectorStore
     [RequiresUnreferencedCode("The SQL Server provider is currently incompatible with trimming.")]
     [RequiresDynamicCode("The SQL Server provider is currently incompatible with NativeAOT.")]
 #if NET8_0_OR_GREATER
-    public override SqlServerCollection<TKey, TRecord> GetCollection<TKey, TRecord>(string name, VectorStoreRecordDefinition? vectorStoreRecordDefinition = null)
+    public override SqlServerCollection<TKey, TRecord> GetCollection<TKey, TRecord>(string name, VectorStoreCollectionDefinition? definition = null)
 #else
-    public override VectorStoreCollection<TKey, TRecord> GetCollection<TKey, TRecord>(string name, VectorStoreRecordDefinition? vectorStoreRecordDefinition = null)
+    public override VectorStoreCollection<TKey, TRecord> GetCollection<TKey, TRecord>(string name, VectorStoreCollectionDefinition? definition = null)
 #endif
         => typeof(TRecord) == typeof(Dictionary<string, object?>)
             ? throw new ArgumentException(VectorDataStrings.GetCollectionWithDictionaryNotSupported)
@@ -74,7 +74,7 @@ public sealed class SqlServerVectorStore : VectorStore
                 new()
                 {
                     Schema = this._schema,
-                    Definition = vectorStoreRecordDefinition,
+                    Definition = definition,
                     EmbeddingGenerator = this._embeddingGenerator
                 });
 
@@ -83,9 +83,9 @@ public sealed class SqlServerVectorStore : VectorStore
     [RequiresUnreferencedCode("The SQL Server provider is currently incompatible with trimming.")]
     [RequiresDynamicCode("The SQL Server provider is currently incompatible with NativeAOT.")]
 #if NET8_0_OR_GREATER
-    public override SqlServerDynamicCollection GetDynamicCollection(string name, VectorStoreRecordDefinition vectorStoreRecordDefinition)
+    public override SqlServerDynamicCollection GetDynamicCollection(string name, VectorStoreCollectionDefinition definition)
 #else
-    public override VectorStoreCollection<object, Dictionary<string, object?>> GetDynamicCollection(string name, VectorStoreRecordDefinition vectorStoreRecordDefinition)
+    public override VectorStoreCollection<object, Dictionary<string, object?>> GetDynamicCollection(string name, VectorStoreCollectionDefinition definition)
 #endif
         => new SqlServerDynamicCollection(
             this._connectionString,
@@ -93,7 +93,7 @@ public sealed class SqlServerVectorStore : VectorStore
             new()
             {
                 Schema = this._schema,
-                Definition = vectorStoreRecordDefinition,
+                Definition = definition,
                 EmbeddingGenerator = this._embeddingGenerator,
             }
         );

--- a/dotnet/src/Connectors/Connectors.Memory.SqliteVec/SqliteVectorStore.cs
+++ b/dotnet/src/Connectors/Connectors.Memory.SqliteVec/SqliteVectorStore.cs
@@ -28,7 +28,7 @@ public sealed class SqliteVectorStore : VectorStore
     private readonly string _connectionString;
 
     /// <summary>A general purpose definition that can be used to construct a collection when needing to proxy schema agnostic operations.</summary>
-    private static readonly VectorStoreRecordDefinition s_generalPurposeDefinition = new() { Properties = [new VectorStoreKeyProperty("Key", typeof(string))] };
+    private static readonly VectorStoreCollectionDefinition s_generalPurposeDefinition = new() { Properties = [new VectorStoreKeyProperty("Key", typeof(string))] };
 
     /// <summary>Custom virtual table name to store vectors.</summary>
     private readonly string? _vectorVirtualTableName;
@@ -64,9 +64,9 @@ public sealed class SqliteVectorStore : VectorStore
     [RequiresDynamicCode("This overload of GetCollection() is incompatible with NativeAOT. For dynamic mapping via Dictionary<string, object?>, call GetDynamicCollection() instead.")]
     [RequiresUnreferencedCode("This overload of GetCollecttion() is incompatible with trimming. For dynamic mapping via Dictionary<string, object?>, call GetDynamicCollection() instead.")]
 #if NET8_0_OR_GREATER
-    public override SqliteCollection<TKey, TRecord> GetCollection<TKey, TRecord>(string name, VectorStoreRecordDefinition? vectorStoreRecordDefinition = null)
+    public override SqliteCollection<TKey, TRecord> GetCollection<TKey, TRecord>(string name, VectorStoreCollectionDefinition? definition = null)
 #else
-    public override VectorStoreCollection<TKey, TRecord> GetCollection<TKey, TRecord>(string name, VectorStoreRecordDefinition? vectorStoreRecordDefinition = null)
+    public override VectorStoreCollection<TKey, TRecord> GetCollection<TKey, TRecord>(string name, VectorStoreCollectionDefinition? definition = null)
 #endif
         => typeof(TRecord) == typeof(Dictionary<string, object?>)
             ? throw new ArgumentException(VectorDataStrings.GetCollectionWithDictionaryNotSupported)
@@ -75,23 +75,23 @@ public sealed class SqliteVectorStore : VectorStore
                 name,
                 new()
                 {
-                    Definition = vectorStoreRecordDefinition,
+                    Definition = definition,
                     VectorVirtualTableName = this._vectorVirtualTableName,
                     EmbeddingGenerator = this._embeddingGenerator
                 });
 
     /// <inheritdoc />
 #if NET8_0_OR_GREATER
-    public override SqliteDynamicCollection GetDynamicCollection(string name, VectorStoreRecordDefinition vectorStoreRecordDefinition)
+    public override SqliteDynamicCollection GetDynamicCollection(string name, VectorStoreCollectionDefinition definition)
 #else
-    public override VectorStoreCollection<object, Dictionary<string, object?>> GetDynamicCollection(string name, VectorStoreRecordDefinition vectorStoreRecordDefinition)
+    public override VectorStoreCollection<object, Dictionary<string, object?>> GetDynamicCollection(string name, VectorStoreCollectionDefinition definition)
 #endif
         => new SqliteDynamicCollection(
             this._connectionString,
             name,
             new()
             {
-                Definition = vectorStoreRecordDefinition,
+                Definition = definition,
                 VectorVirtualTableName = this._vectorVirtualTableName,
                 EmbeddingGenerator = this._embeddingGenerator
             }

--- a/dotnet/src/Connectors/Connectors.Memory.Weaviate/WeaviateVectorStore.cs
+++ b/dotnet/src/Connectors/Connectors.Memory.Weaviate/WeaviateVectorStore.cs
@@ -29,7 +29,7 @@ public sealed class WeaviateVectorStore : VectorStore
     private readonly HttpClient _httpClient;
 
     /// <summary>A general purpose definition that can be used to construct a collection when needing to proxy schema agnostic operations.</summary>
-    private static readonly VectorStoreRecordDefinition s_generalPurposeDefinition = new() { Properties = [new VectorStoreKeyProperty("Key", typeof(Guid)), new VectorStoreVectorProperty("Vector", typeof(ReadOnlyMemory<float>), 1)] };
+    private static readonly VectorStoreCollectionDefinition s_generalPurposeDefinition = new() { Properties = [new VectorStoreKeyProperty("Key", typeof(Guid)), new VectorStoreVectorProperty("Vector", typeof(ReadOnlyMemory<float>), 1)] };
 
     /// <summary>Weaviate endpoint for remote or local cluster.</summary>
     private readonly Uri? _endpoint;
@@ -79,9 +79,9 @@ public sealed class WeaviateVectorStore : VectorStore
     [RequiresUnreferencedCode("The Weaviate provider is currently incompatible with trimming.")]
     [RequiresDynamicCode("The Weaviate provider is currently incompatible with NativeAOT.")]
 #if NET8_0_OR_GREATER
-    public override WeaviateCollection<TKey, TRecord> GetCollection<TKey, TRecord>(string name, VectorStoreRecordDefinition? vectorStoreRecordDefinition = null)
+    public override WeaviateCollection<TKey, TRecord> GetCollection<TKey, TRecord>(string name, VectorStoreCollectionDefinition? definition = null)
 #else
-    public override VectorStoreCollection<TKey, TRecord> GetCollection<TKey, TRecord>(string name, VectorStoreRecordDefinition? vectorStoreRecordDefinition = null)
+    public override VectorStoreCollection<TKey, TRecord> GetCollection<TKey, TRecord>(string name, VectorStoreCollectionDefinition? definition = null)
 #endif
         => typeof(TRecord) == typeof(Dictionary<string, object?>)
             ? throw new ArgumentException(VectorDataStrings.GetCollectionWithDictionaryNotSupported)
@@ -90,7 +90,7 @@ public sealed class WeaviateVectorStore : VectorStore
                 name,
                 new()
                 {
-                    Definition = vectorStoreRecordDefinition,
+                    Definition = definition,
                     Endpoint = this._endpoint,
                     ApiKey = this._apiKey,
                     HasNamedVectors = this._hasNamedVectors,
@@ -102,16 +102,16 @@ public sealed class WeaviateVectorStore : VectorStore
     [RequiresUnreferencedCode("The Weaviate provider is currently incompatible with trimming.")]
     [RequiresDynamicCode("The Weaviate provider is currently incompatible with NativeAOT.")]
 #if NET8_0_OR_GREATER
-    public override WeaviateDynamicCollection GetDynamicCollection(string name, VectorStoreRecordDefinition vectorStoreRecordDefinition)
+    public override WeaviateDynamicCollection GetDynamicCollection(string name, VectorStoreCollectionDefinition definition)
 #else
-    public override VectorStoreCollection<object, Dictionary<string, object?>> GetDynamicCollection(string name, VectorStoreRecordDefinition vectorStoreRecordDefinition)
+    public override VectorStoreCollection<object, Dictionary<string, object?>> GetDynamicCollection(string name, VectorStoreCollectionDefinition definition)
 #endif
         => new WeaviateDynamicCollection(
             this._httpClient,
             name,
             new()
             {
-                Definition = vectorStoreRecordDefinition,
+                Definition = definition,
                 Endpoint = this._endpoint,
                 ApiKey = this._apiKey,
                 HasNamedVectors = this._hasNamedVectors,

--- a/dotnet/src/Connectors/Connectors.MongoDB.UnitTests/MongoCollectionTests.cs
+++ b/dotnet/src/Connectors/Connectors.MongoDB.UnitTests/MongoCollectionTests.cs
@@ -56,7 +56,7 @@ public sealed class MongoCollectionTests
     public void ConstructorWithImperativeModelInitializesCollection()
     {
         // Arrange
-        var definition = new VectorStoreRecordDefinition
+        var definition = new VectorStoreCollectionDefinition
         {
             Properties = [new VectorStoreKeyProperty("Id", typeof(string))]
         };
@@ -355,7 +355,7 @@ public sealed class MongoCollectionTests
     [Fact]
     public async Task UpsertWithModelWorksCorrectlyAsync()
     {
-        var definition = new VectorStoreRecordDefinition
+        var definition = new VectorStoreCollectionDefinition
         {
             Properties = new List<VectorStoreProperty>
             {
@@ -381,7 +381,7 @@ public sealed class MongoCollectionTests
     [Fact]
     public async Task UpsertWithBsonModelWorksCorrectlyAsync()
     {
-        var definition = new VectorStoreRecordDefinition
+        var definition = new VectorStoreCollectionDefinition
         {
             Properties = new List<VectorStoreProperty>
             {
@@ -597,7 +597,7 @@ public sealed class MongoCollectionTests
     private async Task TestUpsertWithModelAsync<TDataModel>(
         TDataModel dataModel,
         string expectedPropertyName,
-        VectorStoreRecordDefinition? definition = null)
+        VectorStoreCollectionDefinition? definition = null)
         where TDataModel : class
     {
         // Arrange

--- a/dotnet/src/Connectors/Connectors.MongoDB.UnitTests/MongoMapperTests.cs
+++ b/dotnet/src/Connectors/Connectors.MongoDB.UnitTests/MongoMapperTests.cs
@@ -20,7 +20,7 @@ public sealed class MongoMapperTests
     {
         var keyProperty = new VectorStoreKeyProperty("HotelId", typeof(string));
 
-        var definition = new VectorStoreRecordDefinition
+        var definition = new VectorStoreCollectionDefinition
         {
             Properties =
             [

--- a/dotnet/src/Connectors/Connectors.PgVector.UnitTests/PostgresCollectionTests.cs
+++ b/dotnet/src/Connectors/Connectors.PgVector.UnitTests/PostgresCollectionTests.cs
@@ -15,7 +15,7 @@ public class PostgresCollectionTests
     public void ThrowsForUnsupportedType()
     {
         // Arrange
-        var recordDefinition = new VectorStoreRecordDefinition
+        var recordDefinition = new VectorStoreCollectionDefinition
         {
             Properties = [
                 new VectorStoreKeyProperty("HotelId", typeof(ulong)),

--- a/dotnet/src/Connectors/Connectors.PgVector.UnitTests/PostgresMapperTests.cs
+++ b/dotnet/src/Connectors/Connectors.PgVector.UnitTests/PostgresMapperTests.cs
@@ -153,9 +153,9 @@ public sealed class PostgresMapperTests
 
     #region private
 
-    private static VectorStoreRecordDefinition GetRecordDefinition<TKey>()
+    private static VectorStoreCollectionDefinition GetRecordDefinition<TKey>()
     {
-        return new VectorStoreRecordDefinition
+        return new VectorStoreCollectionDefinition
         {
             Properties = new List<VectorStoreProperty>
             {
@@ -180,7 +180,7 @@ public sealed class PostgresMapperTests
         };
     }
 
-    private static CollectionModel GetModel<TRecord>(VectorStoreRecordDefinition definition)
+    private static CollectionModel GetModel<TRecord>(VectorStoreCollectionDefinition definition)
         => new PostgresModelBuilder().Build(typeof(TRecord), definition, defaultEmbeddingGenerator: null);
 
 #pragma warning disable CA1812

--- a/dotnet/src/Connectors/Connectors.PgVector.UnitTests/PostgresSqlBuilderTests.cs
+++ b/dotnet/src/Connectors/Connectors.PgVector.UnitTests/PostgresSqlBuilderTests.cs
@@ -26,7 +26,7 @@ public class PostgresSqlBuilderTests
     [InlineData(false)]
     public void TestBuildCreateTableCommand(bool ifNotExists)
     {
-        var recordDefinition = new VectorStoreRecordDefinition()
+        var recordDefinition = new VectorStoreCollectionDefinition()
         {
             Properties = [
                 new VectorStoreKeyProperty("id", typeof(long)),
@@ -257,7 +257,7 @@ public class PostgresSqlBuilderTests
     public void TestBuildGetCommand()
     {
         // Arrange
-        var recordDefinition = new VectorStoreRecordDefinition()
+        var recordDefinition = new VectorStoreCollectionDefinition()
         {
             Properties = [
                 new VectorStoreKeyProperty("id", typeof(long)),
@@ -300,7 +300,7 @@ public class PostgresSqlBuilderTests
     public void TestBuildGetBatchCommand()
     {
         // Arrange
-        var recordDefinition = new VectorStoreRecordDefinition()
+        var recordDefinition = new VectorStoreCollectionDefinition()
         {
             Properties = [
                 new VectorStoreKeyProperty("id", typeof(long)),

--- a/dotnet/src/Connectors/Connectors.Pinecone.UnitTests/PineconeCollectionTests.cs
+++ b/dotnet/src/Connectors/Connectors.Pinecone.UnitTests/PineconeCollectionTests.cs
@@ -25,7 +25,7 @@ public class PineconeCollectionTests
     public void CanCreateCollectionWithMismatchedDefinitionAndType()
     {
         // Arrange.
-        var definition = new VectorStoreRecordDefinition()
+        var definition = new VectorStoreCollectionDefinition()
         {
             Properties = new List<VectorStoreProperty>
             {

--- a/dotnet/src/Connectors/Connectors.Qdrant.UnitTests/QdrantCollectionTests.cs
+++ b/dotnet/src/Connectors/Connectors.Qdrant.UnitTests/QdrantCollectionTests.cs
@@ -443,7 +443,7 @@ public class QdrantCollectionTests
     public void CanCreateCollectionWithMismatchedDefinitionAndType()
     {
         // Arrange.
-        var definition = new VectorStoreRecordDefinition()
+        var definition = new VectorStoreCollectionDefinition()
         {
             Properties = new List<VectorStoreProperty>
             {
@@ -706,7 +706,7 @@ public class QdrantCollectionTests
         };
     }
 
-    private static VectorStoreRecordDefinition CreateSinglePropsDefinition(Type keyType)
+    private static VectorStoreCollectionDefinition CreateSinglePropsDefinition(Type keyType)
     {
         return new()
         {

--- a/dotnet/src/Connectors/Connectors.Qdrant.UnitTests/QdrantMapperTests.cs
+++ b/dotnet/src/Connectors/Connectors.Qdrant.UnitTests/QdrantMapperTests.cs
@@ -372,7 +372,7 @@ public class QdrantMapperTests
         pointStruct.Vectors = new VectorsOutput() { Vectors = namedVectors };
     }
 
-    private static VectorStoreRecordDefinition CreateSinglePropsVectorStoreRecordDefinition(Type keyType) => new()
+    private static VectorStoreCollectionDefinition CreateSinglePropsVectorStoreRecordDefinition(Type keyType) => new()
     {
         Properties = new List<VectorStoreProperty>
         {
@@ -396,7 +396,7 @@ public class QdrantMapperTests
         public string NotAnnotated { get; set; } = string.Empty;
     }
 
-    private static VectorStoreRecordDefinition CreateMultiPropsVectorStoreRecordDefinition(Type keyType) => new()
+    private static VectorStoreCollectionDefinition CreateMultiPropsVectorStoreRecordDefinition(Type keyType) => new()
     {
         Properties = new List<VectorStoreProperty>
         {

--- a/dotnet/src/Connectors/Connectors.Redis.UnitTests/RedisHashSetCollectionTests.cs
+++ b/dotnet/src/Connectors/Connectors.Redis.UnitTests/RedisHashSetCollectionTests.cs
@@ -427,7 +427,7 @@ public class RedisHashSetCollectionTests
     public void CanCreateCollectionWithMismatchedDefinitionAndType()
     {
         // Arrange.
-        var definition = new VectorStoreRecordDefinition()
+        var definition = new VectorStoreCollectionDefinition()
         {
             Properties = new List<VectorStoreProperty>
             {
@@ -542,7 +542,7 @@ public class RedisHashSetCollectionTests
         };
     }
 
-    private readonly VectorStoreRecordDefinition _singlePropsDefinition = new()
+    private readonly VectorStoreCollectionDefinition _singlePropsDefinition = new()
     {
         Properties =
         [

--- a/dotnet/src/Connectors/Connectors.Redis.UnitTests/RedisHashSetDynamicMappingTests.cs
+++ b/dotnet/src/Connectors/Connectors.Redis.UnitTests/RedisHashSetDynamicMappingTests.cs
@@ -14,7 +14,7 @@ namespace Microsoft.SemanticKernel.Connectors.Redis.UnitTests;
 /// </summary>
 public class RedisHashSetDynamicMappingTests
 {
-    private static readonly CollectionModel s_model = BuildModel(RedisHashSetMappingTestHelpers.s_vectorStoreRecordDefinition);
+    private static readonly CollectionModel s_model = BuildModel(RedisHashSetMappingTestHelpers.s_definition);
 
     private static readonly float[] s_floatVector = new float[] { 1.0f, 2.0f, 3.0f, 4.0f };
     private static readonly double[] s_doubleVector = new double[] { 5.0d, 6.0d, 7.0d, 8.0d };
@@ -206,7 +206,7 @@ public class RedisHashSetDynamicMappingTests
         Assert.Equal("key", dataModel["Key"]);
     }
 
-    private static CollectionModel BuildModel(VectorStoreRecordDefinition definition)
+    private static CollectionModel BuildModel(VectorStoreCollectionDefinition definition)
         => new RedisModelBuilder(RedisHashSetCollection<object, Dictionary<string, object?>>.ModelBuildingOptions)
             .BuildDynamic(definition, defaultEmbeddingGenerator: null);
 }

--- a/dotnet/src/Connectors/Connectors.Redis.UnitTests/RedisHashSetMapperTests.cs
+++ b/dotnet/src/Connectors/Connectors.Redis.UnitTests/RedisHashSetMapperTests.cs
@@ -16,7 +16,7 @@ public sealed class RedisHashSetMapperTests
 {
     private static readonly CollectionModel s_model
         = new RedisModelBuilder(RedisHashSetCollection<string, AllTypesModel>.ModelBuildingOptions)
-            .Build(typeof(AllTypesModel), RedisHashSetMappingTestHelpers.s_vectorStoreRecordDefinition, defaultEmbeddingGenerator: null);
+            .Build(typeof(AllTypesModel), RedisHashSetMappingTestHelpers.s_definition, defaultEmbeddingGenerator: null);
 
     [Fact]
     public void MapsAllFieldsFromDataToStorageModel()

--- a/dotnet/src/Connectors/Connectors.Redis.UnitTests/RedisHashSetMappingTestHelpers.cs
+++ b/dotnet/src/Connectors/Connectors.Redis.UnitTests/RedisHashSetMappingTestHelpers.cs
@@ -15,7 +15,7 @@ namespace Microsoft.SemanticKernel.Connectors.Redis.UnitTests;
 /// </summary>
 internal static class RedisHashSetMappingTestHelpers
 {
-    public static readonly VectorStoreRecordDefinition s_vectorStoreRecordDefinition = new()
+    public static readonly VectorStoreCollectionDefinition s_definition = new()
     {
         Properties = new List<VectorStoreProperty>()
         {

--- a/dotnet/src/Connectors/Connectors.Redis.UnitTests/RedisJsonCollectionTests.cs
+++ b/dotnet/src/Connectors/Connectors.Redis.UnitTests/RedisJsonCollectionTests.cs
@@ -533,7 +533,7 @@ public class RedisJsonCollectionTests
         PropertyNamingPolicy = JsonNamingPolicy.CamelCase
     };
 
-    private readonly VectorStoreRecordDefinition _multiPropsDefinition = new()
+    private readonly VectorStoreCollectionDefinition _multiPropsDefinition = new()
     {
         Properties =
         [

--- a/dotnet/src/Connectors/Connectors.Redis.UnitTests/RedisJsonMapperTests.cs
+++ b/dotnet/src/Connectors/Connectors.Redis.UnitTests/RedisJsonMapperTests.cs
@@ -20,7 +20,7 @@ public sealed class RedisJsonMapperTests
     {
         // Arrange.
         var model = new RedisJsonModelBuilder(RedisJsonCollection<string, MultiPropsModel>.ModelBuildingOptions)
-            .Build(typeof(MultiPropsModel), vectorStoreRecordDefinition: null, defaultEmbeddingGenerator: null, JsonSerializerOptions.Default);
+            .Build(typeof(MultiPropsModel), definition: null, defaultEmbeddingGenerator: null, JsonSerializerOptions.Default);
         var sut = new RedisJsonMapper<MultiPropsModel>(model, JsonSerializerOptions.Default);
 
         // Act.
@@ -42,7 +42,7 @@ public sealed class RedisJsonMapperTests
         // Arrange.
         var jsonSerializerOptions = new JsonSerializerOptions { PropertyNamingPolicy = JsonNamingPolicy.CamelCase };
         var model = new RedisJsonModelBuilder(RedisJsonCollection<string, MultiPropsModel>.ModelBuildingOptions)
-            .Build(typeof(MultiPropsModel), vectorStoreRecordDefinition: null, defaultEmbeddingGenerator: null, jsonSerializerOptions);
+            .Build(typeof(MultiPropsModel), definition: null, defaultEmbeddingGenerator: null, jsonSerializerOptions);
         var sut = new RedisJsonMapper<MultiPropsModel>(model, jsonSerializerOptions);
 
         // Act.
@@ -63,7 +63,7 @@ public sealed class RedisJsonMapperTests
     {
         // Arrange.
         var model = new RedisJsonModelBuilder(RedisJsonCollection<string, MultiPropsModel>.ModelBuildingOptions)
-            .Build(typeof(MultiPropsModel), vectorStoreRecordDefinition: null, defaultEmbeddingGenerator: null, JsonSerializerOptions.Default);
+            .Build(typeof(MultiPropsModel), definition: null, defaultEmbeddingGenerator: null, JsonSerializerOptions.Default);
         var sut = new RedisJsonMapper<MultiPropsModel>(model, JsonSerializerOptions.Default);
 
         // Act.
@@ -89,7 +89,7 @@ public sealed class RedisJsonMapperTests
         // Arrange.
         var jsonSerializerOptions = new JsonSerializerOptions { PropertyNamingPolicy = JsonNamingPolicy.CamelCase };
         var model = new RedisJsonModelBuilder(RedisJsonCollection<string, MultiPropsModel>.ModelBuildingOptions)
-            .Build(typeof(MultiPropsModel), vectorStoreRecordDefinition: null, defaultEmbeddingGenerator: null, jsonSerializerOptions);
+            .Build(typeof(MultiPropsModel), definition: null, defaultEmbeddingGenerator: null, jsonSerializerOptions);
         var sut = new RedisJsonMapper<MultiPropsModel>(model, jsonSerializerOptions);
 
         // Act.

--- a/dotnet/src/Connectors/Connectors.SqliteVec.UnitTests/SqliteMapperTests.cs
+++ b/dotnet/src/Connectors/Connectors.SqliteVec.UnitTests/SqliteMapperTests.cs
@@ -146,9 +146,9 @@ public sealed class SqliteMapperTests
 
     #region private
 
-    private static VectorStoreRecordDefinition GetRecordDefinition<TKey>()
+    private static VectorStoreCollectionDefinition GetRecordDefinition<TKey>()
     {
-        return new VectorStoreRecordDefinition
+        return new VectorStoreCollectionDefinition
         {
             Properties = new List<VectorStoreProperty>
             {
@@ -171,7 +171,7 @@ public sealed class SqliteMapperTests
         };
     }
 
-    private static CollectionModel BuildModel(Type type, VectorStoreRecordDefinition definition)
+    private static CollectionModel BuildModel(Type type, VectorStoreCollectionDefinition definition)
         => new SqliteModelBuilder().Build(type, definition, defaultEmbeddingGenerator: null);
 
 #pragma warning disable CA1812

--- a/dotnet/src/Connectors/Connectors.Weaviate.UnitTests/WeaviateCollectionCreateMappingTests.cs
+++ b/dotnet/src/Connectors/Connectors.Weaviate.UnitTests/WeaviateCollectionCreateMappingTests.cs
@@ -22,7 +22,7 @@ public sealed class WeaviateCollectionCreateMappingTests
         // Arrange
         var model = new WeaviateModelBuilder(HasNamedVectors)
             .BuildDynamic(
-                new VectorStoreRecordDefinition
+                new VectorStoreCollectionDefinition
                 {
                     Properties =
                     [
@@ -45,7 +45,7 @@ public sealed class WeaviateCollectionCreateMappingTests
         // Arrange
         var model = new WeaviateModelBuilder(HasNamedVectors)
             .BuildDynamic(
-                new VectorStoreRecordDefinition
+                new VectorStoreCollectionDefinition
                 {
                     Properties =
                     [
@@ -69,7 +69,7 @@ public sealed class WeaviateCollectionCreateMappingTests
         // Arrange
         var model = new WeaviateModelBuilder(HasNamedVectors)
             .BuildDynamic(
-                new VectorStoreRecordDefinition
+                new VectorStoreCollectionDefinition
                 {
                     Properties =
                     [
@@ -94,7 +94,7 @@ public sealed class WeaviateCollectionCreateMappingTests
         // Arrange
         var model = new WeaviateModelBuilder(HasNamedVectors)
             .BuildDynamic(
-                new VectorStoreRecordDefinition
+                new VectorStoreCollectionDefinition
                 {
                     Properties =
                     [
@@ -165,7 +165,7 @@ public sealed class WeaviateCollectionCreateMappingTests
         // Arrange
         var model = new WeaviateModelBuilder(HasNamedVectors)
             .BuildDynamic(
-                new VectorStoreRecordDefinition
+                new VectorStoreCollectionDefinition
                 {
                     Properties =
                     [
@@ -197,7 +197,7 @@ public sealed class WeaviateCollectionCreateMappingTests
         // Arrange
         var model = new WeaviateModelBuilder(hasNamedVectors)
             .BuildDynamic(
-                new VectorStoreRecordDefinition
+                new VectorStoreCollectionDefinition
                 {
                     Properties =
                     [

--- a/dotnet/src/Connectors/Connectors.Weaviate.UnitTests/WeaviateCollectionTests.cs
+++ b/dotnet/src/Connectors/Connectors.Weaviate.UnitTests/WeaviateCollectionTests.cs
@@ -61,7 +61,7 @@ public sealed class WeaviateCollectionTests : IDisposable
     public void ConstructorWithImperativeModelInitializesCollection()
     {
         // Arrange
-        var definition = new VectorStoreRecordDefinition
+        var definition = new VectorStoreCollectionDefinition
         {
             Properties = [new VectorStoreKeyProperty("Id", typeof(Guid))]
         };

--- a/dotnet/src/Connectors/Connectors.Weaviate.UnitTests/WeaviateDynamicMapperTests.cs
+++ b/dotnet/src/Connectors/Connectors.Weaviate.UnitTests/WeaviateDynamicMapperTests.cs
@@ -33,7 +33,7 @@ public sealed class WeaviateDynamicMapperTests
 
     private static readonly CollectionModel s_model = new WeaviateModelBuilder(HasNamedVectors)
         .BuildDynamic(
-            new VectorStoreRecordDefinition
+            new VectorStoreCollectionDefinition
             {
                 Properties =
                 [
@@ -315,7 +315,7 @@ public sealed class WeaviateDynamicMapperTests
     public void MapFromDataToStorageModelSkipsMissingProperties()
     {
         // Arrange
-        var recordDefinition = new VectorStoreRecordDefinition
+        var recordDefinition = new VectorStoreCollectionDefinition
         {
             Properties =
             [
@@ -346,7 +346,7 @@ public sealed class WeaviateDynamicMapperTests
     public void MapFromStorageToDataModelSkipsMissingProperties()
     {
         // Arrange
-        var recordDefinition = new VectorStoreRecordDefinition
+        var recordDefinition = new VectorStoreCollectionDefinition
         {
             Properties =
             [
@@ -383,7 +383,7 @@ public sealed class WeaviateDynamicMapperTests
     public void MapFromDataToStorageModelMapsNamedVectorsCorrectly(bool hasNamedVectors)
     {
         // Arrange
-        var recordDefinition = new VectorStoreRecordDefinition
+        var recordDefinition = new VectorStoreCollectionDefinition
         {
             Properties =
             [
@@ -415,7 +415,7 @@ public sealed class WeaviateDynamicMapperTests
     public void MapFromStorageToDataModelMapsNamedVectorsCorrectly(bool hasNamedVectors)
     {
         // Arrange
-        var recordDefinition = new VectorStoreRecordDefinition
+        var recordDefinition = new VectorStoreCollectionDefinition
         {
             Properties =
             [

--- a/dotnet/src/Connectors/Connectors.Weaviate.UnitTests/WeaviateMapperTests.cs
+++ b/dotnet/src/Connectors/Connectors.Weaviate.UnitTests/WeaviateMapperTests.cs
@@ -111,7 +111,7 @@ public sealed class WeaviateMapperTests
             new WeaviateModelBuilder(hasNamedVectors)
                 .Build(
                     typeof(WeaviateHotel),
-                    new VectorStoreRecordDefinition
+                    new VectorStoreCollectionDefinition
                     {
                         Properties =
                         [

--- a/dotnet/src/Connectors/VectorData.Abstractions/ProviderServices/CollectionJsonModelBuilder.cs
+++ b/dotnet/src/Connectors/VectorData.Abstractions/ProviderServices/CollectionJsonModelBuilder.cs
@@ -27,32 +27,32 @@ public abstract class CollectionJsonModelBuilder : CollectionModelBuilder
     }
 
     /// <summary>
-    /// Builds and returns an <see cref="CollectionModel"/> from the given <paramref name="type"/> and <paramref name="vectorStoreRecordDefinition"/>.
+    /// Builds and returns an <see cref="CollectionModel"/> from the given <paramref name="type"/> and <paramref name="definition"/>.
     /// </summary>
     [RequiresDynamicCode("This model building variant is not compatible with NativeAOT. See BuildDynamic() for dynamic mapping, and a third variant accepting source-generated delegates will be introduced in the future.")]
     [RequiresUnreferencedCode("This model building variant is not compatible with trimming. See BuildDynamic() for dynamic mapping, and a third variant accepting source-generated delegates will be introduced in the future.")]
     public virtual CollectionModel Build(
         Type type,
-        VectorStoreRecordDefinition? vectorStoreRecordDefinition,
+        VectorStoreCollectionDefinition? definition,
         IEmbeddingGenerator? defaultEmbeddingGenerator,
         JsonSerializerOptions jsonSerializerOptions)
     {
         this._jsonSerializerOptions = jsonSerializerOptions;
 
-        return this.Build(type, vectorStoreRecordDefinition, defaultEmbeddingGenerator);
+        return this.Build(type, definition, defaultEmbeddingGenerator);
     }
 
     /// <summary>
-    /// Builds and returns an <see cref="CollectionModel"/> for dynamic mapping scenarios from the given <paramref name="vectorStoreRecordDefinition"/>.
+    /// Builds and returns an <see cref="CollectionModel"/> for dynamic mapping scenarios from the given <paramref name="definition"/>.
     /// </summary>
     public virtual CollectionModel BuildDynamic(
-        VectorStoreRecordDefinition vectorStoreRecordDefinition,
+        VectorStoreCollectionDefinition definition,
         IEmbeddingGenerator? defaultEmbeddingGenerator,
         JsonSerializerOptions jsonSerializerOptions)
     {
         this._jsonSerializerOptions = jsonSerializerOptions;
 
-        return this.BuildDynamic(vectorStoreRecordDefinition, defaultEmbeddingGenerator);
+        return this.BuildDynamic(definition, defaultEmbeddingGenerator);
     }
 
     /// <inheritdoc/>

--- a/dotnet/src/Connectors/VectorData.Abstractions/ProviderServices/CollectionModelBuilder.cs
+++ b/dotnet/src/Connectors/VectorData.Abstractions/ProviderServices/CollectionModelBuilder.cs
@@ -71,7 +71,7 @@ public abstract class CollectionModelBuilder
     /// </summary>
     [RequiresDynamicCode("This model building variant is not compatible with NativeAOT. See BuildDynamic() for dynamic mapping, and a third variant accepting source-generated delegates will be introduced in the future.")]
     [RequiresUnreferencedCode("This model building variant is not compatible with trimming. See BuildDynamic() for dynamic mapping, and a third variant accepting source-generated delegates will be introduced in the future.")]
-    public virtual CollectionModel Build(Type type, VectorStoreRecordDefinition? definition, IEmbeddingGenerator? defaultEmbeddingGenerator)
+    public virtual CollectionModel Build(Type type, VectorStoreCollectionDefinition? definition, IEmbeddingGenerator? defaultEmbeddingGenerator)
     {
         if (type == typeof(Dictionary<string, object?>))
         {
@@ -117,7 +117,7 @@ public abstract class CollectionModelBuilder
     /// <summary>
     /// Builds and returns an <see cref="CollectionModel"/> for dynamic mapping scenarios from the given <paramref name="definition"/>.
     /// </summary>
-    public virtual CollectionModel BuildDynamic(VectorStoreRecordDefinition definition, IEmbeddingGenerator? defaultEmbeddingGenerator)
+    public virtual CollectionModel BuildDynamic(VectorStoreCollectionDefinition definition, IEmbeddingGenerator? defaultEmbeddingGenerator)
     {
         if (definition is null)
         {
@@ -140,7 +140,7 @@ public abstract class CollectionModelBuilder
     // TODO: We could put [DynamicallyAccessedMembers] to preserve all properties, but that approach wouldn't
     // TODO: work with hierarchical data models (#10957).
     [RequiresUnreferencedCode("Traverses the CLR type's properties with reflection, so not compatible with trimming")]
-    protected virtual void ProcessTypeProperties(Type type, VectorStoreRecordDefinition? definition)
+    protected virtual void ProcessTypeProperties(Type type, VectorStoreCollectionDefinition? definition)
     {
         // We want to allow the user-provided record definition to override anything configured via attributes
         // (allowing the same CLR type + attributes to be used with different record definitions).
@@ -247,7 +247,7 @@ public abstract class CollectionModelBuilder
     /// <summary>
     /// As part of building the model, this method processes the given <paramref name="definition"/>.
     /// </summary>
-    protected virtual void ProcessRecordDefinition(VectorStoreRecordDefinition definition, Type? type)
+    protected virtual void ProcessRecordDefinition(VectorStoreCollectionDefinition definition, Type? type)
     {
         foreach (VectorStoreProperty definitionProperty in definition.Properties)
         {
@@ -290,7 +290,7 @@ public abstract class CollectionModelBuilder
                     if (property is not KeyPropertyModel keyPropertyModel)
                     {
                         throw new InvalidOperationException(
-                            $"Property '{property.ModelName}' is present in the {nameof(VectorStoreRecordDefinition)} as a key property, but the .NET property on type '{type?.Name}' has an incompatible attribute.");
+                            $"Property '{property.ModelName}' is present in the {nameof(VectorStoreCollectionDefinition)} as a key property, but the .NET property on type '{type?.Name}' has an incompatible attribute.");
                     }
 
                     break;
@@ -299,7 +299,7 @@ public abstract class CollectionModelBuilder
                     if (property is not DataPropertyModel dataProperty)
                     {
                         throw new InvalidOperationException(
-                            $"Property '{property.ModelName}' is present in the {nameof(VectorStoreRecordDefinition)} as a data property, but the .NET property on type '{type?.Name}' has an incompatible attribute.");
+                            $"Property '{property.ModelName}' is present in the {nameof(VectorStoreCollectionDefinition)} as a data property, but the .NET property on type '{type?.Name}' has an incompatible attribute.");
                     }
 
                     dataProperty.IsIndexed = definitionDataProperty.IsIndexed;
@@ -311,7 +311,7 @@ public abstract class CollectionModelBuilder
                     if (property is not VectorPropertyModel vectorProperty)
                     {
                         throw new InvalidOperationException(
-                            $"Property '{property.ModelName}' is present in the {nameof(VectorStoreRecordDefinition)} as a vector property, but the .NET property on type '{type?.Name}' has an incompatible attribute.");
+                            $"Property '{property.ModelName}' is present in the {nameof(VectorStoreCollectionDefinition)} as a vector property, but the .NET property on type '{type?.Name}' has an incompatible attribute.");
                     }
 
                     vectorProperty.Dimensions = definitionVectorProperty.Dimensions;
@@ -411,26 +411,26 @@ public abstract class CollectionModelBuilder
     /// <summary>
     /// Validates the model after all properties have been processed.
     /// </summary>
-    protected virtual void Validate(Type? type, VectorStoreRecordDefinition? definition)
+    protected virtual void Validate(Type? type, VectorStoreCollectionDefinition? definition)
     {
         if (!this.Options.SupportsMultipleKeys && this.KeyProperties.Count > 1)
         {
-            throw new NotSupportedException($"Multiple key properties found on {TypeMessage()}the provided {nameof(VectorStoreRecordDefinition)} while only one is supported.");
+            throw new NotSupportedException($"Multiple key properties found on {TypeMessage()}the provided {nameof(VectorStoreCollectionDefinition)} while only one is supported.");
         }
 
         if (this.KeyProperties.Count == 0)
         {
-            throw new NotSupportedException($"No key property found on {TypeMessage()}the provided {nameof(VectorStoreRecordDefinition)} while at least one is required.");
+            throw new NotSupportedException($"No key property found on {TypeMessage()}the provided {nameof(VectorStoreCollectionDefinition)} while at least one is required.");
         }
 
         if (this.Options.RequiresAtLeastOneVector && this.VectorProperties.Count == 0)
         {
-            throw new NotSupportedException($"No vector property found on {TypeMessage()}the provided {nameof(VectorStoreRecordDefinition)} while at least one is required.");
+            throw new NotSupportedException($"No vector property found on {TypeMessage()}the provided {nameof(VectorStoreCollectionDefinition)} while at least one is required.");
         }
 
         if (!this.Options.SupportsMultipleVectors && this.VectorProperties.Count > 1)
         {
-            throw new NotSupportedException($"Multiple vector properties found on {TypeMessage()}the provided {nameof(VectorStoreRecordDefinition)} while only one is supported.");
+            throw new NotSupportedException($"Multiple vector properties found on {TypeMessage()}the provided {nameof(VectorStoreCollectionDefinition)} while only one is supported.");
         }
 
         var storageNameMap = new Dictionary<string, PropertyModel>();
@@ -453,7 +453,7 @@ public abstract class CollectionModelBuilder
     /// <summary>
     /// Validates a single property, performing validation on it.
     /// </summary>
-    protected virtual void ValidateProperty(PropertyModel propertyModel, VectorStoreRecordDefinition? definition)
+    protected virtual void ValidateProperty(PropertyModel propertyModel, VectorStoreCollectionDefinition? definition)
     {
         var type = propertyModel.Type;
 

--- a/dotnet/src/Connectors/VectorData.Abstractions/RecordDefinition/VectorStoreCollectionDefinition.cs
+++ b/dotnet/src/Connectors/VectorData.Abstractions/RecordDefinition/VectorStoreCollectionDefinition.cs
@@ -7,12 +7,12 @@ using Microsoft.Extensions.AI;
 namespace Microsoft.Extensions.VectorData;
 
 /// <summary>
-/// Describes the properties of a record stored in a vector store.
+/// Describes the properties of a record in a vector store collection.
 /// </summary>
 /// <remarks>
 /// Each property contains additional information about how the property will be treated by the vector store.
 /// </remarks>
-public sealed class VectorStoreRecordDefinition
+public sealed class VectorStoreCollectionDefinition
 {
     private IList<VectorStoreProperty>? _properties;
 

--- a/dotnet/src/Connectors/VectorData.Abstractions/VectorStorage/VectorStore.cs
+++ b/dotnet/src/Connectors/VectorData.Abstractions/VectorStorage/VectorStore.cs
@@ -23,18 +23,18 @@ public abstract class VectorStore : IDisposable
     /// <typeparam name="TKey">The data type of the record key.</typeparam>
     /// <typeparam name="TRecord">The record data model to use for adding, updating, and retrieving data from the collection.</typeparam>
     /// <param name="name">The name of the collection.</param>
-    /// <param name="vectorStoreRecordDefinition">The schema of the record type.</param>
+    /// <param name="definition">The schema of the record type.</param>
     /// <returns>A new <see cref="VectorStoreCollection{TKey, TRecord}"/> instance for managing the records in the collection.</returns>
     /// <remarks>
     /// To successfully request a collection, either <typeparamref name="TRecord"/> must be annotated with attributes that define the schema of
-    /// the record type, or <paramref name="vectorStoreRecordDefinition"/> must be provided.
+    /// the record type, or <paramref name="definition"/> must be provided.
     /// </remarks>
     /// <seealso cref="VectorStoreKeyAttribute"/>
     /// <seealso cref="VectorStoreDataAttribute"/>
     /// <seealso cref="VectorStoreVectorAttribute"/>
     [RequiresDynamicCode("This API is not compatible with NativeAOT. For dynamic mapping via Dictionary<string, object?>, use GetCollectionDynamic() instead.")]
     [RequiresUnreferencedCode("This API is not compatible with trimming. For dynamic mapping via Dictionary<string, object?>, use GetCollectionDynamic() instead.")]
-    public abstract VectorStoreCollection<TKey, TRecord> GetCollection<TKey, TRecord>(string name, VectorStoreRecordDefinition? vectorStoreRecordDefinition = null)
+    public abstract VectorStoreCollection<TKey, TRecord> GetCollection<TKey, TRecord>(string name, VectorStoreCollectionDefinition? definition = null)
         where TKey : notnull
         where TRecord : class;
 
@@ -42,9 +42,9 @@ public abstract class VectorStore : IDisposable
     /// Gets a collection from the vector store, using dynamic mapping; the record type is represented as a <see cref="Dictionary{TKey, TValue}"/>.
     /// </summary>
     /// <param name="name">The name of the collection.</param>
-    /// <param name="vectorStoreRecordDefinition">The schema of the record type.</param>
+    /// <param name="definition">The schema of the record type.</param>
     /// <returns>A new <see cref="VectorStoreCollection{TKey, TRecord}"/> instance for managing the records in the collection.</returns>
-    public abstract VectorStoreCollection<object, Dictionary<string, object?>> GetDynamicCollection(string name, VectorStoreRecordDefinition vectorStoreRecordDefinition);
+    public abstract VectorStoreCollection<object, Dictionary<string, object?>> GetDynamicCollection(string name, VectorStoreCollectionDefinition definition);
 
     /// <summary>
     /// Retrieves the names of all the collections in the vector store.

--- a/dotnet/src/Connectors/VectorData.Abstractions/VectorStorage/VectorStoreCollectionOptions.cs
+++ b/dotnet/src/Connectors/VectorData.Abstractions/VectorStorage/VectorStoreCollectionOptions.cs
@@ -31,7 +31,7 @@ public abstract class VectorStoreCollectionOptions
     /// In this case, the record model properties must be annotated with the appropriate attributes to indicate their usage.
     /// See <see cref="VectorStoreKeyAttribute"/>, <see cref="VectorStoreDataAttribute"/> and <see cref="VectorStoreVectorAttribute"/>.
     /// </remarks>
-    public VectorStoreRecordDefinition? Definition { get; set; }
+    public VectorStoreCollectionDefinition? Definition { get; set; }
 
     /// <summary>
     /// The default embedding generator to use when generating vectors embeddings with this collection.

--- a/dotnet/src/Connectors/VectorData.UnitTests/CollectionModelBuilderTests.cs
+++ b/dotnet/src/Connectors/VectorData.UnitTests/CollectionModelBuilderTests.cs
@@ -34,7 +34,7 @@ public class CollectionModelBuilderTests
     {
         using var embeddingGenerator = new FakeEmbeddingGenerator<string, Embedding<Half>>();
 
-        var recordDefinition = new VectorStoreRecordDefinition
+        var recordDefinition = new VectorStoreCollectionDefinition
         {
             Properties =
             [
@@ -61,7 +61,7 @@ public class CollectionModelBuilderTests
     {
         using var embeddingGenerator = new FakeEmbeddingGenerator<string, Embedding<float>>();
 
-        var recordDefinition = new VectorStoreRecordDefinition
+        var recordDefinition = new VectorStoreCollectionDefinition
         {
             Properties =
             [
@@ -84,7 +84,7 @@ public class CollectionModelBuilderTests
     {
         using var embeddingGenerator = new FakeEmbeddingGenerator<string, Embedding<Half>>();
 
-        var recordDefinition = new VectorStoreRecordDefinition
+        var recordDefinition = new VectorStoreCollectionDefinition
         {
             Properties =
             [
@@ -110,7 +110,7 @@ public class CollectionModelBuilderTests
         using var propertyEmbeddingGenerator = new FakeEmbeddingGenerator<string, Embedding<float>>();
         using var defaultEmbeddingGenerator = new FakeEmbeddingGenerator<string, Embedding<float>>();
 
-        var recordDefinition = new VectorStoreRecordDefinition
+        var recordDefinition = new VectorStoreCollectionDefinition
         {
             Properties =
             [
@@ -137,7 +137,7 @@ public class CollectionModelBuilderTests
 
         var model = dynamic
             ? new CustomModelBuilder().BuildDynamic(
-                new VectorStoreRecordDefinition
+                new VectorStoreCollectionDefinition
                 {
                     Properties =
                     [
@@ -161,7 +161,7 @@ public class CollectionModelBuilderTests
 
         var model = new CustomModelBuilder().Build(
             typeof(RecordWithEmbeddingVectorProperty),
-            new VectorStoreRecordDefinition
+            new VectorStoreCollectionDefinition
             {
                 Properties =
                 [
@@ -188,7 +188,7 @@ public class CollectionModelBuilderTests
         using var embeddingGenerator = new FakeEmbeddingGenerator<Customer, Embedding<float>>();
 
         // TODO: Allow custom input type without a record definition (i.e. generic attribute)
-        var recordDefinition = new VectorStoreRecordDefinition
+        var recordDefinition = new VectorStoreCollectionDefinition
         {
             Properties =
             [
@@ -247,7 +247,7 @@ public class CollectionModelBuilderTests
     {
         using var embeddingGenerator = new FakeEmbeddingGenerator<string, Embedding<Half>>();
 
-        var recordDefinition = new VectorStoreRecordDefinition
+        var recordDefinition = new VectorStoreCollectionDefinition
         {
             Properties =
             [
@@ -271,7 +271,7 @@ public class CollectionModelBuilderTests
     {
         using var embeddingGenerator = new FakeEmbeddingGenerator<string, Embedding<float>>();
 
-        var recordDefinition = new VectorStoreRecordDefinition
+        var recordDefinition = new VectorStoreCollectionDefinition
         {
             Properties =
             [

--- a/dotnet/src/IntegrationTests/Connectors/Memory/AzureAISearch/AzureAISearchVectorStoreFixture.cs
+++ b/dotnet/src/IntegrationTests/Connectors/Memory/AzureAISearch/AzureAISearchVectorStoreFixture.cs
@@ -65,7 +65,7 @@ public class AzureAISearchVectorStoreFixture : IAsyncLifetime
         Assert.NotNull(config);
         this.Config = config;
         this.SearchIndexClient = new SearchIndexClient(new Uri(config.ServiceUrl), new AzureKeyCredential(config.ApiKey));
-        this.VectorStoreRecordDefinition = new VectorStoreRecordDefinition
+        this.VectorStoreRecordDefinition = new VectorStoreCollectionDefinition
         {
             Properties = new List<VectorStoreProperty>
             {
@@ -102,7 +102,7 @@ public class AzureAISearchVectorStoreFixture : IAsyncLifetime
     /// <summary>
     /// Gets the manually created vector store record definition for our test model.
     /// </summary>
-    public VectorStoreRecordDefinition VectorStoreRecordDefinition { get; private set; }
+    public VectorStoreCollectionDefinition VectorStoreRecordDefinition { get; private set; }
 
     /// <summary>
     /// Gets the configuration for the Azure AI Search service.

--- a/dotnet/src/IntegrationTests/Connectors/Memory/BaseVectorStoreRecordCollectionTests.cs
+++ b/dotnet/src/IntegrationTests/Connectors/Memory/BaseVectorStoreRecordCollectionTests.cs
@@ -24,7 +24,7 @@ public abstract class BaseVectorStoreRecordCollectionTests<TKey>
 
     protected abstract HashSet<string> GetSupportedDistanceFunctions();
 
-    protected abstract VectorStoreCollection<TKey, TRecord> GetTargetRecordCollection<TRecord>(string recordCollectionName, VectorStoreRecordDefinition? vectorStoreRecordDefinition) where TRecord : class;
+    protected abstract VectorStoreCollection<TKey, TRecord> GetTargetRecordCollection<TRecord>(string recordCollectionName, VectorStoreCollectionDefinition? definition) where TRecord : class;
 
     protected virtual int DelayAfterIndexCreateInMilliseconds { get; } = 0;
 
@@ -115,9 +115,9 @@ public abstract class BaseVectorStoreRecordCollectionTests<TKey>
         await sut.EnsureCollectionDeletedAsync();
     }
 
-    private static VectorStoreRecordDefinition CreateKeyWithVectorRecordDefinition(int vectorDimensions, string distanceFunction)
+    private static VectorStoreCollectionDefinition CreateKeyWithVectorRecordDefinition(int vectorDimensions, string distanceFunction)
     {
-        var definition = new VectorStoreRecordDefinition
+        var definition = new VectorStoreCollectionDefinition
         {
             Properties =
             [

--- a/dotnet/src/IntegrationTests/Connectors/Memory/CosmosMongoDB/CosmosMongoCollectionTests.cs
+++ b/dotnet/src/IntegrationTests/Connectors/Memory/CosmosMongoDB/CosmosMongoCollectionTests.cs
@@ -210,7 +210,7 @@ public class CosmosMongoCollectionTests(CosmosMongoVectorStoreFixture fixture)
     public async Task UpsertWithModelWorksCorrectlyAsync()
     {
         // Arrange
-        var definition = new VectorStoreRecordDefinition
+        var definition = new VectorStoreCollectionDefinition
         {
             Properties = new List<VectorStoreProperty>
             {
@@ -258,7 +258,7 @@ public class CosmosMongoCollectionTests(CosmosMongoVectorStoreFixture fixture)
     public async Task UpsertWithBsonModelWorksCorrectlyAsync()
     {
         // Arrange
-        var definition = new VectorStoreRecordDefinition
+        var definition = new VectorStoreCollectionDefinition
         {
             Properties = new List<VectorStoreProperty>
             {

--- a/dotnet/src/IntegrationTests/Connectors/Memory/CosmosMongoDB/CosmosMongoVectorStoreFixture.cs
+++ b/dotnet/src/IntegrationTests/Connectors/Memory/CosmosMongoDB/CosmosMongoVectorStoreFixture.cs
@@ -21,7 +21,7 @@ public class CosmosMongoVectorStoreFixture : IAsyncLifetime
     public IMongoDatabase MongoDatabase { get; }
 
     /// <summary>Gets the manually created vector store record definition for Azure CosmosDB MongoDB test model.</summary>
-    public VectorStoreRecordDefinition HotelVectorStoreRecordDefinition { get; private set; }
+    public VectorStoreCollectionDefinition HotelVectorStoreRecordDefinition { get; private set; }
 
     /// <summary>
     /// Initializes a new instance of the <see cref="CosmosMongoVectorStoreFixture"/> class.

--- a/dotnet/src/IntegrationTests/Connectors/Memory/CosmosNoSql/CosmosNoSqlCollectionTests.cs
+++ b/dotnet/src/IntegrationTests/Connectors/Memory/CosmosNoSql/CosmosNoSqlCollectionTests.cs
@@ -431,7 +431,7 @@ public sealed class CosmosNoSqlCollectionTests(CosmosNoSqlVectorStoreFixture fix
         };
     }
 
-    private VectorStoreRecordDefinition GetTestHotelRecordDefinition()
+    private VectorStoreCollectionDefinition GetTestHotelRecordDefinition()
     {
         return new()
         {

--- a/dotnet/src/IntegrationTests/Connectors/Memory/InMemory/CommonInMemoryVectorStoreRecordCollectionTests.cs
+++ b/dotnet/src/IntegrationTests/Connectors/Memory/InMemory/CommonInMemoryVectorStoreRecordCollectionTests.cs
@@ -16,11 +16,11 @@ public class CommonInMemoryVectorStoreRecordCollectionTests() : BaseVectorStoreR
     protected override string Key3 => "3";
     protected override string Key4 => "4";
 
-    protected override VectorStoreCollection<string, TRecord> GetTargetRecordCollection<TRecord>(string recordCollectionName, VectorStoreRecordDefinition? vectorStoreRecordDefinition)
+    protected override VectorStoreCollection<string, TRecord> GetTargetRecordCollection<TRecord>(string recordCollectionName, VectorStoreCollectionDefinition? definition)
     {
         return new InMemoryCollection<string, TRecord>(recordCollectionName, new()
         {
-            Definition = vectorStoreRecordDefinition
+            Definition = definition
         });
     }
 

--- a/dotnet/src/IntegrationTests/Connectors/Memory/MongoDB/MongoDBVectorStoreFixture.cs
+++ b/dotnet/src/IntegrationTests/Connectors/Memory/MongoDB/MongoDBVectorStoreFixture.cs
@@ -29,7 +29,7 @@ public class MongoDBVectorStoreFixture : IAsyncLifetime
     public IMongoDatabase MongoDatabase { get; private set; }
 
     /// <summary>Gets the manually created vector store record definition for MongoDB test model.</summary>
-    public VectorStoreRecordDefinition HotelVectorStoreRecordDefinition { get; private set; }
+    public VectorStoreCollectionDefinition HotelVectorStoreRecordDefinition { get; private set; }
 
     public async Task InitializeAsync()
     {

--- a/dotnet/src/IntegrationTests/Connectors/Memory/MongoDB/MongoDBVectorStoreRecordCollectionTests.cs
+++ b/dotnet/src/IntegrationTests/Connectors/Memory/MongoDB/MongoDBVectorStoreRecordCollectionTests.cs
@@ -209,7 +209,7 @@ public class MongoDBVectorStoreRecordCollectionTests(MongoDBVectorStoreFixture f
     public async Task UpsertWithModelWorksCorrectlyAsync()
     {
         // Arrange
-        var definition = new VectorStoreRecordDefinition
+        var definition = new VectorStoreCollectionDefinition
         {
             Properties = new List<VectorStoreProperty>
             {
@@ -257,7 +257,7 @@ public class MongoDBVectorStoreRecordCollectionTests(MongoDBVectorStoreFixture f
     public async Task UpsertWithBsonModelWorksCorrectlyAsync()
     {
         // Arrange
-        var definition = new VectorStoreRecordDefinition
+        var definition = new VectorStoreCollectionDefinition
         {
             Properties = new List<VectorStoreProperty>
             {

--- a/dotnet/src/IntegrationTests/Connectors/Memory/PgVector/CommonPostgresVectorStoreRecordCollectionTests.cs
+++ b/dotnet/src/IntegrationTests/Connectors/Memory/PgVector/CommonPostgresVectorStoreRecordCollectionTests.cs
@@ -19,11 +19,11 @@ public class CommonPostgresVectorStoreRecordCollectionTests(PostgresVectorStoreF
     protected override string Key3 => "3";
     protected override string Key4 => "4";
 
-    protected override VectorStoreCollection<string, TRecord> GetTargetRecordCollection<TRecord>(string recordCollectionName, VectorStoreRecordDefinition? vectorStoreRecordDefinition)
+    protected override VectorStoreCollection<string, TRecord> GetTargetRecordCollection<TRecord>(string recordCollectionName, VectorStoreCollectionDefinition? definition)
     {
         return new PostgresCollection<string, TRecord>(fixture.DataSource!, recordCollectionName, ownsDataSource: false, new()
         {
-            Definition = vectorStoreRecordDefinition
+            Definition = definition
         });
     }
 

--- a/dotnet/src/IntegrationTests/Connectors/Memory/PgVector/PostgresVectorStoreFixture.cs
+++ b/dotnet/src/IntegrationTests/Connectors/Memory/PgVector/PostgresVectorStoreFixture.cs
@@ -54,7 +54,7 @@ public class PostgresVectorStoreFixture : IAsyncLifetime
 
     public VectorStoreCollection<TKey, TRecord> GetCollection<TKey, TRecord>(
         string collectionName,
-        VectorStoreRecordDefinition? recordDefinition = default)
+        VectorStoreCollectionDefinition? recordDefinition = default)
         where TKey : notnull
         where TRecord : class
     {

--- a/dotnet/src/IntegrationTests/Connectors/Memory/PgVector/PostgresVectorStoreRecordCollectionTests.cs
+++ b/dotnet/src/IntegrationTests/Connectors/Memory/PgVector/PostgresVectorStoreRecordCollectionTests.cs
@@ -492,7 +492,7 @@ public sealed class PostgresVectorStoreRecordCollectionTests(PostgresVectorStore
 
     #region private ==================================================================================
 
-    private static VectorStoreRecordDefinition GetVectorStoreRecordDefinition<TKey>(string distanceFunction = DistanceFunction.CosineDistance) => new()
+    private static VectorStoreCollectionDefinition GetVectorStoreRecordDefinition<TKey>(string distanceFunction = DistanceFunction.CosineDistance) => new()
     {
         Properties =
         [

--- a/dotnet/src/IntegrationTests/Connectors/Memory/Qdrant/CommonQdrantVectorStoreRecordCollectionTests.cs
+++ b/dotnet/src/IntegrationTests/Connectors/Memory/Qdrant/CommonQdrantVectorStoreRecordCollectionTests.cs
@@ -19,12 +19,12 @@ public class CommonQdrantVectorStoreRecordCollectionTests(QdrantVectorStoreFixtu
     protected override ulong Key3 => 3;
     protected override ulong Key4 => 4;
 
-    protected override VectorStoreCollection<ulong, TRecord> GetTargetRecordCollection<TRecord>(string recordCollectionName, VectorStoreRecordDefinition? vectorStoreRecordDefinition)
+    protected override VectorStoreCollection<ulong, TRecord> GetTargetRecordCollection<TRecord>(string recordCollectionName, VectorStoreCollectionDefinition? definition)
     {
         return new QdrantCollection<ulong, TRecord>(fixture.QdrantClient, recordCollectionName, ownsClient: false, new()
         {
             HasNamedVectors = true,
-            Definition = vectorStoreRecordDefinition
+            Definition = definition
         });
     }
 

--- a/dotnet/src/IntegrationTests/Connectors/Memory/Qdrant/QdrantVectorStoreFixture.cs
+++ b/dotnet/src/IntegrationTests/Connectors/Memory/Qdrant/QdrantVectorStoreFixture.cs
@@ -48,7 +48,7 @@ public class QdrantVectorStoreFixture : IAsyncLifetime
     {
         using var dockerClientConfiguration = new DockerClientConfiguration();
         this._client = dockerClientConfiguration.CreateClient();
-        this.HotelVectorStoreRecordDefinition = new VectorStoreRecordDefinition
+        this.HotelVectorStoreRecordDefinition = new VectorStoreCollectionDefinition
         {
             Properties = new List<VectorStoreProperty>
             {
@@ -63,7 +63,7 @@ public class QdrantVectorStoreFixture : IAsyncLifetime
                 new VectorStoreVectorProperty("DescriptionEmbedding", typeof(ReadOnlyMemory<float>?), VectorDimensions) { DistanceFunction = DistanceFunction.ManhattanDistance }
             }
         };
-        this.HotelWithGuidIdVectorStoreRecordDefinition = new VectorStoreRecordDefinition
+        this.HotelWithGuidIdVectorStoreRecordDefinition = new VectorStoreCollectionDefinition
         {
             Properties = new List<VectorStoreProperty>
             {
@@ -94,10 +94,10 @@ public class QdrantVectorStoreFixture : IAsyncLifetime
     public ITextEmbeddingGenerationService EmbeddingGenerator { get; private set; }
 
     /// <summary>Gets the manually created vector store record definition for our test model.</summary>
-    public VectorStoreRecordDefinition HotelVectorStoreRecordDefinition { get; private set; }
+    public VectorStoreCollectionDefinition HotelVectorStoreRecordDefinition { get; private set; }
 
     /// <summary>Gets the manually created vector store record definition for our test model.</summary>
-    public VectorStoreRecordDefinition HotelWithGuidIdVectorStoreRecordDefinition { get; private set; }
+    public VectorStoreCollectionDefinition HotelWithGuidIdVectorStoreRecordDefinition { get; private set; }
 
     /// <summary>
     /// Create / Recreate qdrant docker container and run it.

--- a/dotnet/src/IntegrationTests/Connectors/Memory/Redis/CommonRedisHashsetVectorStoreRecordCollectionTests.cs
+++ b/dotnet/src/IntegrationTests/Connectors/Memory/Redis/CommonRedisHashsetVectorStoreRecordCollectionTests.cs
@@ -21,11 +21,11 @@ public class CommonRedisHashsetVectorStoreRecordCollectionTests(RedisVectorStore
     protected override string Key3 => "3";
     protected override string Key4 => "4";
 
-    protected override VectorStoreCollection<string, TRecord> GetTargetRecordCollection<TRecord>(string recordCollectionName, VectorStoreRecordDefinition? vectorStoreRecordDefinition)
+    protected override VectorStoreCollection<string, TRecord> GetTargetRecordCollection<TRecord>(string recordCollectionName, VectorStoreCollectionDefinition? definition)
     {
         return new RedisHashSetCollection<string, TRecord>(fixture.Database, recordCollectionName + "hashset", new()
         {
-            Definition = vectorStoreRecordDefinition
+            Definition = definition
         });
     }
 

--- a/dotnet/src/IntegrationTests/Connectors/Memory/Redis/CommonRedisJsonVectorStoreRecordCollectionTests.cs
+++ b/dotnet/src/IntegrationTests/Connectors/Memory/Redis/CommonRedisJsonVectorStoreRecordCollectionTests.cs
@@ -21,11 +21,11 @@ public class CommonRedisJsonVectorStoreRecordCollectionTests(RedisVectorStoreFix
     protected override string Key3 => "3";
     protected override string Key4 => "4";
 
-    protected override VectorStoreCollection<string, TRecord> GetTargetRecordCollection<TRecord>(string recordCollectionName, VectorStoreRecordDefinition? vectorStoreRecordDefinition)
+    protected override VectorStoreCollection<string, TRecord> GetTargetRecordCollection<TRecord>(string recordCollectionName, VectorStoreCollectionDefinition? definition)
     {
         return new RedisJsonCollection<string, TRecord>(fixture.Database, recordCollectionName + "json", new()
         {
-            Definition = vectorStoreRecordDefinition
+            Definition = definition
         });
     }
 

--- a/dotnet/src/IntegrationTests/Connectors/Memory/Redis/RedisVectorStoreFixture.cs
+++ b/dotnet/src/IntegrationTests/Connectors/Memory/Redis/RedisVectorStoreFixture.cs
@@ -35,7 +35,7 @@ public class RedisVectorStoreFixture : IAsyncLifetime
     {
         using var dockerClientConfiguration = new DockerClientConfiguration();
         this._client = dockerClientConfiguration.CreateClient();
-        this.VectorStoreRecordDefinition = new VectorStoreRecordDefinition
+        this.VectorStoreRecordDefinition = new VectorStoreCollectionDefinition
         {
             Properties = new List<VectorStoreProperty>
             {
@@ -52,7 +52,7 @@ public class RedisVectorStoreFixture : IAsyncLifetime
                 new VectorStoreDataProperty("Address", typeof(RedisHotelAddress))
             }
         };
-        this.BasicVectorStoreRecordDefinition = new VectorStoreRecordDefinition
+        this.BasicVectorStoreRecordDefinition = new VectorStoreCollectionDefinition
         {
             Properties = new List<VectorStoreProperty>
             {
@@ -71,10 +71,10 @@ public class RedisVectorStoreFixture : IAsyncLifetime
     public IDatabase Database { get; private set; }
 
     /// <summary>Gets the manually created vector store record definition for our test model.</summary>
-    public VectorStoreRecordDefinition VectorStoreRecordDefinition { get; private set; }
+    public VectorStoreCollectionDefinition VectorStoreRecordDefinition { get; private set; }
 
     /// <summary>Gets the manually created vector store record definition for our basic test model.</summary>
-    public VectorStoreRecordDefinition BasicVectorStoreRecordDefinition { get; private set; }
+    public VectorStoreCollectionDefinition BasicVectorStoreRecordDefinition { get; private set; }
 
     /// <summary>
     /// Create / Recreate redis docker container, create an index and add test data.

--- a/dotnet/src/IntegrationTests/Connectors/Memory/SqliteVec/SqliteVectorStoreRecordCollectionTests.cs
+++ b/dotnet/src/IntegrationTests/Connectors/Memory/SqliteVec/SqliteVectorStoreRecordCollectionTests.cs
@@ -512,7 +512,7 @@ public sealed class SqliteVectorStoreRecordCollectionTests(SqliteVectorStoreFixt
 
     #region
 
-    private static VectorStoreRecordDefinition GetVectorStoreRecordDefinition<TKey>() => new()
+    private static VectorStoreCollectionDefinition GetVectorStoreRecordDefinition<TKey>() => new()
     {
         Properties =
         [

--- a/dotnet/src/IntegrationTests/Connectors/Memory/Weaviate/CommonWeaviateVectorStoreRecordCollectionTests.cs
+++ b/dotnet/src/IntegrationTests/Connectors/Memory/Weaviate/CommonWeaviateVectorStoreRecordCollectionTests.cs
@@ -24,7 +24,7 @@ public class CommonWeaviateVectorStoreRecordCollectionTests(WeaviateVectorStoreF
 
     protected override int DelayAfterUploadInMilliseconds => 1000;
 
-    protected override VectorStoreCollection<Guid, TRecord> GetTargetRecordCollection<TRecord>(string recordCollectionName, VectorStoreRecordDefinition? vectorStoreRecordDefinition)
+    protected override VectorStoreCollection<Guid, TRecord> GetTargetRecordCollection<TRecord>(string recordCollectionName, VectorStoreCollectionDefinition? definition)
     {
         // Weaviate collection names must start with an upper case letter.
         var recordCollectionNameChars = recordCollectionName.ToCharArray();
@@ -32,7 +32,7 @@ public class CommonWeaviateVectorStoreRecordCollectionTests(WeaviateVectorStoreF
 
         return new WeaviateCollection<Guid, TRecord>(fixture.HttpClient!, new string(recordCollectionNameChars), new()
         {
-            Definition = vectorStoreRecordDefinition
+            Definition = definition
         });
     }
 

--- a/dotnet/src/IntegrationTests/Connectors/Memory/Weaviate/WeaviateVectorStoreRecordCollectionTests.cs
+++ b/dotnet/src/IntegrationTests/Connectors/Memory/Weaviate/WeaviateVectorStoreRecordCollectionTests.cs
@@ -449,7 +449,7 @@ public sealed class WeaviateVectorStoreRecordCollectionTests(WeaviateVectorStore
         };
     }
 
-    private VectorStoreRecordDefinition GetTestHotelRecordDefinition()
+    private VectorStoreCollectionDefinition GetTestHotelRecordDefinition()
     {
         return new()
         {

--- a/dotnet/src/InternalUtilities/connectors/Memory/MongoDB/MongoModelBuilder.cs
+++ b/dotnet/src/InternalUtilities/connectors/Memory/MongoDB/MongoModelBuilder.cs
@@ -28,7 +28,7 @@ internal class MongoModelBuilder() : CollectionModelBuilder(s_validationOptions)
     };
 
     [RequiresUnreferencedCode("Traverses the CLR type's properties with reflection, so not compatible with trimming")]
-    protected override void ProcessTypeProperties(Type type, VectorStoreRecordDefinition? definition)
+    protected override void ProcessTypeProperties(Type type, VectorStoreCollectionDefinition? definition)
     {
         base.ProcessTypeProperties(type, definition);
 

--- a/dotnet/src/VectorDataIntegrationTests/PineconeIntegrationTests/Support/PineconeAllTypes.cs
+++ b/dotnet/src/VectorDataIntegrationTests/PineconeIntegrationTests/Support/PineconeAllTypes.cs
@@ -73,7 +73,7 @@ public record PineconeAllTypes()
         Assert.Equal(this.Embedding!.Value.ToArray(), other.Embedding!.Value.ToArray());
     }
 
-    internal static VectorStoreRecordDefinition GetRecordDefinition()
+    internal static VectorStoreCollectionDefinition GetRecordDefinition()
         => new()
         {
             Properties =

--- a/dotnet/src/VectorDataIntegrationTests/RedisIntegrationTests/Filter/RedisBasicFilterTests.cs
+++ b/dotnet/src/VectorDataIntegrationTests/RedisIntegrationTests/Filter/RedisBasicFilterTests.cs
@@ -78,7 +78,7 @@ public class RedisJsonCollectionBasicFilterTests(RedisJsonCollectionBasicFilterT
         public override string CollectionName => "JsonCollectionFilterTests";
 
         // Override to remove the bool property, which isn't (currently) supported on Redis/JSON
-        public override VectorStoreRecordDefinition CreateRecordDefinition()
+        public override VectorStoreCollectionDefinition CreateRecordDefinition()
             => new()
             {
                 Properties = base.CreateRecordDefinition().Properties.Where(p => p.Type != typeof(bool)).ToList()
@@ -130,7 +130,7 @@ public class RedisHashSetCollectionBasicFilterTests(RedisHashSetCollectionBasicF
         public override string CollectionName => "HashSetCollectionFilterTests";
 
         // Override to remove the bool property, which isn't (currently) supported on Redis
-        public override VectorStoreRecordDefinition CreateRecordDefinition()
+        public override VectorStoreCollectionDefinition CreateRecordDefinition()
             => new()
             {
                 Properties = base.CreateRecordDefinition().Properties.Where(p =>

--- a/dotnet/src/VectorDataIntegrationTests/RedisIntegrationTests/Filter/RedisBasicQueryTests.cs
+++ b/dotnet/src/VectorDataIntegrationTests/RedisIntegrationTests/Filter/RedisBasicQueryTests.cs
@@ -78,7 +78,7 @@ public class RedisJsonCollectionBasicQueryTests(RedisJsonCollectionBasicQueryTes
         public override string CollectionName => "JsonCollectionQueryTests";
 
         // Override to remove the bool property, which isn't (currently) supported on Redis/JSON
-        public override VectorStoreRecordDefinition CreateRecordDefinition()
+        public override VectorStoreCollectionDefinition CreateRecordDefinition()
             => new()
             {
                 Properties = base.CreateRecordDefinition().Properties.Where(p => p.Type != typeof(bool)).ToList()
@@ -122,7 +122,7 @@ public class RedisHashSetCollectionBasicQueryTests(RedisHashSetCollectionBasicQu
         public override string CollectionName => "HashSetCollectionQueryTests";
 
         // Override to remove the bool property, which isn't (currently) supported on Redis
-        public override VectorStoreRecordDefinition CreateRecordDefinition()
+        public override VectorStoreCollectionDefinition CreateRecordDefinition()
             => new()
             {
                 Properties = base.CreateRecordDefinition().Properties.Where(p =>

--- a/dotnet/src/VectorDataIntegrationTests/SqlServerIntegrationTests/Filter/SqlServerBasicFilterTests.cs
+++ b/dotnet/src/VectorDataIntegrationTests/SqlServerIntegrationTests/Filter/SqlServerBasicFilterTests.cs
@@ -67,7 +67,7 @@ public class SqlServerBasicFilterTests(SqlServerBasicFilterTests.Fixture fixture
         public override string CollectionName => s_uniqueName;
 
         // Override to remove the string collection properties, which aren't (currently) supported on SqlServer
-        public override VectorStoreRecordDefinition CreateRecordDefinition()
+        public override VectorStoreCollectionDefinition CreateRecordDefinition()
             => new()
             {
                 Properties = base.CreateRecordDefinition().Properties.Where(p => p.Type != typeof(string[]) && p.Type != typeof(List<string>)).ToList()

--- a/dotnet/src/VectorDataIntegrationTests/SqlServerIntegrationTests/Filter/SqlServerBasicQueryTests.cs
+++ b/dotnet/src/VectorDataIntegrationTests/SqlServerIntegrationTests/Filter/SqlServerBasicQueryTests.cs
@@ -51,7 +51,7 @@ public class SqlServerBasicQueryTests(SqlServerBasicQueryTests.Fixture fixture)
         public override string CollectionName => s_uniqueName;
 
         // Override to remove the string collection properties, which aren't (currently) supported on SqlServer
-        public override VectorStoreRecordDefinition CreateRecordDefinition()
+        public override VectorStoreCollectionDefinition CreateRecordDefinition()
             => new()
             {
                 Properties = base.CreateRecordDefinition().Properties.Where(p => p.Type != typeof(string[]) && p.Type != typeof(List<string>)).ToList()

--- a/dotnet/src/VectorDataIntegrationTests/SqliteVecIntegrationTests/Filter/SqliteBasicFilterTests.cs
+++ b/dotnet/src/VectorDataIntegrationTests/SqliteVecIntegrationTests/Filter/SqliteBasicFilterTests.cs
@@ -58,7 +58,7 @@ public class SqliteBasicFilterTests(SqliteBasicFilterTests.Fixture fixture)
         public override TestStore TestStore => SqliteTestStore.Instance;
 
         // Override to remove the string array property, which isn't (currently) supported on SQLite
-        public override VectorStoreRecordDefinition CreateRecordDefinition()
+        public override VectorStoreCollectionDefinition CreateRecordDefinition()
             => new()
             {
                 Properties = base.CreateRecordDefinition().Properties.Where(p => p.Type != typeof(string[]) && p.Type != typeof(List<string>)).ToList()

--- a/dotnet/src/VectorDataIntegrationTests/SqliteVecIntegrationTests/Filter/SqliteBasicQueryTests.cs
+++ b/dotnet/src/VectorDataIntegrationTests/SqliteVecIntegrationTests/Filter/SqliteBasicQueryTests.cs
@@ -49,7 +49,7 @@ public class SqliteBasicQueryTests(SqliteBasicQueryTests.Fixture fixture)
         public override TestStore TestStore => SqliteTestStore.Instance;
 
         // Override to remove the string array property, which isn't (currently) supported on SQLite
-        public override VectorStoreRecordDefinition CreateRecordDefinition()
+        public override VectorStoreCollectionDefinition CreateRecordDefinition()
             => new()
             {
                 Properties = base.CreateRecordDefinition().Properties.Where(p => p.Type != typeof(string[]) && p.Type != typeof(List<string>)).ToList()

--- a/dotnet/src/VectorDataIntegrationTests/VectorDataIntegrationTests/CRUD/NoDataConformanceTests.cs
+++ b/dotnet/src/VectorDataIntegrationTests/VectorDataIntegrationTests/CRUD/NoDataConformanceTests.cs
@@ -148,7 +148,7 @@ public class NoDataConformanceTests<TKey>(NoDataConformanceTests<TKey>.Fixture f
             }
         ];
 
-        public override VectorStoreRecordDefinition CreateRecordDefinition()
+        public override VectorStoreCollectionDefinition CreateRecordDefinition()
             => new()
             {
                 Properties =

--- a/dotnet/src/VectorDataIntegrationTests/VectorDataIntegrationTests/CRUD/NoVectorConformanceTests.cs
+++ b/dotnet/src/VectorDataIntegrationTests/VectorDataIntegrationTests/CRUD/NoVectorConformanceTests.cs
@@ -141,7 +141,7 @@ public class NoVectorConformanceTests<TKey>(NoVectorConformanceTests<TKey>.Fixtu
             }
         ];
 
-        public override VectorStoreRecordDefinition CreateRecordDefinition()
+        public override VectorStoreCollectionDefinition CreateRecordDefinition()
             => new()
             {
                 Properties =

--- a/dotnet/src/VectorDataIntegrationTests/VectorDataIntegrationTests/Collections/CollectionConformanceTests.cs
+++ b/dotnet/src/VectorDataIntegrationTests/VectorDataIntegrationTests/Collections/CollectionConformanceTests.cs
@@ -92,7 +92,7 @@ public abstract class CollectionConformanceTests<TKey>(VectorStoreFixture fixtur
     public virtual VectorStoreCollection<TKey, SimpleRecord<TKey>> GetCollection()
         => fixture.TestStore.DefaultVectorStore.GetCollection<TKey, SimpleRecord<TKey>>(this.CollectionName, this.CreateRecordDefinition());
 
-    public virtual VectorStoreRecordDefinition CreateRecordDefinition()
+    public virtual VectorStoreCollectionDefinition CreateRecordDefinition()
         => new()
         {
             Properties =

--- a/dotnet/src/VectorDataIntegrationTests/VectorDataIntegrationTests/DependencyInjectionTests.cs
+++ b/dotnet/src/VectorDataIntegrationTests/VectorDataIntegrationTests/DependencyInjectionTests.cs
@@ -243,8 +243,8 @@ public abstract class DependencyInjectionTests<TVectorStore, TCollection, TKey, 
     {
         public override Task<bool> CollectionExistsAsync(string name, CancellationToken cancellationToken = default) => throw new NotImplementedException();
         public override Task EnsureCollectionDeletedAsync(string name, CancellationToken cancellationToken = default) => throw new NotImplementedException();
-        public override VectorStoreCollection<TKey1, TRecord1> GetCollection<TKey1, TRecord1>(string name, VectorStoreRecordDefinition? vectorStoreRecordDefinition = null) => throw new NotImplementedException();
-        public override VectorStoreCollection<object, Dictionary<string, object?>> GetDynamicCollection(string name, VectorStoreRecordDefinition? vectorStoreRecordDefinition = null) => throw new NotImplementedException();
+        public override VectorStoreCollection<TKey1, TRecord1> GetCollection<TKey1, TRecord1>(string name, VectorStoreCollectionDefinition? definition = null) => throw new NotImplementedException();
+        public override VectorStoreCollection<object, Dictionary<string, object?>> GetDynamicCollection(string name, VectorStoreCollectionDefinition? definition = null) => throw new NotImplementedException();
         public override object? GetService(Type serviceType, object? serviceKey = null) => throw new NotImplementedException();
         public override IAsyncEnumerable<string> ListCollectionNamesAsync(CancellationToken cancellationToken = default) => throw new NotImplementedException();
     }

--- a/dotnet/src/VectorDataIntegrationTests/VectorDataIntegrationTests/EmbeddingGenerationTests.cs
+++ b/dotnet/src/VectorDataIntegrationTests/VectorDataIntegrationTests/EmbeddingGenerationTests.cs
@@ -106,7 +106,7 @@ public abstract class EmbeddingGenerationTests<TKey>(EmbeddingGenerationTests<TK
     [ConditionalFact]
     public virtual async Task SearchAsync_with_custom_input_type()
     {
-        var recordDefinition = new VectorStoreRecordDefinition()
+        var recordDefinition = new VectorStoreCollectionDefinition()
         {
             Properties = stringVectorFixture.CreateRecordDefinition().Properties
                 .Select(p => p is VectorStoreVectorProperty vectorProperty
@@ -410,7 +410,7 @@ public abstract class EmbeddingGenerationTests<TKey>(EmbeddingGenerationTests<TK
         return stringVectorFixture.GetDynamicCollection(vectorStore, stringVectorFixture.CollectionName, recordDefinition);
     }
 
-    private (VectorStore, VectorStoreRecordDefinition) GetStoreAndRecordDefinition(
+    private (VectorStore, VectorStoreCollectionDefinition) GetStoreAndRecordDefinition(
         bool storeGenerator = false,
         bool collectionGenerator = false,
         bool propertyGenerator = false)
@@ -441,7 +441,7 @@ public abstract class EmbeddingGenerationTests<TKey>(EmbeddingGenerationTests<TK
 
         public override string CollectionName => "EmbeddingGenerationTests";
 
-        public override VectorStoreRecordDefinition CreateRecordDefinition()
+        public override VectorStoreCollectionDefinition CreateRecordDefinition()
             => new()
             {
                 Properties =
@@ -487,14 +487,14 @@ public abstract class EmbeddingGenerationTests<TKey>(EmbeddingGenerationTests<TK
         public virtual VectorStoreCollection<TKey, TRecord> GetCollection<TRecord>(
             VectorStore vectorStore,
             string collectionName,
-            VectorStoreRecordDefinition? recordDefinition = null)
+            VectorStoreCollectionDefinition? recordDefinition = null)
             where TRecord : class
             => vectorStore.GetCollection<TKey, TRecord>(collectionName, recordDefinition);
 
         public virtual VectorStoreCollection<object, Dictionary<string, object?>> GetDynamicCollection(
             VectorStore vectorStore,
             string collectionName,
-            VectorStoreRecordDefinition recordDefinition)
+            VectorStoreCollectionDefinition recordDefinition)
             => vectorStore.GetDynamicCollection(collectionName, recordDefinition);
 
         public abstract VectorStore CreateVectorStore(IEmbeddingGenerator? embeddingGenerator = null);
@@ -512,7 +512,7 @@ public abstract class EmbeddingGenerationTests<TKey>(EmbeddingGenerationTests<TK
 
         public override string CollectionName => "SearchOnlyEmbeddingGenerationTests";
 
-        public override VectorStoreRecordDefinition CreateRecordDefinition()
+        public override VectorStoreCollectionDefinition CreateRecordDefinition()
             => new()
             {
                 Properties =
@@ -558,14 +558,14 @@ public abstract class EmbeddingGenerationTests<TKey>(EmbeddingGenerationTests<TK
         public virtual VectorStoreCollection<TKey, TRecord> GetCollection<TRecord>(
             VectorStore vectorStore,
             string collectionName,
-            VectorStoreRecordDefinition? recordDefinition = null)
+            VectorStoreCollectionDefinition? recordDefinition = null)
             where TRecord : class
             => vectorStore.GetCollection<TKey, TRecord>(collectionName, recordDefinition);
 
         public virtual VectorStoreCollection<object, Dictionary<string, object?>> GetDynamicCollection(
             VectorStore vectorStore,
             string collectionName,
-            VectorStoreRecordDefinition recordDefinition)
+            VectorStoreCollectionDefinition recordDefinition)
             => vectorStore.GetDynamicCollection(collectionName, recordDefinition);
 
         public abstract VectorStore CreateVectorStore(IEmbeddingGenerator? embeddingGenerator = null);

--- a/dotnet/src/VectorDataIntegrationTests/VectorDataIntegrationTests/EmbeddingTypeTests.cs
+++ b/dotnet/src/VectorDataIntegrationTests/VectorDataIntegrationTests/EmbeddingTypeTests.cs
@@ -198,7 +198,7 @@ public abstract class EmbeddingTypeTests<TKey>(EmbeddingTypeTests<TKey>.Fixture 
     {
         public virtual string CollectionName => "EmbeddingTypeTests";
 
-        public virtual VectorStoreRecordDefinition CreateRecordDefinition<TVectorProperty>(IEmbeddingGenerator? embeddingGenerator, string? distanceFunction, int dimensions)
+        public virtual VectorStoreCollectionDefinition CreateRecordDefinition<TVectorProperty>(IEmbeddingGenerator? embeddingGenerator, string? distanceFunction, int dimensions)
             => new()
             {
                 Properties =

--- a/dotnet/src/VectorDataIntegrationTests/VectorDataIntegrationTests/Filter/BasicFilterTests.cs
+++ b/dotnet/src/VectorDataIntegrationTests/VectorDataIntegrationTests/Filter/BasicFilterTests.cs
@@ -557,7 +557,7 @@ public abstract class BasicFilterTests<TKey>(BasicFilterTests<TKey>.Fixture fixt
             }
         }
 
-        public override VectorStoreRecordDefinition CreateRecordDefinition()
+        public override VectorStoreCollectionDefinition CreateRecordDefinition()
             => new()
             {
                 Properties =

--- a/dotnet/src/VectorDataIntegrationTests/VectorDataIntegrationTests/HybridSearch/KeywordVectorizedHybridSearchComplianceTests.cs
+++ b/dotnet/src/VectorDataIntegrationTests/VectorDataIntegrationTests/HybridSearch/KeywordVectorizedHybridSearchComplianceTests.cs
@@ -170,7 +170,7 @@ public abstract class KeywordVectorizedHybridSearchComplianceTests<TKey>(
     {
         public override string CollectionName => "KeywordHybridSearch" + this.GetUniqueCollectionName();
 
-        public override VectorStoreRecordDefinition CreateRecordDefinition()
+        public override VectorStoreCollectionDefinition CreateRecordDefinition()
             => new()
             {
                 Properties = new List<VectorStoreProperty>()
@@ -223,7 +223,7 @@ public abstract class KeywordVectorizedHybridSearchComplianceTests<TKey>(
     {
         public override string CollectionName => "KeywordHybridSearch" + this.GetUniqueCollectionName();
 
-        public override VectorStoreRecordDefinition CreateRecordDefinition()
+        public override VectorStoreCollectionDefinition CreateRecordDefinition()
             => new()
             {
                 Properties = new List<VectorStoreProperty>()

--- a/dotnet/src/VectorDataIntegrationTests/VectorDataIntegrationTests/Support/DynamicDataModelFixture.cs
+++ b/dotnet/src/VectorDataIntegrationTests/VectorDataIntegrationTests/Support/DynamicDataModelFixture.cs
@@ -15,7 +15,7 @@ public abstract class DynamicDataModelFixture<TKey> : VectorStoreCollectionFixtu
     protected override VectorStoreCollection<object, Dictionary<string, object?>> GetCollection()
         => this.TestStore.DefaultVectorStore.GetDynamicCollection(this.CollectionName, this.CreateRecordDefinition());
 
-    public override VectorStoreRecordDefinition CreateRecordDefinition()
+    public override VectorStoreCollectionDefinition CreateRecordDefinition()
         => new()
         {
             Properties =

--- a/dotnet/src/VectorDataIntegrationTests/VectorDataIntegrationTests/Support/SimpleModelFixture.cs
+++ b/dotnet/src/VectorDataIntegrationTests/VectorDataIntegrationTests/Support/SimpleModelFixture.cs
@@ -40,7 +40,7 @@ public abstract class SimpleModelFixture<TKey> : VectorStoreCollectionFixture<TK
         }
     ];
 
-    public override VectorStoreRecordDefinition CreateRecordDefinition()
+    public override VectorStoreCollectionDefinition CreateRecordDefinition()
         => new()
         {
             Properties =

--- a/dotnet/src/VectorDataIntegrationTests/VectorDataIntegrationTests/Support/VectorStoreCollectionFixture.cs
+++ b/dotnet/src/VectorDataIntegrationTests/VectorDataIntegrationTests/Support/VectorStoreCollectionFixture.cs
@@ -16,7 +16,7 @@ public abstract class VectorStoreCollectionFixture<TKey, TRecord> : VectorStoreF
 {
     private List<TRecord>? _testData;
 
-    public abstract VectorStoreRecordDefinition CreateRecordDefinition();
+    public abstract VectorStoreCollectionDefinition CreateRecordDefinition();
     protected abstract List<TRecord> BuildTestData();
 
     public virtual string CollectionName => Guid.NewGuid().ToString();

--- a/dotnet/src/VectorDataIntegrationTests/VectorDataIntegrationTests/VectorSearch/VectorSearchDistanceFunctionComplianceTests.cs
+++ b/dotnet/src/VectorDataIntegrationTests/VectorDataIntegrationTests/VectorSearch/VectorSearchDistanceFunctionComplianceTests.cs
@@ -157,7 +157,7 @@ public abstract class VectorSearchDistanceFunctionComplianceTests<TKey>(VectorSt
         }
     }
 
-    private VectorStoreRecordDefinition GetRecordDefinition(string distanceFunction)
+    private VectorStoreCollectionDefinition GetRecordDefinition(string distanceFunction)
         => new()
         {
             Properties =


### PR DESCRIPTION
One last renaming proposal... Now that all type names have been shortened, we no longer use "record" anywhere - only in the generic type parameter of the collection (TRecord). Since we have VectorStoreCollection, VectorStoreCollectionOptions, I'm proposing we also rename the record definition type VectorStoreCollectionDefinition. I think this is also consistent with how definition/schema is used (in SQL one talks of a table schema rather than a row schema, though obviously both are valid).

I've also shortened parameter names from `vectorStoreRecordDefinition` to just `definition` to make things lighter.

Closes #12056