### PR TITLE
Python: Add incomplete details reason to AzureAIAgent error message

### DIFF
--- a/python/samples/getting_started_with_agents/openai_responses/README.md
+++ b/python/samples/getting_started_with_agents/openai_responses/README.md
@@ -15,12 +15,7 @@ In Semantic Kernel, we don't currently support the Computer User Agent Tool. Thi
 The Semantic Kernel Azure Responses Agent leverages Azure OpenAI's new stateful API. 
 It brings together the best capabilities from the chat completions and assistants API in one unified experience.
 
-Right now, there is no support with the `AzureResponsesAgent` for:
-
-- Structured outputs
-- tool_choice
-- image_url pointing to an internet address
-- The web search tool is also not supported, and is not part of the 2025-03-01-preview API.
+For `AzureResponsesAgent` limitations, please see the latest [Azure OpenAI Responses API Docs](https://learn.microsoft.com/en-us/azure/ai-foundry/openai/how-to/responses?tabs=python-secure).
 
 #### API Support
 

--- a/python/semantic_kernel/agents/azure_ai/agent_thread_actions.py
+++ b/python/semantic_kernel/agents/azure_ai/agent_thread_actions.py
@@ -199,12 +199,15 @@ class AgentThreadActions:
             )
 
             if run.status in cls.error_message_states:
-                error_message = ""
+                error_message = "None"
                 if run.last_error and run.last_error.message:
                     error_message = run.last_error.message
+                incomplete_details_reason = "None"
+                if run.incomplete_details and run.incomplete_details.reason:
+                    incomplete_details_reason = run.incomplete_details.reason
                 raise AgentInvokeException(
                     f"Run failed with status: `{run.status}` for agent `{agent.name}` and thread `{thread_id}` "
-                    f"with error: {error_message}"
+                    f"with error: {error_message} and incomplete details reason: {incomplete_details_reason}"
                 )
 
             # Check if function calling is required
@@ -738,12 +741,16 @@ class AgentThreadActions:
 
                 elif event_type == AgentStreamEvent.THREAD_RUN_FAILED:
                     run_failed = cast(ThreadRun, event_data)
-                    error_message = (
-                        run_failed.last_error.message if run_failed.last_error and run_failed.last_error.message else ""
-                    )
+                    error_message = "None"
+                    if run_failed.last_error and run_failed.last_error.message:
+                        error_message = run_failed.last_error.message
+                    incomplete_details_reason = "None"
+                    if run_failed.incomplete_details and run_failed.incomplete_details.reason:
+                        incomplete_details_reason = run_failed.incomplete_details.reason
                     raise RuntimeError(
                         f"Run failed with status: `{run_failed.status}` for agent `{agent.name}` "
-                        f"thread `{thread_id}` with error: {error_message}"
+                        f"thread `{thread_id}` with error: {error_message} and incomplete details reason: "
+                        f"{incomplete_details_reason}"
                     )
             else:
                 break


### PR DESCRIPTION
### Motivation and Context

When errors occur processing a run of an AzureAIAgent, we surface the error message but not the incomplete_details reason if it exists.

<!-- Thank you for your contribution to the semantic-kernel repo!
Please help reviewers and future users, providing the following information:
  1. Why is this change required?
  2. What problem does it solve?
  3. What scenario does it contribute to?
  4. If it fixes an open issue, please link to the issue here.
-->

### Description

This PR adds handling for the incomplete details reason, if it exists, so it can be passed back via the error message.
- Closes #12752

<!-- Describe your changes, the overall approach, the underlying design.
     These notes will help understanding how your code works. Thanks! -->

### Contribution Checklist

<!-- Before submitting this PR, please make sure: -->

- [X] The code builds clean without any errors or warnings
- [X] The PR follows the [SK Contribution Guidelines](https://github.com/microsoft/semantic-kernel/blob/main/CONTRIBUTING.md) and the [pre-submission formatting script](https://github.com/microsoft/semantic-kernel/blob/main/CONTRIBUTING.md#development-scripts) raises no violations
- [X] All unit tests pass, and I have added new tests where possible
- [X] I didn't break anyone :smile:
