### PR TITLE
.Net: Disable Api Manifest unit tests

### DIFF
--- a/dotnet/src/Functions/Functions.UnitTests/OpenApi/Extensions/ApiManifestKernelExtensionsTests.cs
+++ b/dotnet/src/Functions/Functions.UnitTests/OpenApi/Extensions/ApiManifestKernelExtensionsTests.cs
@@ -8,7 +8,9 @@ using Xunit;
 namespace SemanticKernel.Functions.UnitTests.OpenApi.Extensions;
 public sealed class ApiManifestKernelExtensionsTests
 {
-    [Fact]
+    private const string SkipReason = "Failing intermittently in the integration pipeline with a 429 HTTP status code. To be migrated to the integration tests project.";
+
+    [Fact(Skip = SkipReason)]
     public async Task ItCanCreatePluginFromApiManifestAsync()
     {
         // Act
@@ -24,7 +26,7 @@ public sealed class ApiManifestKernelExtensionsTests
         Assert.Equal(3, plugin.FunctionCount);
     }
 
-    [Fact]
+    [Fact(Skip = SkipReason)]
     public async Task ItCanCreatePluginFromApiManifestWithDescriptionParameterAsync()
     {
         // Act
@@ -41,7 +43,7 @@ public sealed class ApiManifestKernelExtensionsTests
         Assert.Equal(description, plugin.Description);
     }
 
-    [Fact]
+    [Fact(Skip = SkipReason)]
     public async Task ItCanCreatePluginFromApiManifestWithEmptyDescriptionParameterAsync()
     {
         // Act
@@ -57,7 +59,7 @@ public sealed class ApiManifestKernelExtensionsTests
         Assert.Empty(plugin.Description);
     }
 
-    [Fact]
+    [Fact(Skip = SkipReason)]
     public async Task ItCanImportPluginFromApiManifestAsync()
     {
         // Act
@@ -74,7 +76,7 @@ public sealed class ApiManifestKernelExtensionsTests
         Assert.Single(kernel.Plugins);
     }
 
-    [Fact]
+    [Fact(Skip = SkipReason)]
     public async Task ItCanImportPluginFromApiManifestWithDescriptionParameterAsync()
     {
         // Act
@@ -91,7 +93,7 @@ public sealed class ApiManifestKernelExtensionsTests
         Assert.Equal(description, plugin.Description);
     }
 
-    [Fact]
+    [Fact(Skip = SkipReason)]
     public async Task ItCanImportPluginFromApiManifestWithLocalAndRemoteApiDescriptionUrlAsync()
     {
         // Act
@@ -107,7 +109,7 @@ public sealed class ApiManifestKernelExtensionsTests
         Assert.Equal(2, plugin.FunctionCount);
     }
 
-    [Fact]
+    [Fact(Skip = SkipReason)]
     // Verify that functions are correctly imported
     public async Task VerifyPluginFunctionsFromApiManifestAsync()
     {


### PR DESCRIPTION
The unit tests for the API manifest have been temporarily disabled to prevent blocking the integration pipeline.