### PR TITLE
.Net: Fix BaseTest

### DIFF
--- a/dotnet/src/InternalUtilities/samples/InternalUtilities/BaseTest.cs
+++ b/dotnet/src/InternalUtilities/samples/InternalUtilities/BaseTest.cs
@@ -50,13 +50,12 @@ public abstract class BaseTest : TextWriter
     protected bool UseBingSearch => TestConfiguration.Bing.ApiKey is not null;
 
     protected Kernel CreateKernelWithChatCompletion(string? modelName = null)
-        => this.CreateKernelWithChatCompletion(useChatClient: false, out _);
+        => this.CreateKernelWithChatCompletion(useChatClient: false, out _, modelName);
 
     protected Kernel CreateKernelWithChatCompletion(bool useChatClient, out IChatClient? chatClient, string? modelName = null)
     {
         var builder = Kernel.CreateBuilder();
 
-        AddChatCompletionToKernel(builder, modelName);
         if (useChatClient)
         {
             chatClient = AddChatClientToKernel(builder);
@@ -64,7 +63,7 @@ public abstract class BaseTest : TextWriter
         else
         {
             chatClient = null;
-            AddChatCompletionToKernel(builder);
+            AddChatCompletionToKernel(builder, modelName);
         }
 
         return builder.Build();


### PR DESCRIPTION
### Motivation and Context

<!-- Thank you for your contribution to the semantic-kernel repo!
Please help reviewers and future users, providing the following information:
  1. Why is this change required?
  2. What problem does it solve?
  3. What scenario does it contribute to?
  4. If it fixes an open issue, please link to the issue here.
-->
We are seeing exceptions in some samples due to a bug in the `BaseTest.cs` module, that ignores the `modelName` parameter when creating a kernel with chat completion.

### Description

<!-- Describe your changes, the overall approach, the underlying design.
     These notes will help understanding how your code works. Thanks! -->
This PR ensures that the `modelName` parameter is consistently passed to the `AddChatCompletionToKernel` method.

### Contribution Checklist

<!-- Before submitting this PR, please make sure: -->

- [x] The code builds clean without any errors or warnings
- [x] The PR follows the [SK Contribution Guidelines](https://github.com/microsoft/semantic-kernel/blob/main/CONTRIBUTING.md) and the [pre-submission formatting script](https://github.com/microsoft/semantic-kernel/blob/main/CONTRIBUTING.md#development-scripts) raises no violations
- [x] All unit tests pass, and I have added new tests where possible
- [x] I didn't break anyone :smile:
