### PR TITLE
.Net: Fixing CodeQL failure

### DIFF
--- a/dotnet/src/VectorDataIntegrationTests/PgVectorIntegrationTests/PostgresEmbeddingTypeTests.cs
+++ b/dotnet/src/VectorDataIntegrationTests/PgVectorIntegrationTests/PostgresEmbeddingTypeTests.cs
@@ -45,7 +45,7 @@ public class PostgresEmbeddingTypeTests(PostgresEmbeddingTypeTests.Fixture fixtu
 
     [ConditionalFact]
     public virtual Task BitArray()
-        => this.Test<BitArray>(new BitArray([true, false, true]), distanceFunction: DistanceFunction.HammingDistance, embeddingGenerator: null);
+        => this.Test<BitArray>(new BitArray(new bool[] { true, false, true }), distanceFunction: DistanceFunction.HammingDistance, embeddingGenerator: null);
 
     [ConditionalFact]
     public virtual Task SparseVector()


### PR DESCRIPTION
### Description

Fixing CodeQL build error:
```
PostgresEmbeddingTypeTests.cs(48,36): error CS0121: The call is ambiguous between the following methods or properties: 'BitArray.BitArray(bool[])' and 'BitArray.BitArray(BitArray)'
```

### Contribution Checklist

<!-- Before submitting this PR, please make sure: -->

- [ ] The code builds clean without any errors or warnings
- [ ] The PR follows the [SK Contribution Guidelines](https://github.com/microsoft/semantic-kernel/blob/main/CONTRIBUTING.md) and the [pre-submission formatting script](https://github.com/microsoft/semantic-kernel/blob/main/CONTRIBUTING.md#development-scripts) raises no violations
- [ ] All unit tests pass, and I have added new tests where possible
- [ ] I didn't break anyone :smile:
