### PR TITLE
.NET Agents - Fix `AIContext` instruction formatting for `ChatCompletionAgent` streaming invocation

### DIFF
--- a/dotnet/src/Agents/Abstractions/Agent.cs
+++ b/dotnet/src/Agents/Abstractions/Agent.cs
@@ -384,4 +384,32 @@ public abstract class Agent
     {
         return thread.OnNewMessageAsync(message, cancellationToken);
     }
+
+    /// <summary>
+    /// Default formating for additional instructions for the AI agent based on the provided context and invocation options.
+    /// </summary>
+    /// <param name="context">The context containing relevant information for the AI agent's operation.</param>
+    /// <param name="options">Optional parameters that influence the invocation behavior. Can be <see langword="null"/>.</param>
+    /// <returns>A formatted string representing the additional instructions for the AI agent.</returns>
+#pragma warning disable SKEXP0130 // Type is for evaluation purposes only and is subject to change or removal in future updates. Suppress this diagnostic to proceed.
+    protected static string FormatAdditionalInstructions(AIContext context, AgentInvokeOptions? options)
+#pragma warning restore SKEXP0130 // Type is for evaluation purposes only and is subject to change or removal in future updates. Suppress this diagnostic to proceed.
+    {
+        return string.Concat(ProcessInstructions());
+
+        IEnumerable<string> ProcessInstructions()
+        {
+            if (options?.AdditionalInstructions is not null)
+            {
+                yield return options.AdditionalInstructions;
+            }
+
+            if (!string.IsNullOrWhiteSpace(context.Instructions))
+            {
+                yield return Environment.NewLine;
+                yield return Environment.NewLine;
+                yield return context.Instructions!;
+            }
+        }
+    }
 }

--- a/dotnet/src/Agents/AzureAI/AzureAIAgent.cs
+++ b/dotnet/src/Agents/AzureAI/AzureAIAgent.cs
@@ -131,21 +131,21 @@ public sealed partial class AzureAIAgent : Agent
     {
         Verify.NotNull(messages);
 
-        var azureAIAgentThread = await this.EnsureThreadExistsWithMessagesAsync(
+        AzureAIAgentThread azureAIAgentThread = await this.EnsureThreadExistsWithMessagesAsync(
             messages,
             thread,
             () => new AzureAIAgentThread(this.Client),
             cancellationToken).ConfigureAwait(false);
 
-        var kernel = (options?.Kernel ?? this.Kernel).Clone();
+        Kernel kernel = (options?.Kernel ?? this.Kernel).Clone();
 
         // Get the context contributions from the AIContextProviders.
-#pragma warning disable SKEXP0110 // Type is for evaluation purposes only and is subject to change or removal in future updates. Suppress this diagnostic to proceed.
-        var providersContext = await azureAIAgentThread.AIContextProviders.ModelInvokingAsync(messages, cancellationToken).ConfigureAwait(false);
+#pragma warning disable SKEXP0110, SKEXP0130 // Type is for evaluation purposes only and is subject to change or removal in future updates. Suppress this diagnostic to proceed.
+        AIContext providersContext = await azureAIAgentThread.AIContextProviders.ModelInvokingAsync(messages, cancellationToken).ConfigureAwait(false);
         kernel.Plugins.AddFromAIContext(providersContext, "Tools");
-#pragma warning restore SKEXP0110 // Type is for evaluation purposes only and is subject to change or removal in future updates. Suppress this diagnostic to proceed.
+#pragma warning restore SKEXP0110, SKEXP0130 // Type is for evaluation purposes only and is subject to change or removal in future updates. Suppress this diagnostic to proceed.
 
-        var mergedAdditionalInstructions = MergeAdditionalInstructions(options?.AdditionalInstructions, providersContext.Instructions);
+        string mergedAdditionalInstructions = FormatAdditionalInstructions(providersContext, options);
         var extensionsContextOptions = options is null ?
             new AzureAIAgentInvokeOptions() { AdditionalInstructions = mergedAdditionalInstructions } :
             new AzureAIAgentInvokeOptions(options) { AdditionalInstructions = mergedAdditionalInstructions };
@@ -223,7 +223,7 @@ public sealed partial class AzureAIAgent : Agent
     {
         Verify.NotNull(messages);
 
-        var azureAIAgentThread = await this.EnsureThreadExistsWithMessagesAsync(
+        AzureAIAgentThread azureAIAgentThread = await this.EnsureThreadExistsWithMessagesAsync(
             messages,
             thread,
             () => new AzureAIAgentThread(this.Client),
@@ -232,19 +232,19 @@ public sealed partial class AzureAIAgent : Agent
         var kernel = (options?.Kernel ?? this.Kernel).Clone();
 
         // Get the context contributions from the AIContextProviders.
-#pragma warning disable SKEXP0110 // Type is for evaluation purposes only and is subject to change or removal in future updates. Suppress this diagnostic to proceed.
-        var providersContext = await azureAIAgentThread.AIContextProviders.ModelInvokingAsync(messages, cancellationToken).ConfigureAwait(false);
+#pragma warning disable SKEXP0110, SKEXP0130 // Type is for evaluation purposes only and is subject to change or removal in future updates. Suppress this diagnostic to proceed.
+        AIContext providersContext = await azureAIAgentThread.AIContextProviders.ModelInvokingAsync(messages, cancellationToken).ConfigureAwait(false);
         kernel.Plugins.AddFromAIContext(providersContext, "Tools");
-#pragma warning restore SKEXP0110 // Type is for evaluation purposes only and is subject to change or removal in future updates. Suppress this diagnostic to proceed.
+#pragma warning restore SKEXP0110, SKEXP0130 // Type is for evaluation purposes only and is subject to change or removal in future updates. Suppress this diagnostic to proceed.
 
-        var mergedAdditionalInstructions = MergeAdditionalInstructions(options?.AdditionalInstructions, providersContext.Instructions);
+        string mergedAdditionalInstructions = FormatAdditionalInstructions(providersContext, options);
         var extensionsContextOptions = options is null ?
             new AzureAIAgentInvokeOptions() { AdditionalInstructions = mergedAdditionalInstructions } :
             new AzureAIAgentInvokeOptions(options) { AdditionalInstructions = mergedAdditionalInstructions };
 
         // Invoke the Agent with the thread that we already added our message to, and with
         // a chat history to receive complete messages.
-        var newMessagesReceiver = new ChatHistory();
+        ChatHistory newMessagesReceiver = [];
         var invokeResults = ActivityExtensions.RunWithActivityAsync(
             () => ModelDiagnostics.StartAgentInvocationActivity(this.Id, this.GetDisplayName(), this.Description),
             () => AgentThreadActions.InvokeStreamingAsync(
@@ -324,19 +324,4 @@ public sealed partial class AzureAIAgent : Agent
 
         return new AzureAIChannel(this.Client, thread.Id);
     }
-
-    private static string MergeAdditionalInstructions(string? optionsAdditionalInstructions, string? extensionsContext) =>
-        (optionsAdditionalInstructions, extensionsContext) switch
-        {
-            (string ai, string ec) when !string.IsNullOrWhiteSpace(ai) && !string.IsNullOrWhiteSpace(ec) => string.Concat(
-                ai,
-                Environment.NewLine,
-                Environment.NewLine,
-                ec),
-            (string ai, string ec) when string.IsNullOrWhiteSpace(ai) => ec,
-            (string ai, string ec) when string.IsNullOrWhiteSpace(ec) => ai,
-            (null, string ec) => ec,
-            (string ai, null) => ai,
-            _ => string.Empty
-        };
 }

--- a/dotnet/src/Agents/OpenAI/OpenAIAssistantAgent.cs
+++ b/dotnet/src/Agents/OpenAI/OpenAIAssistantAgent.cs
@@ -124,7 +124,7 @@ public sealed partial class OpenAIAssistantAgent : Agent
     {
         Verify.NotNull(messages);
 
-        var openAIAssistantAgentThread = await this.EnsureThreadExistsWithMessagesAsync(
+        OpenAIAssistantAgentThread openAIAssistantAgentThread = await this.EnsureThreadExistsWithMessagesAsync(
             messages,
             thread,
             () => new OpenAIAssistantAgentThread(this.Client),
@@ -138,13 +138,13 @@ public sealed partial class OpenAIAssistantAgent : Agent
             AdditionalInstructions = options?.AdditionalInstructions,
         });
 
-        var kernel = (options?.Kernel ?? this.Kernel).Clone();
+        Kernel kernel = (options?.Kernel ?? this.Kernel).Clone();
 
         // Get the context contributions from the AIContextProviders.
-#pragma warning disable SKEXP0110 // Type is for evaluation purposes only and is subject to change or removal in future updates. Suppress this diagnostic to proceed.
-        var providersContext = await openAIAssistantAgentThread.AIContextProviders.ModelInvokingAsync(messages, cancellationToken).ConfigureAwait(false);
+#pragma warning disable SKEXP0110, SKEXP0130 // Type is for evaluation purposes only and is subject to change or removal in future updates. Suppress this diagnostic to proceed.
+        AIContext providersContext = await openAIAssistantAgentThread.AIContextProviders.ModelInvokingAsync(messages, cancellationToken).ConfigureAwait(false);
         kernel.Plugins.AddFromAIContext(providersContext, "Tools");
-#pragma warning restore SKEXP0110 // Type is for evaluation purposes only and is subject to change or removal in future updates. Suppress this diagnostic to proceed.
+#pragma warning restore SKEXP0110, SKEXP0130 // Type is for evaluation purposes only and is subject to change or removal in future updates. Suppress this diagnostic to proceed.
 
         var invokeResults = ActivityExtensions.RunWithActivityAsync(
             () => ModelDiagnostics.StartAgentInvocationActivity(this.Id, this.GetDisplayName(), this.Description),
@@ -220,19 +220,19 @@ public sealed partial class OpenAIAssistantAgent : Agent
     {
         Verify.NotNull(messages);
 
-        var openAIAssistantAgentThread = await this.EnsureThreadExistsWithMessagesAsync(
+        OpenAIAssistantAgentThread openAIAssistantAgentThread = await this.EnsureThreadExistsWithMessagesAsync(
             messages,
             thread,
             () => new OpenAIAssistantAgentThread(this.Client),
             cancellationToken).ConfigureAwait(false);
 
-        var kernel = (options?.Kernel ?? this.Kernel).Clone();
+        Kernel kernel = (options?.Kernel ?? this.Kernel).Clone();
 
         // Get the context contributions from the AIContextProviders.
-#pragma warning disable SKEXP0110 // Type is for evaluation purposes only and is subject to change or removal in future updates. Suppress this diagnostic to proceed.
-        var providersContext = await openAIAssistantAgentThread.AIContextProviders.ModelInvokingAsync(messages, cancellationToken).ConfigureAwait(false);
+#pragma warning disable SKEXP0110, SKEXP0130 // Type is for evaluation purposes only and is subject to change or removal in future updates. Suppress this diagnostic to proceed.
+        AIContext providersContext = await openAIAssistantAgentThread.AIContextProviders.ModelInvokingAsync(messages, cancellationToken).ConfigureAwait(false);
         kernel.Plugins.AddFromAIContext(providersContext, "Tools");
-#pragma warning restore SKEXP0110 // Type is for evaluation purposes only and is subject to change or removal in future updates. Suppress this diagnostic to proceed.
+#pragma warning restore SKEXP0110, SKEXP0130 // Type is for evaluation purposes only and is subject to change or removal in future updates. Suppress this diagnostic to proceed.
 
         // Create options that use the RunCreationOptions from the options param if provided or
         // falls back to creating a new RunCreationOptions if additional instructions is provided
@@ -243,7 +243,7 @@ public sealed partial class OpenAIAssistantAgent : Agent
         });
 
 #pragma warning disable SKEXP0001 // ModelDiagnostics is marked experimental.
-        var newMessagesReceiver = new ChatHistory();
+        ChatHistory newMessagesReceiver = [];
         var invokeResults = ActivityExtensions.RunWithActivityAsync(
             () => ModelDiagnostics.StartAgentInvocationActivity(this.Id, this.GetDisplayName(), this.Description),
             () => InternalInvokeStreamingAsync(),


### PR DESCRIPTION
### Motivation and Context
<!-- Thank you for your contribution to the semantic-kernel repo!
Please help reviewers and future users, providing the following information:
  1. Why is this change required?
  2. What problem does it solve?
  3. What scenario does it contribute to?
  4. If it fixes an open issue, please link to the issue here.
-->

Additional instruction ``Microsoft.SemanticKernel.AIContext` being added for streaming invocation of `ChatCompletionAgent`

### Description
<!-- Describe your changes, the overall approach, the underlying design.
     These notes will help understanding how your code works. Thanks! -->

- Centralize all formatting of additional instructions
- Remove typo that results in `Microsoft.SemanticKernel.AIContext` additional instruction for streaming `ChatCompletionAgent`
- Clarify type usage

### Contribution Checklist
<!-- Before submitting this PR, please make sure: -->

- [X] The code builds clean without any errors or warnings
- [X] The PR follows the [SK Contribution Guidelines](https://github.com/microsoft/semantic-kernel/blob/main/CONTRIBUTING.md) and the [pre-submission formatting script](https://github.com/microsoft/semantic-kernel/blob/main/CONTRIBUTING.md#development-scripts) raises no violations
- [X] All unit tests pass, and I have added new tests where possible
- [X] I didn't break anyone :smile:
