### PR TITLE
Python: pseudo-stream copilot invoke_stream

### DIFF
--- a/python/semantic_kernel/agents/copilot_studio/copilot_studio_agent.py
+++ b/python/semantic_kernel/agents/copilot_studio/copilot_studio_agent.py
@@ -552,7 +552,6 @@ class CopilotStudioAgent(Agent):
 
         normalized_messages = self._normalize_messages(messages)
 
-        # Collect responses so we can tag the final chunk correctly.
         responses: list[ChatMessageContent] = []
         async for resp in self._inner_invoke(
             thread=thread,


### PR DESCRIPTION
### Motivation and Context

The current copilot studio client doesn't support streaming invocation. The underlying orchestration patterns rely on agents to have an invoke_stream. Since it doesn't exist in the copilot agent, that agent type cannot be used. This PR implements a pseudo-invoke_stream so that the agent can be used with patterns - although it doesn't stream the response back in chunks, it unblocks the use if one desired to use our new orchestration patterns.

<!-- Thank you for your contribution to the semantic-kernel repo!
Please help reviewers and future users, providing the following information:
  1. Why is this change required?
  2. What problem does it solve?
  3. What scenario does it contribute to?
  4. If it fixes an open issue, please link to the issue here.
-->

### Description

- Closes #12449

<!-- Describe your changes, the overall approach, the underlying design.
     These notes will help understanding how your code works. Thanks! -->

### Contribution Checklist

<!-- Before submitting this PR, please make sure: -->

- [X] The code builds clean without any errors or warnings
- [X] The PR follows the [SK Contribution Guidelines](https://github.com/microsoft/semantic-kernel/blob/main/CONTRIBUTING.md) and the [pre-submission formatting script](https://github.com/microsoft/semantic-kernel/blob/main/CONTRIBUTING.md#development-scripts) raises no violations
- [X] All unit tests pass, and I have added new tests where possible
- [X] I didn't break anyone :smile:
