### PR TITLE
.Net: Removing the use of TargetBuilder with multiple parameters in favor of using process.ListenFor().AllOf() or simple TargetBuilder

### DIFF
--- a/dotnet/samples/Demos/ProcessFrameworkWithAspire/ProcessFramework.Aspire/ProcessFramework.Aspire.ProcessOrchestrator/Program.cs
+++ b/dotnet/samples/Demos/ProcessFrameworkWithAspire/ProcessFramework.Aspire/ProcessFramework.Aspire.ProcessOrchestrator/Program.cs
@@ -34,11 +34,11 @@ app.MapGet("/api/processdoc", async (Kernel kernel) =>
 
     processBuilder
         .OnInputEvent(ProcessEvents.TranslateDocument)
-        .SendEventTo(new(translateDocumentStep, TranslateStep.ProcessFunctions.Translate, parameterName: "textToTranslate"));
+        .SendEventTo(new(translateDocumentStep, TranslateStep.ProcessFunctions.Translate));
 
     translateDocumentStep
         .OnEvent(ProcessEvents.DocumentTranslated)
-        .SendEventTo(new ProcessFunctionTargetBuilder(summarizeDocumentStep, SummarizeStep.ProcessFunctions.Summarize, parameterName: "textToSummarize"));
+        .SendEventTo(new ProcessFunctionTargetBuilder(summarizeDocumentStep, SummarizeStep.ProcessFunctions.Summarize));
 
     summarizeDocumentStep
         .OnEvent(ProcessEvents.DocumentSummarized)

--- a/dotnet/samples/GettingStartedWithProcesses/Step01/Step01_Processes.cs
+++ b/dotnet/samples/GettingStartedWithProcesses/Step01/Step01_Processes.cs
@@ -56,7 +56,7 @@ public class Step01_Processes(ITestOutputHelper output) : BaseTest(output, redir
         // When the userInput step emits a user input event, send it to the assistantResponse step
         userInputStep
             .OnEvent(CommonEvents.UserInputReceived)
-            .SendEventTo(new ProcessFunctionTargetBuilder(responseStep, parameterName: "userMessage"));
+            .SendEventTo(new ProcessFunctionTargetBuilder(responseStep));
 
         // When the assistantResponse step emits a response, send it to the userInput step
         responseStep

--- a/dotnet/samples/GettingStartedWithProcesses/Step02/Step02b_AccountOpening.cs
+++ b/dotnet/samples/GettingStartedWithProcesses/Step02/Step02b_AccountOpening.cs
@@ -45,7 +45,7 @@ public class Step02b_AccountOpening(ITestOutputHelper output) : BaseTest(output,
         // Function names are necessary when the step has multiple public functions like CompleteNewCustomerFormStep: NewAccountWelcome and NewAccountProcessUserInfo
         userInputStep
             .OnEvent(CommonEvents.UserInputReceived)
-            .SendEventTo(new ProcessFunctionTargetBuilder(newCustomerFormStep, CompleteNewCustomerFormStep.ProcessStepFunctions.NewAccountProcessUserInfo, "userMessage"));
+            .SendEventTo(new ProcessFunctionTargetBuilder(newCustomerFormStep, CompleteNewCustomerFormStep.ProcessStepFunctions.NewAccountProcessUserInfo));
 
         userInputStep
             .OnEvent(CommonEvents.Exit)

--- a/dotnet/samples/GettingStartedWithProcesses/Step03/Processes/FishAndChipsProcess.cs
+++ b/dotnet/samples/GettingStartedWithProcesses/Step03/Processes/FishAndChipsProcess.cs
@@ -34,13 +34,15 @@ public static class FishAndChipsProcess
             .SendEventTo(makeFriedFishStep.WhereInputEventIs(FriedFishProcess.ProcessEvents.PrepareFriedFish))
             .SendEventTo(makePotatoFriesStep.WhereInputEventIs(PotatoFriesProcess.ProcessEvents.PreparePotatoFries));
 
-        makeFriedFishStep
-            .OnEvent(FriedFishProcess.ProcessEvents.FriedFishReady)
-            .SendEventTo(new ProcessFunctionTargetBuilder(addCondimentsStep, parameterName: "fishActions"));
-
-        makePotatoFriesStep
-            .OnEvent(PotatoFriesProcess.ProcessEvents.PotatoFriesReady)
-            .SendEventTo(new ProcessFunctionTargetBuilder(addCondimentsStep, parameterName: "potatoActions"));
+        processBuilder.ListenFor().AllOf([
+            new(FriedFishProcess.ProcessEvents.FriedFishReady, makeFriedFishStep),
+            new(PotatoFriesProcess.ProcessEvents.PotatoFriesReady, makePotatoFriesStep),
+        ]).SendEventTo(new ProcessStepTargetBuilder(addCondimentsStep, inputMapping: inputEvents => {
+            return new() {
+                { "fishActions", inputEvents[makeFriedFishStep.GetFullEventId(FriedFishProcess.ProcessEvents.FriedFishReady)] },
+                { "potatoActions", inputEvents[makePotatoFriesStep.GetFullEventId(PotatoFriesProcess.ProcessEvents.PotatoFriesReady)] },
+            };
+        }));
 
         addCondimentsStep
             .OnEvent(AddFishAndChipsCondimentsStep.OutputEvents.CondimentsAdded)
@@ -63,13 +65,17 @@ public static class FishAndChipsProcess
             .SendEventTo(makeFriedFishStep.WhereInputEventIs(FriedFishProcess.ProcessEvents.PrepareFriedFish))
             .SendEventTo(makePotatoFriesStep.WhereInputEventIs(PotatoFriesProcess.ProcessEvents.PreparePotatoFries));
 
-        makeFriedFishStep
-            .OnEvent(FriedFishProcess.ProcessEvents.FriedFishReady)
-            .SendEventTo(new ProcessFunctionTargetBuilder(addCondimentsStep, parameterName: "fishActions"));
-
-        makePotatoFriesStep
-            .OnEvent(PotatoFriesProcess.ProcessEvents.PotatoFriesReady)
-            .SendEventTo(new ProcessFunctionTargetBuilder(addCondimentsStep, parameterName: "potatoActions"));
+        processBuilder.ListenFor().AllOf(
+            [
+                new(FriedFishProcess.ProcessEvents.FriedFishReady, makeFriedFishStep),
+                new(PotatoFriesProcess.ProcessEvents.PotatoFriesReady, makePotatoFriesStep),
+            ]).SendEventTo(new ProcessStepTargetBuilder(addCondimentsStep, inputMapping: inputEvents =>
+            {
+                return new() {
+                    { "fishActions", inputEvents[makeFriedFishStep.GetFullEventId(FriedFishProcess.ProcessEvents.FriedFishReady)] },
+                    { "potatoActions", inputEvents[makePotatoFriesStep.GetFullEventId(PotatoFriesProcess.ProcessEvents.PotatoFriesReady)] },
+                };
+            }));
 
         addCondimentsStep
             .OnEvent(AddFishAndChipsCondimentsStep.OutputEvents.CondimentsAdded)

--- a/dotnet/samples/GettingStartedWithProcesses/Step03/Processes/FishAndChipsProcess.cs
+++ b/dotnet/samples/GettingStartedWithProcesses/Step03/Processes/FishAndChipsProcess.cs
@@ -37,7 +37,8 @@ public static class FishAndChipsProcess
         processBuilder.ListenFor().AllOf([
             new(FriedFishProcess.ProcessEvents.FriedFishReady, makeFriedFishStep),
             new(PotatoFriesProcess.ProcessEvents.PotatoFriesReady, makePotatoFriesStep),
-        ]).SendEventTo(new ProcessStepTargetBuilder(addCondimentsStep, inputMapping: inputEvents => {
+        ]).SendEventTo(new ProcessStepTargetBuilder(addCondimentsStep, inputMapping: inputEvents =>
+        {
             return new() {
                 { "fishActions", inputEvents[makeFriedFishStep.GetFullEventId(FriedFishProcess.ProcessEvents.FriedFishReady)] },
                 { "potatoActions", inputEvents[makePotatoFriesStep.GetFullEventId(PotatoFriesProcess.ProcessEvents.PotatoFriesReady)] },

--- a/dotnet/samples/GettingStartedWithProcesses/Step04/Step04_AgentOrchestration.cs
+++ b/dotnet/samples/GettingStartedWithProcesses/Step04/Step04_AgentOrchestration.cs
@@ -168,7 +168,7 @@ public class Step04_AgentOrchestration : BaseTest
         // Pass user input to primary agent
         userInputStep
             .OnEvent(CommonEvents.UserInputReceived)
-            .SendEventTo(new ProcessFunctionTargetBuilder(agentStep, parameterName: "message"))
+            .SendEventTo(new ProcessFunctionTargetBuilder(agentStep))
             .SendEventTo(new ProcessFunctionTargetBuilder(renderMessageStep, RenderMessageStep.ProcessStepFunctions.RenderUserText));
 
         agentStep
@@ -178,7 +178,7 @@ public class Step04_AgentOrchestration : BaseTest
 
         agentStep
             .OnFunctionError()
-            .SendEventTo(new ProcessFunctionTargetBuilder(renderMessageStep, RenderMessageStep.ProcessStepFunctions.RenderError, "error"))
+            .SendEventTo(new ProcessFunctionTargetBuilder(renderMessageStep, RenderMessageStep.ProcessStepFunctions.RenderError))
             .StopProcess();
 
         return process.Build();
@@ -215,7 +215,7 @@ public class Step04_AgentOrchestration : BaseTest
         userInputStep
             .OnEvent(CommonEvents.UserInputReceived)
             .SendEventTo(new ProcessFunctionTargetBuilder(managerAgentStep, ManagerAgentStep.ProcessStepFunctions.InvokeAgent))
-            .SendEventTo(new ProcessFunctionTargetBuilder(renderMessageStep, RenderMessageStep.ProcessStepFunctions.RenderUserText, parameterName: "message"));
+            .SendEventTo(new ProcessFunctionTargetBuilder(renderMessageStep, RenderMessageStep.ProcessStepFunctions.RenderUserText));
 
         // Process completed
         userInputStep
@@ -226,7 +226,7 @@ public class Step04_AgentOrchestration : BaseTest
         // Render response from primary agent
         managerAgentStep
             .OnEvent(AgentOrchestrationEvents.AgentResponse)
-            .SendEventTo(new ProcessFunctionTargetBuilder(renderMessageStep, RenderMessageStep.ProcessStepFunctions.RenderMessage, parameterName: "message"));
+            .SendEventTo(new ProcessFunctionTargetBuilder(renderMessageStep, RenderMessageStep.ProcessStepFunctions.RenderMessage));
 
         // Request is complete
         managerAgentStep
@@ -247,17 +247,17 @@ public class Step04_AgentOrchestration : BaseTest
         // Provide input to inner agents
         managerAgentStep
             .OnEvent(AgentOrchestrationEvents.GroupInput)
-            .SendEventTo(new ProcessFunctionTargetBuilder(agentGroupStep, parameterName: "input"));
+            .SendEventTo(new ProcessFunctionTargetBuilder(agentGroupStep));
 
         // Render response from inner chat (for visibility)
         agentGroupStep
             .OnEvent(AgentOrchestrationEvents.GroupMessage)
-            .SendEventTo(new ProcessFunctionTargetBuilder(renderMessageStep, RenderMessageStep.ProcessStepFunctions.RenderInnerMessage, parameterName: "message"));
+            .SendEventTo(new ProcessFunctionTargetBuilder(renderMessageStep, RenderMessageStep.ProcessStepFunctions.RenderInnerMessage));
 
         // Provide inner response to primary agent
         agentGroupStep
             .OnEvent(AgentOrchestrationEvents.GroupCompleted)
-            .SendEventTo(new ProcessFunctionTargetBuilder(managerAgentStep, ManagerAgentStep.ProcessStepFunctions.ReceiveResponse, parameterName: "response"));
+            .SendEventTo(new ProcessFunctionTargetBuilder(managerAgentStep, ManagerAgentStep.ProcessStepFunctions.ReceiveResponse));
 
         KernelProcess kernelProcess = process.Build();
 
@@ -269,7 +269,7 @@ public class Step04_AgentOrchestration : BaseTest
             {
                 step
                     .OnFunctionError(functionName)
-                    .SendEventTo(new ProcessFunctionTargetBuilder(renderMessageStep, RenderMessageStep.ProcessStepFunctions.RenderError, "error"))
+                    .SendEventTo(new ProcessFunctionTargetBuilder(renderMessageStep, RenderMessageStep.ProcessStepFunctions.RenderError))
                     .StopProcess();
             }
         }

--- a/dotnet/src/Experimental/Process.Core/ProcessAgentBuilder.cs
+++ b/dotnet/src/Experimental/Process.Core/ProcessAgentBuilder.cs
@@ -230,7 +230,12 @@ public class ProcessAgentBuilder<TProcessState> : ProcessStepBuilder<KernelProce
 
     internal ProcessFunctionTargetBuilder GetInvokeAgentFunctionTargetBuilder()
     {
-        return new ProcessFunctionTargetBuilder(this, functionName: KernelProcessAgentExecutor.ProcessFunctions.Invoke, parameterName: "message");
+        return new ProcessFunctionTargetBuilder(this, functionName: KernelProcessAgentExecutor.ProcessFunctions.Invoke, parameterName: Constants.MessageParameterName);
+    }
+
+    internal static class Constants
+    {
+        public const string MessageParameterName = "message";
     }
 }
 

--- a/dotnet/src/Experimental/Process.Core/ProcessFunctionTargetBuilder.cs
+++ b/dotnet/src/Experimental/Process.Core/ProcessFunctionTargetBuilder.cs
@@ -228,7 +228,7 @@ public sealed record ProcessStepTargetBuilder : ProcessFunctionTargetBuilder
     /// </summary>
     /// <param name="stepBuilder"></param>
     /// <param name="inputMapping"></param>
-    public ProcessStepTargetBuilder(ProcessStepBuilder stepBuilder, Func<Dictionary<string, object?>, Dictionary<string, object?>>? inputMapping = null) : base(stepBuilder)
+    public ProcessStepTargetBuilder(ProcessStepBuilder stepBuilder, string? functionName = null, Func<Dictionary<string, object?>, Dictionary<string, object?>>? inputMapping = null) : base(stepBuilder, functionName, null)
     {
         this.InputMapping = inputMapping ?? new Func<Dictionary<string, object?>, Dictionary<string, object?>>((input) => input);
     }

--- a/dotnet/src/Experimental/Process.Core/ProcessFunctionTargetBuilder.cs
+++ b/dotnet/src/Experimental/Process.Core/ProcessFunctionTargetBuilder.cs
@@ -227,6 +227,7 @@ public sealed record ProcessStepTargetBuilder : ProcessFunctionTargetBuilder
     /// Initializes a new instance of the <see cref="ProcessStepTargetBuilder"/> class.
     /// </summary>
     /// <param name="stepBuilder"></param>
+    /// <param name="functionName"></param>
     /// <param name="inputMapping"></param>
     public ProcessStepTargetBuilder(ProcessStepBuilder stepBuilder, string? functionName = null, Func<Dictionary<string, object?>, Dictionary<string, object?>>? inputMapping = null) : base(stepBuilder, functionName, null)
     {

--- a/dotnet/src/Experimental/Process.Core/ProcessFunctionTargetBuilder.cs
+++ b/dotnet/src/Experimental/Process.Core/ProcessFunctionTargetBuilder.cs
@@ -146,12 +146,14 @@ public record ProcessAgentInvokeTargetBuilder : ProcessTargetBuilder
 public record ProcessFunctionTargetBuilder : ProcessTargetBuilder
 {
     /// <summary>
-    /// Initializes a new instance of the <see cref="ProcessFunctionTargetBuilder"/> class.
+    /// Initializes a new instance of the <see cref="ProcessFunctionTargetBuilder"/> class. <br/>
+    /// Constructor only meant to be used by internal SK Builders components to allow piping specific parameters if needed. <br/>
+    /// For external use, <see cref="ProcessBuilder.ListenFor"/> with <see cref="ListenForBuilder.AllOf(List{MessageSourceBuilder})"/> should be used for mapping multiple parameters to a step function
     /// </summary>
     /// <param name="step">The step to target.</param>
     /// <param name="functionName">The function to target.</param>
     /// <param name="parameterName">The parameter to target.</param>
-    public ProcessFunctionTargetBuilder(ProcessStepBuilder step, string? functionName = null, string? parameterName = null) : base(ProcessTargetType.KernelFunction)
+    internal ProcessFunctionTargetBuilder(ProcessStepBuilder step, string? functionName, string? parameterName = null) : base(ProcessTargetType.KernelFunction)
     {
         Verify.NotNull(step, nameof(step));
 
@@ -174,6 +176,15 @@ public record ProcessFunctionTargetBuilder : ProcessTargetBuilder
 
         this.FunctionName = target.FunctionName!;
         this.ParameterName = target.ParameterName;
+    }
+
+    /// <summary>
+    /// Initializes a new instance of the <see cref="ProcessFunctionTargetBuilder"/> class.
+    /// </summary>
+    /// <param name="step">The step to target.</param>
+    /// <param name="functionName">The function to target.</param>
+    public ProcessFunctionTargetBuilder(ProcessStepBuilder step, string? functionName = null) : this(step, functionName, step is ProcessAgentBuilder ? ProcessAgentBuilder.Constants.MessageParameterName : null)
+    {
     }
 
     /// <summary>

--- a/dotnet/src/Experimental/Process.Core/ProcessProxyBuilder.cs
+++ b/dotnet/src/Experimental/Process.Core/ProcessProxyBuilder.cs
@@ -45,7 +45,7 @@ public sealed class ProcessProxyBuilder : ProcessStepBuilder<KernelProxyStep>
 
     internal ProcessFunctionTargetBuilder GetExternalFunctionTargetBuilder()
     {
-        return new ProcessFunctionTargetBuilder(this, functionName: KernelProxyStep.ProcessFunctions.EmitExternalEvent, parameterName: "proxyEvent");
+        return new ProcessFunctionTargetBuilder(this, functionName: KernelProxyStep.ProcessFunctions.EmitExternalEvent);
     }
 
     internal void LinkTopicToStepEdgeInfo(string topicName, ProcessStepBuilder sourceStep, ProcessEventData eventData)

--- a/dotnet/src/Experimental/Process.Core/ProcessStepBuilder.cs
+++ b/dotnet/src/Experimental/Process.Core/ProcessStepBuilder.cs
@@ -214,7 +214,7 @@ public abstract class ProcessStepBuilder
         {
             if (this.FunctionsDict.Count > 1)
             {
-                throw new KernelException("The target step has more than one function, so a function name must be provided.");
+                throw new KernelException($"The target step {this.StepId} has more than one function, so a function name must be provided.");
             }
 
             verifiedFunctionName = this.FunctionsDict.Keys.First();

--- a/dotnet/src/Experimental/Process.Core/ProcessStepBuilder.cs
+++ b/dotnet/src/Experimental/Process.Core/ProcessStepBuilder.cs
@@ -179,6 +179,17 @@ public abstract class ProcessStepBuilder
         edges.Add(edgeBuilder);
     }
 
+    internal static bool FilterSupportedParameterTypes(Type? parameterType, bool hasDefaultValue = false)
+    {
+        if (parameterType != typeof(KernelProcessStepContext) &&
+            parameterType != typeof(KernelProcessStepExternalContext))
+        {
+            return !hasDefaultValue;
+        }
+
+        return false;
+    }
+
     /// <summary>
     /// Used to resolve the target function and parameter for a given optional function name and parameter name.
     /// This is used to simplify the process of creating a <see cref="KernelProcessFunctionTarget"/> by making it possible
@@ -218,7 +229,7 @@ public abstract class ProcessStepBuilder
         // If the parameter name is null or whitespace, then the function must have 0 or 1 parameters
         if (string.IsNullOrWhiteSpace(verifiedParameterName))
         {
-            var undeterminedParameters = kernelFunctionMetadata.Parameters.Where(p => p.ParameterType != typeof(KernelProcessStepContext)).ToList();
+            var undeterminedParameters = kernelFunctionMetadata.Parameters.Where(p => FilterSupportedParameterTypes(p.ParameterType, hasDefaultValue: p.DefaultValue != null)).ToList();
 
             if (undeterminedParameters.Count > 1)
             {

--- a/dotnet/src/Experimental/Process.IntegrationTests.Resources/ProcessCycleTestResources.cs
+++ b/dotnet/src/Experimental/Process.IntegrationTests.Resources/ProcessCycleTestResources.cs
@@ -150,6 +150,7 @@ public sealed class EmitterStep : KernelProcessStep<StepState>
     public const string InternalEventFunction = "SomeInternalFunctionName";
     public const string PublicEventFunction = "SomePublicFunctionName";
     public const string DualInputPublicEventFunction = "SomeDualInputPublicEventFunctionName";
+    public const string QuadInputPublicEventFunction = "SomeQuadInputPublicEventFunctionName";
 
     private readonly int _sleepDurationMs = 150;
 
@@ -166,7 +167,7 @@ public sealed class EmitterStep : KernelProcessStep<StepState>
     {
         Thread.Sleep(this._sleepDurationMs);
 
-        Console.WriteLine($"[EMIT_INTERNAL] {data}");
+        Console.WriteLine($"[EMIT_INTERNAL-{this.StepName}] {data}");
         this._state!.LastMessage = data;
         await context.EmitEventAsync(new() { Id = EventId, Data = data });
     }
@@ -176,7 +177,7 @@ public sealed class EmitterStep : KernelProcessStep<StepState>
     {
         Thread.Sleep(this._sleepDurationMs);
 
-        Console.WriteLine($"[EMIT_PUBLIC] {data}");
+        Console.WriteLine($"[EMIT_PUBLIC-{this.StepName}] {data}");
         this._state!.LastMessage = data;
         await context.EmitEventAsync(new() { Id = PublicEventId, Data = data, Visibility = KernelProcessEventVisibility.Public });
     }
@@ -187,9 +188,20 @@ public sealed class EmitterStep : KernelProcessStep<StepState>
         Thread.Sleep(this._sleepDurationMs);
 
         string outputText = $"{firstInput}-{secondInput}";
-        Console.WriteLine($"[EMIT_PUBLIC_DUAL] {outputText}");
+        Console.WriteLine($"[EMIT_PUBLIC_DUAL-{this.StepName}] {outputText}");
         this._state!.LastMessage = outputText;
         await context.EmitEventAsync(new() { Id = ProcessTestsEvents.OutputReadyPublic, Data = outputText, Visibility = KernelProcessEventVisibility.Public });
+    }
+
+    [KernelFunction(QuadInputPublicEventFunction)]
+    public async Task QuadInputPublicEventFunctionAsync(KernelProcessStepContext context, string firstInput, string secondInput, string thirdInput = "thirdInput", string fourthInput = "fourthInput")
+    {
+        Thread.Sleep(this._sleepDurationMs * 2);
+
+        string outputText = $"{firstInput}-{secondInput}-{thirdInput}-{fourthInput}";
+        Console.WriteLine($"[EMIT_PUBLIC_QUAD-{this.StepName}] {outputText}");
+        this._state!.LastMessage = outputText;
+        await context.EmitEventAsync(new() { Id = ProcessTestsEvents.OutputReadySecondaryPublic, Data = outputText, Visibility = KernelProcessEventVisibility.Public });
     }
 }
 
@@ -322,6 +334,7 @@ public static class ProcessTestsEvents
     public const string StartProcess = "StartProcess";
     public const string StartInnerProcess = "StartInnerProcess";
     public const string OutputReadyPublic = "OutputReadyPublic";
+    public const string OutputReadySecondaryPublic = "OutputReadySecondaryPublic";
     public const string OutputReadyInternal = "OutputReadyInternal";
     public const string ErrorStepSuccess = "ErrorStepSuccess";
 }

--- a/dotnet/src/Experimental/Process.IntegrationTests.Shared/ProcessCloudEventsTests.cs
+++ b/dotnet/src/Experimental/Process.IntegrationTests.Shared/ProcessCloudEventsTests.cs
@@ -188,7 +188,7 @@ public sealed class ProcessCloudEventsTests : IClassFixture<ProcessTestFixture>
 
         echoStep
             .OnFunctionResult()
-            .SendEventTo(new ProcessFunctionTargetBuilder(repeatStep, parameterName: "message"));
+            .SendEventTo(new ProcessFunctionTargetBuilder(repeatStep));
 
         echoStep
             .OnFunctionResult()

--- a/dotnet/src/Experimental/Process.UnitTests/Runtime.Local/LocalProcessTests.cs
+++ b/dotnet/src/Experimental/Process.UnitTests/Runtime.Local/LocalProcessTests.cs
@@ -1,6 +1,7 @@
 ﻿// Copyright (c) Microsoft. All rights reserved.
 
 using System;
+using System.Collections.Generic;
 using System.Linq;
 using System.Text.Json;
 using System.Threading.Tasks;
@@ -19,6 +20,8 @@ namespace Microsoft.SemanticKernel.Process.Runtime.Local.UnitTests;
 /// </summary>
 public class LocalProcessTests
 {
+    private readonly IReadOnlyDictionary<string, KernelProcess> _keyedProcesses = CommonProcesses.GetCommonProcessesKeyedDictionary();
+
     /// <summary>
     /// Validates that the <see cref="LocalProcess"/> constructor initializes the steps correctly.
     /// </summary>
@@ -181,8 +184,6 @@ public class LocalProcessTests
         var processId = "myProcessId";
         var processKey = "someKeyThatDoesNotExist";
 
-        var keyedProcesses = CommonProcesses.GetCommonProcessesKeyedDictionary();
-
         CounterService counterService = new();
         Kernel kernel = KernelSetup.SetupKernelWithCounterService(counterService);
 
@@ -190,7 +191,7 @@ public class LocalProcessTests
         try
         {
             await using LocalKernelProcessContext runningProcess = await LocalKernelProcessFactory.StartAsync(
-                kernel, keyedProcesses, processKey, processId, new KernelProcessEvent()
+                kernel, this._keyedProcesses, processKey, processId, new KernelProcessEvent()
                 {
                     Id = CommonProcesses.ProcessEvents.StartProcess,
                 });
@@ -213,14 +214,12 @@ public class LocalProcessTests
         var processId = "myProcessId";
         var processKey = CommonProcesses.ProcessKeys.CounterProcess;
 
-        var keyedProcesses = CommonProcesses.GetCommonProcessesKeyedDictionary();
-
         CounterService counterService = new();
         Kernel kernel = KernelSetup.SetupKernelWithCounterService(counterService);
 
         // Act
         await using LocalKernelProcessContext runningProcess = await LocalKernelProcessFactory.StartAsync(
-            kernel, keyedProcesses, processKey, processId, new KernelProcessEvent()
+            kernel, this._keyedProcesses, processKey, processId, new KernelProcessEvent()
             {
                 Id = CommonProcesses.ProcessEvents.StartProcess,
             });
@@ -244,7 +243,6 @@ public class LocalProcessTests
         var processKey = CommonProcesses.ProcessKeys.CounterProcess;
         var counterName = "counterStep";
 
-        var keyedProcesses = CommonProcesses.GetCommonProcessesKeyedDictionary();
         var processStorage = new MockStorage();
 
         CounterService counterService = new();
@@ -252,7 +250,7 @@ public class LocalProcessTests
 
         // Act - 1
         await using LocalKernelProcessContext runningProcess = await LocalKernelProcessFactory.StartAsync(
-            kernel, keyedProcesses, processKey, processId, new KernelProcessEvent()
+            kernel, this._keyedProcesses, processKey, processId, new KernelProcessEvent()
             {
                 Id = CommonProcesses.ProcessEvents.StartProcess,
             }, storageConnector: processStorage);
@@ -270,7 +268,7 @@ public class LocalProcessTests
         // Act - 2
         counterService.SetCount(0);
         await using LocalKernelProcessContext runningProcess2 = await LocalKernelProcessFactory.StartAsync(
-            kernel, keyedProcesses, processKey, processId, new KernelProcessEvent()
+            kernel, this._keyedProcesses, processKey, processId, new KernelProcessEvent()
             {
                 Id = CommonProcesses.ProcessEvents.StartProcess,
             }, storageConnector: processStorage);
@@ -299,18 +297,16 @@ public class LocalProcessTests
         var mergeStepStorageEntry = "{0}.MergeStringsStep.StepEdgesData";
         var processKey = CommonProcesses.ProcessKeys.DelayedMergeProcess;
 
-        var keyedProcesses = CommonProcesses.GetCommonProcessesKeyedDictionary();
         var processStorage = new MockStorage();
         // To use local storage, comment line above and uncomment line below + replacing <TEST_DIR> with existing directory path
         //var processStorage = new JsonFileStorage("<TEST_DIR>");
-        //var processStorage = new JsonFileStorage("C:\\Users\\estenori\\Desktop\\TEST2");
 
         CounterService counterService = new();
         Kernel kernel = KernelSetup.SetupKernelWithCounterService(counterService);
 
         // Act - 1
         await using LocalKernelProcessContext runningProcess = await LocalKernelProcessFactory.StartAsync(
-            kernel, keyedProcesses, processKey, processId, new KernelProcessEvent()
+            kernel, this._keyedProcesses, processKey, processId, new KernelProcessEvent()
             {
                 Id = CommonProcesses.ProcessEvents.StartProcess,
                 Data = "Hello",
@@ -336,7 +332,7 @@ public class LocalProcessTests
 
         // Act - 2
         await using LocalKernelProcessContext runningProcess2 = await LocalKernelProcessFactory.StartAsync(
-            kernel, keyedProcesses, processKey, processId, new KernelProcessEvent()
+            kernel, this._keyedProcesses, processKey, processId, new KernelProcessEvent()
             {
                 Id = CommonProcesses.ProcessEvents.OtherEvent,
                 Data = "World",
@@ -371,7 +367,6 @@ public class LocalProcessTests
         var mergeStepStorageEntry = "{0}.MergeStringsStep.StepEdgesData";
         var processKey = CommonProcesses.ProcessKeys.SimpleMergeProcess;
 
-        var keyedProcesses = CommonProcesses.GetCommonProcessesKeyedDictionary();
         var processStorage = new MockStorage();
         // To use local storage, comment line above and uncomment line below + replacing <TEST_DIR> with existing directory path
         //var processStorage = new JsonFileStorage("<TEST_DIR>");
@@ -380,7 +375,7 @@ public class LocalProcessTests
 
         // Act - 1
         await using LocalKernelProcessContext runningProcess = await LocalKernelProcessFactory.StartAsync(
-            kernel, keyedProcesses, processKey, processId, new KernelProcessEvent()
+            kernel, this._keyedProcesses, processKey, processId, new KernelProcessEvent()
             {
                 Id = CommonProcesses.ProcessEvents.StartProcess,
                 Data = "Hello",
@@ -406,7 +401,7 @@ public class LocalProcessTests
 
         // Act - 2
         await using LocalKernelProcessContext runningProcess2 = await LocalKernelProcessFactory.StartAsync(
-            kernel, keyedProcesses, processKey, processId, new KernelProcessEvent()
+            kernel, this._keyedProcesses, processKey, processId, new KernelProcessEvent()
             {
                 Id = CommonProcesses.ProcessEvents.OtherEvent,
                 Data = "World",
@@ -436,7 +431,6 @@ public class LocalProcessTests
         var innerCounterStorageEntry = "{0}.counterStep.StepState";
         var processKey = CommonProcesses.ProcessKeys.NestedCounterWithEvenDetectionAndMergeProcess;
 
-        var keyedProcesses = CommonProcesses.GetCommonProcessesKeyedDictionary();
         var processStorage = new MockStorage();
         // To use local storage, comment line above and uncomment line below + replacing <TEST_DIR> with existing directory path
         //var processStorage = new JsonFileStorage("<TEST_DIR>");
@@ -451,7 +445,7 @@ public class LocalProcessTests
         {
             // Act - 1,2,3
             await using LocalKernelProcessContext runningProcess = await LocalKernelProcessFactory.StartAsync(
-                kernel, keyedProcesses, processKey, processId, new KernelProcessEvent()
+                kernel, this._keyedProcesses, processKey, processId, new KernelProcessEvent()
                 {
                     Id = CommonProcesses.ProcessEvents.StartProcess,
                 }, storageConnector: processStorage);
@@ -488,7 +482,7 @@ public class LocalProcessTests
 
         // Act - 4
         await using LocalKernelProcessContext runningProcess2 = await LocalKernelProcessFactory.StartAsync(
-            kernel, keyedProcesses, processKey, processId, new KernelProcessEvent()
+            kernel, this._keyedProcesses, processKey, processId, new KernelProcessEvent()
             {
                 Id = CommonProcesses.ProcessEvents.StartProcess,
             }, storageConnector: processStorage);
@@ -534,7 +528,6 @@ public class LocalProcessTests
         var mergeStepStorageEntry = "{0}.MergeStringsStep.StepEdgesData";
         var processKey = CommonProcesses.ProcessKeys.InternalNestedCounterWithEvenDetectionAndMergeProcess;
 
-        var keyedProcesses = CommonProcesses.GetCommonProcessesKeyedDictionary();
         var processStorage = new MockStorage();
         // To use local storage, comment line above and uncomment line below + replacing <TEST_DIR> with existing directory path
         //var processStorage = new JsonFileStorage("<TEST_DIR>");
@@ -548,7 +541,7 @@ public class LocalProcessTests
         {
             // Act - 1,2,3,4
             await using LocalKernelProcessContext runningProcess = await LocalKernelProcessFactory.StartAsync(
-                kernel, keyedProcesses, processKey, processId, new KernelProcessEvent()
+                kernel, this._keyedProcesses, processKey, processId, new KernelProcessEvent()
                 {
                     Id = CommonProcesses.ProcessEvents.StartProcess,
                     Data = i.ToString(),

--- a/dotnet/src/Experimental/Process.Utilities.UnitTests/CloneTests.cs
+++ b/dotnet/src/Experimental/Process.Utilities.UnitTests/CloneTests.cs
@@ -137,6 +137,40 @@ public class CloneTests
         VerifyProcess(source, copy);
     }
 
+    /// <summary>
+    /// Verify that cloning a <see cref="KernelProcessStepInfo"/> with a new run ID and edges works correctly.
+    /// </summary>
+    [Fact]
+    public void VerifyCloneWithIdAndEdgesTest()
+    {
+        // Arrange
+        string runningId = Guid.NewGuid().ToString();
+        string stepName = nameof(VerifyCloneWithIdAndEdgesTest);
+        Dictionary<string, List<KernelProcessEdge>> originalStepEdges = new()
+        {
+            { $"{stepName}.SomeOutputEvent1", CreateTestProcessEdges(1) },
+            { $"{stepName}.{stepName}", CreateTestProcessEdges(3) },
+        };
+        KernelProcessStepInfo step = new(typeof(KernelProcessStep), new(stepName, "v1"), originalStepEdges);
+
+        // Act
+        KernelProcessStepInfo copy = step.CloneWithIdAndEdges(runningId, NullLogger.Instance);
+
+        // Assert
+        Assert.NotNull(copy);
+        Assert.Equal(stepName, copy.State.StepId);
+        Assert.Equal(runningId, copy.State.RunId);
+        foreach (var (expectedEdges, actualEdges) in step.Edges.Zip(copy.Edges))
+        {
+            Assert.Contains(runningId, actualEdges.Key);
+
+            var runningIdCountInEvent = actualEdges.Key.Split(runningId).Length - 1;
+            Assert.Equal(1, runningIdCountInEvent);
+
+            Assert.Equivalent(expectedEdges.Value, actualEdges.Value);
+        }
+    }
+
     private static void VerifyProcess(KernelProcess expected, KernelProcess actual)
     {
         Assert.Equal(expected.State.RunId, actual.State.RunId);
@@ -163,11 +197,19 @@ public class CloneTests
         {
             {
                 "sourceId",
-                [
-                    new KernelProcessEdge("sourceId", new KernelProcessFunctionTarget("sourceId", "targetFunction", "targetParameter", "targetEventId")),
-                ]
+                CreateTestProcessEdges(1)
             }
         };
+
+    private static List<KernelProcessEdge> CreateTestProcessEdges(int count = 1)
+    {
+        var edges = new List<KernelProcessEdge>();
+        for (int i = 0; i < count; i++)
+        {
+            edges.Add(new KernelProcessEdge($"sourceId{i}", new KernelProcessFunctionTarget($"sourceId{i}", "targetFunction", "targetParameter", $"targetEventId{i}")));
+        }
+        return edges;
+    }
 
     private sealed record TestState
     {

--- a/dotnet/src/InternalUtilities/process/Abstractions/StepExtensions.cs
+++ b/dotnet/src/InternalUtilities/process/Abstractions/StepExtensions.cs
@@ -3,6 +3,7 @@
 using System;
 using System.Collections.Generic;
 using System.Linq;
+using System.Text.RegularExpressions;
 using Microsoft.Extensions.Logging;
 using Microsoft.SemanticKernel.Agents;
 
@@ -165,7 +166,10 @@ internal static class StepExtensions
 
         foreach (var kvp in edges)
         {
-            var newKey = kvp.Key.Replace(originalSourceName, newSourceName);
+            // Ensuring only replacing the first occurrence of the original source name in case it is also used in event name or other parts of the event name.
+            var regex = new Regex($"^{originalSourceName}");
+            var newKey = regex.Replace(kvp.Key, newSourceName, 1);
+
             updatedEdges[newKey] = kvp.Value;
         }
 


### PR DESCRIPTION
### Description

- Removing the use of TargetBuilder with multiple parameters in favor of using `process.ListenFor().AllOf()` or simple TargetBuilder
- updating samples and demos to make use of new approach
- changing exposed target builder with function and params to only expose use of function only, keeping function and param for internal use only since some SK Builders require use of piping data to specific params (example: agent step)
- Updating EdgeGroup logic to be compatible with steps that have multiple functions with multiple parameters. Current logic only supports steps with a single function with multiple parameters
- Adding UTs
- Improving unresolved param logic to support internal SK param types and custom param default values

### Contribution Checklist

<!-- Before submitting this PR, please make sure: -->

- [x] The code builds clean without any errors or warnings
- [x] The PR follows the [SK Contribution Guidelines](https://github.com/microsoft/semantic-kernel/blob/main/CONTRIBUTING.md) and the [pre-submission formatting script](https://github.com/microsoft/semantic-kernel/blob/main/CONTRIBUTING.md#development-scripts) raises no violations
- [x] All unit tests pass, and I have added new tests where possible
- [x] I didn't break anyone :smile:
