### PR TITLE
.Net: Exposing conversion helpers from SK Contents to MEAI Content primitives 

### DIFF
--- a/dotnet/src/SemanticKernel.Abstractions/Contents/ChatMessageContentExtensions.cs
+++ b/dotnet/src/SemanticKernel.Abstractions/Contents/ChatMessageContentExtensions.cs
@@ -1,14 +1,17 @@
 ﻿// Copyright (c) Microsoft. All rights reserved.
 
+using System.Diagnostics.CodeAnalysis;
 using Microsoft.Extensions.AI;
 
 namespace Microsoft.SemanticKernel;
 
-internal static class ChatMessageContentExtensions
+/// <summary>Provides extension methods for <see cref="ChatMessageContent"/>.</summary>
+[Experimental("SKEXP0001")]
+public static class ChatMessageContentExtensions
 {
     /// <summary>Converts a <see cref="ChatMessageContent"/> to a <see cref="ChatMessage"/>.</summary>
     /// <remarks>This conversion should not be necessary once SK eventually adopts the shared content types.</remarks>
-    internal static ChatMessage ToChatMessage(this ChatMessageContent content)
+    public static ChatMessage ToChatMessage(this ChatMessageContent content)
     {
         ChatMessage message = new()
         {

--- a/dotnet/src/SemanticKernel.Abstractions/Contents/ChatMessageContentExtensions.cs
+++ b/dotnet/src/SemanticKernel.Abstractions/Contents/ChatMessageContentExtensions.cs
@@ -13,6 +13,8 @@ public static class ChatMessageContentExtensions
     /// <remarks>This conversion should not be necessary once SK eventually adopts the shared content types.</remarks>
     public static ChatMessage ToChatMessage(this ChatMessageContent content)
     {
+        Verify.NotNull(content);
+
         ChatMessage message = new()
         {
             AdditionalProperties = content.Metadata is not null ? new(content.Metadata) : null,

--- a/dotnet/src/SemanticKernel.Abstractions/Contents/StreamingChatMessageContentExtensions.cs
+++ b/dotnet/src/SemanticKernel.Abstractions/Contents/StreamingChatMessageContentExtensions.cs
@@ -15,6 +15,8 @@ public static class StreamingChatMessageContentExtensions
     /// <remarks>This conversion should not be necessary once SK eventually adopts the shared content types.</remarks>
     public static ChatResponseUpdate ToChatResponseUpdate(this StreamingChatMessageContent content)
     {
+        Verify.NotNull(content);
+
         ChatResponseUpdate update = new()
         {
             AdditionalProperties = content.Metadata is not null ? new AdditionalPropertiesDictionary(content.Metadata) : null,

--- a/dotnet/src/SemanticKernel.Abstractions/Contents/StreamingChatMessageContentExtensions.cs
+++ b/dotnet/src/SemanticKernel.Abstractions/Contents/StreamingChatMessageContentExtensions.cs
@@ -1,17 +1,19 @@
 ﻿// Copyright (c) Microsoft. All rights reserved.
 
 using System.Collections.Generic;
+using System.Diagnostics.CodeAnalysis;
 using System.Text.Json;
 using Microsoft.Extensions.AI;
 
 namespace Microsoft.SemanticKernel;
 
 /// <summary>Provides extension methods for <see cref="StreamingChatMessageContent"/>.</summary>
-internal static class StreamingChatMessageContentExtensions
+[Experimental("SKEXP0001")]
+public static class StreamingChatMessageContentExtensions
 {
     /// <summary>Converts a <see cref="StreamingChatMessageContent"/> to a <see cref="ChatResponseUpdate"/>.</summary>
     /// <remarks>This conversion should not be necessary once SK eventually adopts the shared content types.</remarks>
-    internal static ChatResponseUpdate ToChatResponseUpdate(this StreamingChatMessageContent content)
+    public static ChatResponseUpdate ToChatResponseUpdate(this StreamingChatMessageContent content)
     {
         ChatResponseUpdate update = new()
         {


### PR DESCRIPTION
### Motivation and Context

Exposing valuable utilities to convert your existing SK types into MEAI primitives.

This can be particularly useful when you are working with SK types and need to convert them to MEAI primitives for custom scenarios or comparison/evaluation purposes.

CC: @shyamnamboodiripad