### PR TITLE
Fix Gemini Auto Invoke when returned function is non-first part

### DIFF
--- a/dotnet/src/Connectors/Connectors.Google.UnitTests/TestData/chat_one_function_response.json
+++ b/dotnet/src/Connectors/Connectors.Google.UnitTests/TestData/chat_one_function_response.json
@@ -4,6 +4,9 @@
       "content": {
         "parts": [
           {
+            "text": "Running the TimePlugin.Now function..."
+          },
+          {
             "functionCall": {
               "name": "TimePlugin%nameSeparator%Now",
               "args": {

--- a/dotnet/src/Connectors/Connectors.Google/Core/Gemini/Clients/GeminiChatCompletionClient.cs
+++ b/dotnet/src/Connectors/Connectors.Google/Core/Gemini/Clients/GeminiChatCompletionClient.cs
@@ -359,9 +359,6 @@ internal sealed class GeminiChatCompletionClient : ClientBase
                     yield break;
                 }
 
-                // We disable auto-invoke because the first message in the stream doesn't contain ToolCalls or auto-invoke is already false
-                state.AutoInvoke = false;
-
                 // If we don't want to attempt to invoke any functions, just return the result.
                 yield return this.GetStreamingChatContentFromChatContent(messageContent);
             }

--- a/dotnet/src/Connectors/Connectors.Google/Core/Gemini/Clients/GeminiChatCompletionClient.cs
+++ b/dotnet/src/Connectors/Connectors.Google/Core/Gemini/Clients/GeminiChatCompletionClient.cs
@@ -356,6 +356,13 @@ internal sealed class GeminiChatCompletionClient : ClientBase
 
                     // If function call was returned there is no more data in stream
                     state.LastMessage = messageContent;
+
+                    // Yield the message also if it contains text
+                    if (!string.IsNullOrWhiteSpace(messageContent.Content))
+                    {
+                        yield return this.GetStreamingChatContentFromChatContent(messageContent);
+                    }
+
                     yield break;
                 }
 


### PR DESCRIPTION
### Motivation and Context

<!-- Thank you for your contribution to the semantic-kernel repo!
Please help reviewers and future users, providing the following information:
  1. Why is this change required?
  2. What problem does it solve?
  3. What scenario does it contribute to?
  4. If it fixes an open issue, please link to the issue here.
-->

Fixes #11651 

### Description

<!-- Describe your changes, the overall approach, the underlying design.
     These notes will help understanding how your code works. Thanks! -->

- Added unit test data for streaming responses with text & tool parts
- Changed `GetChatMessageContentFromCandidate` to return tools from all candidate parts instead of only the first part
- Added extra check in `GenerateChatMessageAsync` for empty Tool results
- Fixed stream responses in auto invoke mode with texts & tool parts not returned to the caller, added unit test

### Contribution Checklist

<!-- Before submitting this PR, please make sure: -->

- [x] The code builds clean without any errors or warnings
- [x] The PR follows the [SK Contribution Guidelines](https://github.com/microsoft/semantic-kernel/blob/main/CONTRIBUTING.md) and the [pre-submission formatting script](https://github.com/microsoft/semantic-kernel/blob/main/CONTRIBUTING.md#development-scripts) raises no violations
- [x] All unit tests pass, and I have added new tests where possible
- [x] I didn't break anyone :smile:
