### PR TITLE
Python: Improve orchestration exception handling

### DIFF
--- a/python/semantic_kernel/agents/orchestration/agent_actor_base.py
+++ b/python/semantic_kernel/agents/orchestration/agent_actor_base.py
@@ -23,6 +23,20 @@ else:
 class ActorBase(RoutedAgent):
     """A base class for actors running in the AgentRuntime."""
 
+    def __init__(
+        self,
+        exception_callback: Callable[[BaseException], None],
+        description: str = "Semantic Kernel Actor",
+    ):
+        """Initialize the actor with a description and an exception callback.
+
+        Args:
+            exception_callback (Callable[[BaseException], None]): A callback function to handle exceptions.
+            description (str): A description of the actor.
+        """
+        super().__init__(description=description)
+        self._exception_callback = exception_callback
+
     @override
     async def on_message_impl(self, message: Any, ctx: MessageContext) -> Any | None:
         """Handle a message.
@@ -43,6 +57,7 @@ class AgentActorBase(ActorBase):
         self,
         agent: Agent,
         internal_topic_type: str,
+        exception_callback: Callable[[BaseException], None],
         agent_response_callback: Callable[[DefaultTypeAlias], Awaitable[None] | None] | None = None,
         streaming_agent_response_callback: Callable[[StreamingChatMessageContent, bool], Awaitable[None] | None]
         | None = None,
@@ -52,6 +67,7 @@ class AgentActorBase(ActorBase):
         Args:
             agent (Agent): An agent to be run in the container.
             internal_topic_type (str): The topic type of the internal topic.
+            exception_callback (Callable): A function that is called when an exception occurs.
             agent_response_callback (Callable | None): A function that is called when a full response is produced
                 by the agents.
             streaming_agent_response_callback (Callable | None): A function that is called when a streaming response
@@ -66,7 +82,7 @@ class AgentActorBase(ActorBase):
         # Chat history to temporarily store messages before each invoke.
         self._message_cache: ChatHistory = ChatHistory()
 
-        ActorBase.__init__(self, description=agent.description or "Semantic Kernel Agent")
+        super().__init__(exception_callback, description=agent.description)
 
     async def _call_agent_response_callback(self, message: DefaultTypeAlias) -> None:
         """Call the agent_response_callback function if it is set.

--- a/python/semantic_kernel/agents/orchestration/agent_actor_base.py
+++ b/python/semantic_kernel/agents/orchestration/agent_actor_base.py
@@ -2,6 +2,7 @@
 
 
 import inspect
+import logging
 import sys
 from collections.abc import Awaitable, Callable
 from functools import wraps
@@ -18,6 +19,8 @@ if sys.version_info >= (3, 12):
     from typing import override  # pragma: no cover
 else:
     from typing_extensions import override  # pragma: no cover
+
+logger: logging.Logger = logging.getLogger(__name__)
 
 
 @experimental
@@ -63,6 +66,8 @@ class ActorBase(RoutedAgent):
         Returns:
             The wrapped function.
         """
+        log_message_template = "Exception occurred in agent {agent_id}:\n{exception}"
+
         if inspect.iscoroutinefunction(func):
 
             @wraps(func)
@@ -71,6 +76,7 @@ class ActorBase(RoutedAgent):
                     return await func(self, *args, **kwargs)
                 except BaseException as e:
                     self._exception_callback(e)
+                    logger.error(log_message_template.format(agent_id=self.id, exception=e))
                     raise
 
             return async_wrapper
@@ -81,6 +87,7 @@ class ActorBase(RoutedAgent):
                 return func(self, *args, **kwargs)
             except BaseException as e:
                 self._exception_callback(e)
+                logger.error(log_message_template.format(agent_id=self.id, exception=e))
                 raise
 
         return sync_wrapper

--- a/python/semantic_kernel/agents/orchestration/concurrent.py
+++ b/python/semantic_kernel/agents/orchestration/concurrent.py
@@ -56,6 +56,7 @@ class ConcurrentAgentActor(AgentActorBase):
         agent: Agent,
         internal_topic_type: str,
         collection_agent_type: str,
+        exception_callback: Callable[[BaseException], None],
         agent_response_callback: Callable[[DefaultTypeAlias], Awaitable[None] | None] | None = None,
         streaming_agent_response_callback: Callable[[StreamingChatMessageContent, bool], Awaitable[None] | None]
         | None = None,
@@ -66,6 +67,7 @@ class ConcurrentAgentActor(AgentActorBase):
             agent: The agent to be executed.
             internal_topic_type: The internal topic type for the actor.
             collection_agent_type: The collection agent type for the actor.
+            exception_callback: A callback function to handle exceptions.
             agent_response_callback: A callback function to handle the full response from the agent.
             streaming_agent_response_callback: A callback function to handle streaming responses from the agent.
         """
@@ -73,6 +75,7 @@ class ConcurrentAgentActor(AgentActorBase):
         super().__init__(
             agent=agent,
             internal_topic_type=internal_topic_type,
+            exception_callback=exception_callback,
             agent_response_callback=agent_response_callback,
             streaming_agent_response_callback=streaming_agent_response_callback,
         )
@@ -102,6 +105,7 @@ class CollectionActor(ActorBase):
         self,
         description: str,
         expected_answer_count: int,
+        exception_callback: Callable[[BaseException], None],
         result_callback: Callable[[DefaultTypeAlias], Awaitable[None]] | None = None,
     ) -> None:
         """Initialize the collection agent container."""
@@ -110,7 +114,7 @@ class CollectionActor(ActorBase):
         self._results: list[ChatMessageContent] = []
         self._lock = asyncio.Lock()
 
-        super().__init__(description=description)
+        super().__init__(exception_callback, description=description)
 
     @message_handler
     async def _handle_message(self, message: ConcurrentResponseMessage, _: MessageContext) -> None:
@@ -147,17 +151,20 @@ class ConcurrentOrchestration(OrchestrationBase[TIn, TOut]):
         self,
         runtime: CoreRuntime,
         internal_topic_type: str,
-        result_callback: Callable[[DefaultTypeAlias], Awaitable[None]] | None = None,
+        exception_callback: Callable[[BaseException], None],
+        result_callback: Callable[[DefaultTypeAlias], Awaitable[None]],
     ) -> None:
         """Register the actors and orchestrations with the runtime and add the required subscriptions."""
         await asyncio.gather(*[
             self._register_members(
                 runtime,
                 internal_topic_type,
+                exception_callback,
             ),
             self._register_collection_actor(
                 runtime,
                 internal_topic_type,
+                exception_callback,
                 result_callback=result_callback,
             ),
             self._add_subscriptions(
@@ -170,6 +177,7 @@ class ConcurrentOrchestration(OrchestrationBase[TIn, TOut]):
         self,
         runtime: CoreRuntime,
         internal_topic_type: str,
+        exception_callback: Callable[[BaseException], None],
     ) -> None:
         """Register the members."""
 
@@ -180,7 +188,8 @@ class ConcurrentOrchestration(OrchestrationBase[TIn, TOut]):
                 lambda agent=agent: ConcurrentAgentActor(  # type: ignore[misc]
                     agent,
                     internal_topic_type,
-                    collection_agent_type=self._get_collection_actor_type(internal_topic_type),
+                    self._get_collection_actor_type(internal_topic_type),
+                    exception_callback,
                     agent_response_callback=self._agent_response_callback,
                     streaming_agent_response_callback=self._streaming_agent_response_callback,
                 ),
@@ -192,6 +201,7 @@ class ConcurrentOrchestration(OrchestrationBase[TIn, TOut]):
         self,
         runtime: CoreRuntime,
         internal_topic_type: str,
+        exception_callback: Callable[[BaseException], None],
         result_callback: Callable[[DefaultTypeAlias], Awaitable[None]] | None = None,
     ) -> None:
         await CollectionActor.register(
@@ -200,6 +210,7 @@ class ConcurrentOrchestration(OrchestrationBase[TIn, TOut]):
             lambda: CollectionActor(
                 description="An internal agent that is responsible for collection results",
                 expected_answer_count=len(self._members),
+                exception_callback=exception_callback,
                 result_callback=result_callback,
             ),
         )

--- a/python/semantic_kernel/agents/orchestration/concurrent.py
+++ b/python/semantic_kernel/agents/orchestration/concurrent.py
@@ -114,7 +114,7 @@ class CollectionActor(ActorBase):
         self._results: list[ChatMessageContent] = []
         self._lock = asyncio.Lock()
 
-        super().__init__(exception_callback, description=description)
+        super().__init__(description, exception_callback)
 
     @message_handler
     async def _handle_message(self, message: ConcurrentResponseMessage, _: MessageContext) -> None:

--- a/python/semantic_kernel/agents/orchestration/group_chat.py
+++ b/python/semantic_kernel/agents/orchestration/group_chat.py
@@ -275,7 +275,7 @@ class GroupChatManagerActor(ActorBase):
         self._participant_descriptions = participant_descriptions
         self._result_callback = result_callback
 
-        super().__init__(exception_callback, description="An actor for the group chat manager.")
+        super().__init__("An actor for the group chat manager.", exception_callback)
 
     @message_handler
     async def _handle_start_message(self, message: GroupChatStartMessage, ctx: MessageContext) -> None:
@@ -304,6 +304,7 @@ class GroupChatManagerActor(ActorBase):
 
         await self._determine_state_and_take_action(ctx.cancellation_token)
 
+    @ActorBase.exception_handler
     async def _determine_state_and_take_action(self, cancellation_token: CancellationToken) -> None:
         """Determine the state of the group chat and take action accordingly."""
         # User input state
@@ -453,7 +454,7 @@ class GroupChatOrchestration(OrchestrationBase[TIn, TOut]):
     ) -> None:
         """Register the actors and orchestrations with the runtime and add the required subscriptions."""
         await self._register_members(runtime, internal_topic_type, exception_callback)
-        await self._register_manager(runtime, internal_topic_type, result_callback=result_callback)
+        await self._register_manager(runtime, internal_topic_type, exception_callback, result_callback)
         await self._add_subscriptions(runtime, internal_topic_type)
 
     async def _register_members(

--- a/python/semantic_kernel/agents/orchestration/group_chat.py
+++ b/python/semantic_kernel/agents/orchestration/group_chat.py
@@ -257,6 +257,7 @@ class GroupChatManagerActor(ActorBase):
         manager: GroupChatManager,
         internal_topic_type: str,
         participant_descriptions: dict[str, str],
+        exception_callback: Callable[[BaseException], None],
         result_callback: Callable[[DefaultTypeAlias], Awaitable[None]] | None = None,
     ):
         """Initialize the group chat manager actor.
@@ -265,8 +266,7 @@ class GroupChatManagerActor(ActorBase):
             manager (GroupChatManager): The group chat manager that manages the flow of the group chat.
             internal_topic_type (str): The topic type of the internal topic.
             participant_descriptions (dict[str, str]): The descriptions of the participants in the group chat.
-            agent_response_callback (Callable | None): A function that is called when a response is produced
-                by the agents.
+            exception_callback (Callable[[BaseException], None]): A function that is called when an exception occurs.
             result_callback (Callable | None): A function that is called when the group chat manager produces a result.
         """
         self._manager = manager
@@ -275,7 +275,7 @@ class GroupChatManagerActor(ActorBase):
         self._participant_descriptions = participant_descriptions
         self._result_callback = result_callback
 
-        super().__init__(description="An actor for the group chat manager.")
+        super().__init__(exception_callback, description="An actor for the group chat manager.")
 
     @message_handler
     async def _handle_start_message(self, message: GroupChatStartMessage, ctx: MessageContext) -> None:
@@ -448,14 +448,20 @@ class GroupChatOrchestration(OrchestrationBase[TIn, TOut]):
         self,
         runtime: CoreRuntime,
         internal_topic_type: str,
+        exception_callback: Callable[[BaseException], None],
         result_callback: Callable[[DefaultTypeAlias], Awaitable[None]],
     ) -> None:
         """Register the actors and orchestrations with the runtime and add the required subscriptions."""
-        await self._register_members(runtime, internal_topic_type)
+        await self._register_members(runtime, internal_topic_type, exception_callback)
         await self._register_manager(runtime, internal_topic_type, result_callback=result_callback)
         await self._add_subscriptions(runtime, internal_topic_type)
 
-    async def _register_members(self, runtime: CoreRuntime, internal_topic_type: str) -> None:
+    async def _register_members(
+        self,
+        runtime: CoreRuntime,
+        internal_topic_type: str,
+        exception_callback: Callable[[BaseException], None],
+    ) -> None:
         """Register the agents."""
         await asyncio.gather(*[
             GroupChatAgentActor.register(
@@ -464,6 +470,7 @@ class GroupChatOrchestration(OrchestrationBase[TIn, TOut]):
                 lambda agent=agent: GroupChatAgentActor(  # type: ignore[misc]
                     agent,
                     internal_topic_type,
+                    exception_callback=exception_callback,
                     agent_response_callback=self._agent_response_callback,
                     streaming_agent_response_callback=self._streaming_agent_response_callback,
                 ),
@@ -475,6 +482,7 @@ class GroupChatOrchestration(OrchestrationBase[TIn, TOut]):
         self,
         runtime: CoreRuntime,
         internal_topic_type: str,
+        exception_callback: Callable[[BaseException], None],
         result_callback: Callable[[DefaultTypeAlias], Awaitable[None]] | None = None,
     ) -> None:
         """Register the group chat manager."""
@@ -485,6 +493,7 @@ class GroupChatOrchestration(OrchestrationBase[TIn, TOut]):
                 self._manager,
                 internal_topic_type=internal_topic_type,
                 participant_descriptions={agent.name: agent.description for agent in self._members},  # type: ignore[misc]
+                exception_callback=exception_callback,
                 result_callback=result_callback,
             ),
         )

--- a/python/semantic_kernel/agents/orchestration/handoffs.py
+++ b/python/semantic_kernel/agents/orchestration/handoffs.py
@@ -9,7 +9,7 @@ from collections.abc import Awaitable, Callable
 from functools import partial
 
 from semantic_kernel.agents.agent import Agent
-from semantic_kernel.agents.orchestration.agent_actor_base import AgentActorBase
+from semantic_kernel.agents.orchestration.agent_actor_base import ActorBase, AgentActorBase
 from semantic_kernel.agents.orchestration.orchestration_base import DefaultTypeAlias, OrchestrationBase, TIn, TOut
 from semantic_kernel.agents.runtime.core.cancellation_token import CancellationToken
 from semantic_kernel.agents.runtime.core.core_runtime import CoreRuntime
@@ -318,6 +318,7 @@ class HandoffAgentActor(AgentActorBase):
             return await self._human_response_function()
         return self._human_response_function()  # type: ignore[return-value]
 
+    @ActorBase.exception_handler
     async def _invoke_agent_with_potentially_no_response(
         self, additional_messages: DefaultTypeAlias | None = None, **kwargs
     ) -> ChatMessageContent | None:

--- a/python/semantic_kernel/agents/orchestration/magentic.py
+++ b/python/semantic_kernel/agents/orchestration/magentic.py
@@ -496,9 +496,10 @@ class MagenticManagerActor(ActorBase):
         self._context: MagenticContext | None = None
         self._task_ledger: ChatMessageContent | None = None
 
-        super().__init__(exception_callback=exception_callback, description="Magentic One Manager")
+        super().__init__("Magentic One Manager", exception_callback)
 
     @message_handler
+    @ActorBase.exception_handler
     async def _handle_start_message(self, message: MagenticStartMessage, ctx: MessageContext) -> None:
         """Handle the start message for the Magentic One manager."""
         logger.debug(f"{self.id}: Received Magentic One start message.")
@@ -514,6 +515,7 @@ class MagenticManagerActor(ActorBase):
         await self._run_outer_loop(ctx.cancellation_token)
 
     @message_handler
+    @ActorBase.exception_handler
     async def _handle_response_message(self, message: MagenticResponseMessage, ctx: MessageContext) -> None:
         """Handle the response message for the Magentic One manager."""
         if self._context is None or self._task_ledger is None:

--- a/python/semantic_kernel/agents/orchestration/magentic.py
+++ b/python/semantic_kernel/agents/orchestration/magentic.py
@@ -477,6 +477,7 @@ class MagenticManagerActor(ActorBase):
         manager: MagenticManagerBase,
         internal_topic_type: str,
         participant_descriptions: dict[str, str],
+        exception_callback: Callable[[BaseException], None],
         result_callback: Callable[[DefaultTypeAlias], Awaitable[None]] | None = None,
     ) -> None:
         """Initialize the Magentic One manager actor.
@@ -485,6 +486,7 @@ class MagenticManagerActor(ActorBase):
             manager (MagenticManagerBase): The Magentic One manager.
             internal_topic_type (str): The internal topic type.
             participant_descriptions (dict[str, str]): The participant descriptions.
+            exception_callback (Callable[[BaseException], None]): A callback function to handle exceptions.
             result_callback (Callable | None): A callback function to handle the final answer.
         """
         self._manager = manager
@@ -494,7 +496,7 @@ class MagenticManagerActor(ActorBase):
         self._context: MagenticContext | None = None
         self._task_ledger: ChatMessageContent | None = None
 
-        super().__init__(description="Magentic One Manager")
+        super().__init__(exception_callback=exception_callback, description="Magentic One Manager")
 
     @message_handler
     async def _handle_start_message(self, message: MagenticStartMessage, ctx: MessageContext) -> None:
@@ -795,14 +797,20 @@ class MagenticOrchestration(OrchestrationBase[TIn, TOut]):
         self,
         runtime: CoreRuntime,
         internal_topic_type: str,
+        exception_callback: Callable[[BaseException], None],
         result_callback: Callable[[DefaultTypeAlias], Awaitable[None]],
     ) -> None:
         """Register the actors and orchestrations with the runtime and add the required subscriptions."""
-        await self._register_members(runtime, internal_topic_type)
-        await self._register_manager(runtime, internal_topic_type, result_callback=result_callback)
+        await self._register_members(runtime, internal_topic_type, exception_callback)
+        await self._register_manager(runtime, internal_topic_type, exception_callback, result_callback=result_callback)
         await self._add_subscriptions(runtime, internal_topic_type)
 
-    async def _register_members(self, runtime: CoreRuntime, internal_topic_type: str) -> None:
+    async def _register_members(
+        self,
+        runtime: CoreRuntime,
+        internal_topic_type: str,
+        exception_callback: Callable[[BaseException], None],
+    ) -> None:
         """Register the agents."""
         await asyncio.gather(*[
             MagenticAgentActor.register(
@@ -811,6 +819,7 @@ class MagenticOrchestration(OrchestrationBase[TIn, TOut]):
                 lambda agent=agent: MagenticAgentActor(  # type: ignore[misc]
                     agent,
                     internal_topic_type,
+                    exception_callback,
                     self._agent_response_callback,
                     self._streaming_agent_response_callback,
                 ),
@@ -822,6 +831,7 @@ class MagenticOrchestration(OrchestrationBase[TIn, TOut]):
         self,
         runtime: CoreRuntime,
         internal_topic_type: str,
+        exception_callback: Callable[[BaseException], None],
         result_callback: Callable[[DefaultTypeAlias], Awaitable[None]] | None = None,
     ) -> None:
         """Register the group chat manager."""
@@ -832,6 +842,7 @@ class MagenticOrchestration(OrchestrationBase[TIn, TOut]):
                 self._manager,
                 internal_topic_type=internal_topic_type,
                 participant_descriptions={agent.name: agent.description for agent in self._members},  # type: ignore[misc]
+                exception_callback=exception_callback,
                 result_callback=result_callback,
             ),
         )

--- a/python/semantic_kernel/agents/orchestration/orchestration_base.py
+++ b/python/semantic_kernel/agents/orchestration/orchestration_base.py
@@ -205,6 +205,11 @@ class OrchestrationBase(ABC, Generic[TIn, TOut]):
             orchestration_result.value = transformed_result
             orchestration_result.event.set()
 
+        def exception_callback(exception: BaseException) -> None:
+            nonlocal orchestration_result
+            orchestration_result.exception = exception
+            orchestration_result.event.set()
+
         # This unique topic type is used to isolate the orchestration run from others.
         internal_topic_type = uuid.uuid4().hex
 
@@ -212,6 +217,7 @@ class OrchestrationBase(ABC, Generic[TIn, TOut]):
             runtime,
             internal_topic_type=internal_topic_type,
             result_callback=result_callback,
+            exception_callback=exception_callback,
         )
 
         if isinstance(task, str):
@@ -271,6 +277,7 @@ class OrchestrationBase(ABC, Generic[TIn, TOut]):
         self,
         runtime: CoreRuntime,
         internal_topic_type: str,
+        exception_callback: Callable[[BaseException], None],
         result_callback: Callable[[DefaultTypeAlias], Awaitable[None]],
     ) -> None:
         """Register the actors and orchestrations with the runtime and add the required subscriptions.
@@ -278,8 +285,7 @@ class OrchestrationBase(ABC, Generic[TIn, TOut]):
         Args:
             runtime (CoreRuntime): The runtime environment for the agents.
             internal_topic_type (str): The internal topic type for the orchestration that this actor is part of.
-            external_topic_type (str | None): The external topic type for the orchestration.
-            direct_actor_type (str | None): The direct actor type for which this actor will relay the output message to.
+            exception_callback (Callable): A function that is called when an exception occurs.
             result_callback (Callable): A function that is called when the result is available.
         """
         pass

--- a/python/semantic_kernel/agents/orchestration/sequential.py
+++ b/python/semantic_kernel/agents/orchestration/sequential.py
@@ -93,7 +93,7 @@ class CollectionActor(ActorBase):
         """Initialize the collection actor."""
         self._result_callback = result_callback
 
-        super().__init__(exception_callback, description=description)
+        super().__init__(description, exception_callback)
 
     @message_handler
     async def _handle_message(self, message: SequentialRequestMessage, _: MessageContext) -> None:

--- a/python/semantic_kernel/agents/orchestration/sequential.py
+++ b/python/semantic_kernel/agents/orchestration/sequential.py
@@ -48,6 +48,7 @@ class SequentialAgentActor(AgentActorBase):
         agent: Agent,
         internal_topic_type: str,
         next_agent_type: str,
+        exception_callback: Callable[[BaseException], None],
         agent_response_callback: Callable[[DefaultTypeAlias], Awaitable[None] | None] | None = None,
         streaming_agent_response_callback: Callable[[StreamingChatMessageContent, bool], Awaitable[None] | None]
         | None = None,
@@ -57,6 +58,7 @@ class SequentialAgentActor(AgentActorBase):
         super().__init__(
             agent=agent,
             internal_topic_type=internal_topic_type,
+            exception_callback=exception_callback,
             agent_response_callback=agent_response_callback,
             streaming_agent_response_callback=streaming_agent_response_callback,
         )
@@ -85,12 +87,13 @@ class CollectionActor(ActorBase):
     def __init__(
         self,
         description: str,
+        exception_callback: Callable[[BaseException], None],
         result_callback: Callable[[DefaultTypeAlias], Awaitable[None]],
     ) -> None:
         """Initialize the collection actor."""
         self._result_callback = result_callback
 
-        super().__init__(description=description)
+        super().__init__(exception_callback, description=description)
 
     @message_handler
     async def _handle_message(self, message: SequentialRequestMessage, _: MessageContext) -> None:
@@ -123,16 +126,18 @@ class SequentialOrchestration(OrchestrationBase[TIn, TOut]):
         self,
         runtime: CoreRuntime,
         internal_topic_type: str,
+        exception_callback: Callable[[BaseException], None],
         result_callback: Callable[[DefaultTypeAlias], Awaitable[None]],
     ) -> None:
         """Register the actors and orchestrations with the runtime and add the required subscriptions."""
-        await self._register_members(runtime, internal_topic_type)
-        await self._register_collection_actor(runtime, internal_topic_type, result_callback)
+        await self._register_members(runtime, internal_topic_type, exception_callback)
+        await self._register_collection_actor(runtime, internal_topic_type, exception_callback, result_callback)
 
     async def _register_members(
         self,
         runtime: CoreRuntime,
         internal_topic_type: str,
+        exception_callback: Callable[[BaseException], None],
     ) -> None:
         """Register the members.
 
@@ -143,6 +148,7 @@ class SequentialOrchestration(OrchestrationBase[TIn, TOut]):
         Args:
             runtime (CoreRuntime): The agent runtime.
             internal_topic_type (str): The internal topic type for the orchestration that this actor is part of.
+            exception_callback (Callable[[BaseException], None]): A callback function to handle exceptions.
 
         Returns:
             str: The first actor type in the sequence.
@@ -156,6 +162,7 @@ class SequentialOrchestration(OrchestrationBase[TIn, TOut]):
                     agent,
                     internal_topic_type,
                     next_agent_type=next_actor_type,
+                    exception_callback=exception_callback,
                     agent_response_callback=self._agent_response_callback,
                     streaming_agent_response_callback=self._streaming_agent_response_callback,
                 ),
@@ -167,6 +174,7 @@ class SequentialOrchestration(OrchestrationBase[TIn, TOut]):
         self,
         runtime: CoreRuntime,
         internal_topic_type: str,
+        exception_callback: Callable[[BaseException], None],
         result_callback: Callable[[DefaultTypeAlias], Awaitable[None]],
     ) -> None:
         """Register the collection actor."""
@@ -175,6 +183,7 @@ class SequentialOrchestration(OrchestrationBase[TIn, TOut]):
             self._get_collection_actor_type(internal_topic_type),
             lambda: CollectionActor(
                 description="An internal agent that is responsible for collection results",
+                exception_callback=exception_callback,
                 result_callback=result_callback,
             ),
         )

--- a/python/tests/integration/agents/openai_assistant_agent/test_openai_assistant_agent_integration.py
+++ b/python/tests/integration/agents/openai_assistant_agent/test_openai_assistant_agent_integration.py
@@ -193,8 +193,12 @@ class TestOpenAIAssistantAgentIntegration:
     @pytest.mark.parametrize(
         "assistant_agent",
         [
-            ("azure", {"enable_code_interpreter": True}),
-            ("openai", {"enable_code_interpreter": True}),
+            pytest.param(
+                ("azure", {"enable_code_interpreter": True}), marks=pytest.mark.xfail(reason="Service outage")
+            ),
+            pytest.param(
+                ("openai", {"enable_code_interpreter": True}),
+            ),
         ],
         indirect=["assistant_agent"],
         ids=["azure-code-interpreter", "openai-code-interpreter"],
@@ -219,8 +223,12 @@ Dolphin  2
     @pytest.mark.parametrize(
         "assistant_agent",
         [
-            ("azure", {"enable_code_interpreter": True}),
-            ("openai", {"enable_code_interpreter": True}),
+            pytest.param(
+                ("azure", {"enable_code_interpreter": True}), marks=pytest.mark.xfail(reason="Service outage")
+            ),
+            pytest.param(
+                ("openai", {"enable_code_interpreter": True}),
+            ),
         ],
         indirect=["assistant_agent"],
         ids=["azure-code-interpreter", "openai-code-interpreter"],
@@ -245,8 +253,12 @@ Dolphin  2
     @pytest.mark.parametrize(
         "assistant_agent",
         [
-            ("azure", {"enable_code_interpreter": True}),
-            ("openai", {"enable_code_interpreter": True}),
+            pytest.param(
+                ("azure", {"enable_code_interpreter": True}), marks=pytest.mark.xfail(reason="Service outage")
+            ),
+            pytest.param(
+                ("openai", {"enable_code_interpreter": True}),
+            ),
         ],
         indirect=["assistant_agent"],
         ids=["azure-code-interpreter", "openai-code-interpreter"],

--- a/python/tests/unit/agents/orchestration/conftest.py
+++ b/python/tests/unit/agents/orchestration/conftest.py
@@ -90,6 +90,35 @@ class MockAgent(Agent):
         )
 
 
+class MockAgentWithException(MockAgent):
+    """A mock agent that raises an exception for testing purposes."""
+
+    @override
+    async def invoke_stream(
+        self,
+        messages: str | ChatMessageContent | list[str | ChatMessageContent] | None = None,
+        *,
+        thread: AgentThread | None = None,
+        on_intermediate_message: Callable[[ChatMessageContent], Awaitable[None]] | None = None,
+        **kwargs,
+    ) -> AsyncIterable[AgentResponseItem[StreamingChatMessageContent]]:
+        """Simulate streaming response from the agent that raises an exception."""
+        # Simulate some processing time
+        await asyncio.sleep(0.05)
+
+        yield AgentResponseItem[StreamingChatMessageContent](
+            message=StreamingChatMessageContent(
+                role=AuthorRole.ASSISTANT,
+                name=self.name,
+                content="mock",
+                choice_index=0,
+            ),
+            thread=thread or MockAgentThread(),
+        )
+
+        raise RuntimeError("Mock agent exception")
+
+
 class MockRuntime(CoreRuntime):
     """A mock agent runtime for testing purposes."""
 

--- a/python/tests/unit/agents/orchestration/test_orchestration_base.py
+++ b/python/tests/unit/agents/orchestration/test_orchestration_base.py
@@ -65,7 +65,7 @@ class MockOrchestration(OrchestrationBase[TIn, TOut]):
     async def _start(self, task, runtime, internal_topic_type, collection_agent_type):
         pass
 
-    async def _prepare(self, runtime, internal_topic_type, result_callback):
+    async def _prepare(self, runtime, internal_topic_type, exception_callback, result_callback):
         pass
 
 

--- a/python/tests/unit/agents/orchestration/test_sequential.py
+++ b/python/tests/unit/agents/orchestration/test_sequential.py
@@ -11,7 +11,7 @@ from semantic_kernel.agents.orchestration.sequential import SequentialOrchestrat
 from semantic_kernel.agents.runtime.in_process.in_process_runtime import InProcessRuntime
 from semantic_kernel.contents.chat_message_content import ChatMessageContent
 from semantic_kernel.contents.streaming_chat_message_content import StreamingChatMessageContent
-from tests.unit.agents.orchestration.conftest import MockAgent, MockRuntime
+from tests.unit.agents.orchestration.conftest import MockAgent, MockAgentWithException, MockRuntime
 
 
 async def test_prepare():
@@ -179,5 +179,24 @@ async def test_invoke_with_double_get_result():
 
         assert isinstance(result, ChatMessageContent)
         assert result.content == "mock_response"
+    finally:
+        await runtime.stop_when_idle()
+
+
+async def test_invoke_with_agent_raising_exception():
+    """Test the invoke method of the SequentialOrchestration with an agent raising an exception."""
+    agent_a = MockAgent()
+    agent_b = MockAgentWithException()
+
+    runtime = InProcessRuntime()
+    runtime.start()
+
+    try:
+        orchestration = SequentialOrchestration(members=[agent_a, agent_b])
+        orchestration_result = await orchestration.invoke(task="test_message", runtime=runtime)
+
+        with pytest.raises(RuntimeError, match="Mock agent exception"):
+            await orchestration_result.get(1.0)
+        assert orchestration_result.exception is not None
     finally:
         await runtime.stop_when_idle()


### PR DESCRIPTION
### Motivation and Context

<!-- Thank you for your contribution to the semantic-kernel repo!
Please help reviewers and future users, providing the following information:
  1. Why is this change required?
  2. What problem does it solve?
  3. What scenario does it contribute to?
  4. If it fixes an open issue, please link to the issue here.
-->
Currently, exceptions that occur inside the orchestration actors are not properly surfaced to the caller as it happens. 

Fixes: https://github.com/microsoft/semantic-kernel/issues/12719

### Description

<!-- Describe your changes, the overall approach, the underlying design.
     These notes will help understanding how your code works. Thanks! -->
This PR addresses the issue by introducing a new exception_callback that is hidden from the user but will raise exceptions that occurs inside the orchestration actors to the caller.

### Contribution Checklist

<!-- Before submitting this PR, please make sure: -->

- [x] The code builds clean without any errors or warnings
- [x] The PR follows the [SK Contribution Guidelines](https://github.com/microsoft/semantic-kernel/blob/main/CONTRIBUTING.md) and the [pre-submission formatting script](https://github.com/microsoft/semantic-kernel/blob/main/CONTRIBUTING.md#development-scripts) raises no violations
- [x] All unit tests pass, and I have added new tests where possible
- [x] I didn't break anyone :smile:
