### PR TITLE
.NET: Add support for Guid and ObjectID keys in the MongoDB Connector

### DIFF
--- a/dotnet/src/InternalUtilities/connectors/Memory/MongoDB/MongoModelBuilder.cs
+++ b/dotnet/src/InternalUtilities/connectors/Memory/MongoDB/MongoModelBuilder.cs
@@ -7,6 +7,7 @@ using System.Reflection;
 using Microsoft.Extensions.AI;
 using Microsoft.Extensions.VectorData;
 using Microsoft.Extensions.VectorData.ProviderServices;
+using MongoDB.Bson;
 using MongoDB.Bson.Serialization.Attributes;
 
 namespace Microsoft.SemanticKernel.Connectors.MongoDB;
@@ -43,9 +44,9 @@ internal class MongoModelBuilder() : CollectionModelBuilder(s_validationOptions)
 
     protected override bool IsKeyPropertyTypeValid(Type type, [NotNullWhen(false)] out string? supportedTypes)
     {
-        supportedTypes = "string";
+        supportedTypes = "string, Guid, ObjectId";
 
-        return type == typeof(string);
+        return type == typeof(string) || type == typeof(Guid) || type == typeof(ObjectId);
     }
 
     protected override bool IsDataPropertyTypeValid(Type type, [NotNullWhen(false)] out string? supportedTypes)

--- a/dotnet/src/VectorData/MongoDB/MongoVectorStore.cs
+++ b/dotnet/src/VectorData/MongoDB/MongoVectorStore.cs
@@ -54,7 +54,7 @@ public sealed class MongoVectorStore : VectorStore
 #pragma warning disable IDE0090 // Use 'new(...)'
     /// <inheritdoc />
     [RequiresDynamicCode("This overload of GetCollection() is incompatible with NativeAOT. For dynamic mapping via Dictionary<string, object?>, call GetDynamicCollection() instead.")]
-    [RequiresUnreferencedCode("This overload of GetCollecttion() is incompatible with trimming. For dynamic mapping via Dictionary<string, object?>, call GetDynamicCollection() instead.")]
+    [RequiresUnreferencedCode("This overload of GetCollection() is incompatible with trimming. For dynamic mapping via Dictionary<string, object?>, call GetDynamicCollection() instead.")]
 #if NET8_0_OR_GREATER
     public override MongoCollection<TKey, TRecord> GetCollection<TKey, TRecord>(string name, VectorStoreCollectionDefinition? definition = null)
 #else

--- a/dotnet/test/VectorData/MongoDB.ConformanceTests/CRUD/MongoBatchConformanceTests.cs
+++ b/dotnet/test/VectorData/MongoDB.ConformanceTests/CRUD/MongoBatchConformanceTests.cs
@@ -1,12 +1,23 @@
 ﻿// Copyright (c) Microsoft. All rights reserved.
 
+using MongoDB.Bson;
 using MongoDB.ConformanceTests.Support;
 using VectorData.ConformanceTests.CRUD;
 using Xunit;
 
 namespace MongoDB.ConformanceTests.CRUD;
 
-public class MongoBatchConformanceTests(MongoSimpleModelFixture fixture)
-    : BatchConformanceTests<string>(fixture), IClassFixture<MongoSimpleModelFixture>
+public class MongoBatchConformanceTests_String(MongoSimpleModelFixture<string> fixture)
+    : BatchConformanceTests<string>(fixture), IClassFixture<MongoSimpleModelFixture<string>>
+{
+}
+
+public class MongoBatchConformanceTests_Guid(MongoSimpleModelFixture<Guid> fixture)
+    : BatchConformanceTests<Guid>(fixture), IClassFixture<MongoSimpleModelFixture<Guid>>
+{
+}
+
+public class MongoBatchConformanceTests_ObjectId(MongoSimpleModelFixture<ObjectId> fixture)
+    : BatchConformanceTests<ObjectId>(fixture), IClassFixture<MongoSimpleModelFixture<ObjectId>>
 {
 }

--- a/dotnet/test/VectorData/MongoDB.ConformanceTests/CRUD/MongoRecordConformanceTests.cs
+++ b/dotnet/test/VectorData/MongoDB.ConformanceTests/CRUD/MongoRecordConformanceTests.cs
@@ -1,12 +1,23 @@
 ﻿// Copyright (c) Microsoft. All rights reserved.
 
+using MongoDB.Bson;
 using MongoDB.ConformanceTests.Support;
 using VectorData.ConformanceTests.CRUD;
 using Xunit;
 
 namespace MongoDB.ConformanceTests.CRUD;
 
-public class MongoRecordConformanceTests(MongoSimpleModelFixture fixture)
-    : RecordConformanceTests<string>(fixture), IClassFixture<MongoSimpleModelFixture>
+public class MongoRecordConformanceTests_String(MongoSimpleModelFixture<string> fixture)
+    : RecordConformanceTests<string>(fixture), IClassFixture<MongoSimpleModelFixture<string>>
+{
+}
+
+public class MongoRecordConformanceTests_Guid(MongoSimpleModelFixture<Guid> fixture)
+    : RecordConformanceTests<Guid>(fixture), IClassFixture<MongoSimpleModelFixture<Guid>>
+{
+}
+
+public class MongoRecordConformanceTests_ObjectId(MongoSimpleModelFixture<ObjectId> fixture)
+    : RecordConformanceTests<ObjectId>(fixture), IClassFixture<MongoSimpleModelFixture<ObjectId>>
 {
 }

--- a/dotnet/test/VectorData/MongoDB.ConformanceTests/Support/MongoSimpleModelFixture.cs
+++ b/dotnet/test/VectorData/MongoDB.ConformanceTests/Support/MongoSimpleModelFixture.cs
@@ -4,7 +4,8 @@ using VectorData.ConformanceTests.Support;
 
 namespace MongoDB.ConformanceTests.Support;
 
-public class MongoSimpleModelFixture : SimpleModelFixture<string>
+public class MongoSimpleModelFixture<TKey> : SimpleModelFixture<TKey>
+    where TKey : notnull
 {
     public override TestStore TestStore => MongoTestStore.Instance;
 }

--- a/dotnet/test/VectorData/MongoDB.ConformanceTests/Support/MongoTestStore.cs
+++ b/dotnet/test/VectorData/MongoDB.ConformanceTests/Support/MongoTestStore.cs
@@ -1,6 +1,7 @@
 ﻿// Copyright (c) Microsoft. All rights reserved.
 
 using Microsoft.SemanticKernel.Connectors.MongoDB;
+using MongoDB.Bson;
 using MongoDB.Driver;
 using Testcontainers.MongoDb;
 using VectorData.ConformanceTests.Support;
@@ -49,4 +50,16 @@ internal sealed class MongoTestStore : TestStore
 
     protected override Task StopAsync()
         => this._container.StopAsync();
+
+    private static readonly string? s_baseObjectId = ObjectId.GenerateNewId().ToString().Substring(0, 14);
+
+    public override TKey GenerateKey<TKey>(int value)
+    {
+        if (typeof(TKey) == typeof(ObjectId))
+        {
+            return (TKey)(object)ObjectId.Parse(s_baseObjectId + value.ToString("0000000000"));
+        }
+
+        return base.GenerateKey<TKey>(value);
+    }
 }


### PR DESCRIPTION
### Motivation and Context

The MongoDB connector currently only supports string key types.

### Description

Adds support for Guid and ObjectId key types to the MongoDB Connector. 

### Contribution Checklist

- [x] The code builds clean without any errors or warnings
- [x] The PR follows the [SK Contribution Guidelines](https://github.com/microsoft/semantic-kernel/blob/main/CONTRIBUTING.md) and the [pre-submission formatting script](https://github.com/microsoft/semantic-kernel/blob/main/CONTRIBUTING.md#development-scripts) raises no violations
- [x] All unit tests pass, and I have added new tests where possible
- [x] I didn't break anyone :smile:
