### PR TITLE
Python: fix Bing grounding & custom search content generation

### DIFF
--- a/python/semantic_kernel/agents/azure_ai/agent_thread_actions.py
+++ b/python/semantic_kernel/agents/azure_ai/agent_thread_actions.py
@@ -16,6 +16,7 @@ from azure.ai.agents.models import (
     ResponseFormatJsonSchemaType,
     RunStep,
     RunStepAzureAISearchToolCall,
+    RunStepBingCustomSearchToolCall,
     RunStepBingGroundingToolCall,
     RunStepCodeInterpreterToolCall,
     RunStepDeltaChunk,
@@ -340,11 +341,12 @@ class AgentThreadActions:
                                     | AgentsNamedToolChoiceType.BING_CUSTOM_SEARCH
                                 ):
                                     logger.debug(
-                                        f"Entering tool_calls (bing_grounding) for run [{run.id}], agent "
-                                        f" `{agent.name}` and thread `{thread_id}`"
+                                        f"Entering tool_calls (bing_grounding/bing_custom_search) for run [{run.id}], "
+                                        f"agent `{agent.name}` and thread `{thread_id}`"
                                     )
-                                    bing_call: RunStepBingGroundingToolCall = cast(
-                                        RunStepBingGroundingToolCall, tool_call
+                                    # Handle both Bing grounding and custom search tool calls
+                                    bing_call: RunStepBingGroundingToolCall | RunStepBingCustomSearchToolCall = cast(
+                                        RunStepBingGroundingToolCall | RunStepBingCustomSearchToolCall, tool_call
                                     )
                                     content = generate_bing_grounding_content(
                                         agent_name=agent.name, bing_tool_call=bing_call


### PR DESCRIPTION
### Motivation and Context

The same `agent_content_generation` method is used to handle both `bing_grounding` and `bing_custom_search` tool calls; however, the method expected that the dicts on the underlying types were named the same - which they aren't. They have their respective names, as shown above.

<!-- Thank you for your contribution to the semantic-kernel repo!
Please help reviewers and future users, providing the following information:
  1. Why is this change required?
  2. What problem does it solve?
  3. What scenario does it contribute to?
  4. If it fixes an open issue, please link to the issue here.
-->

### Description

Fix Bing content generation based on the instance we're dealing with.
- Add unit tests.
- Closes #12746

<!-- Describe your changes, the overall approach, the underlying design.
     These notes will help understanding how your code works. Thanks! -->

### Contribution Checklist

<!-- Before submitting this PR, please make sure: -->

- [X] The code builds clean without any errors or warnings
- [X] The PR follows the [SK Contribution Guidelines](https://github.com/microsoft/semantic-kernel/blob/main/CONTRIBUTING.md) and the [pre-submission formatting script](https://github.com/microsoft/semantic-kernel/blob/main/CONTRIBUTING.md#development-scripts) raises no violations
- [X] All unit tests pass, and I have added new tests where possible
- [X] I didn't break anyone :smile:
