### PR TITLE
#12728 Use Odata2Linq nuget for .NET8

### DIFF
--- a/dotnet/Directory.Packages.props
+++ b/dotnet/Directory.Packages.props
@@ -69,6 +69,7 @@
     <PackageVersion Include="MSTest.TestFramework" Version="3.8.0" />
     <PackageVersion Include="Newtonsoft.Json" Version="13.0.3" />
     <PackageVersion Include="Npgsql" Version="8.0.7" />
+    <PackageVersion Include="OData2Linq" Version="2.1.0" />
     <PackageVersion Include="OllamaSharp" Version="5.2.3" />
     <PackageVersion Include="OpenAI" Version="[2.2.0-beta.4]" />
     <PackageVersion Include="OpenTelemetry.Exporter.Console" Version="1.12.0" />

--- a/dotnet/src/Plugins/Plugins.StructuredData.EntityFramework/Plugins.StructuredData.EntityFramework.csproj
+++ b/dotnet/src/Plugins/Plugins.StructuredData.EntityFramework/Plugins.StructuredData.EntityFramework.csproj
@@ -27,7 +27,7 @@
   </ItemGroup>
   
   <ItemGroup>
-    <Compile Remove="$(RepoRoot)/dotnet/src/InternalUtilities/src/Diagnostics/ModelDiagnostics.cs" Link="%(RecursiveDir)/InternalUtilities/Diagnostics/%(Filename)%(Extension)"/>
+    <Compile Remove="$(RepoRoot)/dotnet/src/InternalUtilities/src/Diagnostics/ModelDiagnostics.cs" Link="%(RecursiveDir)/InternalUtilities/Diagnostics/%(Filename)%(Extension)" />
   </ItemGroup>
 
   <ItemGroup>
@@ -36,8 +36,14 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Community.OData.Linq" />
     <PackageReference Include="EntityFramework" />
+  </ItemGroup>
+
+  <ItemGroup Condition="'$(TargetFramework)' == 'net462'">
+    <PackageReference Include="Community.OData.Linq" />
+  </ItemGroup>
+  <ItemGroup Condition="'$(TargetFramework)' != 'net462'">
+    <PackageReference Include="OData2Linq" />
   </ItemGroup>
 
 </Project>

--- a/dotnet/src/Plugins/Plugins.StructuredData.EntityFramework/StructuredDataService.cs
+++ b/dotnet/src/Plugins/Plugins.StructuredData.EntityFramework/StructuredDataService.cs
@@ -6,7 +6,11 @@ using System.Data.Entity.Infrastructure;
 using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
+#if NET462
 using Community.OData.Linq;
+#else
+using OData2Linq;
+#endif
 
 #pragma warning disable CA1308 // Normalize strings to uppercase
 


### PR DESCRIPTION
Fixes #12728

### Motivation and Context
Replacing a deprecated nuget library


### Description

Replaced deprecated library https://github.com/IharYakimush/comminity-data-odata-linq
with the successor (for .NET8): https://github.com/ArnaudB88/OData2Linq

### Contribution Checklist

<!-- Before submitting this PR, please make sure: -->

- [ ] The code builds clean without any errors or warnings
- [ ] The PR follows the [SK Contribution Guidelines](https://github.com/microsoft/semantic-kernel/blob/main/CONTRIBUTING.md) and the [pre-submission formatting script](https://github.com/microsoft/semantic-kernel/blob/main/CONTRIBUTING.md#development-scripts) raises no violations
- [ ] All unit tests pass, and I have added new tests where possible
- [ ] I didn't break anyone :smile:
