### PR TITLE
Remove orchestration persona adaptation messages

### DIFF
--- a/python/samples/getting_started_with_agents/multi_agent_orchestration/step3a_group_chat_human_in_the_loop.py
+++ b/python/samples/getting_started_with_agents/multi_agent_orchestration/step3a_group_chat_human_in_the_loop.py
@@ -130,35 +130,26 @@ async def main():
 
     """
     **Writer**
-    "Electrify Your Drive: Affordable Fun for Everyone!"
+    "Electrify Your Journey: Affordable Adventure Awaits!"
     **Reviewer**
-    This slogan, "Electrify Your Drive: Affordable Fun for Everyone!" does a great job of conveying the core benefits
-    of an electric SUV. Here's some feedback to consider:
-
-    ...
-
-    Consider testing this slogan with focus groups or within your target market to gather insights on resonance and
-    perception. Overall, it is a compelling and engaging statement that successfully captures the essence of your
-    electric SUV.
-    User: Make it rhyme
+    Your slogan captures the essence of being both affordable and fun, which is great! However, you might want to ...
+    User: I'd like to also make it rhyme
     **Writer**
-    "Drive Electric, Feel the Thrill, Affordable Fun That Fits the Bill!"
+    Sure! Here are a few rhyming slogan options for your electric SUV:
+
+    1. "Zoom Through the Streets, Feel the Beats!"
+    2. "Charge and Drive, Feel the Jive!"
+    3. "Electrify Your Ride, Let Fun Be Your Guide!"
+    4. "Zoom in Style, Drive with a Smile!"
+
+    Let me know if you'd like more options or variations!
     **Reviewer**
-    The slogan, "Drive Electric, Feel the Thrill, Affordable Fun That Fits the Bill!" successfully incorporates rhyme,
-    adding a catchy and memorable element to your marketing message. Here's some detailed feedback on this version:
-
-    ...
-
-    Overall, this rhyming slogan is an improvement for making the tagline more memorable and appealing. It captures the
-    excitement and accessibility of the product effectively. Consider checking how it resonates with your target
-    demographic to ensure it aligns well with their preferences and expectations.
-    User: Nice!
+    These rhyming slogans are creative and energetic! They effectively capture the fun aspect while promoting ...
+    User: Please continue with the reviewer's suggestions
     **Writer**
-    Thank you! I'm glad you liked the feedback. If you need help with anything else, like tailoring the slogan for
-    specific platforms or audiences, just let me know!
+    Absolutely! Let's refine and expand on the reviewer's suggestions for a more polished and appealing set of rhym...
     ***** Result *****
-    Thank you! I'm glad you liked the feedback. If you need help with anything else, like tailoring the slogan for
-    specific platforms or audiences, just let me know!
+    Absolutely! Let's refine and expand on the reviewer's suggestions for a more polished and appealing set of rhym...
     """
 
 

--- a/python/samples/getting_started_with_agents/multi_agent_orchestration/step4_handoff.py
+++ b/python/samples/getting_started_with_agents/multi_agent_orchestration/step4_handoff.py
@@ -4,7 +4,7 @@ import asyncio
 
 from semantic_kernel.agents import Agent, ChatCompletionAgent, HandoffOrchestration, OrchestrationHandoffs
 from semantic_kernel.agents.runtime import InProcessRuntime
-from semantic_kernel.connectors.ai.open_ai import OpenAIChatCompletion
+from semantic_kernel.connectors.ai.open_ai import AzureChatCompletion
 from semantic_kernel.contents import AuthorRole, ChatMessageContent
 from semantic_kernel.functions import kernel_function
 
@@ -61,14 +61,14 @@ def get_agents() -> tuple[list[Agent], OrchestrationHandoffs]:
         name="TriageAgent",
         description="A customer support agent that triages issues.",
         instructions="Handle customer requests.",
-        service=OpenAIChatCompletion(),
+        service=AzureChatCompletion(),
     )
 
     refund_agent = ChatCompletionAgent(
         name="RefundAgent",
         description="A customer support agent that handles refunds.",
         instructions="Handle refund requests.",
-        service=OpenAIChatCompletion(),
+        service=AzureChatCompletion(),
         plugins=[OrderRefundPlugin()],
     )
 
@@ -76,7 +76,7 @@ def get_agents() -> tuple[list[Agent], OrchestrationHandoffs]:
         name="OrderStatusAgent",
         description="A customer support agent that checks order status.",
         instructions="Handle order status requests.",
-        service=OpenAIChatCompletion(),
+        service=AzureChatCompletion(),
         plugins=[OrderStatusPlugin()],
     )
 
