### PR TITLE
Python: Allow for structured outputs with Ollama

### DIFF
--- a/python/semantic_kernel/connectors/ai/ollama/ollama_prompt_execution_settings.py
+++ b/python/semantic_kernel/connectors/ai/ollama/ollama_prompt_execution_settings.py
@@ -10,7 +10,7 @@ from semantic_kernel.connectors.ai.prompt_execution_settings import PromptExecut
 class OllamaPromptExecutionSettings(PromptExecutionSettings):
     """Settings for Ollama prompt execution."""
 
-    format: Literal["json"] | None = None
+    format: Literal["json"] | dict[str, Any] | None = None
     options: dict[str, Any] | None = None
 
 


### PR DESCRIPTION
### Motivation and Context

Ollama's execution settings currently only allow for `json` literal. We also want to support structured outputs for models that support it.

<!-- Thank you for your contribution to the semantic-kernel repo!
Please help reviewers and future users, providing the following information:
  1. Why is this change required?
  2. What problem does it solve?
  3. What scenario does it contribute to?
  4. If it fixes an open issue, please link to the issue here.
-->

### Description

- Closes #12355
- Supersedes #12386

<!-- Describe your changes, the overall approach, the underlying design.
     These notes will help understanding how your code works. Thanks! -->

### Contribution Checklist

<!-- Before submitting this PR, please make sure: -->

- [X] The code builds clean without any errors or warnings
- [X] The PR follows the [SK Contribution Guidelines](https://github.com/microsoft/semantic-kernel/blob/main/CONTRIBUTING.md) and the [pre-submission formatting script](https://github.com/microsoft/semantic-kernel/blob/main/CONTRIBUTING.md#development-scripts) raises no violations
- [X] All unit tests pass, and I have added new tests where possible
- [X] I didn't break anyone :smile:
