### PR TITLE
.Net: Update GettingStarted to use M.E.AI.ChatClient

### DIFF
--- a/dotnet/global.json
+++ b/dotnet/global.json
@@ -1,6 +1,6 @@
 {
   "sdk": {
-    "version": "9.0.203",
+    "version": "9.0.300",
     "rollForward": "latestMajor",
     "allowPrerelease": false
   }

--- a/dotnet/global.json
+++ b/dotnet/global.json
@@ -1,6 +1,6 @@
 {
   "sdk": {
-    "version": "9.0.300",
+    "version": "9.0.203",
     "rollForward": "latestMajor",
     "allowPrerelease": false
   }

--- a/dotnet/samples/GettingStarted/Step1_Create_Kernel.cs
+++ b/dotnet/samples/GettingStarted/Step1_Create_Kernel.cs
@@ -6,19 +6,19 @@ using Microsoft.SemanticKernel.Connectors.OpenAI;
 namespace GettingStarted;
 
 /// <summary>
-/// This example shows how to create and use a <see cref="Kernel"/>.
+/// This example shows how to create and use a <see cref="Kernel"/> with ChatClient.
 /// </summary>
 public sealed class Step1_Create_Kernel(ITestOutputHelper output) : BaseTest(output)
 {
     /// <summary>
-    /// Show how to create a <see cref="Kernel"/> and use it to execute prompts.
+    /// Show how to create a <see cref="Kernel"/> using ChatClient and use it to execute prompts.
     /// </summary>
     [Fact]
     public async Task CreateKernel()
     {
-        // Create a kernel with OpenAI chat completion
+        // Create a kernel with OpenAI chat completion using ChatClient
         Kernel kernel = Kernel.CreateBuilder()
-            .AddOpenAIChatCompletion(
+            .AddOpenAIChatClient(
                 modelId: TestConfiguration.OpenAI.ChatModelId,
                 apiKey: TestConfiguration.OpenAI.ApiKey)
             .Build();

--- a/dotnet/samples/GettingStarted/Step2_Add_Plugins.cs
+++ b/dotnet/samples/GettingStarted/Step2_Add_Plugins.cs
@@ -9,21 +9,21 @@ using Microsoft.SemanticKernel.Connectors.OpenAI;
 namespace GettingStarted;
 
 /// <summary>
-/// This example shows how to load a <see cref="KernelPlugin"/> instances.
+/// This example shows how to load a <see cref="KernelPlugin"/> instances with ChatClient.
 /// </summary>
 public sealed class Step2_Add_Plugins(ITestOutputHelper output) : BaseTest(output)
 {
     /// <summary>
-    /// Shows different ways to load a <see cref="KernelPlugin"/> instances.
+    /// Shows different ways to load a <see cref="KernelPlugin"/> instances with ChatClient.
     /// </summary>
     [Fact]
     public async Task AddPlugins()
     {
-        // Create a kernel with OpenAI chat completion
+        // Create a kernel with ChatClient and plugins
         IKernelBuilder kernelBuilder = Kernel.CreateBuilder();
-        kernelBuilder.AddOpenAIChatCompletion(
-                modelId: TestConfiguration.OpenAI.ChatModelId,
-                apiKey: TestConfiguration.OpenAI.ApiKey);
+        kernelBuilder.AddOpenAIChatClient(
+            modelId: TestConfiguration.OpenAI.ChatModelId,
+            apiKey: TestConfiguration.OpenAI.ApiKey);
         kernelBuilder.Plugins.AddFromType<TimeInformation>();
         kernelBuilder.Plugins.AddFromType<WidgetFactory>();
         Kernel kernel = kernelBuilder.Build();
@@ -31,14 +31,14 @@ public sealed class Step2_Add_Plugins(ITestOutputHelper output) : BaseTest(outpu
         // Example 1. Invoke the kernel with a prompt that asks the AI for information it cannot provide and may hallucinate
         Console.WriteLine(await kernel.InvokePromptAsync("How many days until Christmas?"));
 
-        // Example 2. Invoke the kernel with a templated prompt that invokes a plugin and display the result
+        // Example 2. Use kernel for templated prompts that invoke plugins directly
         Console.WriteLine(await kernel.InvokePromptAsync("The current time is {{TimeInformation.GetCurrentUtcTime}}. How many days until Christmas?"));
 
-        // Example 3. Invoke the kernel with a prompt and allow the AI to automatically invoke functions
+        // Example 3. Use kernel with function calling for automatic plugin invocation
         OpenAIPromptExecutionSettings settings = new() { FunctionChoiceBehavior = FunctionChoiceBehavior.Auto() };
         Console.WriteLine(await kernel.InvokePromptAsync("How many days until Christmas? Explain your thinking.", new(settings)));
 
-        // Example 4. Invoke the kernel with a prompt and allow the AI to automatically invoke functions that use enumerations
+        // Example 4. Use kernel with function calling for complex scenarios with enumerations
         Console.WriteLine(await kernel.InvokePromptAsync("Create a handy lime colored widget for me.", new(settings)));
         Console.WriteLine(await kernel.InvokePromptAsync("Create a beautiful scarlet colored widget for me.", new(settings)));
         Console.WriteLine(await kernel.InvokePromptAsync("Create an attractive maroon and navy colored widget for me.", new(settings)));

--- a/dotnet/samples/GettingStarted/Step2_Add_Plugins.cs
+++ b/dotnet/samples/GettingStarted/Step2_Add_Plugins.cs
@@ -29,16 +29,20 @@ public sealed class Step2_Add_Plugins(ITestOutputHelper output) : BaseTest(outpu
         Kernel kernel = kernelBuilder.Build();
 
         // Example 1. Invoke the kernel with a prompt that asks the AI for information it cannot provide and may hallucinate
+        Console.WriteLine("Example 1: Asking the AI for information it cannot provide:");
         Console.WriteLine(await kernel.InvokePromptAsync("How many days until Christmas?"));
 
         // Example 2. Use kernel for templated prompts that invoke plugins directly
+        Console.WriteLine("\nExample 2: Using templated prompts that invoke plugins directly:");
         Console.WriteLine(await kernel.InvokePromptAsync("The current time is {{TimeInformation.GetCurrentUtcTime}}. How many days until Christmas?"));
 
         // Example 3. Use kernel with function calling for automatic plugin invocation
         OpenAIPromptExecutionSettings settings = new() { FunctionChoiceBehavior = FunctionChoiceBehavior.Auto() };
+        Console.WriteLine("\nExample 3: Using function calling for automatic plugin invocation:");
         Console.WriteLine(await kernel.InvokePromptAsync("How many days until Christmas? Explain your thinking.", new(settings)));
 
         // Example 4. Use kernel with function calling for complex scenarios with enumerations
+        Console.WriteLine("\nExample 4: Using function calling for complex scenarios with enumerations:");
         Console.WriteLine(await kernel.InvokePromptAsync("Create a handy lime colored widget for me.", new(settings)));
         Console.WriteLine(await kernel.InvokePromptAsync("Create a beautiful scarlet colored widget for me.", new(settings)));
         Console.WriteLine(await kernel.InvokePromptAsync("Create an attractive maroon and navy colored widget for me.", new(settings)));

--- a/dotnet/samples/GettingStarted/Step3_Yaml_Prompt.cs
+++ b/dotnet/samples/GettingStarted/Step3_Yaml_Prompt.cs
@@ -19,7 +19,7 @@ public sealed class Step3_Yaml_Prompt(ITestOutputHelper output) : BaseTest(outpu
     {
         // Create a kernel with OpenAI chat completion
         Kernel kernel = Kernel.CreateBuilder()
-            .AddOpenAIChatCompletion(
+            .AddOpenAIChatClient(
                 modelId: TestConfiguration.OpenAI.ChatModelId,
                 apiKey: TestConfiguration.OpenAI.ApiKey)
             .Build();

--- a/dotnet/samples/GettingStarted/Step4_Dependency_Injection.cs
+++ b/dotnet/samples/GettingStarted/Step4_Dependency_Injection.cs
@@ -38,7 +38,7 @@ public sealed class Step4_Dependency_Injection(ITestOutputHelper output) : BaseT
     [Fact]
     public async Task PluginUsingDependencyInjection()
     {
-        // If an application follows DI guidelines, the following line is unnecessary because DI will inject an instance of the KernelClient class to a class that references it.
+        // If an application follows DI guidelines, the following line is unnecessary because DI will inject an instance of the Kernel class to a class that references it.
         // DI container guidelines - https://learn.microsoft.com/en-us/dotnet/core/extensions/dependency-injection-guidelines#recommendations
         var serviceProvider = BuildServiceProvider();
         var kernel = serviceProvider.GetRequiredService<Kernel>();
@@ -57,8 +57,12 @@ public sealed class Step4_Dependency_Injection(ITestOutputHelper output) : BaseT
         collection.AddSingleton<ILoggerFactory>(new XunitLogger(this.Output));
         collection.AddSingleton<IUserService>(new FakeUserService());
 
+        // Add ChatClient using OpenAI
+        collection.AddOpenAIChatClient(
+            modelId: TestConfiguration.OpenAI.ChatModelId,
+            apiKey: TestConfiguration.OpenAI.ApiKey);
+
         var kernelBuilder = collection.AddKernel();
-        kernelBuilder.Services.AddOpenAIChatCompletion(TestConfiguration.OpenAI.ChatModelId, TestConfiguration.OpenAI.ApiKey);
         kernelBuilder.Plugins.AddFromType<TimeInformation>();
         kernelBuilder.Plugins.AddFromType<UserInformation>();
 

--- a/dotnet/samples/GettingStarted/Step5_Chat_Prompt.cs
+++ b/dotnet/samples/GettingStarted/Step5_Chat_Prompt.cs
@@ -14,7 +14,7 @@ public sealed class Step5_Chat_Prompt(ITestOutputHelper output) : BaseTest(outpu
     {
         // Create a kernel with OpenAI chat completion
         Kernel kernel = Kernel.CreateBuilder()
-            .AddOpenAIChatCompletion(
+            .AddOpenAIChatClient(
                 modelId: TestConfiguration.OpenAI.ChatModelId,
                 apiKey: TestConfiguration.OpenAI.ApiKey)
             .Build();

--- a/dotnet/samples/GettingStarted/Step6_Responsible_AI.cs
+++ b/dotnet/samples/GettingStarted/Step6_Responsible_AI.cs
@@ -15,7 +15,7 @@ public sealed class Step6_Responsible_AI(ITestOutputHelper output) : BaseTest(ou
     {
         // Create a kernel with OpenAI chat completion
         var builder = Kernel.CreateBuilder()
-            .AddOpenAIChatCompletion(
+            .AddOpenAIChatClient(
                 modelId: TestConfiguration.OpenAI.ChatModelId,
                 apiKey: TestConfiguration.OpenAI.ApiKey);
 

--- a/dotnet/samples/GettingStarted/Step7_Observability.cs
+++ b/dotnet/samples/GettingStarted/Step7_Observability.cs
@@ -54,7 +54,7 @@ public sealed class Step7_Observability(ITestOutputHelper output) : BaseTest(out
     {
         private readonly ITestOutputHelper _output = output;
 
-        public async Task OnFunctionInvocationAsync(Microsoft.SemanticKernel.FunctionInvocationContext context, Func<Microsoft.SemanticKernel.FunctionInvocationContext, Task> next)
+        public async Task OnFunctionInvocationAsync(FunctionInvocationContext context, Func<FunctionInvocationContext, Task> next)
         {
             this._output.WriteLine($"Invoking {context.Function.Name}");
 

--- a/dotnet/samples/GettingStarted/Step7_Observability.cs
+++ b/dotnet/samples/GettingStarted/Step7_Observability.cs
@@ -17,7 +17,7 @@ public sealed class Step7_Observability(ITestOutputHelper output) : BaseTest(out
     {
         // Create a kernel with OpenAI chat completion
         IKernelBuilder kernelBuilder = Kernel.CreateBuilder();
-        kernelBuilder.AddOpenAIChatCompletion(
+        kernelBuilder.AddOpenAIChatClient(
                 modelId: TestConfiguration.OpenAI.ChatModelId,
                 apiKey: TestConfiguration.OpenAI.ApiKey);
 
@@ -54,7 +54,7 @@ public sealed class Step7_Observability(ITestOutputHelper output) : BaseTest(out
     {
         private readonly ITestOutputHelper _output = output;
 
-        public async Task OnFunctionInvocationAsync(FunctionInvocationContext context, Func<FunctionInvocationContext, Task> next)
+        public async Task OnFunctionInvocationAsync(Microsoft.SemanticKernel.FunctionInvocationContext context, Func<Microsoft.SemanticKernel.FunctionInvocationContext, Task> next)
         {
             this._output.WriteLine($"Invoking {context.Function.Name}");
 

--- a/dotnet/samples/GettingStarted/Step8_Pipelining.cs
+++ b/dotnet/samples/GettingStarted/Step8_Pipelining.cs
@@ -17,7 +17,7 @@ public sealed class Step8_Pipelining(ITestOutputHelper output) : BaseTest(output
     public async Task CreateFunctionPipeline()
     {
         IKernelBuilder builder = Kernel.CreateBuilder();
-        builder.AddOpenAIChatCompletion(
+        builder.AddOpenAIChatClient(
             TestConfiguration.OpenAI.ChatModelId,
             TestConfiguration.OpenAI.ApiKey);
         builder.Services.AddLogging(c => c.AddConsole().SetMinimumLevel(LogLevel.Trace));

--- a/dotnet/samples/GettingStarted/Step9_OpenAPI_Plugins.cs
+++ b/dotnet/samples/GettingStarted/Step9_OpenAPI_Plugins.cs
@@ -19,7 +19,7 @@ public sealed class Step9_OpenAPI_Plugins(ITestOutputHelper output) : BaseTest(o
     {
         // Create a kernel with OpenAI chat completion
         IKernelBuilder kernelBuilder = Kernel.CreateBuilder();
-        kernelBuilder.AddOpenAIChatCompletion(
+        kernelBuilder.AddOpenAIChatClient(
                 modelId: TestConfiguration.OpenAI.ChatModelId,
                 apiKey: TestConfiguration.OpenAI.ApiKey);
         Kernel kernel = kernelBuilder.Build();
@@ -33,12 +33,12 @@ public sealed class Step9_OpenAPI_Plugins(ITestOutputHelper output) : BaseTest(o
     }
 
     /// <summary>
-    /// Shows how to transform an Open API <see cref="KernelPlugin"/> instance to support dependency injection.
+    /// Shows how to transform an Open API <see cref="KernelPlugin"/> instance to support dependency injection with ChatClient.
     /// </summary>
     [Fact]
     public async Task TransformOpenAPIPlugins()
     {
-        // Create a kernel with OpenAI chat completion
+        // Create a kernel with ChatClient and dependency injection
         var serviceProvider = BuildServiceProvider();
         var kernel = serviceProvider.GetRequiredService<Kernel>();
 
@@ -61,8 +61,12 @@ public sealed class Step9_OpenAPI_Plugins(ITestOutputHelper output) : BaseTest(o
         var collection = new ServiceCollection();
         collection.AddSingleton<IMechanicService>(new FakeMechanicService());
 
+        // Add ChatClient using OpenAI
+        collection.AddOpenAIChatClient(
+            modelId: TestConfiguration.OpenAI.ChatModelId,
+            apiKey: TestConfiguration.OpenAI.ApiKey);
+
         var kernelBuilder = collection.AddKernel();
-        kernelBuilder.Services.AddOpenAIChatCompletion(TestConfiguration.OpenAI.ChatModelId, TestConfiguration.OpenAI.ApiKey);
 
         return collection.BuildServiceProvider();
     }


### PR DESCRIPTION
### Motivation and Context

This pull request updates the `GettingStarted` samples to replace the use of `AddOpenAIChatCompletion` with `AddOpenAIChatClient` for creating kernels, aligning the code with the newer `ChatClient` API. Additionally, it updates documentation and examples to reflect this change and introduces minor improvements to the dependency injection setup.