@@ -84,7 +84,7 @@ def get_agents() -> tuple[list[Agent], OrchestrationHandoffs]:
         name="OrderReturnAgent",
         description="A customer support agent that handles order returns.",
         instructions="Handle order return requests.",
-        service=OpenAIChatCompletion(),
+        service=AzureChatCompletion(),
         plugins=[OrderReturnPlugin()],
     )
 

--- a/python/samples/getting_started_with_agents/multi_agent_orchestration/step4a_handoff_structured_inputs.py
+++ b/python/samples/getting_started_with_agents/multi_agent_orchestration/step4a_handoff_structured_inputs.py
@@ -7,7 +7,7 @@ from pydantic import BaseModel
 
 from semantic_kernel.agents import Agent, ChatCompletionAgent, HandoffOrchestration, OrchestrationHandoffs
 from semantic_kernel.agents.runtime import InProcessRuntime
-from semantic_kernel.connectors.ai.open_ai import OpenAIChatCompletion
+from semantic_kernel.connectors.ai.open_ai import AzureChatCompletion
 from semantic_kernel.contents import AuthorRole, ChatMessageContent
 from semantic_kernel.functions import kernel_function
 
@@ -78,20 +78,20 @@ def get_agents() -> tuple[list[Agent], OrchestrationHandoffs]:
         name="TriageAgent",
         description="An agent that triages GitHub issues",
         instructions="Given a GitHub issue, triage it.",
-        service=OpenAIChatCompletion(),
+        service=AzureChatCompletion(),
     )
     python_agent = ChatCompletionAgent(
         name="PythonAgent",
         description="An agent that handles Python related issues",
         instructions="You are an agent that handles Python related GitHub issues.",
-        service=OpenAIChatCompletion(),
+        service=AzureChatCompletion(),
         plugins=[GithubPlugin()],
     )
     dotnet_agent = ChatCompletionAgent(
         name="DotNetAgent",
         description="An agent that handles .NET related issues",
         instructions="You are an agent that handles .NET related GitHub issues.",
-        service=OpenAIChatCompletion(),
+        service=AzureChatCompletion(),
         plugins=[GithubPlugin()],
     )
 

--- a/python/semantic_kernel/agents/orchestration/group_chat.py
+++ b/python/semantic_kernel/agents/orchestration/group_chat.py
@@ -125,22 +125,8 @@ class GroupChatAgentActor(AgentActorBase):
     async def _handle_response_message(self, message: GroupChatResponseMessage, ctx: MessageContext) -> None:
         logger.debug(f"{self.id}: Received group chat response message.")
         if self._agent_thread is not None:
-            if message.body.role != AuthorRole.USER:
-                await self._agent_thread.on_new_message(
-                    ChatMessageContent(
-                        role=AuthorRole.USER,
-                        content=f"Transferred to {message.body.name}",
-                    )
-                )
             await self._agent_thread.on_new_message(message.body)
         else:
-            if message.body.role != AuthorRole.USER:
-                self._chat_history.add_message(
-                    ChatMessageContent(
-                        role=AuthorRole.USER,
-                        content=f"Transferred to {message.body.name}",
-                    )
-                )
             self._chat_history.add_message(message.body)
 
     @message_handler
@@ -150,11 +136,7 @@ class GroupChatAgentActor(AgentActorBase):
 
         logger.debug(f"{self.id}: Received group chat request message.")
 
-        persona_adoption_message = ChatMessageContent(
-            role=AuthorRole.USER,
-            content=f"Transferred to {self._agent.name}, adopt the persona immediately.",
-        )
-        response = await self._invoke_agent(additional_messages=persona_adoption_message)
+        response = await self._invoke_agent()
 
         logger.debug(f"{self.id} responded with {response}.")
 

--- a/python/semantic_kernel/agents/orchestration/handoffs.py
+++ b/python/semantic_kernel/agents/orchestration/handoffs.py
@@ -279,14 +279,7 @@ class HandoffAgentActor(AgentActorBase):
             return
         logger.debug(f"{self.id}: Received handoff request message.")
 
-        persona_adoption_message = ChatMessageContent(
-            role=AuthorRole.USER,
-            content=f"Transferred to {self._agent.name}, adopt the persona immediately.",
-        )
-        response = await self._invoke_agent_with_potentially_no_response(
-            additional_messages=persona_adoption_message,
-            kernel=self._kernel,
-        )
+        response = await self._invoke_agent_with_potentially_no_response(kernel=self._kernel)
 
         while not self._task_completed:
             if self._handoff_agent_name:

--- a/python/semantic_kernel/agents/orchestration/magentic.py
+++ b/python/semantic_kernel/agents/orchestration/magentic.py
@@ -678,22 +678,8 @@ class MagenticAgentActor(AgentActorBase):
     async def _handle_response_message(self, message: MagenticResponseMessage, ctx: MessageContext) -> None:
         logger.debug(f"{self.id}: Received response message.")
         if self._agent_thread is not None:
-            if message.body.role != AuthorRole.USER:
-                await self._agent_thread.on_new_message(
-                    ChatMessageContent(
-                        role=AuthorRole.USER,
-                        content=f"Transferred to {message.body.name}",
-                    )
-                )
             await self._agent_thread.on_new_message(message.body)
         else:
-            if message.body.role != AuthorRole.USER:
-                self._chat_history.add_message(
-                    ChatMessageContent(
-                        role=AuthorRole.USER,
-                        content=f"Transferred to {message.body.name}",
-                    )
-                )
             self._chat_history.add_message(message.body)
 
     @message_handler
@@ -703,11 +689,7 @@ class MagenticAgentActor(AgentActorBase):
 
         logger.debug(f"{self.id}: Received request message.")
 
-        persona_adoption_message = ChatMessageContent(
-            role=AuthorRole.USER,
-            content=f"Transferred to {self._agent.name}, adopt the persona immediately.",
-        )
-        response = await self._invoke_agent(additional_messages=persona_adoption_message)
+        response = await self._invoke_agent()
 
         logger.debug(f"{self.id} responded with {response}.")
 

--- a/python/tests/unit/agents/orchestration/test_group_chat.py
+++ b/python/tests/unit/agents/orchestration/test_group_chat.py
@@ -133,10 +133,10 @@ async def test_invoke_with_list():
             await runtime.stop_when_idle()
 
         assert mock_invoke_stream.call_count == 2
-        # Two messages + one message added internally to steer the conversation
-        assert len(mock_invoke_stream.call_args_list[0][1]["messages"]) == 3
-        # Two messages + two message added internally to steer the conversation + response from agent A
-        assert len(mock_invoke_stream.call_args_list[1][1]["messages"]) == 5
+        # Two messages
+        assert len(mock_invoke_stream.call_args_list[0][1]["messages"]) == 2
+        # Two messages + response from agent A
+        assert len(mock_invoke_stream.call_args_list[1][1]["messages"]) == 3
 
 
 async def test_invoke_with_response_callback():

--- a/python/tests/unit/agents/orchestration/test_handoff.py
+++ b/python/tests/unit/agents/orchestration/test_handoff.py
@@ -402,8 +402,8 @@ async def test_invoke_with_list():
             await runtime.stop_when_idle()
 
         assert mock_invoke_stream.call_count == 1
-        # Two messages + one message added internally to steer the conversation
-        assert len(mock_invoke_stream.call_args_list[0][1]["messages"]) == 3
+        # Two messages
+        assert len(mock_invoke_stream.call_args_list[0][1]["messages"]) == 2
         # The kernel in the agent should not be modified
         assert len(agent_a.kernel.plugins) == 0
         assert len(agent_b.kernel.plugins) == 0


### PR DESCRIPTION
### Motivation and Context

<!-- Thank you for your contribution to the semantic-kernel repo!
Please help reviewers and future users, providing the following information:
  1. Why is this change required?
  2. What problem does it solve?
  3. What scenario does it contribute to?
  4. If it fixes an open issue, please link to the issue here.
-->
We previously found that agents might get carried away from in long contexts. The persona adaptation messages were designed to steer the agents in an orchestration to respond more closely to the instructions provided (as system message).

As we perform more testing with newer models, we believe that the persona adaptation messages are no longer necessary. The additional instability (because they are hardcoded messages that devs can't override) and cost (the additional token cost which is not significant, but they do pollute the context which makes debugging difficult) they introduce is not worth the benefit they provide.


Closing #12294 

### Description

<!-- Describe your changes, the overall approach, the underlying design.
     These notes will help understanding how your code works. Thanks! -->
1. Remove the persona adaptation messages.
2. Unit tests.
3. Replace `OpenAIChatCompletion` with `AzureChatCompletion` in some of the samples.

### Contribution Checklist

<!-- Before submitting this PR, please make sure: -->

- [ ] The code builds clean without any errors or warnings
- [ ] The PR follows the [SK Contribution Guidelines](https://github.com/microsoft/semantic-kernel/blob/main/CONTRIBUTING.md) and the [pre-submission formatting script](https://github.com/microsoft/semantic-kernel/blob/main/CONTRIBUTING.md#development-scripts) raises no violations
- [ ] All unit tests pass, and I have added new tests where possible
- [ ] I didn't break anyone :smile:
