### PR TITLE
Add React Agent sample using Azure OpenAI and update README with usage instructions

### DIFF
--- a/python/samples/concepts/README.md
+++ b/python/samples/concepts/README.md
@@ -106,6 +106,10 @@
 - [OpenAI Responses Reuse Existing Thread ID](./agents/openai_responses/responses_agent_reuse_existing_thread_id.py)
 - [OpenAI Responses Web Search Streaming](./agents/openai_responses/responses_agent_web_search_streaming.py)
 
+#### React Agents - Implementing the React (Reasoning and Acting) pattern with agents
+
+- [Azure AI React Agent](./react/azure_ai_react_agent.py)
+
 ### Audio - Using services that support audio-to-text and text-to-audio conversion
 
 - [Chat with Audio Input](./audio/01-chat_with_audio_input.py)
@@ -255,9 +259,11 @@ In Semantic Kernel for Python, we leverage Pydantic Settings to manage configura
 ## Steps for Configuration
 
 1. **Reading Environment Variables:**
+
    - **Primary Source:** Pydantic first attempts to read the required settings from environment variables.
 
 2. **Using a .env File:**
+
    - **Fallback Source:** If the required environment variables are not set, Pydantic will look for a `.env` file in the current working directory.
    - **Custom Path (Optional):** You can specify an alternative path for the `.env` file via `env_file_path`. This can be either a relative or an absolute path.
 

--- a/python/samples/concepts/react/azure_ai_react_agent.py
+++ b/python/samples/concepts/react/azure_ai_react_agent.py
@@ -1,0 +1,325 @@
+# Copyright (c) Microsoft. All rights reserved.
+
+import asyncio
+import json
+import re
+from typing import Annotated
+
+from semantic_kernel import Kernel
+from semantic_kernel.agents import ChatCompletionAgent, ChatHistoryAgentThread
+from semantic_kernel.connectors.ai.open_ai import AzureChatCompletion
+from semantic_kernel.functions import kernel_function, KernelArguments
+from semantic_kernel.prompt_template import PromptTemplateConfig
+
+"""
+The following sample demonstrates how to create a React (Reasoning and Acting) agent
+using Azure OpenAI within Semantic Kernel. The React pattern enables the agent to
+think step by step, take actions using available functions, and observe the results
+before making a final decision.
+
+React stands for:
+- Reasoning: The agent thinks about the problem and plans the next step
+- Acting: The agent executes an action using available functions  
+- Observing: The agent examines the results and decides on the next step
+
+This cycle continues until the agent reaches a final answer.
+"""
+
+# React prompt template that guides the agent through the reasoning-acting cycle
+REACT_PROMPT_TEMPLATE = """
+[INSTRUCTION]
+Answer the following questions as accurately as possible using the provided functions.
+
+[AVAILABLE FUNCTIONS]
+The function definitions below are in the following format:
+<functionName>: <description>
+ - <parameterName>: <parameterDescription>
+ - ...
+[END AVAILABLE FUNCTIONS]
+
+[USAGE INSTRUCTIONS]
+To use the functions, specify a JSON blob representing an action. The JSON blob should contain the fully qualified name of the function to use, and an "action_variables" key with a JSON object of string values to use when calling the function.
+Do not call functions directly; they must be invoked through an action.
+
+Here is an example of a valid $JSON_BLOB:
+```
+{
+  "action": "CalculatorPlugin.Add",
+  "action_variables": {"number1": "5", "number2": "3"}
+}
+```
+
+IMPORTANT: 
+* Use only the available functions listed in the [AVAILABLE FUNCTIONS] section.
+* Do not attempt to use any other functions that are not specified.
+* You must provide a single action per step.
+* All parameter values must be strings.
+[END USAGE INSTRUCTIONS]
+[END INSTRUCTION]
+
+[THOUGHT PROCESS]
+[QUESTION]
+{{$question}}
+[THOUGHT]
+To solve this problem, I should carefully analyze the given question and identify the necessary steps. Any facts I discover earlier in my thought process should be repeated here to keep them readily available.
+[ACTION]
+$JSON_BLOB
+[OBSERVATION]
+The result of the action will be provided here.
+... (These THOUGHT/ACTION/OBSERVATION can repeat until the final answer is reached.)
+[FINAL ANSWER]
+Once I have gathered all the necessary observations and performed any required actions, provide the final answer in a clear and human-readable format.
+[END THOUGHT PROCESS]
+
+IMPORTANT REMINDER: Your response should contain only one next step with a single [ACTION] part. Do not provide more than one step at a time.
+
+Begin!
+
+[AVAILABLE FUNCTIONS]
+{{$function_descriptions}}
+[END AVAILABLE FUNCTIONS]
+[QUESTION]
+{{$question}}
+{{$agent_scratchpad}}
+[THOUGHT]
+"""
+
+
+# Sample plugins for the React agent to use
+class CalculatorPlugin:
+    """A calculator plugin that provides basic mathematical operations."""
+
+    @kernel_function(description="Adds two numbers together.")
+    def add(
+        self,
+        number1: Annotated[str, "The first number to add"],
+        number2: Annotated[str, "The second number to add"],
+    ) -> Annotated[str, "The sum of the two numbers"]:
+        try:
+            result = float(number1) + float(number2)
+            return str(result)
+        except ValueError:
+            return "Error: Invalid number format"
+
+    @kernel_function(description="Multiplies two numbers together.")
+    def multiply(
+        self,
+        number1: Annotated[str, "The first number to multiply"],
+        number2: Annotated[str, "The second number to multiply"],
+    ) -> Annotated[str, "The product of the two numbers"]:
+        try:
+            result = float(number1) * float(number2)
+            return str(result)
+        except ValueError:
+            return "Error: Invalid number format"
+
+    @kernel_function(description="Divides the first number by the second number.")
+    def divide(
+        self,
+        number1: Annotated[str, "The dividend"],
+        number2: Annotated[str, "The divisor"],
+    ) -> Annotated[str, "The quotient of the division"]:
+        try:
+            num1, num2 = float(number1), float(number2)
+            if num2 == 0:
+                return "Error: Division by zero"
+            result = num1 / num2
+            return str(result)
+        except ValueError:
+            return "Error: Invalid number format"
+
+
+class WeatherPlugin:
+    """A simple weather plugin for demonstration purposes."""
+
+    @kernel_function(description="Gets the current weather for a given city.")
+    def get_weather(
+        self, city: Annotated[str, "The name of the city"]
+    ) -> Annotated[str, "The current weather information"]:
+        # Simulated weather data
+        weather_data = {
+            "istanbul": "Sunny, 22°C",
+            "ankara": "Cloudy, 18°C",
+            "izmir": "Partly cloudy, 25°C",
+            "antalya": "Sunny, 28°C",
+            "new york": "Rainy, 15°C",
+            "london": "Foggy, 12°C",
+            "paris": "Sunny, 20°C",
+        }
+        city_lower = city.lower()
+        if city_lower in weather_data:
+            return f"The weather in {city} is: {weather_data[city_lower]}"
+        else:
+            return f"Weather information for {city} is not available."
+
+
+def extract_function_descriptions(kernel: Kernel) -> str:
+    """Extract function descriptions from kernel plugins for the React prompt."""
+    descriptions = []
+
+    for plugin_name, plugin in kernel.plugins.items():
+        for function_name, function in plugin.items():
+            full_name = f"{plugin_name}.{function_name}"
+            desc = function.metadata.description or "No description available"
+
+            descriptions.append(f"{full_name}: {desc}")
+
+            # Add parameter descriptions
+            for param in function.metadata.parameters:
+                param_desc = param.description or "No description"
+                descriptions.append(f" - {param.name}: {param_desc}")
+
+    return "\n".join(descriptions)
+
+
+def parse_action_from_response(response: str) -> tuple[str | None, dict[str, str]]:
+    """Parse the action JSON blob from the agent's response."""
+    # Look for JSON blob in the response
+    json_pattern = r"```\s*\n?({.*?})\s*\n?```"
+    match = re.search(json_pattern, response, re.DOTALL)
+
+    if not match:
+        # Try to find JSON without code blocks
+        json_pattern = r'({[^}]*"action"[^}]*})'
+        match = re.search(json_pattern, response, re.DOTALL)
+
+    if match:
+        try:
+            action_data = json.loads(match.group(1))
+            action_name = action_data.get("action")
+            action_variables = action_data.get("action_variables", {})
+            return action_name, action_variables
+        except json.JSONDecodeError:
+            pass
+
+    return None, {}
+
+
+async def execute_react_step(
+    agent: ChatCompletionAgent, question: str, scratchpad: str
+) -> tuple[str, bool]:
+    """Execute one step of the React cycle and return the updated scratchpad and completion status."""
+
+    # Get function descriptions from the agent's kernel
+    function_descriptions = extract_function_descriptions(agent.kernel)
+
+    # Create the full prompt with current scratchpad
+    prompt_args = KernelArguments(
+        question=question,
+        function_descriptions=function_descriptions,
+        agent_scratchpad=scratchpad,
+    )
+
+    # Get agent's response
+    response = await agent.get_response(messages="", arguments=prompt_args)
+    response_text = str(response.content)
+
+    print(f"Agent Response:\n{response_text}\n")
+
+    # Check if this is a final answer
+    if "[FINAL ANSWER]" in response_text:
+        return scratchpad + response_text, True
+
+    # Parse action from response
+    action_name, action_variables = parse_action_from_response(response_text)
+
+    if action_name and action_variables:
+        # Execute the action
+        try:
+            # Parse plugin and function names
+            parts = action_name.split(".")
+            if len(parts) == 2:
+                plugin_name, function_name = parts
+
+                if plugin_name in agent.kernel.plugins:
+                    function = agent.kernel.plugins[plugin_name][function_name]
+                    result = await function.invoke(
+                        kernel=agent.kernel, arguments=action_variables
+                    )
+                    observation = f"[OBSERVATION]\n{result.value}\n"
+                else:
+                    observation = (
+                        f"[OBSERVATION]\nError: Plugin '{plugin_name}' not found.\n"
+                    )
+            else:
+                observation = (
+                    f"[OBSERVATION]\nError: Invalid action format '{action_name}'.\n"
+                )
+
+        except Exception as e:
+            observation = f"[OBSERVATION]\nError executing action: {str(e)}\n"
+    else:
+        observation = "[OBSERVATION]\nFailed to parse action from response.\n"
+
+    # Update scratchpad with the step
+    updated_scratchpad = scratchpad + response_text + "\n" + observation
+
+    return updated_scratchpad, False
+
+
+async def run_react_agent(
+    agent: ChatCompletionAgent, question: str, max_steps: int = 10
+) -> str:
+    """Run the React agent on a question with a maximum number of steps."""
+
+    print(f"Question: {question}\n")
+    print("=" * 50)
+
+    scratchpad = ""
+
+    for step in range(max_steps):
+        print(f"Step {step + 1}:")
+        print("-" * 20)
+
+        scratchpad, is_complete = await execute_react_step(agent, question, scratchpad)
+
+        if is_complete:
+            print("React cycle completed!")
+            break
+
+        if step == max_steps - 1:
+            print("Maximum steps reached!")
+
+    return scratchpad
+
+
+async def main():
+    # Create kernel and add plugins
+    kernel = Kernel()
+    kernel.add_service(AzureChatCompletion())
+    kernel.add_plugin(CalculatorPlugin(), "CalculatorPlugin")
+    kernel.add_plugin(WeatherPlugin(), "WeatherPlugin")
+
+    # Configure the React prompt template
+    prompt_config = PromptTemplateConfig(
+        template=REACT_PROMPT_TEMPLATE, template_format="semantic-kernel"
+    )
+
+    # Create the React agent
+    react_agent = ChatCompletionAgent(
+        kernel=kernel,
+        name="ReactAgent",
+        instructions="You are a helpful assistant that uses the React (Reasoning and Acting) pattern to solve problems step by step.",
+        prompt_template_config=prompt_config,
+    )
+
+    # Test questions for the React agent
+    questions = [
+        "What is 15 multiplied by 8, and then add 25 to the result?",
+        "What's the weather like in Istanbul and how much is 100 divided by 4?",
+        "Calculate 20 + 30, then multiply the result by 2, and tell me the weather in Paris",
+    ]
+
+    for i, question in enumerate(questions, 1):
+        print(f"\n{'=' * 60}")
+        print(f"TEST {i}")
+        print(f"{'=' * 60}")
+
+        result = await run_react_agent(react_agent, question)
+
+        print(f"\nFinal Result:\n{result}")
+        print(f"\n{'=' * 60}")
+
+
+if __name__ == "__main__":
+    asyncio.run(main())

--- a/python/tests/samples/test_concepts.py
+++ b/python/tests/samples/test_concepts.py
@@ -19,71 +19,35 @@ from samples.concepts.auto_function_calling.functions_defined_in_yaml_prompt imp
 )
 from samples.concepts.caching.semantic_caching import main as semantic_caching
 from samples.concepts.chat_completion.simple_chatbot import main as simple_chatbot
-from samples.concepts.chat_completion.simple_chatbot_kernel_function import (
-    main as simple_chatbot_kernel_function,
-)
-from samples.concepts.chat_completion.simple_chatbot_logit_bias import (
-    main as simple_chatbot_logit_bias,
-)
-from samples.concepts.chat_completion.simple_chatbot_streaming import (
-    main as simple_chatbot_streaming,
-)
-from samples.concepts.chat_completion.simple_chatbot_with_image import (
-    main as simple_chatbot_with_image,
-)
-from samples.concepts.embedding.text_embedding_generation import (
-    main as text_embedding_generation,
-)
-from samples.concepts.filtering.auto_function_invoke_filters import (
-    main as auto_function_invoke_filters,
-)
-from samples.concepts.filtering.function_invocation_filters import (
-    main as function_invocation_filters,
-)
-from samples.concepts.filtering.function_invocation_filters_stream import (
-    main as function_invocation_filters_stream,
-)
+from samples.concepts.chat_completion.simple_chatbot_kernel_function import main as simple_chatbot_kernel_function
+from samples.concepts.chat_completion.simple_chatbot_logit_bias import main as simple_chatbot_logit_bias
+from samples.concepts.chat_completion.simple_chatbot_streaming import main as simple_chatbot_streaming
+from samples.concepts.chat_completion.simple_chatbot_with_image import main as simple_chatbot_with_image
+from samples.concepts.embedding.text_embedding_generation import main as text_embedding_generation
+from samples.concepts.filtering.auto_function_invoke_filters import main as auto_function_invoke_filters
+from samples.concepts.filtering.function_invocation_filters import main as function_invocation_filters
+from samples.concepts.filtering.function_invocation_filters_stream import main as function_invocation_filters_stream
 from samples.concepts.filtering.prompt_filters import main as prompt_filters
-from samples.concepts.filtering.retry_with_different_model import (
-    main as retry_with_different_model,
-)
+from samples.concepts.filtering.retry_with_different_model import main as retry_with_different_model
 from samples.concepts.functions.kernel_arguments import main as kernel_arguments
 from samples.concepts.grounding.grounded import main as grounded
 from samples.concepts.images.image_generation import main as image_generation
-from samples.concepts.local_models.lm_studio_chat_completion import (
-    main as lm_studio_chat_completion,
-)
-from samples.concepts.local_models.lm_studio_text_embedding import (
-    main as lm_studio_text_embedding,
-)
-from samples.concepts.local_models.ollama_chat_completion import (
-    main as ollama_chat_completion,
-)
+from samples.concepts.local_models.lm_studio_chat_completion import main as lm_studio_chat_completion
+from samples.concepts.local_models.lm_studio_text_embedding import main as lm_studio_text_embedding
+from samples.concepts.local_models.ollama_chat_completion import main as ollama_chat_completion
 from samples.concepts.mcp.agent_with_mcp_agent import main as agent_with_mcp_agent
 from samples.concepts.memory.simple_memory import main as simple_memory
 from samples.concepts.plugins.openai_function_calling_with_custom_plugin import (
     main as openai_function_calling_with_custom_plugin,
 )
 from samples.concepts.plugins.plugins_from_dir import main as plugins_from_dir
-from samples.concepts.prompt_templates.azure_chat_gpt_api_handlebars import (
-    main as azure_chat_gpt_api_handlebars,
-)
-from samples.concepts.prompt_templates.azure_chat_gpt_api_jinja2 import (
-    main as azure_chat_gpt_api_jinja2,
-)
-from samples.concepts.prompt_templates.configuring_prompts import (
-    main as configuring_prompts,
-)
+from samples.concepts.prompt_templates.azure_chat_gpt_api_handlebars import main as azure_chat_gpt_api_handlebars
+from samples.concepts.prompt_templates.azure_chat_gpt_api_jinja2 import main as azure_chat_gpt_api_jinja2
+from samples.concepts.prompt_templates.configuring_prompts import main as configuring_prompts
 from samples.concepts.prompt_templates.load_yaml_prompt import main as load_yaml_prompt
-from samples.concepts.prompt_templates.template_language import (
-    main as template_language,
-)
-from samples.concepts.rag.rag_with_vector_collection import (
-    main as rag_with_vector_collection,
-)
-from samples.concepts.service_selector.custom_service_selector import (
-    main as custom_service_selector,
-)
+from samples.concepts.prompt_templates.template_language import main as template_language
+from samples.concepts.rag.rag_with_vector_collection import main as rag_with_vector_collection
+from samples.concepts.service_selector.custom_service_selector import main as custom_service_selector
 from samples.concepts.react.azure_ai_react_agent import main as azure_ai_react_agent
 from samples.concepts.text_completion.text_completion import main as text_completion
 from samples.getting_started_with_agents.chat_completion.step01_chat_completion_agent_simple import (
@@ -101,9 +65,7 @@ from samples.getting_started_with_agents.chat_completion.step05_chat_completion_
 from samples.getting_started_with_agents.chat_completion.step06_chat_completion_agent_group_chat import (
     main as step5_chat_completion_agent_group_chat,
 )
-from samples.getting_started_with_agents.openai_assistant.step1_assistant import (
-    main as step1_openai_assistant,
-)
+from samples.getting_started_with_agents.openai_assistant.step1_assistant import main as step1_openai_assistant
 from tests.utils import retry
 
 # These environment variable names are used to control which samples are run during integration testing.
@@ -117,8 +79,7 @@ concepts = [
         [],
         id="semantic_caching",
         marks=pytest.mark.skipif(
-            os.getenv(COMPLETIONS_CONCEPT_SAMPLE, None) is None,
-            reason="Not running completion samples.",
+            os.getenv(COMPLETIONS_CONCEPT_SAMPLE, None) is None, reason="Not running completion samples."
         ),
     ),
     param(
@@ -126,8 +87,7 @@ concepts = [
         ["Why is the sky blue in one sentence?", "exit"],
         id="simple_chatbot",
         marks=pytest.mark.skipif(
-            os.getenv(COMPLETIONS_CONCEPT_SAMPLE, None) is None,
-            reason="Not running completion samples.",
+            os.getenv(COMPLETIONS_CONCEPT_SAMPLE, None) is None, reason="Not running completion samples."
         ),
     ),
     param(
@@ -135,8 +95,7 @@ concepts = [
         ["Why is the sky blue in one sentence?", "exit"],
         id="simple_chatbot_streaming",
         marks=pytest.mark.skipif(
-            os.getenv(COMPLETIONS_CONCEPT_SAMPLE, None) is None,
-            reason="Not running completion samples.",
+            os.getenv(COMPLETIONS_CONCEPT_SAMPLE, None) is None, reason="Not running completion samples."
         ),
     ),
     param(
@@ -144,8 +103,7 @@ concepts = [
         ["exit"],
         id="simple_chatbot_with_image",
         marks=pytest.mark.skipif(
-            os.getenv(COMPLETIONS_CONCEPT_SAMPLE, None) is None,
-            reason="Not running completion samples.",
+            os.getenv(COMPLETIONS_CONCEPT_SAMPLE, None) is None, reason="Not running completion samples."
         ),
     ),
     param(
@@ -153,8 +111,7 @@ concepts = [
         ["Who has the most career points in NBA history?", "exit"],
         id="simple_chatbot_logit_bias",
         marks=pytest.mark.skipif(
-            os.getenv(COMPLETIONS_CONCEPT_SAMPLE, None) is None,
-            reason="Not running completion samples.",
+            os.getenv(COMPLETIONS_CONCEPT_SAMPLE, None) is None, reason="Not running completion samples."
         ),
     ),
     param(
@@ -162,8 +119,7 @@ concepts = [
         ["Why is the sky blue in one sentence?", "exit"],
         id="simple_chatbot_kernel_function",
         marks=pytest.mark.skipif(
-            os.getenv(COMPLETIONS_CONCEPT_SAMPLE, None) is None,
-            reason="Not running completion samples.",
+            os.getenv(COMPLETIONS_CONCEPT_SAMPLE, None) is None, reason="Not running completion samples."
         ),
     ),
     param(
@@ -171,8 +127,7 @@ concepts = [
         ["What is 3+3?", "exit"],
         id="chat_completion_with_function_calling",
         marks=pytest.mark.skipif(
-            os.getenv(COMPLETIONS_CONCEPT_SAMPLE, None) is None,
-            reason="Not running completion samples.",
+            os.getenv(COMPLETIONS_CONCEPT_SAMPLE, None) is None, reason="Not running completion samples."
         ),
     ),
     param(
@@ -180,8 +135,7 @@ concepts = [
         ["What is 3+3?", "exit"],
         id="auto_function_invoke_filters",
         marks=pytest.mark.skipif(
-            os.getenv(COMPLETIONS_CONCEPT_SAMPLE, None) is None,
-            reason="Not running completion samples.",
+            os.getenv(COMPLETIONS_CONCEPT_SAMPLE, None) is None, reason="Not running completion samples."
         ),
     ),
     param(
@@ -189,8 +143,7 @@ concepts = [
         ["What is 3+3?", "exit"],
         id="function_invocation_filters",
         marks=pytest.mark.skipif(
-            os.getenv(COMPLETIONS_CONCEPT_SAMPLE, None) is None,
-            reason="Not running completion samples.",
+            os.getenv(COMPLETIONS_CONCEPT_SAMPLE, None) is None, reason="Not running completion samples."
         ),
     ),
     param(
@@ -198,8 +151,7 @@ concepts = [
         ["What is 3+3?", "exit"],
         id="function_invocation_filters_stream",
         marks=pytest.mark.skipif(
-            os.getenv(COMPLETIONS_CONCEPT_SAMPLE, None) is None,
-            reason="Not running completion samples.",
+            os.getenv(COMPLETIONS_CONCEPT_SAMPLE, None) is None, reason="Not running completion samples."
         ),
     ),
     param(
@@ -207,8 +159,7 @@ concepts = [
         ["What is the fastest animal?", "exit"],
         id="prompt_filters",
         marks=pytest.mark.skipif(
-            os.getenv(COMPLETIONS_CONCEPT_SAMPLE, None) is None,
-            reason="Not running completion samples.",
+            os.getenv(COMPLETIONS_CONCEPT_SAMPLE, None) is None, reason="Not running completion samples."
         ),
     ),
     param(
@@ -225,8 +176,7 @@ concepts = [
         [],
         id="kernel_arguments",
         marks=pytest.mark.skipif(
-            os.getenv(COMPLETIONS_CONCEPT_SAMPLE, None) is None,
-            reason="Not running completion samples.",
+            os.getenv(COMPLETIONS_CONCEPT_SAMPLE, None) is None, reason="Not running completion samples."
         ),
     ),
     param(
@@ -234,8 +184,7 @@ concepts = [
         [],
         id="grounded",
         marks=pytest.mark.skipif(
-            os.getenv(COMPLETIONS_CONCEPT_SAMPLE, None) is None,
-            reason="Not running completion samples.",
+            os.getenv(COMPLETIONS_CONCEPT_SAMPLE, None) is None, reason="Not running completion samples."
         ),
     ),
     param(
@@ -243,8 +192,7 @@ concepts = [
         [],
         id="openai_function_calling_with_custom_plugin",
         marks=pytest.mark.skipif(
-            os.getenv(COMPLETIONS_CONCEPT_SAMPLE, None) is None,
-            reason="Not running completion samples.",
+            os.getenv(COMPLETIONS_CONCEPT_SAMPLE, None) is None, reason="Not running completion samples."
         ),
     ),
     param(
@@ -252,8 +200,7 @@ concepts = [
         [],
         id="plugins_from_dir",
         marks=pytest.mark.skipif(
-            os.getenv(COMPLETIONS_CONCEPT_SAMPLE, None) is None,
-            reason="Not running completion samples.",
+            os.getenv(COMPLETIONS_CONCEPT_SAMPLE, None) is None, reason="Not running completion samples."
         ),
     ),
     param(
@@ -261,8 +208,7 @@ concepts = [
         ["What is 3+3?", "exit"],
         id="azure_chat_gpt_api_handlebars",
         marks=pytest.mark.skipif(
-            os.getenv(COMPLETIONS_CONCEPT_SAMPLE, None) is None,
-            reason="Not running completion samples.",
+            os.getenv(COMPLETIONS_CONCEPT_SAMPLE, None) is None, reason="Not running completion samples."
         ),
     ),
     param(
@@ -270,21 +216,15 @@ concepts = [
         ["What is 3+3?", "exit"],
         id="azure_chat_gpt_api_jinja2",
         marks=pytest.mark.skipif(
-            os.getenv(COMPLETIONS_CONCEPT_SAMPLE, None) is None,
-            reason="Not running completion samples.",
+            os.getenv(COMPLETIONS_CONCEPT_SAMPLE, None) is None, reason="Not running completion samples."
         ),
     ),
     param(
         agent_with_mcp_agent,
-        [
-            "what restaurants can I choose from?",
-            "the farm sounds nice, what are the specials there?",
-            "exit",
-        ],
+        ["what restaurants can I choose from?", "the farm sounds nice, what are the specials there?", "exit"],
         id="agent_with_mcp_agent",
         marks=pytest.mark.skipif(
-            os.getenv(COMPLETIONS_CONCEPT_SAMPLE, None) is None,
-            reason="Not running completion samples.",
+            os.getenv(COMPLETIONS_CONCEPT_SAMPLE, None) is None, reason="Not running completion samples."
         ),
     ),
     param(
@@ -292,8 +232,7 @@ concepts = [
         ["What is my name?", "exit"],
         id="configuring_prompts",
         marks=pytest.mark.skipif(
-            os.getenv(COMPLETIONS_CONCEPT_SAMPLE, None) is None,
-            reason="Not running completion samples.",
+            os.getenv(COMPLETIONS_CONCEPT_SAMPLE, None) is None, reason="Not running completion samples."
         ),
     ),
     param(
@@ -301,8 +240,7 @@ concepts = [
         [],
         id="load_yaml_prompt",
         marks=pytest.mark.skipif(
-            os.getenv(COMPLETIONS_CONCEPT_SAMPLE, None) is None,
-            reason="Not running completion samples.",
+            os.getenv(COMPLETIONS_CONCEPT_SAMPLE, None) is None, reason="Not running completion samples."
         ),
     ),
     param(
@@ -310,36 +248,22 @@ concepts = [
         [],
         id="template_language",
         marks=pytest.mark.skipif(
-            os.getenv(COMPLETIONS_CONCEPT_SAMPLE, None) is None,
-            reason="Not running completion samples.",
+            os.getenv(COMPLETIONS_CONCEPT_SAMPLE, None) is None, reason="Not running completion samples."
         ),
     ),
     param(
         simple_memory,
         [],
         id="simple_memory",
-        marks=pytest.mark.skipif(
-            os.getenv(MEMORY_CONCEPT_SAMPLE, None) is None,
-            reason="Not running memory samples.",
-        ),
+        marks=pytest.mark.skipif(os.getenv(MEMORY_CONCEPT_SAMPLE, None) is None, reason="Not running memory samples."),
     ),
     param(rag_with_vector_collection, [], id="rag_with_vector_collection"),
-    param(
-        azure_ai_react_agent,
-        [],
-        id="azure_ai_react_agent",
-        marks=pytest.mark.skipif(
-            os.getenv(COMPLETIONS_CONCEPT_SAMPLE, None) is None,
-            reason="Not running completion samples.",
-        ),
-    ),
     param(
         custom_service_selector,
         [],
         id="custom_service_selector",
         marks=pytest.mark.skipif(
-            os.getenv(COMPLETIONS_CONCEPT_SAMPLE, None) is None,
-            reason="Not running completion samples.",
+            os.getenv(COMPLETIONS_CONCEPT_SAMPLE, None) is None, reason="Not running completion samples."
         ),
     ),
     param(
@@ -347,8 +271,7 @@ concepts = [
         ["What is 3+3?", "exit"],
         id="function_defined_in_json_prompt",
         marks=pytest.mark.skipif(
-            os.getenv(COMPLETIONS_CONCEPT_SAMPLE, None) is None,
-            reason="Not running completion samples.",
+            os.getenv(COMPLETIONS_CONCEPT_SAMPLE, None) is None, reason="Not running completion samples."
         ),
     ),
     param(
@@ -356,8 +279,7 @@ concepts = [
         ["What is 3+3?", "exit"],
         id="function_defined_in_yaml_prompt",
         marks=pytest.mark.skipif(
-            os.getenv(COMPLETIONS_CONCEPT_SAMPLE, None) is None,
-            reason="Not running completion samples.",
+            os.getenv(COMPLETIONS_CONCEPT_SAMPLE, None) is None, reason="Not running completion samples."
         ),
     ),
     param(
@@ -365,8 +287,7 @@ concepts = [
         [],
         id="step1_chat_completion_agent_simple",
         marks=pytest.mark.skipif(
-            os.getenv(COMPLETIONS_CONCEPT_SAMPLE, None) is None,
-            reason="Not running completion samples.",
+            os.getenv(COMPLETIONS_CONCEPT_SAMPLE, None) is None, reason="Not running completion samples."
         ),
     ),
     param(
@@ -374,8 +295,7 @@ concepts = [
         [],
         id="step2_chat_completion_agent_with_kernel",
         marks=pytest.mark.skipif(
-            os.getenv(COMPLETIONS_CONCEPT_SAMPLE, None) is None,
-            reason="Not running completion samples.",
+            os.getenv(COMPLETIONS_CONCEPT_SAMPLE, None) is None, reason="Not running completion samples."
         ),
     ),
     param(
@@ -383,8 +303,7 @@ concepts = [
         [],
         id="step3_chat_completion_agent_plugin_simple",
         marks=pytest.mark.skipif(
-            os.getenv(COMPLETIONS_CONCEPT_SAMPLE, None) is None,
-            reason="Not running completion samples.",
+            os.getenv(COMPLETIONS_CONCEPT_SAMPLE, None) is None, reason="Not running completion samples."
         ),
     ),
     param(
@@ -392,8 +311,7 @@ concepts = [
         [],
         id="step4_chat_completion_agent_plugin_with_kernel",
         marks=pytest.mark.skipif(
-            os.getenv(COMPLETIONS_CONCEPT_SAMPLE, None) is None,
-            reason="Not running completion samples.",
+            os.getenv(COMPLETIONS_CONCEPT_SAMPLE, None) is None, reason="Not running completion samples."
         ),
     ),
     param(
@@ -401,8 +319,7 @@ concepts = [
         [],
         id="step5_chat_completion_agent_group_chat",
         marks=pytest.mark.skipif(
-            os.getenv(COMPLETIONS_CONCEPT_SAMPLE, None) is None,
-            reason="Not running completion samples.",
+            os.getenv(COMPLETIONS_CONCEPT_SAMPLE, None) is None, reason="Not running completion samples."
         ),
     ),
     param(
@@ -410,41 +327,33 @@ concepts = [
         [],
         id="step1_openai_assistant",
         marks=pytest.mark.skipif(
-            os.getenv(COMPLETIONS_CONCEPT_SAMPLE, None) is None,
-            reason="Not running completion samples.",
+            os.getenv(COMPLETIONS_CONCEPT_SAMPLE, None) is None, reason="Not running completion samples."
         ),
     ),
     param(
         ollama_chat_completion,
         ["Why is the sky blue?", "exit"],
         id="ollama_chat_completion",
-        marks=pytest.mark.skip(
-            reason="Need to set up Ollama locally. Check out the module for more details."
-        ),
+        marks=pytest.mark.skip(reason="Need to set up Ollama locally. Check out the module for more details."),
     ),
     param(
         lm_studio_chat_completion,
         ["Why is the sky blue?", "exit"],
         id="lm_studio_chat_completion",
-        marks=pytest.mark.skip(
-            reason="Need to set up LM Studio locally. Check out the module for more details."
-        ),
+        marks=pytest.mark.skip(reason="Need to set up LM Studio locally. Check out the module for more details."),
     ),
     param(
         lm_studio_text_embedding,
         [],
         id="lm_studio_text_embedding",
-        marks=pytest.mark.skip(
-            reason="Need to set up LM Studio locally. Check out the module for more details."
-        ),
+        marks=pytest.mark.skip(reason="Need to set up LM Studio locally. Check out the module for more details."),
     ),
     param(
         image_generation,
         [],
         id="image_generation",
         marks=pytest.mark.skipif(
-            os.getenv(COMPLETIONS_CONCEPT_SAMPLE, None) is None,
-            reason="Not running completion samples.",
+            os.getenv(COMPLETIONS_CONCEPT_SAMPLE, None) is None, reason="Not running completion samples."
         ),
     ),
     param(
@@ -452,8 +361,7 @@ concepts = [
         [],
         id="text_completion",
         marks=pytest.mark.skipif(
-            os.getenv(COMPLETIONS_CONCEPT_SAMPLE, None) is None,
-            reason="Not running completion samples.",
+            os.getenv(COMPLETIONS_CONCEPT_SAMPLE, None) is None, reason="Not running completion samples."
         ),
     ),
     param(
@@ -461,17 +369,22 @@ concepts = [
         [],
         id="text_embedding_generation",
         marks=pytest.mark.skipif(
-            os.getenv(COMPLETIONS_CONCEPT_SAMPLE, None) is None,
-            reason="Not running completion samples.",
+            os.getenv(COMPLETIONS_CONCEPT_SAMPLE, None) is None, reason="Not running completion samples."
+        ),
+    ),
+    param(
+        azure_ai_react_agent,
+        [],
+        id="azure_ai_react_agent",
+        marks=pytest.mark.skipif(
+            os.getenv(COMPLETIONS_CONCEPT_SAMPLE, None) is None, reason="Not running completion samples."
         ),
     ),
 ]
 
 
 @mark.parametrize("sample, responses", concepts)
-async def test_concepts(
-    sample: Callable[..., Awaitable[Any]], responses: list[str], monkeypatch
-):
+async def test_concepts(sample: Callable[..., Awaitable[Any]], responses: list[str], monkeypatch):
     saved_responses = copy.deepcopy(responses)
 
     def reset():

--- a/python/tests/samples/test_concepts.py
+++ b/python/tests/samples/test_concepts.py
@@ -19,35 +19,72 @@ from samples.concepts.auto_function_calling.functions_defined_in_yaml_prompt imp
 )
 from samples.concepts.caching.semantic_caching import main as semantic_caching
 from samples.concepts.chat_completion.simple_chatbot import main as simple_chatbot
-from samples.concepts.chat_completion.simple_chatbot_kernel_function import main as simple_chatbot_kernel_function
-from samples.concepts.chat_completion.simple_chatbot_logit_bias import main as simple_chatbot_logit_bias
-from samples.concepts.chat_completion.simple_chatbot_streaming import main as simple_chatbot_streaming
-from samples.concepts.chat_completion.simple_chatbot_with_image import main as simple_chatbot_with_image
-from samples.concepts.embedding.text_embedding_generation import main as text_embedding_generation
-from samples.concepts.filtering.auto_function_invoke_filters import main as auto_function_invoke_filters
-from samples.concepts.filtering.function_invocation_filters import main as function_invocation_filters
-from samples.concepts.filtering.function_invocation_filters_stream import main as function_invocation_filters_stream
+from samples.concepts.chat_completion.simple_chatbot_kernel_function import (
+    main as simple_chatbot_kernel_function,
+)
+from samples.concepts.chat_completion.simple_chatbot_logit_bias import (
+    main as simple_chatbot_logit_bias,
+)
+from samples.concepts.chat_completion.simple_chatbot_streaming import (
+    main as simple_chatbot_streaming,
+)
+from samples.concepts.chat_completion.simple_chatbot_with_image import (
+    main as simple_chatbot_with_image,
+)
+from samples.concepts.embedding.text_embedding_generation import (
+    main as text_embedding_generation,
+)
+from samples.concepts.filtering.auto_function_invoke_filters import (
+    main as auto_function_invoke_filters,
+)
+from samples.concepts.filtering.function_invocation_filters import (
+    main as function_invocation_filters,
+)
+from samples.concepts.filtering.function_invocation_filters_stream import (
+    main as function_invocation_filters_stream,
+)
 from samples.concepts.filtering.prompt_filters import main as prompt_filters
-from samples.concepts.filtering.retry_with_different_model import main as retry_with_different_model
+from samples.concepts.filtering.retry_with_different_model import (
+    main as retry_with_different_model,
+)
 from samples.concepts.functions.kernel_arguments import main as kernel_arguments
 from samples.concepts.grounding.grounded import main as grounded
 from samples.concepts.images.image_generation import main as image_generation
-from samples.concepts.local_models.lm_studio_chat_completion import main as lm_studio_chat_completion
-from samples.concepts.local_models.lm_studio_text_embedding import main as lm_studio_text_embedding
-from samples.concepts.local_models.ollama_chat_completion import main as ollama_chat_completion
+from samples.concepts.local_models.lm_studio_chat_completion import (
+    main as lm_studio_chat_completion,
+)
+from samples.concepts.local_models.lm_studio_text_embedding import (
+    main as lm_studio_text_embedding,
+)
+from samples.concepts.local_models.ollama_chat_completion import (
+    main as ollama_chat_completion,
+)
 from samples.concepts.mcp.agent_with_mcp_agent import main as agent_with_mcp_agent
 from samples.concepts.memory.simple_memory import main as simple_memory
 from samples.concepts.plugins.openai_function_calling_with_custom_plugin import (
     main as openai_function_calling_with_custom_plugin,
 )
 from samples.concepts.plugins.plugins_from_dir import main as plugins_from_dir
-from samples.concepts.prompt_templates.azure_chat_gpt_api_handlebars import main as azure_chat_gpt_api_handlebars
-from samples.concepts.prompt_templates.azure_chat_gpt_api_jinja2 import main as azure_chat_gpt_api_jinja2
-from samples.concepts.prompt_templates.configuring_prompts import main as configuring_prompts
+from samples.concepts.prompt_templates.azure_chat_gpt_api_handlebars import (
+    main as azure_chat_gpt_api_handlebars,
+)
+from samples.concepts.prompt_templates.azure_chat_gpt_api_jinja2 import (
+    main as azure_chat_gpt_api_jinja2,
+)
+from samples.concepts.prompt_templates.configuring_prompts import (
+    main as configuring_prompts,
+)
 from samples.concepts.prompt_templates.load_yaml_prompt import main as load_yaml_prompt
-from samples.concepts.prompt_templates.template_language import main as template_language
-from samples.concepts.rag.rag_with_vector_collection import main as rag_with_vector_collection
-from samples.concepts.service_selector.custom_service_selector import main as custom_service_selector
+from samples.concepts.prompt_templates.template_language import (
+    main as template_language,
+)
+from samples.concepts.rag.rag_with_vector_collection import (
+    main as rag_with_vector_collection,
+)
+from samples.concepts.service_selector.custom_service_selector import (
+    main as custom_service_selector,
+)
+from samples.concepts.react.azure_ai_react_agent import main as azure_ai_react_agent
 from samples.concepts.text_completion.text_completion import main as text_completion
 from samples.getting_started_with_agents.chat_completion.step01_chat_completion_agent_simple import (
     main as step1_chat_completion_agent_simple,
@@ -64,7 +101,9 @@ from samples.getting_started_with_agents.chat_completion.step05_chat_completion_
 from samples.getting_started_with_agents.chat_completion.step06_chat_completion_agent_group_chat import (
     main as step5_chat_completion_agent_group_chat,
 )
-from samples.getting_started_with_agents.openai_assistant.step1_assistant import main as step1_openai_assistant
+from samples.getting_started_with_agents.openai_assistant.step1_assistant import (
+    main as step1_openai_assistant,
+)
 from tests.utils import retry
 
 # These environment variable names are used to control which samples are run during integration testing.
@@ -78,7 +117,8 @@ concepts = [
         [],
         id="semantic_caching",
         marks=pytest.mark.skipif(
-            os.getenv(COMPLETIONS_CONCEPT_SAMPLE, None) is None, reason="Not running completion samples."
+            os.getenv(COMPLETIONS_CONCEPT_SAMPLE, None) is None,
+            reason="Not running completion samples.",
         ),
     ),
     param(
@@ -86,7 +126,8 @@ concepts = [
         ["Why is the sky blue in one sentence?", "exit"],
         id="simple_chatbot",
         marks=pytest.mark.skipif(
-            os.getenv(COMPLETIONS_CONCEPT_SAMPLE, None) is None, reason="Not running completion samples."
+            os.getenv(COMPLETIONS_CONCEPT_SAMPLE, None) is None,
+            reason="Not running completion samples.",
         ),
     ),
     param(
@@ -94,7 +135,8 @@ concepts = [
         ["Why is the sky blue in one sentence?", "exit"],
         id="simple_chatbot_streaming",
         marks=pytest.mark.skipif(
-            os.getenv(COMPLETIONS_CONCEPT_SAMPLE, None) is None, reason="Not running completion samples."
+            os.getenv(COMPLETIONS_CONCEPT_SAMPLE, None) is None,
+            reason="Not running completion samples.",
         ),
     ),
     param(
@@ -102,7 +144,8 @@ concepts = [
         ["exit"],
         id="simple_chatbot_with_image",
         marks=pytest.mark.skipif(
-            os.getenv(COMPLETIONS_CONCEPT_SAMPLE, None) is None, reason="Not running completion samples."
+            os.getenv(COMPLETIONS_CONCEPT_SAMPLE, None) is None,
+            reason="Not running completion samples.",
         ),
     ),
     param(
@@ -110,7 +153,8 @@ concepts = [
         ["Who has the most career points in NBA history?", "exit"],
         id="simple_chatbot_logit_bias",
         marks=pytest.mark.skipif(
-            os.getenv(COMPLETIONS_CONCEPT_SAMPLE, None) is None, reason="Not running completion samples."
+            os.getenv(COMPLETIONS_CONCEPT_SAMPLE, None) is None,
+            reason="Not running completion samples.",
         ),
     ),
     param(
@@ -118,7 +162,8 @@ concepts = [
         ["Why is the sky blue in one sentence?", "exit"],
         id="simple_chatbot_kernel_function",
         marks=pytest.mark.skipif(
-            os.getenv(COMPLETIONS_CONCEPT_SAMPLE, None) is None, reason="Not running completion samples."
+            os.getenv(COMPLETIONS_CONCEPT_SAMPLE, None) is None,
+            reason="Not running completion samples.",
         ),
     ),
     param(
@@ -126,7 +171,8 @@ concepts = [
         ["What is 3+3?", "exit"],
         id="chat_completion_with_function_calling",
         marks=pytest.mark.skipif(
-            os.getenv(COMPLETIONS_CONCEPT_SAMPLE, None) is None, reason="Not running completion samples."
+            os.getenv(COMPLETIONS_CONCEPT_SAMPLE, None) is None,
+            reason="Not running completion samples.",
         ),
     ),
     param(
@@ -134,7 +180,8 @@ concepts = [
         ["What is 3+3?", "exit"],
         id="auto_function_invoke_filters",
         marks=pytest.mark.skipif(
-            os.getenv(COMPLETIONS_CONCEPT_SAMPLE, None) is None, reason="Not running completion samples."
+            os.getenv(COMPLETIONS_CONCEPT_SAMPLE, None) is None,
+            reason="Not running completion samples.",
         ),
     ),
     param(
@@ -142,7 +189,8 @@ concepts = [
         ["What is 3+3?", "exit"],
         id="function_invocation_filters",
         marks=pytest.mark.skipif(
-            os.getenv(COMPLETIONS_CONCEPT_SAMPLE, None) is None, reason="Not running completion samples."
+            os.getenv(COMPLETIONS_CONCEPT_SAMPLE, None) is None,
+            reason="Not running completion samples.",
         ),
     ),
     param(
@@ -150,7 +198,8 @@ concepts = [
         ["What is 3+3?", "exit"],
         id="function_invocation_filters_stream",
         marks=pytest.mark.skipif(
-            os.getenv(COMPLETIONS_CONCEPT_SAMPLE, None) is None, reason="Not running completion samples."
+            os.getenv(COMPLETIONS_CONCEPT_SAMPLE, None) is None,
+            reason="Not running completion samples.",
         ),
     ),
     param(
@@ -158,7 +207,8 @@ concepts = [
         ["What is the fastest animal?", "exit"],
         id="prompt_filters",
         marks=pytest.mark.skipif(
-            os.getenv(COMPLETIONS_CONCEPT_SAMPLE, None) is None, reason="Not running completion samples."
+            os.getenv(COMPLETIONS_CONCEPT_SAMPLE, None) is None,
+            reason="Not running completion samples.",
         ),
     ),
     param(
@@ -175,7 +225,8 @@ concepts = [
         [],
         id="kernel_arguments",
         marks=pytest.mark.skipif(
-            os.getenv(COMPLETIONS_CONCEPT_SAMPLE, None) is None, reason="Not running completion samples."
+            os.getenv(COMPLETIONS_CONCEPT_SAMPLE, None) is None,
+            reason="Not running completion samples.",
         ),
     ),
     param(
@@ -183,7 +234,8 @@ concepts = [
         [],
         id="grounded",
         marks=pytest.mark.skipif(
-            os.getenv(COMPLETIONS_CONCEPT_SAMPLE, None) is None, reason="Not running completion samples."
+            os.getenv(COMPLETIONS_CONCEPT_SAMPLE, None) is None,
+            reason="Not running completion samples.",
         ),
     ),
     param(
@@ -191,7 +243,8 @@ concepts = [
         [],
         id="openai_function_calling_with_custom_plugin",
         marks=pytest.mark.skipif(
-            os.getenv(COMPLETIONS_CONCEPT_SAMPLE, None) is None, reason="Not running completion samples."
+            os.getenv(COMPLETIONS_CONCEPT_SAMPLE, None) is None,
+            reason="Not running completion samples.",
         ),
     ),
     param(
@@ -199,7 +252,8 @@ concepts = [
         [],
         id="plugins_from_dir",
         marks=pytest.mark.skipif(
-            os.getenv(COMPLETIONS_CONCEPT_SAMPLE, None) is None, reason="Not running completion samples."
+            os.getenv(COMPLETIONS_CONCEPT_SAMPLE, None) is None,
+            reason="Not running completion samples.",
         ),
     ),
     param(
@@ -207,7 +261,8 @@ concepts = [
         ["What is 3+3?", "exit"],
         id="azure_chat_gpt_api_handlebars",
         marks=pytest.mark.skipif(
-            os.getenv(COMPLETIONS_CONCEPT_SAMPLE, None) is None, reason="Not running completion samples."
+            os.getenv(COMPLETIONS_CONCEPT_SAMPLE, None) is None,
+            reason="Not running completion samples.",
         ),
     ),
     param(
@@ -215,15 +270,21 @@ concepts = [
         ["What is 3+3?", "exit"],
         id="azure_chat_gpt_api_jinja2",
         marks=pytest.mark.skipif(
-            os.getenv(COMPLETIONS_CONCEPT_SAMPLE, None) is None, reason="Not running completion samples."
+            os.getenv(COMPLETIONS_CONCEPT_SAMPLE, None) is None,
+            reason="Not running completion samples.",
         ),
     ),
     param(
         agent_with_mcp_agent,
-        ["what restaurants can I choose from?", "the farm sounds nice, what are the specials there?", "exit"],
+        [
+            "what restaurants can I choose from?",
+            "the farm sounds nice, what are the specials there?",
+            "exit",
+        ],
         id="agent_with_mcp_agent",
         marks=pytest.mark.skipif(
-            os.getenv(COMPLETIONS_CONCEPT_SAMPLE, None) is None, reason="Not running completion samples."
+            os.getenv(COMPLETIONS_CONCEPT_SAMPLE, None) is None,
+            reason="Not running completion samples.",
         ),
     ),
     param(
@@ -231,7 +292,8 @@ concepts = [
         ["What is my name?", "exit"],
         id="configuring_prompts",
         marks=pytest.mark.skipif(
-            os.getenv(COMPLETIONS_CONCEPT_SAMPLE, None) is None, reason="Not running completion samples."
+            os.getenv(COMPLETIONS_CONCEPT_SAMPLE, None) is None,
+            reason="Not running completion samples.",
         ),
     ),
     param(
@@ -239,7 +301,8 @@ concepts = [
         [],
         id="load_yaml_prompt",
         marks=pytest.mark.skipif(
-            os.getenv(COMPLETIONS_CONCEPT_SAMPLE, None) is None, reason="Not running completion samples."
+            os.getenv(COMPLETIONS_CONCEPT_SAMPLE, None) is None,
+            reason="Not running completion samples.",
         ),
     ),
     param(
@@ -247,22 +310,36 @@ concepts = [
         [],
         id="template_language",
         marks=pytest.mark.skipif(
-            os.getenv(COMPLETIONS_CONCEPT_SAMPLE, None) is None, reason="Not running completion samples."
+            os.getenv(COMPLETIONS_CONCEPT_SAMPLE, None) is None,
+            reason="Not running completion samples.",
         ),
     ),
     param(
         simple_memory,
         [],
         id="simple_memory",
-        marks=pytest.mark.skipif(os.getenv(MEMORY_CONCEPT_SAMPLE, None) is None, reason="Not running memory samples."),
+        marks=pytest.mark.skipif(
+            os.getenv(MEMORY_CONCEPT_SAMPLE, None) is None,
+            reason="Not running memory samples.",
+        ),
     ),
     param(rag_with_vector_collection, [], id="rag_with_vector_collection"),
+    param(
+        azure_ai_react_agent,
+        [],
+        id="azure_ai_react_agent",
+        marks=pytest.mark.skipif(
+            os.getenv(COMPLETIONS_CONCEPT_SAMPLE, None) is None,
+            reason="Not running completion samples.",
+        ),
+    ),
     param(
         custom_service_selector,
         [],
         id="custom_service_selector",
         marks=pytest.mark.skipif(
-            os.getenv(COMPLETIONS_CONCEPT_SAMPLE, None) is None, reason="Not running completion samples."
+            os.getenv(COMPLETIONS_CONCEPT_SAMPLE, None) is None,
+            reason="Not running completion samples.",
         ),
     ),
     param(
@@ -270,7 +347,8 @@ concepts = [
         ["What is 3+3?", "exit"],
         id="function_defined_in_json_prompt",
         marks=pytest.mark.skipif(
-            os.getenv(COMPLETIONS_CONCEPT_SAMPLE, None) is None, reason="Not running completion samples."
+            os.getenv(COMPLETIONS_CONCEPT_SAMPLE, None) is None,
+            reason="Not running completion samples.",
         ),
     ),
     param(
@@ -278,7 +356,8 @@ concepts = [
         ["What is 3+3?", "exit"],
         id="function_defined_in_yaml_prompt",
         marks=pytest.mark.skipif(
-            os.getenv(COMPLETIONS_CONCEPT_SAMPLE, None) is None, reason="Not running completion samples."
+            os.getenv(COMPLETIONS_CONCEPT_SAMPLE, None) is None,
+            reason="Not running completion samples.",
         ),
     ),
     param(
@@ -286,7 +365,8 @@ concepts = [
         [],
         id="step1_chat_completion_agent_simple",
         marks=pytest.mark.skipif(
-            os.getenv(COMPLETIONS_CONCEPT_SAMPLE, None) is None, reason="Not running completion samples."
+            os.getenv(COMPLETIONS_CONCEPT_SAMPLE, None) is None,
+            reason="Not running completion samples.",
         ),
     ),
     param(
@@ -294,7 +374,8 @@ concepts = [
         [],
         id="step2_chat_completion_agent_with_kernel",
         marks=pytest.mark.skipif(
-            os.getenv(COMPLETIONS_CONCEPT_SAMPLE, None) is None, reason="Not running completion samples."
+            os.getenv(COMPLETIONS_CONCEPT_SAMPLE, None) is None,
+            reason="Not running completion samples.",
         ),
     ),
     param(
@@ -302,7 +383,8 @@ concepts = [
         [],
         id="step3_chat_completion_agent_plugin_simple",
         marks=pytest.mark.skipif(
-            os.getenv(COMPLETIONS_CONCEPT_SAMPLE, None) is None, reason="Not running completion samples."
+            os.getenv(COMPLETIONS_CONCEPT_SAMPLE, None) is None,
+            reason="Not running completion samples.",
         ),
     ),
     param(
@@ -310,7 +392,8 @@ concepts = [
         [],
         id="step4_chat_completion_agent_plugin_with_kernel",
         marks=pytest.mark.skipif(
-            os.getenv(COMPLETIONS_CONCEPT_SAMPLE, None) is None, reason="Not running completion samples."
+            os.getenv(COMPLETIONS_CONCEPT_SAMPLE, None) is None,
+            reason="Not running completion samples.",
         ),
     ),
     param(
@@ -318,7 +401,8 @@ concepts = [
         [],
         id="step5_chat_completion_agent_group_chat",
         marks=pytest.mark.skipif(
-            os.getenv(COMPLETIONS_CONCEPT_SAMPLE, None) is None, reason="Not running completion samples."
+            os.getenv(COMPLETIONS_CONCEPT_SAMPLE, None) is None,
+            reason="Not running completion samples.",
         ),
     ),
     param(
@@ -326,33 +410,41 @@ concepts = [
         [],
         id="step1_openai_assistant",
         marks=pytest.mark.skipif(
-            os.getenv(COMPLETIONS_CONCEPT_SAMPLE, None) is None, reason="Not running completion samples."
+            os.getenv(COMPLETIONS_CONCEPT_SAMPLE, None) is None,
+            reason="Not running completion samples.",
         ),
     ),
     param(
         ollama_chat_completion,
         ["Why is the sky blue?", "exit"],
         id="ollama_chat_completion",
-        marks=pytest.mark.skip(reason="Need to set up Ollama locally. Check out the module for more details."),
+        marks=pytest.mark.skip(
+            reason="Need to set up Ollama locally. Check out the module for more details."
+        ),
     ),
     param(
         lm_studio_chat_completion,
         ["Why is the sky blue?", "exit"],
         id="lm_studio_chat_completion",
-        marks=pytest.mark.skip(reason="Need to set up LM Studio locally. Check out the module for more details."),
+        marks=pytest.mark.skip(
+            reason="Need to set up LM Studio locally. Check out the module for more details."
+        ),
     ),
     param(
         lm_studio_text_embedding,
         [],
         id="lm_studio_text_embedding",
-        marks=pytest.mark.skip(reason="Need to set up LM Studio locally. Check out the module for more details."),
+        marks=pytest.mark.skip(
+            reason="Need to set up LM Studio locally. Check out the module for more details."
+        ),
     ),
     param(
         image_generation,
         [],
         id="image_generation",
         marks=pytest.mark.skipif(
-            os.getenv(COMPLETIONS_CONCEPT_SAMPLE, None) is None, reason="Not running completion samples."
+            os.getenv(COMPLETIONS_CONCEPT_SAMPLE, None) is None,
+            reason="Not running completion samples.",
         ),
     ),
     param(
@@ -360,7 +452,8 @@ concepts = [
         [],
         id="text_completion",
         marks=pytest.mark.skipif(
-            os.getenv(COMPLETIONS_CONCEPT_SAMPLE, None) is None, reason="Not running completion samples."
+            os.getenv(COMPLETIONS_CONCEPT_SAMPLE, None) is None,
+            reason="Not running completion samples.",
         ),
     ),
     param(
@@ -368,14 +461,17 @@ concepts = [
         [],
         id="text_embedding_generation",
         marks=pytest.mark.skipif(
-            os.getenv(COMPLETIONS_CONCEPT_SAMPLE, None) is None, reason="Not running completion samples."
+            os.getenv(COMPLETIONS_CONCEPT_SAMPLE, None) is None,
+            reason="Not running completion samples.",
         ),
     ),
 ]
 
 
 @mark.parametrize("sample, responses", concepts)
-async def test_concepts(sample: Callable[..., Awaitable[Any]], responses: list[str], monkeypatch):
+async def test_concepts(
+    sample: Callable[..., Awaitable[Any]], responses: list[str], monkeypatch
+):
     saved_responses = copy.deepcopy(responses)
 
     def reset():

--- a/python/tests/unit/react/test_azure_ai_react_agent.py
+++ b/python/tests/unit/react/test_azure_ai_react_agent.py
@@ -1,0 +1,237 @@
+# Copyright (c) Microsoft. All rights reserved.
+
+import json
+import pytest
+
+from samples.concepts.react.azure_ai_react_agent import (
+    CalculatorPlugin,
+    WeatherPlugin,
+    extract_function_descriptions,
+    parse_action_from_response,
+)
+
+
+class TestCalculatorPlugin:
+    """Test the CalculatorPlugin functionality."""
+
+    def test_add_valid_numbers(self):
+        """Test adding two valid numbers."""
+        plugin = CalculatorPlugin()
+        result = plugin.add("5", "3")
+        assert result == "8.0"
+
+    def test_add_invalid_numbers(self):
+        """Test adding invalid number formats."""
+        plugin = CalculatorPlugin()
+        result = plugin.add("invalid", "3")
+        assert result == "Error: Invalid number format"
+
+    def test_multiply_valid_numbers(self):
+        """Test multiplying two valid numbers."""
+        plugin = CalculatorPlugin()
+        result = plugin.multiply("4", "7")
+        assert result == "28.0"
+
+    def test_multiply_invalid_numbers(self):
+        """Test multiplying invalid number formats."""
+        plugin = CalculatorPlugin()
+        result = plugin.multiply("abc", "def")
+        assert result == "Error: Invalid number format"
+
+    def test_divide_valid_numbers(self):
+        """Test dividing two valid numbers."""
+        plugin = CalculatorPlugin()
+        result = plugin.divide("10", "2")
+        assert result == "5.0"
+
+    def test_divide_by_zero(self):
+        """Test division by zero handling."""
+        plugin = CalculatorPlugin()
+        result = plugin.divide("10", "0")
+        assert result == "Error: Division by zero"
+
+    def test_divide_invalid_numbers(self):
+        """Test dividing invalid number formats."""
+        plugin = CalculatorPlugin()
+        result = plugin.divide("10", "invalid")
+        assert result == "Error: Invalid number format"
+
+
+class TestWeatherPlugin:
+    """Test the WeatherPlugin functionality."""
+
+    def test_get_weather_known_city(self):
+        """Test getting weather for a known city."""
+        plugin = WeatherPlugin()
+        result = plugin.get_weather("Istanbul")
+        assert "Istanbul" in result
+        assert "Sunny, 22°C" in result
+
+    def test_get_weather_case_insensitive(self):
+        """Test getting weather with case insensitive city names."""
+        plugin = WeatherPlugin()
+        result = plugin.get_weather("ISTANBUL")
+        assert "ISTANBUL" in result
+        assert "Sunny, 22°C" in result
+
+    def test_get_weather_unknown_city(self):
+        """Test getting weather for an unknown city."""
+        plugin = WeatherPlugin()
+        result = plugin.get_weather("UnknownCity")
+        assert "not available" in result
+        assert "UnknownCity" in result
+
+
+class TestActionParsing:
+    """Test the action parsing functionality."""
+
+    def test_parse_valid_action_with_code_blocks(self):
+        """Test parsing a valid action JSON in code blocks."""
+        response = """
+        I need to add two numbers.
+        
+        ```
+        {
+          "action": "CalculatorPlugin.add",
+          "action_variables": {"number1": "5", "number2": "3"}
+        }
+        ```
+        """
+
+        action_name, action_variables = parse_action_from_response(response)
+
+        assert action_name == "CalculatorPlugin.add"
+        assert action_variables == {"number1": "5", "number2": "3"}
+
+    def test_parse_valid_action_without_code_blocks(self):
+        """Test parsing a valid action JSON without code blocks."""
+        response = """
+        I need to multiply two numbers.
+        {"action": "CalculatorPlugin.multiply", "action_variables": {"number1": "4", "number2": "7"}}
+        """
+
+        action_name, action_variables = parse_action_from_response(response)
+
+        assert action_name == "CalculatorPlugin.multiply"
+        assert action_variables == {"number1": "4", "number2": "7"}
+
+    def test_parse_invalid_json(self):
+        """Test parsing response with invalid JSON."""
+        response = """
+        This is not a valid JSON action.
+        {invalid json}
+        """
+
+        action_name, action_variables = parse_action_from_response(response)
+
+        assert action_name is None
+        assert action_variables == {}
+
+    def test_parse_no_action_in_response(self):
+        """Test parsing response with no action."""
+        response = """
+        This is just a regular response without any action.
+        """
+
+        action_name, action_variables = parse_action_from_response(response)
+
+        assert action_name is None
+        assert action_variables == {}
+
+    def test_parse_action_missing_variables(self):
+        """Test parsing action with missing action_variables."""
+        response = """
+        ```
+        {
+          "action": "CalculatorPlugin.add"
+        }
+        ```
+        """
+
+        action_name, action_variables = parse_action_from_response(response)
+
+        assert action_name == "CalculatorPlugin.add"
+        assert action_variables == {}
+
+
+class TestFunctionDescriptions:
+    """Test function description extraction."""
+
+    def test_extract_function_descriptions_with_mock_kernel(self):
+        """Test extracting function descriptions from a mock kernel."""
+
+        # Create a mock kernel-like structure
+        class MockFunction:
+            def __init__(self, name, description, parameters):
+                self.name = name
+                self.metadata = MockMetadata(description, parameters)
+
+        class MockMetadata:
+            def __init__(self, description, parameters):
+                self.description = description
+                self.parameters = parameters
+
+        class MockParameter:
+            def __init__(self, name, description):
+                self.name = name
+                self.description = description
+
+        class MockPlugin:
+            def __init__(self, functions):
+                self._functions = functions
+
+            def items(self):
+                return self._functions.items()
+
+        class MockKernel:
+            def __init__(self):
+                self.plugins = {
+                    "CalculatorPlugin": MockPlugin(
+                        {
+                            "add": MockFunction(
+                                "add",
+                                "Adds two numbers together.",
+                                [
+                                    MockParameter("number1", "The first number"),
+                                    MockParameter("number2", "The second number"),
+                                ],
+                            )
+                        }
+                    )
+                }
+
+        mock_kernel = MockKernel()
+        result = extract_function_descriptions(mock_kernel)  # type: ignore
+
+        assert "CalculatorPlugin.add: Adds two numbers together." in result
+        assert "- number1: The first number" in result
+        assert "- number2: The second number" in result
+
+
+class TestReactPatternComponents:
+    """Test React pattern specific components."""
+
+    def test_react_prompt_template_constants(self):
+        """Test that the React prompt template contains required sections."""
+        from samples.concepts.react.azure_ai_react_agent import REACT_PROMPT_TEMPLATE
+
+        # Check for key React pattern elements
+        assert "[THOUGHT]" in REACT_PROMPT_TEMPLATE
+        assert "[ACTION]" in REACT_PROMPT_TEMPLATE
+        assert "[OBSERVATION]" in REACT_PROMPT_TEMPLATE
+        assert "[FINAL ANSWER]" in REACT_PROMPT_TEMPLATE
+        assert "{{$question}}" in REACT_PROMPT_TEMPLATE
+        assert "{{$function_descriptions}}" in REACT_PROMPT_TEMPLATE
+        assert "{{$agent_scratchpad}}" in REACT_PROMPT_TEMPLATE
+
+    def test_react_prompt_template_json_example(self):
+        """Test that the prompt template includes JSON action example."""
+        from samples.concepts.react.azure_ai_react_agent import REACT_PROMPT_TEMPLATE
+
+        assert '"action":' in REACT_PROMPT_TEMPLATE
+        assert '"action_variables":' in REACT_PROMPT_TEMPLATE
+        assert "CalculatorPlugin.Add" in REACT_PROMPT_TEMPLATE
+
+
+if __name__ == "__main__":
+    pytest.main([__file__])


### PR DESCRIPTION
## Motivation and Context

This PR introduces a new sample that demonstrates the ReAct (Reasoning and Acting) agent pattern, inspired by the LangChain ReAct framework.  
The example shows how to build a multi-step reasoning loop that enables an agent to think step by step, take actions using available plugins, and observe results before producing a final answer.

This contribution was inspired by #12564 and provides a practical starting point for anyone interested in extending Semantic Kernel with a reusable ReAct agent in the future.

## Changes

- Added `react_agent/azure_ai_react_agent.py` under `python/samples/getting_started_with_agents/` to demonstrate the ReAct pattern with Azure OpenAI.
- Created simple `CalculatorPlugin` and `WeatherPlugin` to show how the agent can call multiple tools in a reasoning loop.
- Implemented a clear Thought-Action-Observation prompt template to guide the agent step by step.
- Updated the related `README.md` to include configuration steps, usage instructions, and environment variable hints for running the sample locally.

## Why is this useful?

- Helps new users understand how to build agents that think and act in multiple steps.
- Bridges the gap between simple agent examples and more advanced agent orchestration patterns.
- Provides an initial foundation for a possible future `ReActAgent` as a reusable predefined agent class.

## Notes for reviewers

- This sample does not yet introduce a new predefined agent — instead, it demonstrates how the pattern could work and serves as inspiration for a future built-in ReAct agent.
- The sample is fully self-contained and does not affect any existing functionality.
- Tested locally with different scenarios to validate the Thought-Action-Observation cycle.
- Feedback is welcome for any improvements or next steps!

---

