### PR TITLE
.Net: Add nuget-package.props to runtime.core

### DIFF
--- a/dotnet/src/Agents/Runtime/Core/Runtime.Core.csproj
+++ b/dotnet/src/Agents/Runtime/Core/Runtime.Core.csproj
@@ -8,6 +8,8 @@
     <DefineConstants>SKIPSKABSTRACTION</DefineConstants>
   </PropertyGroup>
 
+  <Import Project="$(RepoRoot)/dotnet/nuget/nuget-package.props" />
+
   <ItemGroup>
     <Compile Include="$(RepoRoot)/dotnet/src/InternalUtilities/src/System/*" Link="%(RecursiveDir)Utilities/%(Filename)%(Extension)" />
     <Compile Include="$(RepoRoot)/dotnet/src/InternalUtilities/src/Diagnostics/NullableAttributes.cs" Link="%(RecursiveDir)Utilities/%(Filename)%(Extension)" />


### PR DESCRIPTION
### Motivation and Context

The project requires a reference to nuget-package.props to get published.

### Description

Add nuget-package.props to runtime.core

### Contribution Checklist

<!-- Before submitting this PR, please make sure: -->

- [ ] The code builds clean without any errors or warnings
- [ ] The PR follows the [SK Contribution Guidelines](https://github.com/microsoft/semantic-kernel/blob/main/CONTRIBUTING.md) and the [pre-submission formatting script](https://github.com/microsoft/semantic-kernel/blob/main/CONTRIBUTING.md#development-scripts) raises no violations
- [ ] All unit tests pass, and I have added new tests where possible
- [ ] I didn't break anyone :smile:
