### PR TITLE
.NET Agents - Fix `OpenAIAssistant` and `AzureAIAgent` 

### DIFF
--- a/dotnet/samples/Concepts/Agents/AzureAIAgent_Streaming.cs
+++ b/dotnet/samples/Concepts/Agents/AzureAIAgent_Streaming.cs
@@ -138,9 +138,10 @@ public class AzureAIAgent_Streaming(ITestOutputHelper output) : BaseAzureAgentTe
             if (string.IsNullOrEmpty(response.Content))
             {
                 StreamingFunctionCallUpdateContent? functionCall = response.Items.OfType<StreamingFunctionCallUpdateContent>().SingleOrDefault();
-                if (functionCall != null)
+                if (functionCall?.Name != null)
                 {
-                    Console.WriteLine($"\n# {response.Role} - {response.AuthorName ?? "*"}: FUNCTION CALL - {functionCall.Name}");
+                    (string? pluginName, string functionName) = this.ParseFunctionName(functionCall.Name);
+                    Console.WriteLine($"\n# {response.Role} - {response.AuthorName ?? "*"}: FUNCTION CALL - {$"{pluginName}." ?? string.Empty}{functionName}");
                 }
 
                 continue;
@@ -187,11 +188,12 @@ public class AzureAIAgent_Streaming(ITestOutputHelper output) : BaseAzureAgentTe
         [System.Diagnostics.CodeAnalysis.SuppressMessage("Design", "CA1024:Use properties where appropriate", Justification = "Too smart")]
         public string GetSpecials()
         {
-            return @"
-Special Soup: Clam Chowder
-Special Salad: Cobb Salad
-Special Drink: Chai Tea
-";
+            return
+                """
+                Special Soup: Clam Chowder
+                Special Salad: Cobb Salad
+                Special Drink: Chai Tea
+                """;
         }
 
         [KernelFunction, Description("Provides the price of the requested menu item.")]

--- a/dotnet/samples/Concepts/Agents/OpenAIAssistant_Streaming.cs
+++ b/dotnet/samples/Concepts/Agents/OpenAIAssistant_Streaming.cs
@@ -112,9 +112,10 @@ public class OpenAIAssistant_Streaming(ITestOutputHelper output) : BaseAssistant
             if (string.IsNullOrEmpty(response.Content))
             {
                 StreamingFunctionCallUpdateContent? functionCall = response.Items.OfType<StreamingFunctionCallUpdateContent>().SingleOrDefault();
-                if (functionCall != null)
+                if (functionCall?.Name != null)
                 {
-                    Console.WriteLine($"\n# {response.Role} - {response.AuthorName ?? "*"}: FUNCTION CALL - {functionCall.Name}");
+                    (string? pluginName, string functionName) = this.ParseFunctionName(functionCall.Name);
+                    Console.WriteLine($"\n# {response.Role} - {response.AuthorName ?? "*"}: FUNCTION CALL - {$"{pluginName}." ?? string.Empty}{functionName}");
                 }
 
                 continue;
@@ -161,11 +162,12 @@ public class OpenAIAssistant_Streaming(ITestOutputHelper output) : BaseAssistant
         [System.Diagnostics.CodeAnalysis.SuppressMessage("Design", "CA1024:Use properties where appropriate", Justification = "Too smart")]
         public string GetSpecials()
         {
-            return @"
-Special Soup: Clam Chowder
-Special Salad: Cobb Salad
-Special Drink: Chai Tea
-";
+            return
+                """
+                Special Soup: Clam Chowder
+                Special Salad: Cobb Salad
+                Special Drink: Chai Tea
+                """;
         }
 
         [KernelFunction, Description("Provides the price of the requested menu item.")]

--- a/dotnet/src/Agents/AzureAI/Internal/AgentThreadActions.cs
+++ b/dotnet/src/Agents/AzureAI/Internal/AgentThreadActions.cs
@@ -421,13 +421,14 @@ internal static class AgentThreadActions
                     {
                         yield return toolContent;
                     }
-                    else if (detailsUpdate.FunctionOutput != null)
+                    else if (detailsUpdate.FunctionName != null || detailsUpdate.FunctionArguments != null)
                     {
                         yield return
                             new StreamingChatMessageContent(AuthorRole.Assistant, null)
                             {
                                 AuthorName = agent.Name,
-                                Items = [new StreamingFunctionCallUpdateContent(detailsUpdate.ToolCallId, detailsUpdate.FunctionName, detailsUpdate.FunctionArguments)]
+                                Items = [new StreamingFunctionCallUpdateContent(detailsUpdate.ToolCallId, detailsUpdate.FunctionName, detailsUpdate.FunctionArguments, detailsUpdate.ToolCallIndex ?? 0)],
+                                InnerContent = detailsUpdate,
                             };
                     }
                 }

--- a/dotnet/src/Agents/OpenAI/Internal/AssistantThreadActions.cs
+++ b/dotnet/src/Agents/OpenAI/Internal/AssistantThreadActions.cs
@@ -412,13 +412,14 @@ internal static class AssistantThreadActions
                     {
                         yield return toolContent;
                     }
-                    else if (detailsUpdate.FunctionOutput != null)
+                    else if (detailsUpdate.FunctionName != null || detailsUpdate.FunctionArguments != null)
                     {
                         yield return
                             new StreamingChatMessageContent(AuthorRole.Assistant, null)
                             {
                                 AuthorName = agent.Name,
-                                Items = [new StreamingFunctionCallUpdateContent(detailsUpdate.ToolCallId, detailsUpdate.FunctionName, detailsUpdate.FunctionArguments)]
+                                Items = [new StreamingFunctionCallUpdateContent(detailsUpdate.ToolCallId, detailsUpdate.FunctionName, detailsUpdate.FunctionArguments, detailsUpdate.ToolCallIndex ?? 0)],
+                                InnerContent = detailsUpdate,
                             };
                     }
                 }

--- a/dotnet/src/InternalUtilities/samples/AgentUtilities/BaseAgentsTest.cs
+++ b/dotnet/src/InternalUtilities/samples/AgentUtilities/BaseAgentsTest.cs
@@ -48,6 +48,16 @@ public abstract class BaseAgentsTest(ITestOutputHelper output) : BaseTest(output
             { SampleMetadataKey, bool.TrueString }
         });
 
+    protected (string? pluginName, string functionName) ParseFunctionName(string functionName)
+    {
+        string[] parts = functionName.Split("-", 2);
+        if (parts.Length == 1)
+        {
+            return (null, parts[0]);
+        }
+        return (parts[0], parts[1]);
+    }
+
     /// <summary>
     /// Common method to write formatted agent chat content to the console.
     /// </summary>


### PR DESCRIPTION
### Motivation and Context
<!-- Thank you for your contribution to the semantic-kernel repo!
Please help reviewers and future users, providing the following information:
  1. Why is this change required?
  2. What problem does it solve?
  3. What scenario does it contribute to?
  4. If it fixes an open issue, please link to the issue here.
-->

`StreamingFunctionCallUpdateContent` not being provided by `OpenAIAssistantAgent` and `AzureAIAgent`

### Description
<!-- Describe your changes, the overall approach, the underlying design.
     These notes will help understanding how your code works. Thanks! -->

The lack of `StreamingFunctionCallUpdateContent` interferes with the ability to display progress information.

### Contribution Checklist
<!-- Before submitting this PR, please make sure: -->

- [X] The code builds clean without any errors or warnings
- [X] The PR follows the [SK Contribution Guidelines](https://github.com/microsoft/semantic-kernel/blob/main/CONTRIBUTING.md) and the [pre-submission formatting script](https://github.com/microsoft/semantic-kernel/blob/main/CONTRIBUTING.md#development-scripts) raises no violations
- [X] All unit tests pass, and I have added new tests where possible
- [X] I didn't break anyone :smile:
