### PR TITLE
.Net: Google Gemini - Move API key from the URL to `x-goog-api-key` HTTP header

### DIFF
--- a/dotnet/src/Connectors/Connectors.Google.UnitTests/Core/Gemini/Clients/GeminiChatGenerationTests.cs
+++ b/dotnet/src/Connectors/Connectors.Google.UnitTests/Core/Gemini/Clients/GeminiChatGenerationTests.cs
@@ -423,6 +423,38 @@ public sealed class GeminiChatGenerationTests : IDisposable
     }
 
     [Fact]
+    public async Task ItCreatesPostRequestWithApiKeyInHeaderAsync()
+    {
+        // Arrange
+        var client = this.CreateChatCompletionClient();
+        var chatHistory = CreateSampleChatHistory();
+
+        // Act
+        await client.GenerateChatMessageAsync(chatHistory);
+
+        // Assert
+        Assert.NotNull(this._messageHandlerStub.RequestHeaders);
+        var apiKeyHeader = this._messageHandlerStub.RequestHeaders.GetValues("x-goog-api-key").SingleOrDefault();
+        Assert.NotNull(apiKeyHeader);
+        Assert.Equal("fake-key", apiKeyHeader);
+    }
+
+    [Fact]
+    public async Task ItCreatesPostRequestWithoutApiKeyInUrlAsync()
+    {
+        // Arrange
+        var client = this.CreateChatCompletionClient();
+        var chatHistory = CreateSampleChatHistory();
+
+        // Act
+        await client.GenerateChatMessageAsync(chatHistory);
+
+        // Assert
+        Assert.NotNull(this._messageHandlerStub.RequestUri);
+        Assert.DoesNotContain("key=", this._messageHandlerStub.RequestUri.ToString());
+    }
+
+    [Fact]
     public async Task ItCreatesPostRequestWithResponseSchemaPropertyAsync()
     {
         // Get a mock logger that will return true for IsEnabled(LogLevel.Trace)

--- a/dotnet/src/Connectors/Connectors.Google.UnitTests/Core/Gemini/Clients/GeminiChatStreamingTests.cs
+++ b/dotnet/src/Connectors/Connectors.Google.UnitTests/Core/Gemini/Clients/GeminiChatStreamingTests.cs
@@ -392,6 +392,38 @@ public sealed class GeminiChatStreamingTests : IDisposable
         Assert.Equal(expectedVersion, header);
     }
 
+    [Fact]
+    public async Task ItCreatesPostRequestWithApiKeyInHeaderAsync()
+    {
+        // Arrange
+        var client = this.CreateChatCompletionClient();
+        var chatHistory = CreateSampleChatHistory();
+
+        // Act
+        await client.StreamGenerateChatMessageAsync(chatHistory).ToListAsync();
+
+        // Assert
+        Assert.NotNull(this._messageHandlerStub.RequestHeaders);
+        var apiKeyHeader = this._messageHandlerStub.RequestHeaders.GetValues("x-goog-api-key").SingleOrDefault();
+        Assert.NotNull(apiKeyHeader);
+        Assert.Equal("fake-key", apiKeyHeader);
+    }
+
+    [Fact]
+    public async Task ItCreatesPostRequestWithoutApiKeyInUrlAsync()
+    {
+        // Arrange
+        var client = this.CreateChatCompletionClient();
+        var chatHistory = CreateSampleChatHistory();
+
+        // Act
+        await client.StreamGenerateChatMessageAsync(chatHistory).ToListAsync();
+
+        // Assert
+        Assert.NotNull(this._messageHandlerStub.RequestUri);
+        Assert.DoesNotContain("key=", this._messageHandlerStub.RequestUri.ToString());
+    }
+
     private static ChatHistory CreateSampleChatHistory()
     {
         var chatHistory = new ChatHistory();

--- a/dotnet/src/Connectors/Connectors.Google.UnitTests/Core/Gemini/Clients/GeminiCountingTokensTests.cs
+++ b/dotnet/src/Connectors/Connectors.Google.UnitTests/Core/Gemini/Clients/GeminiCountingTokensTests.cs
@@ -116,6 +116,36 @@ public sealed class GeminiCountingTokensTests : IDisposable
         Assert.Equal(expectedVersion, header);
     }
 
+    [Fact]
+    public async Task ItCreatesPostRequestWithApiKeyInHeaderAsync()
+    {
+        // Arrange
+        var client = this.CreateTokenCounterClient();
+
+        // Act
+        await client.CountTokensAsync("fake-text");
+
+        // Assert
+        Assert.NotNull(this._messageHandlerStub.RequestHeaders);
+        var apiKeyHeader = this._messageHandlerStub.RequestHeaders.GetValues("x-goog-api-key").SingleOrDefault();
+        Assert.NotNull(apiKeyHeader);
+        Assert.Equal("fake-key", apiKeyHeader);
+    }
+
+    [Fact]
+    public async Task ItCreatesPostRequestWithoutApiKeyInUrlAsync()
+    {
+        // Arrange
+        var client = this.CreateTokenCounterClient();
+
+        // Act
+        await client.CountTokensAsync("fake-text");
+
+        // Assert
+        Assert.NotNull(this._messageHandlerStub.RequestUri);
+        Assert.DoesNotContain("key=", this._messageHandlerStub.RequestUri.ToString());
+    }
+
     [Theory]
     [InlineData("https://malicious-site.com")]
     [InlineData("http://internal-network.local")]

--- a/dotnet/src/Connectors/Connectors.Google.UnitTests/Core/GoogleAI/GoogleAIClientEmbeddingsGenerationTests.cs
+++ b/dotnet/src/Connectors/Connectors.Google.UnitTests/Core/GoogleAI/GoogleAIClientEmbeddingsGenerationTests.cs
@@ -143,6 +143,38 @@ public sealed class GoogleAIClientEmbeddingsGenerationTests : IDisposable
     }
 
     [Fact]
+    public async Task ItCreatesPostRequestWithApiKeyInHeaderAsync()
+    {
+        // Arrange
+        var client = this.CreateEmbeddingsClient();
+        IList<string> data = ["sample data"];
+
+        // Act
+        await client.GenerateEmbeddingsAsync(data);
+
+        // Assert
+        Assert.NotNull(this._messageHandlerStub.RequestHeaders);
+        var apiKeyHeader = this._messageHandlerStub.RequestHeaders.GetValues("x-goog-api-key").SingleOrDefault();
+        Assert.NotNull(apiKeyHeader);
+        Assert.Equal("fake-key", apiKeyHeader);
+    }
+
+    [Fact]
+    public async Task ItCreatesPostRequestWithoutApiKeyInUrlAsync()
+    {
+        // Arrange
+        var client = this.CreateEmbeddingsClient();
+        IList<string> data = ["sample data"];
+
+        // Act
+        await client.GenerateEmbeddingsAsync(data);
+
+        // Assert
+        Assert.NotNull(this._messageHandlerStub.RequestUri);
+        Assert.DoesNotContain("key=", this._messageHandlerStub.RequestUri.ToString());
+    }
+
+    [Fact]
     public async Task ShouldIncludeDimensionsInAllRequestsAsync()
     {
         // Arrange

--- a/dotnet/src/Connectors/Connectors.Google/Core/ClientBase.cs
+++ b/dotnet/src/Connectors/Connectors.Google/Core/ClientBase.cs
@@ -15,6 +15,7 @@ namespace Microsoft.SemanticKernel.Connectors.Google.Core;
 internal abstract class ClientBase
 {
     private readonly Func<ValueTask<string>>? _bearerTokenProvider;
+    private readonly string? _apiKey;
 
     protected ILogger Logger { get; }
 
@@ -32,12 +33,14 @@ internal abstract class ClientBase
 
     protected ClientBase(
         HttpClient httpClient,
-        ILogger? logger)
+        ILogger? logger,
+        string? apiKey = null)
     {
         Verify.NotNull(httpClient);
 
         this.HttpClient = httpClient;
         this.Logger = logger ?? NullLogger.Instance;
+        this._apiKey = apiKey;
     }
 
     protected static void ValidateMaxTokens(int? maxTokens)
@@ -95,6 +98,10 @@ internal abstract class ClientBase
         {
             httpRequestMessage.Headers.Authorization =
                 new AuthenticationHeaderValue("Bearer", bearerKey);
+        }
+        else if (!string.IsNullOrWhiteSpace(this._apiKey))
+        {
+            httpRequestMessage.Headers.Add("x-goog-api-key", this._apiKey);
         }
 
         return httpRequestMessage;

--- a/dotnet/src/Connectors/Connectors.Google/Core/Gemini/Clients/GeminiChatCompletionClient.cs
+++ b/dotnet/src/Connectors/Connectors.Google/Core/Gemini/Clients/GeminiChatCompletionClient.cs
@@ -100,7 +100,8 @@ internal sealed class GeminiChatCompletionClient : ClientBase
         ILogger? logger = null)
         : base(
             httpClient: httpClient,
-            logger: logger)
+            logger: logger,
+            apiKey: apiKey)
     {
         Verify.NotNullOrWhiteSpace(modelId);
         Verify.NotNullOrWhiteSpace(apiKey);
@@ -108,8 +109,8 @@ internal sealed class GeminiChatCompletionClient : ClientBase
         string versionSubLink = GetApiVersionSubLink(apiVersion);
 
         this._modelId = modelId;
-        this._chatGenerationEndpoint = new Uri($"https://generativelanguage.googleapis.com/{versionSubLink}/models/{this._modelId}:generateContent?key={apiKey}");
-        this._chatStreamingEndpoint = new Uri($"https://generativelanguage.googleapis.com/{versionSubLink}/models/{this._modelId}:streamGenerateContent?key={apiKey}&alt=sse");
+        this._chatGenerationEndpoint = new Uri($"https://generativelanguage.googleapis.com/{versionSubLink}/models/{this._modelId}:generateContent");
+        this._chatStreamingEndpoint = new Uri($"https://generativelanguage.googleapis.com/{versionSubLink}/models/{this._modelId}:streamGenerateContent?alt=sse");
     }
 
     /// <summary>

--- a/dotnet/src/Connectors/Connectors.Google/Core/Gemini/Clients/GeminiTokenCounterClient.cs
+++ b/dotnet/src/Connectors/Connectors.Google/Core/Gemini/Clients/GeminiTokenCounterClient.cs
@@ -33,7 +33,8 @@ internal sealed class GeminiTokenCounterClient : ClientBase
         ILogger? logger = null)
         : base(
             httpClient: httpClient,
-            logger: logger)
+            logger: logger,
+            apiKey: apiKey)
     {
         Verify.NotNullOrWhiteSpace(modelId);
         Verify.NotNullOrWhiteSpace(apiKey);
@@ -41,7 +42,7 @@ internal sealed class GeminiTokenCounterClient : ClientBase
         string versionSubLink = GetApiVersionSubLink(apiVersion);
 
         this._modelId = modelId;
-        this._tokenCountingEndpoint = new Uri($"https://generativelanguage.googleapis.com/{versionSubLink}/models/{this._modelId}:countTokens?key={apiKey}");
+        this._tokenCountingEndpoint = new Uri($"https://generativelanguage.googleapis.com/{versionSubLink}/models/{this._modelId}:countTokens");
     }
 
     /// <summary>

--- a/dotnet/src/Connectors/Connectors.Google/Core/GoogleAI/GoogleAIEmbeddingClient.cs
+++ b/dotnet/src/Connectors/Connectors.Google/Core/GoogleAI/GoogleAIEmbeddingClient.cs
@@ -37,7 +37,8 @@ internal sealed class GoogleAIEmbeddingClient : ClientBase
         int? dimensions = null)
         : base(
             httpClient: httpClient,
-            logger: logger)
+            logger: logger,
+            apiKey: apiKey)
     {
         Verify.NotNullOrWhiteSpace(modelId);
         Verify.NotNullOrWhiteSpace(apiKey);
@@ -45,7 +46,7 @@ internal sealed class GoogleAIEmbeddingClient : ClientBase
         string versionSubLink = GetApiVersionSubLink(apiVersion);
 
         this._embeddingModelId = modelId;
-        this._embeddingEndpoint = new Uri($"https://generativelanguage.googleapis.com/{versionSubLink}/models/{this._embeddingModelId}:batchEmbedContents?key={apiKey}");
+        this._embeddingEndpoint = new Uri($"https://generativelanguage.googleapis.com/{versionSubLink}/models/{this._embeddingModelId}:batchEmbedContents");
         this._dimensions = dimensions;
     }
 


### PR DESCRIPTION
### Motivation and Context

- Resolves #12666

The implementation successfully addresses the security concern raised in GitHub issue #12666 by moving the Google API key from the URL query parameter to the secure x-goog-api-key HTTP header, preventing sensitive information from being logged or traced.

- Modified ClientBase class to support API key in headers
- Updated all Google AI clients (Chat, Streaming, Token Counter, Embeddings) to use header-based authentication
- Removed API key from URLs to prevent exposure in logs and OTEL traces
- Comprehensive Testing:

