### PR TITLE
Python: Emit usage chunks via callback as they have empty content

### DIFF
--- a/python/samples/concepts/agents/chat_completion_agent/chat_completion_agent_streaming_token_usage.py
+++ b/python/samples/concepts/agents/chat_completion_agent/chat_completion_agent_streaming_token_usage.py
@@ -4,11 +4,9 @@ import asyncio
 from typing import Annotated
 
 from semantic_kernel.agents import ChatCompletionAgent, ChatHistoryAgentThread
-from semantic_kernel.connectors.ai.completion_usage import CompletionUsage
+from semantic_kernel.connectors.ai import CompletionUsage
 from semantic_kernel.connectors.ai.open_ai import AzureChatCompletion
-from semantic_kernel.contents.chat_message_content import ChatMessageContent
-from semantic_kernel.contents.function_call_content import FunctionCallContent
-from semantic_kernel.contents.function_result_content import FunctionResultContent
+from semantic_kernel.contents import ChatMessageContent, FunctionCallContent, FunctionResultContent
 from semantic_kernel.functions import kernel_function
 
 """

--- a/python/samples/concepts/agents/chat_completion_agent/chat_completion_agent_streaming_token_usage.py
+++ b/python/samples/concepts/agents/chat_completion_agent/chat_completion_agent_streaming_token_usage.py
@@ -38,7 +38,7 @@ class MenuPlugin:
 completion_usage = CompletionUsage()
 
 
-async def handle_streaming_intermediate_steps(message: ChatMessageContent) -> None:
+async def handle_intermediate_messages(message: ChatMessageContent) -> None:
     global completion_usage
 
     if message.metadata.get("usage"):
@@ -76,7 +76,7 @@ async def main() -> None:
         async for response in agent.invoke_stream(
             messages=user_input,
             thread=thread,
-            on_intermediate_message=handle_streaming_intermediate_steps,
+            on_intermediate_message=handle_intermediate_messages,
         ):
             if response.content:
                 print(response.content, end="", flush=True)


### PR DESCRIPTION
### Motivation and Context

We recently made an update to emit streaming chunk usage for the ChatCompletionAgent, but that can now include further complications as responses with usage will have empty content. We should be emitting this information via the optional `on_intermediate_message` callback, so that the caller has content provided in the normal flow (anything un-related to the final message should be handled via the callback).

<!-- Thank you for your contribution to the semantic-kernel repo!
Please help reviewers and future users, providing the following information:
  1. Why is this change required?
  2. What problem does it solve?
  3. What scenario does it contribute to?
  4. If it fixes an open issue, please link to the issue here.
-->

### Description

Fix the usage chunk flow and update the sample to show this behavior.

<!-- Describe your changes, the overall approach, the underlying design.
     These notes will help understanding how your code works. Thanks! -->

### Contribution Checklist

<!-- Before submitting this PR, please make sure: -->

- [X] The code builds clean without any errors or warnings
- [X] The PR follows the [SK Contribution Guidelines](https://github.com/microsoft/semantic-kernel/blob/main/CONTRIBUTING.md) and the [pre-submission formatting script](https://github.com/microsoft/semantic-kernel/blob/main/CONTRIBUTING.md#development-scripts) raises no violations
- [X] All unit tests pass, and I have added new tests where possible
- [X] I didn't break anyone :smile:
