### PR TITLE
Enable clients to remove safe_prompt attribute from json

### DIFF
--- a/dotnet/src/Connectors/Connectors.MistralAI/Client/ChatCompletionRequest.cs
+++ b/dotnet/src/Connectors/Connectors.MistralAI/Client/ChatCompletionRequest.cs
@@ -30,7 +30,8 @@ internal sealed class ChatCompletionRequest
     public bool Stream { get; set; } = false;
 
     [JsonPropertyName("safe_prompt")]
-    public bool SafePrompt { get; set; } = false;
+    [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
+    public bool? SafePrompt { get; set; } = false;
 
     [JsonPropertyName("tools")]
     [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]

--- a/dotnet/src/Connectors/Connectors.MistralAI/MistralAIPromptExecutionSettings.cs
+++ b/dotnet/src/Connectors/Connectors.MistralAI/MistralAIPromptExecutionSettings.cs
@@ -78,7 +78,7 @@ public sealed class MistralAIPromptExecutionSettings : PromptExecutionSettings
     /// </summary>
     [JsonPropertyName("safe_prompt")]
     [JsonConverter(typeof(BoolJsonConverter))]
-    public bool SafePrompt
+    public bool? SafePrompt
     {
         get => this._safePrompt;
 
@@ -338,7 +338,7 @@ public sealed class MistralAIPromptExecutionSettings : PromptExecutionSettings
     private double _temperature = 0.7;
     private double _topP = 1;
     private int? _maxTokens;
-    private bool _safePrompt = false;
+    private bool? _safePrompt = false;
     private int? _randomSeed;
     private string _apiVersion = "v1";
     private MistralAIToolCallBehavior? _toolCallBehavior;


### PR DESCRIPTION
### Motivation and Context

Solves: https://github.com/microsoft/semantic-kernel/issues/12629

### Description

See linked issue

### Contribution Checklist

- [x] The code builds clean without any errors or warnings
- [x] The PR follows the [SK Contribution Guidelines](https://github.com/microsoft/semantic-kernel/blob/main/CONTRIBUTING.md) and the [pre-submission formatting script](https://github.com/microsoft/semantic-kernel/blob/main/CONTRIBUTING.md#development-scripts) raises no violations
- [x] All unit tests pass, and I have added new tests where possible
- [😓] I didn't break anyone :smile:
