### PR TITLE
added operationid validation in openapi spec

### DIFF
--- a/python/semantic_kernel/connectors/openapi_plugin/openapi_parser.py
+++ b/python/semantic_kernel/connectors/openapi_plugin/openapi_parser.py
@@ -229,8 +229,11 @@ class OpenApiParser:
 
         for path, methods in paths.items():
             for method, details in methods.items():
+                # Validate that operationId exists
+                if "operationId" not in details:
+                    raise PluginInitializationError(f"operationId missing, path: '{path}', method: '{method}'")
                 request_method = method.lower()
-                operationId = details.get("operationId", path + "_" + request_method)
+                operationId = details["operationId"]
 
                 summary = details.get("summary", None)
                 description = details.get("description", None)

--- a/python/tests/unit/connectors/openapi_plugin/no-operationid-openapi.yaml
+++ b/python/tests/unit/connectors/openapi_plugin/no-operationid-openapi.yaml
@@ -1,0 +1,17 @@
+openapi: 3.0.3
+info:
+  title: Simple HTTPBin API
+  version: 1.0.0
+servers:
+  - url: https://httpbin.org
+paths:
+  /get:
+    get:
+      summary: Simple GET request to httpbin.org
+      responses:
+        '200':
+          description: Successful response from httpbin
+          content:
+            application/json:
+              schema:
+                type: object


### PR DESCRIPTION
Description
This PR enforces the presence of an explicit `operationId` for every operation in the OpenAPI specification. Previously, if `operationId` was missing, a default value was generated using the path and HTTP method. Now, the parser will raise a PluginInitializationError if operationId is not provided, ensuring that all operations are uniquely and explicitly identified as required by the OpenAPI standard.

Key changes:

- Added validation to check for the existence of operationId in each operation.
- If operationId is missing, a clear error is raised, preventing fallback to a default value.
- [python/tests/unit/connectors/openapi_plugin/no-operationid-openapi.yaml](https://github.com/microsoft/semantic-kernel/compare/main...sshandilya1991:semantic-kernel:sshandilya/12443_add_operation_id_validation?expand=1#diff-3d272039b3afa97f89805f0ee0258a98b613f0f373c603467b336a8912d5651a) serves as a test case.