### PR TITLE
Add special notes to samples that are still using `AgentGroupchat`

### DIFF
--- a/python/samples/concepts/agents/autogen_conversable_agent/README.md
+++ b/python/samples/concepts/agents/autogen_conversable_agent/README.md
@@ -7,7 +7,6 @@ Semantic Kernel Python supports running AutoGen Conversable Agents provided in t
 Currently, there are some limitations to note:
 
 - AutoGen Conversable Agents in Semantic Kernel run asynchronously and do not support streaming of agent inputs or responses.
-- The `AutoGenConversableAgent` in Semantic Kernel Python cannot be configured as part of a Semantic Kernel `AgentGroupChat`. As we progress towards GA for our agent group chat patterns, we will explore ways to integrate AutoGen agents into a Semantic Kernel group chat scenario.
 
 ### Installation
 

--- a/python/samples/concepts/agents/bedrock_agent/bedrock_mixed_chat_agents.py
+++ b/python/samples/concepts/agents/bedrock_agent/bedrock_mixed_chat_agents.py
@@ -16,6 +16,15 @@ This sample uses the following main component(s):
 - an AgentGroupChat
 You will learn how to create a new or connect to an existing Bedrock agent and put it in a group chat with
 another agent.
+
+Note: This sample use the `AgentGroupChat` feature of Semantic Kernel, which is
+no longer maintained. For a replacement, consider using the `GroupChatOrchestration`.
+
+Read more about the `GroupChatOrchestration` here:
+https://learn.microsoft.com/semantic-kernel/frameworks/agent/agent-orchestration/group-chat?pivots=programming-language-python
+
+Here is a migration guide from `AgentGroupChat` to `GroupChatOrchestration`:
+https://learn.microsoft.com/semantic-kernel/support/migration/group-chat-orchestration-migration-guide?pivots=programming-language-python
 """
 
 # This will be a chat completion agent

--- a/python/samples/concepts/agents/bedrock_agent/bedrock_mixed_chat_agents_streaming.py
+++ b/python/samples/concepts/agents/bedrock_agent/bedrock_mixed_chat_agents_streaming.py
@@ -16,6 +16,15 @@ This sample uses the following main component(s):
 - an AgentGroupChat
 You will learn how to create a new or connect to an existing Bedrock agent and put it in a group chat with
 another agent.
+
+Note: This sample use the `AgentGroupChat` feature of Semantic Kernel, which is
+no longer maintained. For a replacement, consider using the `GroupChatOrchestration`.
+
+Read more about the `GroupChatOrchestration` here:
+https://learn.microsoft.com/semantic-kernel/frameworks/agent/agent-orchestration/group-chat?pivots=programming-language-python
+
+Here is a migration guide from `AgentGroupChat` to `GroupChatOrchestration`:
+https://learn.microsoft.com/semantic-kernel/support/migration/group-chat-orchestration-migration-guide?pivots=programming-language-python
 """
 
 # This will be a chat completion agent

--- a/python/samples/concepts/agents/chat_completion_agent/chat_completion_agent_summary_history_reducer_agent_chat.py
+++ b/python/samples/concepts/agents/chat_completion_agent/chat_completion_agent_summary_history_reducer_agent_chat.py
@@ -2,14 +2,9 @@
 
 import asyncio
 
-from semantic_kernel.agents import (
-    AgentGroupChat,
-    ChatCompletionAgent,
-)
+from semantic_kernel.agents import AgentGroupChat, ChatCompletionAgent
 from semantic_kernel.connectors.ai.open_ai import AzureChatCompletion
-from semantic_kernel.contents import (
-    ChatHistorySummarizationReducer,
-)
+from semantic_kernel.contents import ChatHistorySummarizationReducer
 
 """
 The following sample demonstrates how to implement a chat history
@@ -17,6 +12,15 @@ reducer as part of the Semantic Kernel Agent Framework. For this sample,
 the ChatCompletionAgent with an AgentGroupChat is used. The Chat History
 Reducer is a Summary Reducer. View the README for more information on 
 how to use the reducer and what each parameter does.
+
+Note: This sample use the `AgentGroupChat` feature of Semantic Kernel, which is
+no longer maintained. For a replacement, consider using the `GroupChatOrchestration`.
+
+Read more about the `GroupChatOrchestration` here:
+https://learn.microsoft.com/semantic-kernel/frameworks/agent/agent-orchestration/group-chat?pivots=programming-language-python
+
+Here is a migration guide from `AgentGroupChat` to `GroupChatOrchestration`:
+https://learn.microsoft.com/semantic-kernel/support/migration/group-chat-orchestration-migration-guide?pivots=programming-language-python
 """
 
 

--- a/python/samples/concepts/agents/chat_completion_agent/chat_completion_agent_truncate_history_reducer_agent_chat.py
+++ b/python/samples/concepts/agents/chat_completion_agent/chat_completion_agent_truncate_history_reducer_agent_chat.py
@@ -3,14 +3,9 @@
 import asyncio
 import logging
 
-from semantic_kernel.agents import (
-    AgentGroupChat,
-    ChatCompletionAgent,
-)
+from semantic_kernel.agents import AgentGroupChat, ChatCompletionAgent
 from semantic_kernel.connectors.ai.open_ai import AzureChatCompletion
-from semantic_kernel.contents import (
-    ChatHistoryTruncationReducer,
-)
+from semantic_kernel.contents import ChatHistoryTruncationReducer
 
 """
 The following sample demonstrates how to implement a chat history
@@ -18,6 +13,15 @@ reducer as part of the Semantic Kernel Agent Framework. For this sample,
 the ChatCompletionAgent with an AgentGroupChat is used. The Chat History
 Reducer is a Truncation Reducer. View the README for more information on 
 how to use the reducer and what each parameter does.
+
+Note: This sample use the `AgentGroupChat` feature of Semantic Kernel, which is
+no longer maintained. For a replacement, consider using the `GroupChatOrchestration`.
+
+Read more about the `GroupChatOrchestration` here:
+https://learn.microsoft.com/semantic-kernel/frameworks/agent/agent-orchestration/group-chat?pivots=programming-language-python
+
+Here is a migration guide from `AgentGroupChat` to `GroupChatOrchestration`:
+https://learn.microsoft.com/semantic-kernel/support/migration/group-chat-orchestration-migration-guide?pivots=programming-language-python
 """
 
 

--- a/python/samples/concepts/agents/mixed_chat/mixed_chat_agents.py
+++ b/python/samples/concepts/agents/mixed_chat/mixed_chat_agents.py
@@ -13,6 +13,15 @@ from semantic_kernel.contents import AuthorRole
 The following sample demonstrates how to create a Azure AI Foundry Agent, 
 a chat completion agent and have them participate in a group chat to work towards
 the user's requirement.
+
+Note: This sample use the `AgentGroupChat` feature of Semantic Kernel, which is
+no longer maintained. For a replacement, consider using the `GroupChatOrchestration`.
+
+Read more about the `GroupChatOrchestration` here:
+https://learn.microsoft.com/semantic-kernel/frameworks/agent/agent-orchestration/group-chat?pivots=programming-language-python
+
+Here is a migration guide from `AgentGroupChat` to `GroupChatOrchestration`:
+https://learn.microsoft.com/semantic-kernel/support/migration/group-chat-orchestration-migration-guide?pivots=programming-language-python
 """
 
 

--- a/python/samples/concepts/agents/mixed_chat/mixed_chat_agents_plugins.py
+++ b/python/samples/concepts/agents/mixed_chat/mixed_chat_agents_plugins.py
@@ -11,13 +11,22 @@ from semantic_kernel.contents import AuthorRole
 from semantic_kernel.functions import KernelArguments, kernel_function
 from semantic_kernel.kernel import Kernel
 
-#####################################################################
-# The following sample demonstrates how to create an OpenAI         #
-# assistant using either Azure OpenAI or OpenAI, a chat completion  #
-# agent and have them participate in a group chat to work towards   #
-# the user's requirement. The ChatCompletionAgent uses a plugin     #
-# that is part of the agent group chat.                             #
-#####################################################################
+"""
+The following sample demonstrates how to create an OpenAI
+assistant using either Azure OpenAI or OpenAI, a chat completion
+agent and have them participate in a group chat to work towards
+the user's requirement. The ChatCompletionAgent uses a plugin
+that is part of the agent group chat.
+
+Note: This sample use the `AgentGroupChat` feature of Semantic Kernel, which is
+no longer maintained. For a replacement, consider using the `GroupChatOrchestration`.
+
+Read more about the `GroupChatOrchestration` here:
+https://learn.microsoft.com/semantic-kernel/frameworks/agent/agent-orchestration/group-chat?pivots=programming-language-python
+
+Here is a migration guide from `AgentGroupChat` to `GroupChatOrchestration`:
+https://learn.microsoft.com/semantic-kernel/support/migration/group-chat-orchestration-migration-guide?pivots=programming-language-python
+"""
 
 
 class ApprovalTerminationStrategy(TerminationStrategy):

--- a/python/samples/concepts/agents/mixed_chat/mixed_chat_files.py
+++ b/python/samples/concepts/agents/mixed_chat/mixed_chat_files.py
@@ -13,6 +13,15 @@ The following sample demonstrates how to create an OpenAI
 assistant using either Azure OpenAI or OpenAI, a chat completion
 agent and have them participate in a group chat working on
 an uploaded file.
+
+Note: This sample use the `AgentGroupChat` feature of Semantic Kernel, which is
+no longer maintained. For a replacement, consider using the `GroupChatOrchestration`.
+
+Read more about the `GroupChatOrchestration` here:
+https://learn.microsoft.com/semantic-kernel/frameworks/agent/agent-orchestration/group-chat?pivots=programming-language-python
+
+Here is a migration guide from `AgentGroupChat` to `GroupChatOrchestration`:
+https://learn.microsoft.com/semantic-kernel/support/migration/group-chat-orchestration-migration-guide?pivots=programming-language-python
 """
 
 

--- a/python/samples/concepts/agents/mixed_chat/mixed_chat_images.py
+++ b/python/samples/concepts/agents/mixed_chat/mixed_chat_images.py
@@ -13,6 +13,15 @@ The following sample demonstrates how to create an OpenAI
 assistant using either Azure OpenAI or OpenAI, a chat completion
 agent and have them participate in a group chat working with
 image content.
+
+Note: This sample use the `AgentGroupChat` feature of Semantic Kernel, which is
+no longer maintained. For a replacement, consider using the `GroupChatOrchestration`.
+
+Read more about the `GroupChatOrchestration` here:
+https://learn.microsoft.com/semantic-kernel/frameworks/agent/agent-orchestration/group-chat?pivots=programming-language-python
+
+Here is a migration guide from `AgentGroupChat` to `GroupChatOrchestration`:
+https://learn.microsoft.com/semantic-kernel/support/migration/group-chat-orchestration-migration-guide?pivots=programming-language-python
 """
 
 

--- a/python/samples/concepts/agents/mixed_chat/mixed_chat_reset.py
+++ b/python/samples/concepts/agents/mixed_chat/mixed_chat_reset.py
@@ -17,6 +17,15 @@ assistant using either Azure OpenAI or OpenAI, a chat completion
 agent and have them participate in a group chat to work towards
 the user's requirement. It also demonstrates how the underlying
 agent reset method is used to clear the current state of the chat
+
+Note: This sample use the `AgentGroupChat` feature of Semantic Kernel, which is
+no longer maintained. For a replacement, consider using the `GroupChatOrchestration`.
+
+Read more about the `GroupChatOrchestration` here:
+https://learn.microsoft.com/semantic-kernel/frameworks/agent/agent-orchestration/group-chat?pivots=programming-language-python
+
+Here is a migration guide from `AgentGroupChat` to `GroupChatOrchestration`:
+https://learn.microsoft.com/semantic-kernel/support/migration/group-chat-orchestration-migration-guide?pivots=programming-language-python
 """
 
 

--- a/python/samples/concepts/agents/mixed_chat/mixed_chat_streaming.py
+++ b/python/samples/concepts/agents/mixed_chat/mixed_chat_streaming.py
@@ -8,12 +8,21 @@ from semantic_kernel.connectors.ai.open_ai import AzureChatCompletion, AzureOpen
 from semantic_kernel.contents import AuthorRole
 from semantic_kernel.kernel import Kernel
 
-#####################################################################
-# The following sample demonstrates how to create an OpenAI         #
-# assistant using either Azure OpenAI or OpenAI, a chat completion  #
-# agent and have them participate in a group chat to work towards   #
-# the user's requirement.                                           #
-#####################################################################
+"""
+The following sample demonstrates how to create an OpenAI
+assistant using either Azure OpenAI or OpenAI, a chat completion
+agent and have them participate in a group chat to work towards
+the user's requirement.
+
+Note: This sample use the `AgentGroupChat` feature of Semantic Kernel, which is
+no longer maintained. For a replacement, consider using the `GroupChatOrchestration`.
+
+Read more about the `GroupChatOrchestration` here:
+https://learn.microsoft.com/semantic-kernel/frameworks/agent/agent-orchestration/group-chat?pivots=programming-language-python
+
+Here is a migration guide from `AgentGroupChat` to `GroupChatOrchestration`:
+https://learn.microsoft.com/semantic-kernel/support/migration/group-chat-orchestration-migration-guide?pivots=programming-language-python
+"""
 
 
 class ApprovalTerminationStrategy(TerminationStrategy):

--- a/python/samples/getting_started_with_agents/azure_ai_agent/step3_azure_ai_agent_group_chat.py
+++ b/python/samples/getting_started_with_agents/azure_ai_agent/step3_azure_ai_agent_group_chat.py
@@ -12,6 +12,15 @@ from semantic_kernel.contents import AuthorRole
 The following sample demonstrates how to create an OpenAI assistant using either
 Azure OpenAI or OpenAI, a chat completion agent and have them participate in a
 group chat to work towards the user's requirement.
+
+Note: This sample use the `AgentGroupChat` feature of Semantic Kernel, which is
+no longer maintained. For a replacement, consider using the `GroupChatOrchestration`.
+
+Read more about the `GroupChatOrchestration` here:
+https://learn.microsoft.com/semantic-kernel/frameworks/agent/agent-orchestration/group-chat?pivots=programming-language-python
+
+Here is a migration guide from `AgentGroupChat` to `GroupChatOrchestration`:
+https://learn.microsoft.com/semantic-kernel/support/migration/group-chat-orchestration-migration-guide?pivots=programming-language-python
 """
 
 

--- a/python/samples/getting_started_with_agents/chat_completion/step06_chat_completion_agent_group_chat.py
+++ b/python/samples/getting_started_with_agents/chat_completion/step06_chat_completion_agent_group_chat.py
@@ -11,6 +11,15 @@ from semantic_kernel.connectors.ai.open_ai import AzureChatCompletion
 The following sample demonstrates how to create a simple, agent group chat that
 utilizes An Art Director Chat Completion Agent along with a Copy Writer Chat
 Completion Agent to complete a task.
+
+Note: This sample use the `AgentGroupChat` feature of Semantic Kernel, which is
+no longer maintained. For a replacement, consider using the `GroupChatOrchestration`.
+
+Read more about the `GroupChatOrchestration` here:
+https://learn.microsoft.com/semantic-kernel/frameworks/agent/agent-orchestration/group-chat?pivots=programming-language-python
+
+Here is a migration guide from `AgentGroupChat` to `GroupChatOrchestration`:
+https://learn.microsoft.com/semantic-kernel/support/migration/group-chat-orchestration-migration-guide?pivots=programming-language-python
 """
 
 

--- a/python/samples/getting_started_with_agents/chat_completion/step07_kernel_function_strategies.py
+++ b/python/samples/getting_started_with_agents/chat_completion/step07_kernel_function_strategies.py
@@ -14,6 +14,15 @@ An Art Director Chat Completion Agent along with a Copy Writer Chat Completion A
 complete a task. The sample also shows how to specify a Kernel Function termination and
 selection strategy to determine when to end the chat or how to select the next agent to
 take a turn in the conversation.
+
+Note: This sample use the `AgentGroupChat` feature of Semantic Kernel, which is
+no longer maintained. For a replacement, consider using the `GroupChatOrchestration`.
+
+Read more about the `GroupChatOrchestration` here:
+https://learn.microsoft.com/semantic-kernel/frameworks/agent/agent-orchestration/group-chat?pivots=programming-language-python
+
+Here is a migration guide from `AgentGroupChat` to `GroupChatOrchestration`:
+https://learn.microsoft.com/semantic-kernel/support/migration/group-chat-orchestration-migration-guide?pivots=programming-language-python
 """
 
 

--- a/python/samples/getting_started_with_agents/chat_completion/step08_chat_completion_agent_json_result.py
+++ b/python/samples/getting_started_with_agents/chat_completion/step08_chat_completion_agent_json_result.py
@@ -15,6 +15,15 @@ The following sample demonstrates how to configure an Agent Group Chat, and invo
 agent with only a single turn.A custom termination strategy is provided where the model
 is to rate the user input on creativity and expressiveness and end the chat when a score
 of 70 or higher is provided.
+
+Note: This sample use the `AgentGroupChat` feature of Semantic Kernel, which is
+no longer maintained. For a replacement, consider using the `GroupChatOrchestration`.
+
+Read more about the `GroupChatOrchestration` here:
+https://learn.microsoft.com/semantic-kernel/frameworks/agent/agent-orchestration/group-chat?pivots=programming-language-python
+
+Here is a migration guide from `AgentGroupChat` to `GroupChatOrchestration`:
+https://learn.microsoft.com/semantic-kernel/support/migration/group-chat-orchestration-migration-guide?pivots=programming-language-python
 """
 
 

--- a/python/samples/getting_started_with_agents/chat_completion/step09_chat_completion_agent_logging.py
+++ b/python/samples/getting_started_with_agents/chat_completion/step09_chat_completion_agent_logging.py
@@ -13,6 +13,15 @@ The following sample demonstrates how to create a simple, agent group chat that
 utilizes An Art Director Chat Completion Agent along with a Copy Writer Chat
 Completion Agent to complete a task. The main point of this sample is to note
 how to enable logging to view all interactions between the agents and the model.
+
+Note: This sample use the `AgentGroupChat` feature of Semantic Kernel, which is
+no longer maintained. For a replacement, consider using the `GroupChatOrchestration`.
+
+Read more about the `GroupChatOrchestration` here:
+https://learn.microsoft.com/semantic-kernel/frameworks/agent/agent-orchestration/group-chat?pivots=programming-language-python
+
+Here is a migration guide from `AgentGroupChat` to `GroupChatOrchestration`:
+https://learn.microsoft.com/semantic-kernel/support/migration/group-chat-orchestration-migration-guide?pivots=programming-language-python
 """
 
 # 0. Enable logging


### PR DESCRIPTION
### Motivation and Context

<!-- Thank you for your contribution to the semantic-kernel repo!
Please help reviewers and future users, providing the following information:
  1. Why is this change required?
  2. What problem does it solve?
  3. What scenario does it contribute to?
  4. If it fixes an open issue, please link to the issue here.
-->
As we move away from `AgentGroupChat` to the new orchestrations, we want to make sure it's clear to developers getting started with SK are aware of the changes.

### Description

<!-- Describe your changes, the overall approach, the underlying design.
     These notes will help understanding how your code works. Thanks! -->
We are including a special note to all the samples that use `AgentGroupChat` to inform developers that this feature is no longer maintained and they should consider using `GroupChatOrchestration` instead.

We are keeping the samples for now so that developers can still refer to them and we don't break any external links to these samples, but we want to make sure they are aware of the changes and can migrate to the new orchestrations.


### Contribution Checklist

<!-- Before submitting this PR, please make sure: -->

- [ ] The code builds clean without any errors or warnings
- [ ] The PR follows the [SK Contribution Guidelines](https://github.com/microsoft/semantic-kernel/blob/main/CONTRIBUTING.md) and the [pre-submission formatting script](https://github.com/microsoft/semantic-kernel/blob/main/CONTRIBUTING.md#development-scripts) raises no violations
- [ ] All unit tests pass, and I have added new tests where possible
- [ ] I didn't break anyone :smile:
