### PR TITLE
.NET Fix Agent Orchestration: Fix message type

### DIFF
--- a/dotnet/src/Agents/Magentic/MagenticManagerActor.cs
+++ b/dotnet/src/Agents/Magentic/MagenticManagerActor.cs
@@ -8,7 +8,6 @@ using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.Extensions.Logging;
 using Microsoft.SemanticKernel.Agents.Orchestration;
-using Microsoft.SemanticKernel.Agents.Orchestration.GroupChat;
 using Microsoft.SemanticKernel.Agents.Runtime;
 using Microsoft.SemanticKernel.Agents.Runtime.Core;
 using Microsoft.SemanticKernel.ChatCompletion;

--- a/dotnet/src/Agents/Magentic/MagenticMessages.cs
+++ b/dotnet/src/Agents/Magentic/MagenticMessages.cs
@@ -1,6 +1,7 @@
 ﻿// Copyright (c) Microsoft. All rights reserved.
 
 using System.Collections.Generic;
+using Microsoft.SemanticKernel.ChatCompletion;
 
 namespace Microsoft.SemanticKernel.Agents.Magentic;
 
@@ -76,4 +77,9 @@ public static class MagenticMessages
     /// Extension method to convert a <see cref="ChatMessageContent"/> to a <see cref="Result"/> message.
     /// </summary>
     public static Result AsResultMessage(this ChatMessageContent message) => new() { Message = message };
+
+    /// <summary>
+    /// Extension method to convert a <see cref="string"/> to a <see cref="Result"/>.
+    /// </summary>
+    public static Result AsResultMessage(this string text) => new() { Message = new(AuthorRole.Assistant, text) };
 }

--- a/dotnet/src/Agents/Orchestration/GroupChat/GroupChatMessages.cs
+++ b/dotnet/src/Agents/Orchestration/GroupChat/GroupChatMessages.cs
@@ -8,7 +8,7 @@ namespace Microsoft.SemanticKernel.Agents.Orchestration.GroupChat;
 /// <summary>
 /// Common messages used for agent chat patterns.
 /// </summary>
-public static class GroupChatMessages
+internal static class GroupChatMessages
 {
     /// <summary>
     /// An empty message instance as a default.
@@ -79,7 +79,7 @@ public static class GroupChatMessages
     public static InputTask AsInputTaskMessage(this IEnumerable<ChatMessageContent> messages) => new() { Messages = messages };
 
     /// <summary>
-    /// Extension method to convert a <see cref="ChatMessageContent"/> to a <see cref="Result"/>.
+    /// Extension method to convert a <see cref="string"/> to a <see cref="Result"/>.
     /// </summary>
     public static Result AsResultMessage(this string text) => new() { Message = new(AuthorRole.Assistant, text) };
 }


### PR DESCRIPTION
### Motivation and Context
<!-- Thank you for your contribution to the semantic-kernel repo!
Please help reviewers and future users, providing the following information:
  1. Why is this change required?
  2. What problem does it solve?
  3. What scenario does it contribute to?
  4. If it fixes an open issue, please link to the issue here.
-->

Replace inadvertant use of GroupChatOrchestration `Result` message with the expected `Magentic` message type.

### Description
<!-- Describe your changes, the overall approach, the underlying design.
     These notes will help understanding how your code works. Thanks! -->

MagenticOrchestration does not define a handler for GroupChatOrchestration `Result` message since it was not intended to mix message protocols.

### Contribution Checklist
<!-- Before submitting this PR, please make sure: -->

- [X] The code builds clean without any errors or warnings
- [X] The PR follows the [SK Contribution Guidelines](https://github.com/microsoft/semantic-kernel/blob/main/CONTRIBUTING.md) and the [pre-submission formatting script](https://github.com/microsoft/semantic-kernel/blob/main/CONTRIBUTING.md#development-scripts) raises no violations
- [X] All unit tests pass, and I have added new tests where possible
- [X] I didn't break anyone :smile:
