### PR TITLE
Allow omitting property type from definition

### DIFF
--- a/dotnet/src/Connectors/VectorData.Abstractions/ProviderServices/CollectionModelBuilder.cs
+++ b/dotnet/src/Connectors/VectorData.Abstractions/ProviderServices/CollectionModelBuilder.cs
@@ -255,17 +255,22 @@ public abstract class CollectionModelBuilder
             {
                 // Property wasn't found attribute-annotated on the CLR type, so we need to add it.
 
-                // TODO: Make the property CLR type optional - no need to specify it when using a CLR type.
+                var propertyType = definitionProperty.Type;
+                if (propertyType is null)
+                {
+                    throw new InvalidOperationException(VectorDataStrings.MissingTypeOnPropertyDefinition(definitionProperty));
+                }
+
                 switch (definitionProperty)
                 {
                     case VectorStoreKeyProperty definitionKeyProperty:
-                        var keyProperty = new KeyPropertyModel(definitionKeyProperty.Name, definitionKeyProperty.Type);
+                        var keyProperty = new KeyPropertyModel(definitionKeyProperty.Name, propertyType!);
                         this.KeyProperties.Add(keyProperty);
                         this.PropertyMap.Add(definitionKeyProperty.Name, keyProperty);
                         property = keyProperty;
                         break;
                     case VectorStoreDataProperty definitionDataProperty:
-                        var dataProperty = new DataPropertyModel(definitionDataProperty.Name, definitionDataProperty.Type);
+                        var dataProperty = new DataPropertyModel(definitionDataProperty.Name, propertyType);
                         this.DataProperties.Add(dataProperty);
                         this.PropertyMap.Add(definitionDataProperty.Name, dataProperty);
                         property = dataProperty;
@@ -281,7 +286,6 @@ public abstract class CollectionModelBuilder
                 }
             }
 
-            property.Type = definitionProperty.Type;
             this.SetPropertyStorageName(property, definitionProperty.StorageName, type);
 
             switch (definitionProperty)
@@ -330,10 +334,9 @@ public abstract class CollectionModelBuilder
 
                     vectorProperty.EmbeddingGenerator = definitionVectorProperty.EmbeddingGenerator ?? this.DefaultEmbeddingGenerator;
 
-                    if (this.IsVectorPropertyTypeValid(definitionVectorProperty.Type, out _))
+                    if (this.IsVectorPropertyTypeValid(vectorProperty.Type, out _))
                     {
-                        if (definitionVectorProperty.EmbeddingType is not null
-                            && definitionVectorProperty.EmbeddingType != definitionVectorProperty.Type)
+                        if (definitionVectorProperty.EmbeddingType is not null && definitionVectorProperty.EmbeddingType != vectorProperty.Type)
                         {
                             throw new InvalidOperationException(VectorDataStrings.DifferentEmbeddingTypeSpecifiedForNativelySupportedType(vectorProperty, definitionVectorProperty.EmbeddingType));
                         }

--- a/dotnet/src/Connectors/VectorData.Abstractions/ProviderServices/VectorDataStrings.cs
+++ b/dotnet/src/Connectors/VectorData.Abstractions/ProviderServices/VectorDataStrings.cs
@@ -45,6 +45,9 @@ public static class VectorDataStrings
     public static string InvalidSearchInputAndNoEmbeddingGeneratorWasConfigured(Type inputType, string supportedVectorTypes)
         => $"A value of type '{TypeName(inputType)}' was passed to 'SearchAsync', but that isn't a supported vector type by your provider and no embedding generator was configured. The supported vector types are: {supportedVectorTypes}.";
 
+    public static string MissingTypeOnPropertyDefinition(VectorStoreProperty property)
+        => $"Property '{property.Name}' has no type specified in its definition, and does not have a corresponding .NET property. Specify the type on the definition.";
+
     public static string UnsupportedVectorPropertyWithoutEmbeddingGenerator(VectorPropertyModel vectorProperty)
         => $"Vector property '{vectorProperty.ModelName}' has type '{TypeName(vectorProperty.Type)}' which isn't supported by your provider, and no embedding generator is configured. Configure a generator that supports converting '{TypeName(vectorProperty.Type)}' to vector type supported by your provider.";
 

--- a/dotnet/src/Connectors/VectorData.Abstractions/RecordDefinition/VectorStoreDataProperty.cs
+++ b/dotnet/src/Connectors/VectorData.Abstractions/RecordDefinition/VectorStoreDataProperty.cs
@@ -16,8 +16,8 @@ public sealed class VectorStoreDataProperty : VectorStoreProperty
     /// Initializes a new instance of the <see cref="VectorStoreDataProperty"/> class.
     /// </summary>
     /// <param name="name">The name of the property on the data model. If the record is mapped to a .NET type, this corresponds to the .NET property name on that type.</param>
-    /// <param name="type">The type of the property.</param>
-    public VectorStoreDataProperty(string name, Type type)
+    /// <param name="type">The type of the property. Required when using a record type of <c>Dictionary&lt;string, object?&gt;</c> (dynamic mapping), but can omitted when mapping any other .NET type.</param>
+    public VectorStoreDataProperty(string name, Type? type = null)
         : base(name, type)
     {
     }

--- a/dotnet/src/Connectors/VectorData.Abstractions/RecordDefinition/VectorStoreKeyProperty.cs
+++ b/dotnet/src/Connectors/VectorData.Abstractions/RecordDefinition/VectorStoreKeyProperty.cs
@@ -16,8 +16,8 @@ public sealed class VectorStoreKeyProperty : VectorStoreProperty
     /// Initializes a new instance of the <see cref="VectorStoreKeyProperty"/> class.
     /// </summary>
     /// <param name="name">The name of the property on the data model. If the record is mapped to a .NET type, this corresponds to the .NET property name on that type.</param>
-    /// <param name="type">The type of the property.</param>
-    public VectorStoreKeyProperty(string name, Type type)
+    /// <param name="type">The type of the property. Required when using a record type of <c>Dictionary&lt;string, object?&gt;</c> (dynamic mapping), but can omitted when mapping any other .NET type.</param>
+    public VectorStoreKeyProperty(string name, Type? type = null)
         : base(name, type)
     {
     }

--- a/dotnet/src/Connectors/VectorData.Abstractions/RecordDefinition/VectorStoreProperty.cs
+++ b/dotnet/src/Connectors/VectorData.Abstractions/RecordDefinition/VectorStoreProperty.cs
@@ -17,16 +17,11 @@ public abstract class VectorStoreProperty
     /// </summary>
     /// <param name="name">The name of the property on the data model. If the record is mapped to a .NET type, this corresponds to the .NET property name on that type.</param>
     /// <param name="type">The type of the property.</param>
-    private protected VectorStoreProperty(string name, Type type)
+    private protected VectorStoreProperty(string name, Type? type)
     {
         if (string.IsNullOrWhiteSpace(name))
         {
             throw new ArgumentException("Value cannot be null or whitespace.", nameof(name));
-        }
-
-        if (type == null)
-        {
-            throw new ArgumentNullException(nameof(type));
         }
 
         this.Name = name;
@@ -59,5 +54,5 @@ public abstract class VectorStoreProperty
     /// <summary>
     /// Gets the type of the property.
     /// </summary>
-    public Type Type { get; set; }
+    public Type? Type { get; set; }
 }

--- a/dotnet/src/Connectors/VectorData.Abstractions/RecordDefinition/VectorStoreVectorProperty.cs
+++ b/dotnet/src/Connectors/VectorData.Abstractions/RecordDefinition/VectorStoreVectorProperty.cs
@@ -20,6 +20,17 @@ public class VectorStoreVectorProperty : VectorStoreProperty
     /// Initializes a new instance of the <see cref="VectorStoreVectorProperty"/> class.
     /// </summary>
     /// <param name="name">The name of the property on the data model. If the record is mapped to a .NET type, this corresponds to the .NET property name on that type.</param>
+    /// <param name="dimensions">The number of dimensions that the vector has.</param>
+    public VectorStoreVectorProperty(string name, int dimensions)
+        : base(name, type: null)
+    {
+        this.Dimensions = dimensions;
+    }
+
+    /// <summary>
+    /// Initializes a new instance of the <see cref="VectorStoreVectorProperty"/> class.
+    /// </summary>
+    /// <param name="name">The name of the property on the data model. If the record is mapped to a .NET type, this corresponds to the .NET property name on that type.</param>
     /// <param name="type">The type of the property.</param>
     /// <param name="dimensions">The number of dimensions that the vector has.</param>
     public VectorStoreVectorProperty(string name, Type type, int dimensions)
@@ -83,7 +94,7 @@ public class VectorStoreVectorProperty : VectorStoreProperty
     public Type? EmbeddingType { get; set; }
 
     internal virtual VectorPropertyModel CreatePropertyModel()
-        => new(this.Name, this.Type)
+        => new(this.Name, this.Type ?? throw new InvalidOperationException(VectorDataStrings.MissingTypeOnPropertyDefinition(this)))
         {
             Dimensions = this.Dimensions,
             IndexKind = this.IndexKind,

--- a/dotnet/src/Connectors/VectorData.UnitTests/CollectionModelBuilderTests.cs
+++ b/dotnet/src/Connectors/VectorData.UnitTests/CollectionModelBuilderTests.cs
@@ -290,6 +290,37 @@ public class CollectionModelBuilderTests
         Assert.Equal("Vector property 'Embedding' has embedding type 'Embedding<Half>' configured, but that type isn't supported by your embedding generator.", exception.Message);
     }
 
+    [Fact]
+    public void Missing_Type_on_property_definition()
+    {
+        var recordDefinition = new VectorStoreCollectionDefinition
+        {
+            Properties =
+            [
+                new VectorStoreKeyProperty(nameof(RecordWithEmbeddingVectorProperty.Id), typeof(int)),
+                new VectorStoreDataProperty(nameof(RecordWithEmbeddingVectorProperty.Name), typeof(string)),
+                new VectorStoreVectorProperty(nameof(RecordWithEmbeddingVectorProperty.Embedding), typeof(ReadOnlyMemory<float>), dimensions: 3)
+            ]
+        };
+
+        // Key
+        recordDefinition.Properties[0].Type = null;
+        var exception = Assert.Throws<InvalidOperationException>(() => new CustomModelBuilder().BuildDynamic(recordDefinition, defaultEmbeddingGenerator: null));
+        Assert.Equal($"Property '{nameof(RecordWithEmbeddingVectorProperty.Id)}' has no type specified in its definition, and does not have a corresponding .NET property. Specify the type on the definition.", exception.Message);
+
+        // Data
+        recordDefinition.Properties[0].Type = typeof(int);
+        recordDefinition.Properties[1].Type = null;
+        exception = Assert.Throws<InvalidOperationException>(() => new CustomModelBuilder().BuildDynamic(recordDefinition, defaultEmbeddingGenerator: null));
+        Assert.Equal($"Property '{nameof(RecordWithEmbeddingVectorProperty.Name)}' has no type specified in its definition, and does not have a corresponding .NET property. Specify the type on the definition.", exception.Message);
+
+        // Vector
+        recordDefinition.Properties[1].Type = typeof(string);
+        recordDefinition.Properties[2].Type = null;
+        exception = Assert.Throws<InvalidOperationException>(() => new CustomModelBuilder().BuildDynamic(recordDefinition, defaultEmbeddingGenerator: null));
+        Assert.Equal($"Property '{nameof(RecordWithEmbeddingVectorProperty.Embedding)}' has no type specified in its definition, and does not have a corresponding .NET property. Specify the type on the definition.", exception.Message);
+    }
+
     public class RecordWithStringVectorProperty
     {
         [VectorStoreKey]


### PR DESCRIPTION
We currently always require the Type to be passed to property definitions. If POCO mapping is used (the common case), that Type must match the .NET property type and has no value - we can simply use the .NET property type and allow the user to not specify it in the definition.

This PR makes Type optional on the property definition, and throws only for dynamic mapping, where we have no .NET properties.