### PR TITLE
.NET Agents - Switch all instance of "SendMessage" to "PublishMessage"

### DIFF
--- a/dotnet/src/Agents/Magentic/MagenticManagerActor.cs
+++ b/dotnet/src/Agents/Magentic/MagenticManagerActor.cs
@@ -101,7 +101,7 @@ internal sealed class MagenticManagerActor :
                 if (status.IsTaskComplete)
                 {
                     ChatMessageContent finalAnswer = await this._manager.PrepareFinalAnswerAsync(context, cancellationToken).ConfigureAwait(false);
-                    await this.SendMessageAsync(finalAnswer.AsResultMessage(), this._orchestrationType, cancellationToken).ConfigureAwait(false);
+                    await this.PublishMessageAsync(finalAnswer.AsResultMessage(), this._orchestrationType, cancellationToken).ConfigureAwait(false);
                     break;
                 }
 
@@ -142,14 +142,14 @@ internal sealed class MagenticManagerActor :
 
                 if (this._invocationCount >= this._manager.MaximumInvocationCount)
                 {
-                    await this.SendMessageAsync("Maximum number of invocations reached.".AsResultMessage(), this._orchestrationType, cancellationToken).ConfigureAwait(false);
+                    await this.PublishMessageAsync("Maximum number of invocations reached.".AsResultMessage(), this._orchestrationType, cancellationToken).ConfigureAwait(false);
                     break;
                 }
 
                 ChatMessageContent instruction = new(AuthorRole.Assistant, agentInstruction);
                 this._chat.Add(instruction);
                 await this.PublishMessageAsync(instruction.AsGroupMessage(), this.Context.Topic, messageId: null, cancellationToken).ConfigureAwait(false);
-                await this.SendMessageAsync(new MagenticMessages.Speak(), agent.Type, cancellationToken).ConfigureAwait(false);
+                await this.PublishMessageAsync(new MagenticMessages.Speak(), agent.Type, cancellationToken).ConfigureAwait(false);
                 break;
             }
 
@@ -158,7 +158,7 @@ internal sealed class MagenticManagerActor :
                 if (this._retryCount >= this._manager.MaximumResetCount)
                 {
                     this.Logger.LogMagenticManagerTaskFailed(this.Context.Topic);
-                    await this.SendMessageAsync("I've experienced multiple failures and am unable to continue.".AsResultMessage(), this._orchestrationType, cancellationToken).ConfigureAwait(false);
+                    await this.PublishMessageAsync("I've experienced multiple failures and am unable to continue.".AsResultMessage(), this._orchestrationType, cancellationToken).ConfigureAwait(false);
                     break;
                 }
 

--- a/dotnet/src/Agents/Magentic/MagenticOrchestration.cs
+++ b/dotnet/src/Agents/Magentic/MagenticOrchestration.cs
@@ -40,7 +40,7 @@ public class MagenticOrchestration<TInput, TOutput> :
         {
             throw new ArgumentException("Entry agent is not defined.", nameof(entryAgent));
         }
-        return runtime.SendMessageAsync(input.AsInputTaskMessage(), entryAgent.Value);
+        return runtime.PublishMessageAsync(input.AsInputTaskMessage(), entryAgent.Value);
     }
 
     /// <inheritdoc />
@@ -65,7 +65,7 @@ public class MagenticOrchestration<TInput, TOutput> :
         }
 
         AgentType managerType =
-            await runtime.RegisterAgentFactoryAsync(
+            await runtime.RegisterOrchestrationAgentAsync(
                 this.FormatAgentType(context.Topic, "Manager"),
                 (agentId, runtime) =>
                 {
@@ -83,7 +83,7 @@ public class MagenticOrchestration<TInput, TOutput> :
         return managerType;
 
         ValueTask<AgentType> RegisterAgentAsync(Agent agent, int agentCount) =>
-            runtime.RegisterAgentFactoryAsync(
+            runtime.RegisterOrchestrationAgentAsync(
                 this.FormatAgentType(context.Topic, $"Agent_{agentCount}"),
                 (agentId, runtime) =>
                 {

--- a/dotnet/src/Agents/Orchestration/AgentOrchestration.cs
+++ b/dotnet/src/Agents/Orchestration/AgentOrchestration.cs
@@ -114,7 +114,7 @@ public abstract partial class AgentOrchestration<TInput, TOutput>
 
         logger.LogOrchestrationInvoke(this.OrchestrationLabel, topic);
 
-        Task task = runtime.SendMessageAsync(input, orchestrationType, cancellationToken).AsTask();
+        Task task = runtime.PublishMessageAsync(input, orchestrationType, cancellationToken).AsTask();
 
         logger.LogOrchestrationYield(this.OrchestrationLabel, topic);
 
@@ -168,7 +168,7 @@ public abstract partial class AgentOrchestration<TInput, TOutput>
 
         // Register actor for orchestration entry-point
         AgentType orchestrationEntry =
-            await runtime.RegisterAgentFactoryAsync(
+            await runtime.RegisterOrchestrationAgentAsync(
                 this.FormatAgentType(context.Topic, "Boot"),
                     (agentId, runtime) =>
                     {
@@ -210,8 +210,8 @@ public abstract partial class AgentOrchestration<TInput, TOutput>
         public async ValueTask<AgentType> RegisterResultTypeAsync<TResult>(OrchestrationResultTransform<TResult> resultTransform)
         {
             // Register actor for final result
-            return
-                await runtime.RegisterAgentFactoryAsync(
+            AgentType registeredType =
+                await runtime.RegisterOrchestrationAgentAsync(
                     agentType,
                     (agentId, runtime) =>
                     {
@@ -229,6 +229,8 @@ public abstract partial class AgentOrchestration<TInput, TOutput>
                         return ValueTask.FromResult<IHostableAgent>(actor);
 #endif
                     }).ConfigureAwait(false);
+
+            return registeredType;
         }
     }
 }

--- a/dotnet/src/Agents/Orchestration/Concurrent/ConcurrentActor.cs
+++ b/dotnet/src/Agents/Orchestration/Concurrent/ConcurrentActor.cs
@@ -38,6 +38,6 @@ internal sealed class ConcurrentActor : AgentActor, IHandle<ConcurrentMessages.R
 
         this.Logger.LogConcurrentAgentResult(this.Id, response.Content);
 
-        await this.SendMessageAsync(response.AsResultMessage(), this._handoffActor, messageContext.CancellationToken).ConfigureAwait(false);
+        await this.PublishMessageAsync(response.AsResultMessage(), this._handoffActor, messageContext.CancellationToken).ConfigureAwait(false);
     }
 }

--- a/dotnet/src/Agents/Orchestration/Concurrent/ConcurrentOrchestration.cs
+++ b/dotnet/src/Agents/Orchestration/Concurrent/ConcurrentOrchestration.cs
@@ -40,7 +40,7 @@ public class ConcurrentOrchestration<TInput, TOutput>
 
         // Register result actor
         AgentType resultType = this.FormatAgentType(context.Topic, "Results");
-        await runtime.RegisterAgentFactoryAsync(
+        await runtime.RegisterOrchestrationAgentAsync(
             resultType,
             (agentId, runtime) =>
             {

--- a/dotnet/src/Agents/Orchestration/Concurrent/ConcurrentResultActor.cs
+++ b/dotnet/src/Agents/Orchestration/Concurrent/ConcurrentResultActor.cs
@@ -53,7 +53,7 @@ internal sealed class ConcurrentResultActor :
 
         if (Interlocked.Increment(ref this._resultCount) == this._expectedCount)
         {
-            await this.SendMessageAsync(this._results.ToArray(), this._orchestrationType, messageContext.CancellationToken).ConfigureAwait(false);
+            await this.PublishMessageAsync(this._results.ToArray(), this._orchestrationType, messageContext.CancellationToken).ConfigureAwait(false);
         }
     }
 }

--- a/dotnet/src/Agents/Orchestration/GroupChat/GroupChatManagerActor.cs
+++ b/dotnet/src/Agents/Orchestration/GroupChat/GroupChatManagerActor.cs
@@ -88,13 +88,13 @@ internal sealed class GroupChatManagerActor :
         {
             GroupChatManagerResult<string> filterResult = await this._manager.FilterResults(this._chat, messageContext.CancellationToken).ConfigureAwait(false);
             this.Logger.LogChatManagerResult(this.Id, filterResult.Value, filterResult.Reason);
-            await this.SendMessageAsync(filterResult.Value.AsResultMessage(), this._orchestrationType, messageContext.CancellationToken).ConfigureAwait(false);
+            await this.PublishMessageAsync(filterResult.Value.AsResultMessage(), this._orchestrationType, messageContext.CancellationToken).ConfigureAwait(false);
             return;
         }
 
         GroupChatManagerResult<string> selectionResult = await this._manager.SelectNextAgent(this._chat, this._team, messageContext.CancellationToken).ConfigureAwait(false);
         AgentType selectionType = this._team[selectionResult.Value].Type;
         this.Logger.LogChatManagerSelect(this.Id, selectionType);
-        await this.SendMessageAsync(new GroupChatMessages.Speak(), selectionType, messageContext.CancellationToken).ConfigureAwait(false);
+        await this.PublishMessageAsync(new GroupChatMessages.Speak(), selectionType, messageContext.CancellationToken).ConfigureAwait(false);
     }
 }

--- a/dotnet/src/Agents/Orchestration/GroupChat/GroupChatOrchestration.cs
+++ b/dotnet/src/Agents/Orchestration/GroupChat/GroupChatOrchestration.cs
@@ -39,7 +39,7 @@ public class GroupChatOrchestration<TInput, TOutput> :
         {
             throw new ArgumentException("Entry agent is not defined.", nameof(entryAgent));
         }
-        return runtime.SendMessageAsync(input.AsInputTaskMessage(), entryAgent.Value);
+        return runtime.PublishMessageAsync(input.AsInputTaskMessage(), entryAgent.Value);
     }
 
     /// <inheritdoc />
@@ -64,7 +64,7 @@ public class GroupChatOrchestration<TInput, TOutput> :
         }
 
         AgentType managerType =
-            await runtime.RegisterAgentFactoryAsync(
+            await runtime.RegisterOrchestrationAgentAsync(
                 this.FormatAgentType(context.Topic, "Manager"),
                 (agentId, runtime) =>
                 {
@@ -82,7 +82,7 @@ public class GroupChatOrchestration<TInput, TOutput> :
         return managerType;
 
         ValueTask<AgentType> RegisterAgentAsync(Agent agent, int agentCount) =>
-            runtime.RegisterAgentFactoryAsync(
+            runtime.RegisterOrchestrationAgentAsync(
                 this.FormatAgentType(context.Topic, $"Agent_{agentCount}"),
                 (agentId, runtime) =>
                 {

--- a/dotnet/src/Agents/Orchestration/Handoff/HandoffActor.cs
+++ b/dotnet/src/Agents/Orchestration/Handoff/HandoffActor.cs
@@ -125,7 +125,7 @@ internal sealed class HandoffActor :
             if (this._handoffAgent != null)
             {
                 AgentType handoffType = this._handoffs[this._handoffAgent].AgentType;
-                await this.SendMessageAsync(new HandoffMessages.Request(), handoffType, messageContext.CancellationToken).ConfigureAwait(false);
+                await this.PublishMessageAsync(new HandoffMessages.Request(), handoffType, messageContext.CancellationToken).ConfigureAwait(false);
 
                 this._handoffAgent = null;
                 break;
@@ -183,6 +183,6 @@ internal sealed class HandoffActor :
     {
         this.Logger.LogHandoffSummary(this.Id, summary);
         this._taskSummary = summary;
-        await this.SendMessageAsync(new HandoffMessages.Result { Message = new ChatMessageContent(AuthorRole.Assistant, summary) }, this._resultHandoff, cancellationToken).ConfigureAwait(false);
+        await this.PublishMessageAsync(new HandoffMessages.Result { Message = new ChatMessageContent(AuthorRole.Assistant, summary) }, this._resultHandoff, cancellationToken).ConfigureAwait(false);
     }
 }

--- a/dotnet/src/Agents/Orchestration/Handoff/HandoffOrchestration.cs
+++ b/dotnet/src/Agents/Orchestration/Handoff/HandoffOrchestration.cs
@@ -53,7 +53,7 @@ public class HandoffOrchestration<TInput, TOutput> : AgentOrchestration<TInput, 
             throw new ArgumentException("Entry agent is not defined.", nameof(entryAgent));
         }
         await runtime.PublishMessageAsync(input.AsInputTaskMessage(), topic).ConfigureAwait(false);
-        await runtime.SendMessageAsync(new HandoffMessages.Request(), entryAgent.Value).ConfigureAwait(false);
+        await runtime.PublishMessageAsync(new HandoffMessages.Request(), entryAgent.Value).ConfigureAwait(false);
     }
 
     /// <inheritdoc />
@@ -71,7 +71,7 @@ public class HandoffOrchestration<TInput, TOutput> : AgentOrchestration<TInput, 
             HandoffLookup map = [];
             handoffMap[agent.Name ?? agent.Id] = map;
             agentType =
-                await runtime.RegisterAgentFactoryAsync(
+                await runtime.RegisterOrchestrationAgentAsync(
                     this.GetAgentType(context.Topic, index),
                     (agentId, runtime) =>
                     {

--- a/dotnet/src/Agents/Orchestration/OrchestrationActor.cs
+++ b/dotnet/src/Agents/Orchestration/OrchestrationActor.cs
@@ -34,18 +34,11 @@ public abstract class OrchestrationActor : BaseAgent
     /// <param name="agentType">The recipient agent's type.</param>
     /// <param name="cancellationToken">A token used to cancel the operation if needed.</param>
     /// <returns>The agent identifier, if it exists.</returns>
-    protected async ValueTask<AgentId?> SendMessageAsync(
+    protected async ValueTask PublishMessageAsync(
         object message,
         AgentType agentType,
         CancellationToken cancellationToken = default)
     {
-        AgentId? agentId = await this.GetAgentAsync(agentType, cancellationToken).ConfigureAwait(false);
-
-        if (agentId.HasValue)
-        {
-            await this.SendMessageAsync(message, agentId.Value, messageId: null, cancellationToken).ConfigureAwait(false);
-        }
-
-        return agentId;
+        await base.PublishMessageAsync(message, new TopicId(agentType), messageId: null, cancellationToken).ConfigureAwait(false);
     }
 }

--- a/dotnet/src/Agents/Orchestration/Sequential/SequentialActor.cs
+++ b/dotnet/src/Agents/Orchestration/Sequential/SequentialActor.cs
@@ -56,6 +56,6 @@ internal sealed class SequentialActor :
 
         this.Logger.LogSequentialAgentResult(this.Id, response.Content);
 
-        await this.SendMessageAsync(response.AsResponseMessage(), this._nextAgent, messageContext.CancellationToken).ConfigureAwait(false);
+        await this.PublishMessageAsync(response.AsResponseMessage(), this._nextAgent, messageContext.CancellationToken).ConfigureAwait(false);
     }
 }

--- a/dotnet/src/Agents/Orchestration/Sequential/SequentialOrchestration.cs
+++ b/dotnet/src/Agents/Orchestration/Sequential/SequentialOrchestration.cs
@@ -31,7 +31,7 @@ public class SequentialOrchestration<TInput, TOutput> : AgentOrchestration<TInpu
         {
             throw new ArgumentException("Entry agent is not defined.", nameof(entryAgent));
         }
-        await runtime.SendMessageAsync(input.AsRequestMessage(), entryAgent.Value).ConfigureAwait(false);
+        await runtime.PublishMessageAsync(input.AsRequestMessage(), entryAgent.Value).ConfigureAwait(false);
     }
 
     /// <inheritdoc />
@@ -52,11 +52,12 @@ public class SequentialOrchestration<TInput, TOutput> : AgentOrchestration<TInpu
         return nextAgent;
 
         ValueTask<AgentType> RegisterAgentAsync(Agent agent, int index, AgentType nextAgent) =>
-            runtime.RegisterAgentFactoryAsync(
+            runtime.RegisterOrchestrationAgentAsync(
                 this.GetAgentType(context.Topic, index),
                 (agentId, runtime) =>
                 {
                     SequentialActor actor = new(agentId, runtime, context, agent, nextAgent, context.LoggerFactory.CreateLogger<SequentialActor>());
+
 #if !NETCOREAPP
                     return actor.AsValueTask<IHostableAgent>();
 #else


### PR DESCRIPTION
### Motivation and Context
<!-- Thank you for your contribution to the semantic-kernel repo!
Please help reviewers and future users, providing the following information:
  1. Why is this change required?
  2. What problem does it solve?
  3. What scenario does it contribute to?
  4. If it fixes an open issue, please link to the issue here.
-->

Eliminates usage of `SendMessageAsync`

### Description
<!-- Describe your changes, the overall approach, the underlying design.
     These notes will help understanding how your code works. Thanks! -->

While `SendMessageAsync` targets a specific agent, it will block until the target result is provided.  `PublishMessageAsync` allows for execution to yield back to the caller as soon as the message is sent.

### Contribution Checklist
<!-- Before submitting this PR, please make sure: -->

- [X] The code builds clean without any errors or warnings
- [X] The PR follows the [SK Contribution Guidelines](https://github.com/microsoft/semantic-kernel/blob/main/CONTRIBUTING.md) and the [pre-submission formatting script](https://github.com/microsoft/semantic-kernel/blob/main/CONTRIBUTING.md#development-scripts) raises no violations
- [X] All unit tests pass, and I have added new tests where possible
- [X] I didn't break anyone :smile:
