### PR TITLE
Python: Use BaseModel instead of KernelBaseModel in samples

### DIFF
--- a/python/samples/getting_started_with_agents/multi_agent_orchestration/step4a_handoff_structured_inputs.py
+++ b/python/samples/getting_started_with_agents/multi_agent_orchestration/step4a_handoff_structured_inputs.py
@@ -3,12 +3,13 @@
 import asyncio
 from enum import Enum
 
+from pydantic import BaseModel
+
 from semantic_kernel.agents import Agent, ChatCompletionAgent, HandoffOrchestration, OrchestrationHandoffs
 from semantic_kernel.agents.runtime import InProcessRuntime
 from semantic_kernel.connectors.ai.open_ai import OpenAIChatCompletion
 from semantic_kernel.contents import AuthorRole, ChatMessageContent
 from semantic_kernel.functions import kernel_function
-from semantic_kernel.kernel_pydantic import KernelBaseModel
 
 """
 The following sample demonstrates how to create a handoff orchestration that can triage
@@ -37,7 +38,7 @@ class GitHubLabels(Enum):
     AGENT = "agent"
 
 
-class GithubIssue(KernelBaseModel):
+class GithubIssue(BaseModel):
     """Model representing a GitHub issue."""
 
     id: str
@@ -46,7 +47,7 @@ class GithubIssue(KernelBaseModel):
     labels: list[str] = []
 
 
-class Plan(KernelBaseModel):
+class Plan(BaseModel):
     """Model representing a plan for resolving a GitHub issue."""
 
     tasks: list[str]


### PR DESCRIPTION
### Motivation and Context

<!-- Thank you for your contribution to the semantic-kernel repo!
Please help reviewers and future users, providing the following information:
  1. Why is this change required?
  2. What problem does it solve?
  3. What scenario does it contribute to?
  4. If it fixes an open issue, please link to the issue here.
-->
It's unnecessary to use `KernelBaseModel` in the samples.

### Description

<!-- Describe your changes, the overall approach, the underlying design.
     These notes will help understanding how your code works. Thanks! -->
Switch to `BaseModel`.


### Contribution Checklist

<!-- Before submitting this PR, please make sure: -->

- [x] The code builds clean without any errors or warnings
- [x] The PR follows the [SK Contribution Guidelines](https://github.com/microsoft/semantic-kernel/blob/main/CONTRIBUTING.md) and the [pre-submission formatting script](https://github.com/microsoft/semantic-kernel/blob/main/CONTRIBUTING.md#development-scripts) raises no violations
- [x] All unit tests pass, and I have added new tests where possible
- [x] I didn't break anyone :smile:
