### PR TITLE
Features/onnx with provider choice

### DIFF
--- a/dotnet/Directory.Packages.props
+++ b/dotnet/Directory.Packages.props
@@ -60,9 +60,9 @@
     <PackageVersion Include="Microsoft.IdentityModel.JsonWebTokens" Version="7.5.1" />
     <PackageVersion Include="Microsoft.ML.OnnxRuntime" Version="1.22.0" />
     <PackageVersion Include="Microsoft.ML.Tokenizers.Data.Cl100kBase" Version="1.0.1" />
-    <PackageVersion Include="Microsoft.SemanticKernel.Abstractions" Version="1.58.0" />
-    <PackageVersion Include="Microsoft.SemanticKernel.Connectors.OpenAI" Version="1.58.0" />
-    <PackageVersion Include="Microsoft.SemanticKernel.Core" Version="1.58.0" />
+    <PackageVersion Include="Microsoft.SemanticKernel.Abstractions" Version="1.60.0" />
+    <PackageVersion Include="Microsoft.SemanticKernel.Connectors.OpenAI" Version="1.60.0" />
+    <PackageVersion Include="Microsoft.SemanticKernel.Core" Version="1.60.0" />
     <PackageVersion Include="Microsoft.SemanticKernel.Planners.OpenAI" Version="1.47.0-preview" />
     <PackageVersion Include="Microsoft.VisualStudio.Threading" Version="17.12.19" />
     <PackageVersion Include="ModelContextProtocol" Version="0.3.0-preview.2" />

--- a/dotnet/Directory.Packages.props
+++ b/dotnet/Directory.Packages.props
@@ -210,7 +210,6 @@
     <PackageVersion Include="Microsoft.ML.OnnxRuntimeGenAI" Version="0.8.2" />
     <PackageVersion Include="Microsoft.ML.OnnxRuntimeGenAI.Cuda" Version="0.8.1" />
     <PackageVersion Include="Microsoft.ML.OnnxRuntimeGenAI.DirectML" Version="0.8.1" />
-    <PackageVersion Include="Microsoft.ML.OnnxRuntime.Gpu.Windows" Version="1.22.1" />
     <!-- SpectreConsole-->
     <PackageVersion Include="Spectre.Console" Version="0.49.1" />
     <PackageVersion Include="Spectre.Console.Cli" Version="0.49.1" />

--- a/dotnet/Directory.Packages.props
+++ b/dotnet/Directory.Packages.props
@@ -10,19 +10,19 @@
     <PackageVersion Include="Aspire.Hosting.AppHost" Version="9.3.1" />
     <PackageVersion Include="Aspire.Hosting.Azure.CognitiveServices" Version="9.3.1" />
     <PackageVersion Include="Aspire.Hosting.Azure.Search" Version="9.3.1" />
-    <PackageVersion Include="AWSSDK.BedrockAgent" Version="4.0.4.1" />
-    <PackageVersion Include="AWSSDK.BedrockAgentRuntime" Version="4.0.4.10" />
-    <PackageVersion Include="AWSSDK.BedrockRuntime" Version="4.0.2.1" />
-    <PackageVersion Include="AWSSDK.Core" Version="4.0.0.17" />
-    <PackageVersion Include="AWSSDK.Extensions.Bedrock.MEAI" Version="4.0.2" />
+    <PackageVersion Include="AWSSDK.BedrockAgent" Version="4.0.3.8" />
+    <PackageVersion Include="AWSSDK.BedrockAgentRuntime" Version="4.0.4.7" />
+    <PackageVersion Include="AWSSDK.BedrockRuntime" Version="4.0.1.1" />
+    <PackageVersion Include="AWSSDK.Core" Version="4.0.0.14" />
+    <PackageVersion Include="AWSSDK.Extensions.Bedrock.MEAI" Version="4.0.1.1" />
     <PackageVersion Include="AWSSDK.Extensions.NETCore.Setup" Version="4.0.2" />
-    <PackageVersion Include="AWSSDK.SecurityToken" Version="4.0.1.6" />
+    <PackageVersion Include="AWSSDK.SecurityToken" Version="4.0.1.3" />
     <PackageVersion Include="Azure.AI.Agents.Persistent" Version="1.0.0" />
     <PackageVersion Include="Azure.AI.ContentSafety" Version="1.0.0" />
     <PackageVersion Include="Azure.AI.OpenAI" Version="[2.2.0-beta.5]" />
     <PackageVersion Include="Azure.AI.Projects" Version="1.0.0-beta.9" />
-    <PackageVersion Include="Azure.Identity" Version="1.14.2" />
-    <PackageVersion Include="Azure.Monitor.OpenTelemetry.Exporter" Version="1.4.0" />
+    <PackageVersion Include="Azure.Identity" Version="1.14.1" />
+    <PackageVersion Include="Azure.Monitor.OpenTelemetry.Exporter" Version="1.3.0" />
     <PackageVersion Include="Azure.Search.Documents" Version="11.6.1" />
     <PackageVersion Include="Community.OData.Linq" Version="2.1.0" />
     <PackageVersion Include="Dapr.Actors" Version="1.14.0" />
@@ -33,13 +33,13 @@
     <PackageVersion Include="Google.Apis.Auth" Version="1.69.0" />
     <PackageVersion Include="Google.Apis.CustomSearchAPI.v1" Version="1.68.0.3520" />
     <PackageVersion Include="Google.Protobuf" Version="3.31.1" />
-    <PackageVersion Include="Grpc.AspNetCore" Version="2.71.0" />
+    <PackageVersion Include="Grpc.AspNetCore" Version="2.70.0" />
     <PackageVersion Include="Grpc.AspNetCore.Server" Version="2.70.0" />
-    <PackageVersion Include="Grpc.AspNetCore.Server.Reflection" Version="2.71.0" />
-    <PackageVersion Include="Grpc.AspNetCore.Web" Version="2.71.0" />
-    <PackageVersion Include="Grpc.Net.Client" Version="2.71.0" />
-    <PackageVersion Include="Grpc.Tools" Version="2.72.0" />
-    <PackageVersion Include="Handlebars.Net.Helpers" Version="2.5.2" />
+    <PackageVersion Include="Grpc.AspNetCore.Server.Reflection" Version="2.70.0" />
+    <PackageVersion Include="Grpc.AspNetCore.Web" Version="2.70.0" />
+    <PackageVersion Include="Grpc.Net.Client" Version="2.70.0" />
+    <PackageVersion Include="Grpc.Tools" Version="2.71.0" />
+    <PackageVersion Include="Handlebars.Net.Helpers" Version="2.4.10" />
     <PackageVersion Include="Handlebars.Net" Version="2.1.6" />
     <PackageVersion Include="HtmlAgilityPack" Version="1.11.72" />
     <PackageVersion Include="JmesPath.Net" Version="1.0.330" />
@@ -55,10 +55,10 @@
     <PackageVersion Include="Microsoft.Bcl.Numerics" Version="9.0.5" />
     <PackageVersion Include="Microsoft.CodeAnalysis.Common" Version="4.13.0" />
     <PackageVersion Include="Microsoft.CodeAnalysis.CSharp" Version="4.13.0" />
-    <PackageVersion Include="Microsoft.Identity.Client" Version="4.74.1" />
-    <PackageVersion Include="Microsoft.Identity.Client.Extensions.Msal" Version="4.74.1" />
-    <PackageVersion Include="Microsoft.IdentityModel.JsonWebTokens" Version="8.13.0" />
-    <PackageVersion Include="Microsoft.ML.OnnxRuntime" Version="1.22.1" />
+    <PackageVersion Include="Microsoft.Identity.Client" Version="4.73.1" />
+    <PackageVersion Include="Microsoft.Identity.Client.Extensions.Msal" Version="4.73.1" />
+    <PackageVersion Include="Microsoft.IdentityModel.JsonWebTokens" Version="7.5.1" />
+    <PackageVersion Include="Microsoft.ML.OnnxRuntime" Version="1.22.0" />
     <PackageVersion Include="Microsoft.ML.Tokenizers.Data.Cl100kBase" Version="1.0.1" />
     <PackageVersion Include="Microsoft.SemanticKernel.Abstractions" Version="1.58.0" />
     <PackageVersion Include="Microsoft.SemanticKernel.Connectors.OpenAI" Version="1.58.0" />
@@ -80,7 +80,7 @@
     <PackageVersion Include="OpenTelemetry.Instrumentation.Runtime" Version="1.12.0" />
     <PackageVersion Include="PdfPig" Version="0.1.10" />
     <PackageVersion Include="Pinecone.Client" Version="3.1.0" />
-    <PackageVersion Include="Prompty.Core" Version="0.2.3-beta" />
+    <PackageVersion Include="Prompty.Core" Version="0.2.2-beta" />
     <PackageVersion Include="PuppeteerSharp" Version="20.0.5" />
     <PackageVersion Include="System.Diagnostics.DiagnosticSource" Version="8.0.1" />
     <PackageVersion Include="System.IdentityModel.Tokens.Jwt" Version="7.5.1" />
@@ -88,7 +88,7 @@
     <PackageVersion Include="System.Linq.Async" Version="6.0.3" />
     <PackageVersion Include="System.Memory.Data" Version="8.0.1" />
     <PackageVersion Include="System.Net.Http" Version="4.3.4" />
-    <PackageVersion Include="System.Numerics.Tensors" Version="9.0.7" />
+    <PackageVersion Include="System.Numerics.Tensors" Version="9.0.6" />
     <PackageVersion Include="System.Text.Json" Version="8.0.6" />
     <PackageVersion Include="System.ValueTuple" Version="4.6.1" />
     <PackageVersion Include="System.Threading.Tasks.Extensions" Version="4.6.3" />
@@ -110,14 +110,14 @@
     <PackageVersion Include="Microsoft.Extensions.Configuration.Json" Version="8.0.1" />
     <PackageVersion Include="Microsoft.Extensions.Configuration.UserSecrets" Version="8.0.1" />
     <PackageVersion Include="Microsoft.Extensions.DependencyInjection" Version="8.0.1" />
-    <PackageVersion Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="9.0.7" />
+    <PackageVersion Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="9.0.5" />
     <PackageVersion Include="Microsoft.Extensions.Diagnostics.Testing" Version="9.0.0" />
     <PackageVersion Include="Microsoft.Extensions.Hosting" Version="8.0.1" />
     <PackageVersion Include="Microsoft.Extensions.Http" Version="8.0.1" />
     <PackageVersion Include="Microsoft.Extensions.Http.Resilience" Version="8.9.1" />
     <PackageVersion Include="Microsoft.Extensions.ServiceDiscovery" Version="9.0.0" />
     <PackageVersion Include="Microsoft.Extensions.Logging" Version="8.0.1" />
-    <PackageVersion Include="Microsoft.Extensions.Logging.Abstractions" Version="9.0.7" />
+    <PackageVersion Include="Microsoft.Extensions.Logging.Abstractions" Version="8.0.1"/>
     <PackageVersion Include="Microsoft.Extensions.Logging.Console" Version="8.0.1" />
     <PackageVersion Include="Microsoft.Extensions.Logging.Debug" Version="8.0.1" />
     <PackageVersion Include="Microsoft.Extensions.Options.DataAnnotations" Version="8.0.0" />
@@ -133,7 +133,7 @@
     <PackageVersion Include="System.Threading.Tasks.Dataflow" Version="8.0.0" />
     <PackageVersion Include="xunit" Version="2.9.3" />
     <PackageVersion Include="xunit.abstractions" Version="2.0.3" />
-    <PackageVersion Include="xunit.runner.visualstudio" Version="3.1.3" />
+    <PackageVersion Include="xunit.runner.visualstudio" Version="3.1.1" />
     <PackageVersion Include="xretry" Version="1.9.0" />
     <PackageVersion Include="coverlet.collector" Version="6.0.4" />
     <PackageVersion Include="Docker.DotNet" Version="3.125.15" />
@@ -180,7 +180,7 @@
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-    <PackageVersion Include="xunit.analyzers" Version="1.23.0" />
+    <PackageVersion Include="xunit.analyzers" Version="1.22.0" />
     <PackageReference Include="xunit.analyzers">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
@@ -206,7 +206,8 @@
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
     <!-- OnnxRuntimeGenAI -->
-    <PackageVersion Include="Microsoft.ML.OnnxRuntimeGenAI" Version="0.8.3" />
+    <PackageVersion Include="Microsoft.ML.OnnxRuntime.Gpu.Windows" Version="1.22.1"/>
+    <PackageVersion Include="Microsoft.ML.OnnxRuntimeGenAI" Version="0.8.2" />
     <PackageVersion Include="Microsoft.ML.OnnxRuntimeGenAI.Cuda" Version="0.8.1" />
     <PackageVersion Include="Microsoft.ML.OnnxRuntimeGenAI.DirectML" Version="0.8.1" />
     <!-- SpectreConsole-->

--- a/dotnet/Directory.Packages.props
+++ b/dotnet/Directory.Packages.props
@@ -210,6 +210,7 @@
     <PackageVersion Include="Microsoft.ML.OnnxRuntimeGenAI" Version="0.8.2" />
     <PackageVersion Include="Microsoft.ML.OnnxRuntimeGenAI.Cuda" Version="0.8.1" />
     <PackageVersion Include="Microsoft.ML.OnnxRuntimeGenAI.DirectML" Version="0.8.1" />
+    <PackageVersion Include="Microsoft.ML.OnnxRuntime.Gpu.Windows" Version="1.22.1" />
     <!-- SpectreConsole-->
     <PackageVersion Include="Spectre.Console" Version="0.49.1" />
     <PackageVersion Include="Spectre.Console.Cli" Version="0.49.1" />

--- a/dotnet/Directory.Packages.props
+++ b/dotnet/Directory.Packages.props
@@ -10,19 +10,19 @@
     <PackageVersion Include="Aspire.Hosting.AppHost" Version="9.3.1" />
     <PackageVersion Include="Aspire.Hosting.Azure.CognitiveServices" Version="9.3.1" />
     <PackageVersion Include="Aspire.Hosting.Azure.Search" Version="9.3.1" />
-    <PackageVersion Include="AWSSDK.BedrockAgent" Version="4.0.3.8" />
-    <PackageVersion Include="AWSSDK.BedrockAgentRuntime" Version="4.0.4.7" />
-    <PackageVersion Include="AWSSDK.BedrockRuntime" Version="4.0.1.1" />
-    <PackageVersion Include="AWSSDK.Core" Version="4.0.0.14" />
-    <PackageVersion Include="AWSSDK.Extensions.Bedrock.MEAI" Version="4.0.1.1" />
+    <PackageVersion Include="AWSSDK.BedrockAgent" Version="4.0.4.1" />
+    <PackageVersion Include="AWSSDK.BedrockAgentRuntime" Version="4.0.4.10" />
+    <PackageVersion Include="AWSSDK.BedrockRuntime" Version="4.0.2.1" />
+    <PackageVersion Include="AWSSDK.Core" Version="4.0.0.17" />
+    <PackageVersion Include="AWSSDK.Extensions.Bedrock.MEAI" Version="4.0.2" />
     <PackageVersion Include="AWSSDK.Extensions.NETCore.Setup" Version="4.0.2" />
-    <PackageVersion Include="AWSSDK.SecurityToken" Version="4.0.1.3" />
+    <PackageVersion Include="AWSSDK.SecurityToken" Version="4.0.1.6" />
     <PackageVersion Include="Azure.AI.Agents.Persistent" Version="1.0.0" />
     <PackageVersion Include="Azure.AI.ContentSafety" Version="1.0.0" />
     <PackageVersion Include="Azure.AI.OpenAI" Version="[2.2.0-beta.5]" />
     <PackageVersion Include="Azure.AI.Projects" Version="1.0.0-beta.9" />
-    <PackageVersion Include="Azure.Identity" Version="1.14.1" />
-    <PackageVersion Include="Azure.Monitor.OpenTelemetry.Exporter" Version="1.3.0" />
+    <PackageVersion Include="Azure.Identity" Version="1.14.2" />
+    <PackageVersion Include="Azure.Monitor.OpenTelemetry.Exporter" Version="1.4.0" />
     <PackageVersion Include="Azure.Search.Documents" Version="11.6.1" />
     <PackageVersion Include="Community.OData.Linq" Version="2.1.0" />
     <PackageVersion Include="Dapr.Actors" Version="1.14.0" />
@@ -33,13 +33,13 @@
     <PackageVersion Include="Google.Apis.Auth" Version="1.69.0" />
     <PackageVersion Include="Google.Apis.CustomSearchAPI.v1" Version="1.68.0.3520" />
     <PackageVersion Include="Google.Protobuf" Version="3.31.1" />
-    <PackageVersion Include="Grpc.AspNetCore" Version="2.70.0" />
+    <PackageVersion Include="Grpc.AspNetCore" Version="2.71.0" />
     <PackageVersion Include="Grpc.AspNetCore.Server" Version="2.70.0" />
-    <PackageVersion Include="Grpc.AspNetCore.Server.Reflection" Version="2.70.0" />
-    <PackageVersion Include="Grpc.AspNetCore.Web" Version="2.70.0" />
-    <PackageVersion Include="Grpc.Net.Client" Version="2.70.0" />
-    <PackageVersion Include="Grpc.Tools" Version="2.71.0" />
-    <PackageVersion Include="Handlebars.Net.Helpers" Version="2.4.10" />
+    <PackageVersion Include="Grpc.AspNetCore.Server.Reflection" Version="2.71.0" />
+    <PackageVersion Include="Grpc.AspNetCore.Web" Version="2.71.0" />
+    <PackageVersion Include="Grpc.Net.Client" Version="2.71.0" />
+    <PackageVersion Include="Grpc.Tools" Version="2.72.0" />
+    <PackageVersion Include="Handlebars.Net.Helpers" Version="2.5.2" />
     <PackageVersion Include="Handlebars.Net" Version="2.1.6" />
     <PackageVersion Include="HtmlAgilityPack" Version="1.11.72" />
     <PackageVersion Include="JmesPath.Net" Version="1.0.330" />
@@ -55,14 +55,14 @@
     <PackageVersion Include="Microsoft.Bcl.Numerics" Version="9.0.5" />
     <PackageVersion Include="Microsoft.CodeAnalysis.Common" Version="4.13.0" />
     <PackageVersion Include="Microsoft.CodeAnalysis.CSharp" Version="4.13.0" />
-    <PackageVersion Include="Microsoft.Identity.Client" Version="4.73.1" />
-    <PackageVersion Include="Microsoft.Identity.Client.Extensions.Msal" Version="4.73.1" />
-    <PackageVersion Include="Microsoft.IdentityModel.JsonWebTokens" Version="7.5.1" />
-    <PackageVersion Include="Microsoft.ML.OnnxRuntime" Version="1.22.0" />
+    <PackageVersion Include="Microsoft.Identity.Client" Version="4.74.1" />
+    <PackageVersion Include="Microsoft.Identity.Client.Extensions.Msal" Version="4.74.1" />
+    <PackageVersion Include="Microsoft.IdentityModel.JsonWebTokens" Version="8.13.0" />
+    <PackageVersion Include="Microsoft.ML.OnnxRuntime" Version="1.22.1" />
     <PackageVersion Include="Microsoft.ML.Tokenizers.Data.Cl100kBase" Version="1.0.1" />
-    <PackageVersion Include="Microsoft.SemanticKernel.Abstractions" Version="1.60.0" />
-    <PackageVersion Include="Microsoft.SemanticKernel.Connectors.OpenAI" Version="1.60.0" />
-    <PackageVersion Include="Microsoft.SemanticKernel.Core" Version="1.60.0" />
+    <PackageVersion Include="Microsoft.SemanticKernel.Abstractions" Version="1.58.0" />
+    <PackageVersion Include="Microsoft.SemanticKernel.Connectors.OpenAI" Version="1.58.0" />
+    <PackageVersion Include="Microsoft.SemanticKernel.Core" Version="1.58.0" />
     <PackageVersion Include="Microsoft.SemanticKernel.Planners.OpenAI" Version="1.47.0-preview" />
     <PackageVersion Include="Microsoft.VisualStudio.Threading" Version="17.12.19" />
     <PackageVersion Include="ModelContextProtocol" Version="0.3.0-preview.2" />
@@ -80,7 +80,7 @@
     <PackageVersion Include="OpenTelemetry.Instrumentation.Runtime" Version="1.12.0" />
     <PackageVersion Include="PdfPig" Version="0.1.10" />
     <PackageVersion Include="Pinecone.Client" Version="3.1.0" />
-    <PackageVersion Include="Prompty.Core" Version="0.2.2-beta" />
+    <PackageVersion Include="Prompty.Core" Version="0.2.3-beta" />
     <PackageVersion Include="PuppeteerSharp" Version="20.0.5" />
     <PackageVersion Include="System.Diagnostics.DiagnosticSource" Version="8.0.1" />
     <PackageVersion Include="System.IdentityModel.Tokens.Jwt" Version="7.5.1" />
@@ -88,7 +88,7 @@
     <PackageVersion Include="System.Linq.Async" Version="6.0.3" />
     <PackageVersion Include="System.Memory.Data" Version="8.0.1" />
     <PackageVersion Include="System.Net.Http" Version="4.3.4" />
-    <PackageVersion Include="System.Numerics.Tensors" Version="9.0.6" />
+    <PackageVersion Include="System.Numerics.Tensors" Version="9.0.7" />
     <PackageVersion Include="System.Text.Json" Version="8.0.6" />
     <PackageVersion Include="System.ValueTuple" Version="4.6.1" />
     <PackageVersion Include="System.Threading.Tasks.Extensions" Version="4.6.3" />
@@ -110,14 +110,14 @@
     <PackageVersion Include="Microsoft.Extensions.Configuration.Json" Version="8.0.1" />
     <PackageVersion Include="Microsoft.Extensions.Configuration.UserSecrets" Version="8.0.1" />
     <PackageVersion Include="Microsoft.Extensions.DependencyInjection" Version="8.0.1" />
-    <PackageVersion Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="9.0.5" />
+    <PackageVersion Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="9.0.7" />
     <PackageVersion Include="Microsoft.Extensions.Diagnostics.Testing" Version="9.0.0" />
     <PackageVersion Include="Microsoft.Extensions.Hosting" Version="8.0.1" />
     <PackageVersion Include="Microsoft.Extensions.Http" Version="8.0.1" />
     <PackageVersion Include="Microsoft.Extensions.Http.Resilience" Version="8.9.1" />
     <PackageVersion Include="Microsoft.Extensions.ServiceDiscovery" Version="9.0.0" />
     <PackageVersion Include="Microsoft.Extensions.Logging" Version="8.0.1" />
-    <PackageVersion Include="Microsoft.Extensions.Logging.Abstractions" Version="8.0.1"/>
+    <PackageVersion Include="Microsoft.Extensions.Logging.Abstractions" Version="9.0.7" />
     <PackageVersion Include="Microsoft.Extensions.Logging.Console" Version="8.0.1" />
     <PackageVersion Include="Microsoft.Extensions.Logging.Debug" Version="8.0.1" />
     <PackageVersion Include="Microsoft.Extensions.Options.DataAnnotations" Version="8.0.0" />
@@ -133,7 +133,7 @@
     <PackageVersion Include="System.Threading.Tasks.Dataflow" Version="8.0.0" />
     <PackageVersion Include="xunit" Version="2.9.3" />
     <PackageVersion Include="xunit.abstractions" Version="2.0.3" />
-    <PackageVersion Include="xunit.runner.visualstudio" Version="3.1.1" />
+    <PackageVersion Include="xunit.runner.visualstudio" Version="3.1.3" />
     <PackageVersion Include="xretry" Version="1.9.0" />
     <PackageVersion Include="coverlet.collector" Version="6.0.4" />
     <PackageVersion Include="Docker.DotNet" Version="3.125.15" />
@@ -180,7 +180,7 @@
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-    <PackageVersion Include="xunit.analyzers" Version="1.22.0" />
+    <PackageVersion Include="xunit.analyzers" Version="1.23.0" />
     <PackageReference Include="xunit.analyzers">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
@@ -207,7 +207,7 @@
     </PackageReference>
     <!-- OnnxRuntimeGenAI -->
     <PackageVersion Include="Microsoft.ML.OnnxRuntime.Gpu.Windows" Version="1.22.1"/>
-    <PackageVersion Include="Microsoft.ML.OnnxRuntimeGenAI" Version="0.8.2" />
+    <PackageVersion Include="Microsoft.ML.OnnxRuntimeGenAI" Version="0.8.3" />
     <PackageVersion Include="Microsoft.ML.OnnxRuntimeGenAI.Cuda" Version="0.8.1" />
     <PackageVersion Include="Microsoft.ML.OnnxRuntimeGenAI.DirectML" Version="0.8.1" />
     <!-- SpectreConsole-->

--- a/dotnet/SK-dotnet.slnx
+++ b/dotnet/SK-dotnet.slnx
@@ -40,6 +40,7 @@
     <Project Path="samples/Demos/ModelContextProtocolPlugin/ModelContextProtocolPlugin.csproj" />
     <Project Path="samples/Demos/ModelContextProtocolPluginAuth/ModelContextProtocolPluginAuth.csproj" />
     <Project Path="samples/Demos/OllamaFunctionCalling/OllamaFunctionCalling.csproj" />
+    <Project Path="samples/Demos/OnnxWithProviderChoice/OnnxWithProviderChoice.csproj" />
     <Project Path="samples/Demos/OnnxSimpleRAG/OnnxSimpleRAG.csproj" />
     <Project Path="samples/Demos/OpenAIRealtime/OpenAIRealtime.csproj" />
     <Project Path="samples/Demos/ProcessWithDapr/ProcessWithDapr.csproj" />

--- a/dotnet/SK-dotnet.slnx
+++ b/dotnet/SK-dotnet.slnx
@@ -25,7 +25,6 @@
     <Project Path="samples/Demos/OnnxFunctionCalling/OnnxFunctionCalling.csproj"/>
     <Project Path="samples/Demos/OnnxSimpleRAG/OnnxSimpleRAG.csproj"/>
     <Project Path="samples/Demos/OnnxWithProviderChoice/OnnxWithProviderChoice.csproj"/>
-    <Project Path="samples/Demos/OpenAIFunctionCalling/OpenAIFunctionCalling.csproj" />
     <Project Path="samples/Demos/OpenAIRealtime/OpenAIRealtime.csproj" />
     <Project Path="samples/Demos/ProcessWithDapr/ProcessWithDapr.csproj" />
     <Project Path="samples/Demos/QualityCheck/QualityCheckWithFilters/QualityCheckWithFilters.csproj" />
@@ -34,7 +33,6 @@
     <Project Path="samples/Demos/TelemetryWithAppInsights/TelemetryWithAppInsights.csproj" />
     <Project Path="samples/Demos/TimePlugin/TimePlugin.csproj" />
     <Project Path="samples/Demos/VectorStoreRAG/VectorStoreRAG.csproj" />
-    <Project Path="samples/Demos/OpenAIFunctionCalling/OpenAIFunctionCalling.csproj" />
   </Folder>
   <Folder Name="/samples/Demos/A2AClientServer/">
     <Project Path="samples/Demos/A2AClientServer/A2AClient/A2AClient.csproj" />

--- a/dotnet/SK-dotnet.slnx
+++ b/dotnet/SK-dotnet.slnx
@@ -1,22 +1,4 @@
 <Solution>
-  <Folder Name="/Solution Items/">
-    <File Path="../.editorconfig" />
-    <File Path="../.github/workflows/dotnet-format.yml" />
-    <File Path="../.gitignore" />
-    <File Path="../nuget.config" />
-    <File Path="../README.md" />
-    <File Path="Directory.Build.props" />
-    <File Path="Directory.Build.targets" />
-    <File Path="Directory.Packages.props" />
-    <File Path="docs/EXPERIMENTS.md" />
-    <File Path="global.json" />
-  </Folder>
-  <Folder Name="/Solution Items/nuget/">
-    <File Path="nuget/icon.png" />
-    <File Path="nuget/nuget-package.props" />
-    <File Path="nuget/NUGET.md" />
-    <File Path="nuget/VECTORDATA-CONNECTORS-NUGET.md" />
-  </Folder>
   <Folder Name="/samples/">
     <File Path="samples/README.md" />
     <Project Path="samples/Concepts/Concepts.csproj" />
@@ -40,8 +22,10 @@
     <Project Path="samples/Demos/ModelContextProtocolPlugin/ModelContextProtocolPlugin.csproj" />
     <Project Path="samples/Demos/ModelContextProtocolPluginAuth/ModelContextProtocolPluginAuth.csproj" />
     <Project Path="samples/Demos/OllamaFunctionCalling/OllamaFunctionCalling.csproj" />
-    <Project Path="samples/Demos/OnnxWithProviderChoice/OnnxWithProviderChoice.csproj" />
-    <Project Path="samples/Demos/OnnxSimpleRAG/OnnxSimpleRAG.csproj" />
+    <Project Path="samples/Demos/OnnxFunctionCalling/OnnxFunctionCalling.csproj"/>
+    <Project Path="samples/Demos/OnnxSimpleRAG/OnnxSimpleRAG.csproj"/>
+    <Project Path="samples/Demos/OnnxWithProviderChoice/OnnxWithProviderChoice.csproj"/>
+    <Project Path="samples/Demos/OpenAIFunctionCalling/OpenAIFunctionCalling.csproj" />
     <Project Path="samples/Demos/OpenAIRealtime/OpenAIRealtime.csproj" />
     <Project Path="samples/Demos/ProcessWithDapr/ProcessWithDapr.csproj" />
     <Project Path="samples/Demos/QualityCheck/QualityCheckWithFilters/QualityCheckWithFilters.csproj" />
@@ -50,6 +34,7 @@
     <Project Path="samples/Demos/TelemetryWithAppInsights/TelemetryWithAppInsights.csproj" />
     <Project Path="samples/Demos/TimePlugin/TimePlugin.csproj" />
     <Project Path="samples/Demos/VectorStoreRAG/VectorStoreRAG.csproj" />
+    <Project Path="samples/Demos/OpenAIFunctionCalling/OpenAIFunctionCalling.csproj" />
   </Folder>
   <Folder Name="/samples/Demos/A2AClientServer/">
     <Project Path="samples/Demos/A2AClientServer/A2AClient/A2AClient.csproj" />
@@ -133,24 +118,6 @@
     <Project Path="src/Connectors/Connectors.Onnx/Connectors.Onnx.csproj" />
     <Project Path="src/Connectors/Connectors.OpenAI.UnitTests/Connectors.OpenAI.UnitTests.csproj" />
     <Project Path="src/Connectors/Connectors.OpenAI/Connectors.OpenAI.csproj" />
-  </Folder>
-  <Folder Name="/src/VectorData/">
-    <File Path="src/VectorData/Directory.Build.props" />
-    <Project Path="src/VectorData/AzureAISearch/AzureAISearch.csproj" />
-    <Project Path="src/VectorData/Chroma/Chroma.csproj" />
-    <Project Path="src/VectorData/CosmosMongoDB/CosmosMongoDB.csproj" />
-    <Project Path="src/VectorData/CosmosNoSql/CosmosNoSql.csproj" />
-    <Project Path="src/VectorData/InMemory/InMemory.csproj" />
-    <Project Path="src/VectorData/Milvus/Milvus.csproj" />
-    <Project Path="src/VectorData/MongoDB/MongoDB.csproj" />
-    <Project Path="src/VectorData/PgVector/PgVector.csproj" />
-    <Project Path="src/VectorData/Pinecone/Pinecone.csproj" />
-    <Project Path="src/VectorData/Qdrant/Qdrant.csproj" />
-    <Project Path="src/VectorData/Redis/Redis.csproj" />
-    <Project Path="src/VectorData/SqliteVec/SqliteVec.csproj" />
-    <Project Path="src/VectorData/SqlServer/SqlServer.csproj" />
-    <Project Path="src/VectorData/VectorData.Abstractions/VectorData.Abstractions.csproj" />
-    <Project Path="src/VectorData/Weaviate/Weaviate.csproj" />
   </Folder>
   <Folder Name="/src/experimental/">
     <Project Path="src/Experimental/Orchestration.Flow.IntegrationTests/Experimental.Orchestration.Flow.IntegrationTests.csproj" />

--- a/dotnet/samples/Concepts/ChatCompletion/Onnx_ChatCompletion.cs
+++ b/dotnet/samples/Concepts/ChatCompletion/Onnx_ChatCompletion.cs
@@ -93,6 +93,7 @@ public class Onnx_ChatCompletion(ITestOutputHelper output) : BaseTest(output)
 
         var kernel = Kernel.CreateBuilder()
             .AddOnnxRuntimeGenAIChatCompletion(
+                serviceId: TestConfiguration.Onnx.ModelId,
                 modelId: TestConfiguration.Onnx.ModelId,
                 modelPath: TestConfiguration.Onnx.ModelPath)
             .Build();

--- a/dotnet/samples/Concepts/ChatCompletion/Onnx_ChatCompletionStreaming.cs
+++ b/dotnet/samples/Concepts/ChatCompletion/Onnx_ChatCompletionStreaming.cs
@@ -92,6 +92,7 @@ public class Onnx_ChatCompletionStreaming(ITestOutputHelper output) : BaseTest(o
 
         var kernel = Kernel.CreateBuilder()
             .AddOnnxRuntimeGenAIChatCompletion(
+                serviceId: "onnx",
                 modelId: TestConfiguration.Onnx.ModelId,
                 modelPath: TestConfiguration.Onnx.ModelPath)
             .Build();

--- a/dotnet/samples/Demos/OnnxFunctionCalling/OnnxFunctionCalling.csproj
+++ b/dotnet/samples/Demos/OnnxFunctionCalling/OnnxFunctionCalling.csproj
@@ -1,0 +1,16 @@
+﻿<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <OutputType>Exe</OutputType>
+    <TargetFramework>net8.0</TargetFramework>
+    <NoWarn>$(NoWarn);CA2007,CA2208,CS1591,CA1024,IDE0009,IDE0055,IDE0073,IDE0211,VSTHRD111,SKEXP0001</NoWarn>
+  </PropertyGroup>
+  <ItemGroup>
+    <PackageReference Include="Microsoft.Extensions.Logging"/>
+    <PackageReference Include="Microsoft.Extensions.Logging.Console"/>
+    <PackageReference Include="Microsoft.Net.Compilers.Toolset"/>
+    <PackageReference Include="Microsoft.ML.OnnxRuntimeGenAI.Cuda"/>
+    <PackageReference Include="Microsoft.ML.OnnxRuntime.Gpu.Windows"/>
+    <ProjectReference Include="..\..\..\src\Connectors\Connectors.Onnx\Connectors.Onnx.csproj"/>
+    <ProjectReference Include="..\..\..\src\SemanticKernel.Abstractions\SemanticKernel.Abstractions.csproj"/>
+  </ItemGroup>
+</Project>

--- a/dotnet/samples/Demos/OnnxFunctionCalling/Plugins/MyAlarmPlugin.cs
+++ b/dotnet/samples/Demos/OnnxFunctionCalling/Plugins/MyAlarmPlugin.cs
@@ -1,0 +1,34 @@
+﻿// Copyright (c) Microsoft. All rights reserved.
+
+using System.ComponentModel;
+using Microsoft.SemanticKernel;
+
+namespace OnnxFunctionCalling.Plugins;
+
+/// <summary>
+/// Class that represents a controllable alarm.
+/// </summary>
+public class MyAlarmPlugin
+{
+    private string _hour;
+
+    public MyAlarmPlugin(string providedHour)
+    {
+        this._hour = providedHour;
+    }
+
+    [KernelFunction]
+    [Description("Sets an alarm at the provided time")]
+    public string SetAlarm(string time)
+    {
+        this._hour = time;
+        return GetCurrentAlarm();
+    }
+
+    [KernelFunction]
+    [Description("Get current alarm set")]
+    public string GetCurrentAlarm()
+    {
+        return $"Alarm set for {_hour}";
+    }
+}

--- a/dotnet/samples/Demos/OnnxFunctionCalling/Plugins/MyLightPlugin.cs
+++ b/dotnet/samples/Demos/OnnxFunctionCalling/Plugins/MyLightPlugin.cs
@@ -1,0 +1,27 @@
+﻿// Copyright (c) Microsoft. All rights reserved.
+
+using System.ComponentModel;
+using Microsoft.SemanticKernel;
+
+namespace OnnxFunctionCalling.Plugins;
+
+/// <summary>
+/// Class that represents a controllable light bulb.
+/// </summary>
+[Description("Represents a light bulb")]
+public class MyLightPlugin(bool turnedOn = false)
+{
+    private bool _turnedOn = turnedOn;
+
+    [KernelFunction]
+    [Description("Returns whether this light is on")]
+    public bool IsTurnedOn() => _turnedOn;
+
+    [KernelFunction]
+    [Description("Turn on this light")]
+    public void TurnOn() => _turnedOn = true;
+
+    [KernelFunction]
+    [Description("Turn off this light")]
+    public void TurnOff() => _turnedOn = false;
+}

--- a/dotnet/samples/Demos/OnnxFunctionCalling/Plugins/MyTimePlugin.cs
+++ b/dotnet/samples/Demos/OnnxFunctionCalling/Plugins/MyTimePlugin.cs
@@ -1,0 +1,16 @@
+﻿// Copyright (c) Microsoft. All rights reserved.
+
+using System;
+using System.ComponentModel;
+using Microsoft.SemanticKernel;
+
+namespace OnnxFunctionCalling.Plugins;
+
+/// <summary>
+/// Simple plugin that just returns the time.
+/// </summary>
+public class MyTimePlugin
+{
+    [KernelFunction, Description("Get the current time")]
+    public DateTimeOffset Time() => DateTimeOffset.Now;
+}

--- a/dotnet/samples/Demos/OnnxFunctionCalling/Program.cs
+++ b/dotnet/samples/Demos/OnnxFunctionCalling/Program.cs
@@ -57,10 +57,10 @@ string modelId = "Phi_4_multimodal_instruct";
 string modelPath = "D:\\VisionCATS_AI_Agent\\Development\\.cache\\models\\microsoft_Phi_4_multimodal_instruct_onnx-gpu_gpu_int4_rtn_block_32";
 
 IKernelBuilder builder = Kernel.CreateBuilder();
-builder.AddOnnxRuntimeGenAIFunctionCallingChatCompletion(
+builder.AddOnnxRuntimeGenAIChatCompletion(
     modelPath: modelPath,
     serviceId: "onnx",
-    providers: ["cuda"],
+    providers: [new Provider { Id = "cuda" }],
     loggerFactory: loggerFactory
 );
 builder.Plugins
@@ -95,7 +95,7 @@ Console.WriteLine("""
 
 await DoLoop(history, chatCompletionService, settings, kernel);
 
-if (chatCompletionService is OnnxRuntimeGenAIFunctionCallingChatCompletionService onnxService)
+if (chatCompletionService is OnnxRuntimeGenAIChatCompletionService onnxService)
 {
     onnxService.Dispose();
 }

--- a/dotnet/samples/Demos/OnnxFunctionCalling/Program.cs
+++ b/dotnet/samples/Demos/OnnxFunctionCalling/Program.cs
@@ -1,6 +1,5 @@
 ﻿using System;
 using System.Threading.Tasks;
-using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Logging;
 using Microsoft.SemanticKernel;
 using Microsoft.SemanticKernel.ChatCompletion;

--- a/dotnet/samples/Demos/OnnxFunctionCalling/Program.cs
+++ b/dotnet/samples/Demos/OnnxFunctionCalling/Program.cs
@@ -1,0 +1,101 @@
+﻿using System;
+using System.Threading.Tasks;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Logging;
+using Microsoft.SemanticKernel;
+using Microsoft.SemanticKernel.ChatCompletion;
+using Microsoft.SemanticKernel.Connectors.Onnx;
+using OnnxFunctionCalling.Plugins;
+
+async Task DoLoop(ChatHistory history, IChatCompletionService chatCompletionService, OnnxRuntimeGenAIPromptExecutionSettings settings, Kernel kernel)
+{
+    while (true)
+    {
+        Console.Write("User > ");
+        string userMessage = Console.ReadLine()!;
+        if (userMessage == "exit" || userMessage == "quit")
+        {
+            break;
+        }
+
+        if (string.IsNullOrEmpty(userMessage))
+        {
+            continue;
+        }
+
+        history.AddUserMessage(userMessage);
+
+        try
+        {
+            ChatMessageContent results = await chatCompletionService.GetChatMessageContentAsync(history, settings, kernel);
+            Console.WriteLine($"Assistant > {results.Content}");
+            history.AddAssistantMessage(results.Content!);
+        }
+        catch (Exception e)
+        {
+            Console.WriteLine(e.Message);
+        }
+    }
+}
+
+async Task DoDemo(ChatHistory history, IChatCompletionService chatCompletionService, OnnxRuntimeGenAIPromptExecutionSettings settings, Kernel kernel)
+{
+    string userMessage = "change the alarm to 8";
+    Console.WriteLine($"User > {userMessage}");
+    history.AddUserMessage(userMessage);
+    ChatMessageContent results = await chatCompletionService.GetChatMessageContentAsync(history, settings, kernel);
+    Console.WriteLine($"Assistant > {results.Content}");
+    history.AddAssistantMessage(results.Content!);
+}
+
+ILoggerFactory loggerFactory = LoggerFactory.Create(builder =>
+{
+    builder.AddConsole();
+});
+
+string modelId = "Phi_4_multimodal_instruct";
+string modelPath = "D:\\VisionCATS_AI_Agent\\Development\\.cache\\models\\microsoft_Phi_4_multimodal_instruct_onnx-gpu_gpu_int4_rtn_block_32";
+
+IKernelBuilder builder = Kernel.CreateBuilder();
+builder.AddOnnxRuntimeGenAIFunctionCallingChatCompletion(
+    modelPath: modelPath,
+    serviceId: "onnx",
+    providers: ["cuda"],
+    loggerFactory: loggerFactory
+);
+builder.Plugins
+    .AddFromType<MyTimePlugin>()
+    .AddFromObject(new MyLightPlugin(turnedOn: true))
+    .AddFromObject(new MyAlarmPlugin("11"));
+
+Kernel kernel = builder.Build();
+
+ChatHistory history = [];
+history.AddSystemMessage("""
+                         You are a helpful assistant.
+                         You are not restricted to using the provided plugins,
+                         and you can use information from your training.
+                         Please explain your reasoning with the response.
+                         """);
+
+IChatCompletionService chatCompletionService = kernel.GetRequiredService<IChatCompletionService>();
+OnnxRuntimeGenAIPromptExecutionSettings settings = new()
+{
+    FunctionChoiceBehavior = FunctionChoiceBehavior.Auto()
+};
+
+Console.WriteLine("""
+                  Ask questions or give instructions to the copilot such as:
+                  - change the alarm to 8
+                  - what is the current alarm set?
+                  - is the light on?
+                  - turn the light off please
+                  - set an alarm for 6:00 am
+                  """);
+
+await DoLoop(history, chatCompletionService, settings, kernel);
+
+if (chatCompletionService is OnnxRuntimeGenAIFunctionCallingChatCompletionService onnxService)
+{
+    onnxService.Dispose();
+}

--- a/dotnet/samples/Demos/OnnxWithProviderChoice/OnnxWithProviderChoice.csproj
+++ b/dotnet/samples/Demos/OnnxWithProviderChoice/OnnxWithProviderChoice.csproj
@@ -1,0 +1,16 @@
+﻿<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <OutputType>Exe</OutputType>
+    <TargetFramework>net8.0</TargetFramework>
+    <NoWarn>$(NoWarn);CA2007,CA2208,CS1591,CA1024,IDE0009,IDE0055,IDE0073,IDE0211,VSTHRD111,SKEXP0001</NoWarn>
+  </PropertyGroup>
+  <ItemGroup>
+    <PackageReference Include="Microsoft.Extensions.Logging"/>
+    <PackageReference Include="Microsoft.Extensions.Logging.Console"/>
+    <PackageReference Include="Microsoft.Net.Compilers.Toolset"/>
+    <PackageReference Include="Microsoft.ML.OnnxRuntimeGenAI.Cuda"/>
+    <PackageReference Include="Microsoft.ML.OnnxRuntime.Gpu.Windows"/>
+    <ProjectReference Include="..\..\..\src\Connectors\Connectors.Onnx\Connectors.Onnx.csproj"/>
+    <ProjectReference Include="..\..\..\src\SemanticKernel.Abstractions\SemanticKernel.Abstractions.csproj"/>
+  </ItemGroup>
+</Project>

--- a/dotnet/samples/Demos/OnnxWithProviderChoice/Program.cs
+++ b/dotnet/samples/Demos/OnnxWithProviderChoice/Program.cs
@@ -62,7 +62,6 @@ ChatHistory history = [];
 IChatCompletionService chatCompletionService = kernel.GetRequiredService<IChatCompletionService>();
 OnnxRuntimeGenAIPromptExecutionSettings settings = new()
 {
-    FunctionChoiceBehavior = FunctionChoiceBehavior.Auto(),
     MaxTokens = 5120
 };
 

--- a/dotnet/samples/Demos/OnnxWithProviderChoice/Program.cs
+++ b/dotnet/samples/Demos/OnnxWithProviderChoice/Program.cs
@@ -1,6 +1,5 @@
 ﻿using System;
 using System.Threading.Tasks;
-using Microsoft.Extensions.Logging;
 using Microsoft.SemanticKernel;
 using Microsoft.SemanticKernel.ChatCompletion;
 using Microsoft.SemanticKernel.Connectors.Onnx;

--- a/dotnet/samples/Demos/OnnxWithProviderChoice/Program.cs
+++ b/dotnet/samples/Demos/OnnxWithProviderChoice/Program.cs
@@ -58,27 +58,13 @@ builder.AddOnnxRuntimeGenAIChatCompletion(
 Kernel kernel = builder.Build();
 
 ChatHistory history = [];
-history.AddSystemMessage("""
-                         You are a helpful assistant.
-                         You are not restricted to using the provided plugins,
-                         and you can use information from your training.
-                         Please explain your reasoning with the response.
-                         """);
 
 IChatCompletionService chatCompletionService = kernel.GetRequiredService<IChatCompletionService>();
 OnnxRuntimeGenAIPromptExecutionSettings settings = new()
 {
-    FunctionChoiceBehavior = FunctionChoiceBehavior.Auto()
+    FunctionChoiceBehavior = FunctionChoiceBehavior.Auto(),
+    MaxTokens = 5120
 };
-
-Console.WriteLine("""
-                  Ask questions or give instructions to the copilot such as:
-                  - change the alarm to 8
-                  - what is the current alarm set?
-                  - is the light on?
-                  - turn the light off please
-                  - set an alarm for 6:00 am
-                  """);
 
 await DoLoop(history, chatCompletionService, settings, kernel);
 

--- a/dotnet/samples/Demos/OnnxWithProviderChoice/Program.cs
+++ b/dotnet/samples/Demos/OnnxWithProviderChoice/Program.cs
@@ -1,0 +1,88 @@
+﻿using System;
+using System.Threading.Tasks;
+using Microsoft.Extensions.Logging;
+using Microsoft.SemanticKernel;
+using Microsoft.SemanticKernel.ChatCompletion;
+using Microsoft.SemanticKernel.Connectors.Onnx;
+
+async Task DoLoop(ChatHistory history, IChatCompletionService chatCompletionService, OnnxRuntimeGenAIPromptExecutionSettings settings, Kernel kernel)
+{
+    while (true)
+    {
+        Console.Write("User > ");
+        string userMessage = Console.ReadLine()!;
+        if (userMessage == "exit" || userMessage == "quit")
+        {
+            break;
+        }
+
+        if (string.IsNullOrEmpty(userMessage))
+        {
+            continue;
+        }
+
+        history.AddUserMessage(userMessage);
+
+        try
+        {
+            ChatMessageContent results = await chatCompletionService.GetChatMessageContentAsync(history, settings, kernel);
+            Console.WriteLine($"Assistant > {results.Content}");
+            history.AddAssistantMessage(results.Content!);
+        }
+        catch (Exception e)
+        {
+            Console.WriteLine(e.Message);
+        }
+    }
+}
+
+async Task DoDemo(ChatHistory history, IChatCompletionService chatCompletionService, OnnxRuntimeGenAIPromptExecutionSettings settings, Kernel kernel)
+{
+    string userMessage = "change the alarm to 8";
+    Console.WriteLine($"User > {userMessage}");
+    history.AddUserMessage(userMessage);
+    ChatMessageContent results = await chatCompletionService.GetChatMessageContentAsync(history, settings, kernel);
+    Console.WriteLine($"Assistant > {results.Content}");
+    history.AddAssistantMessage(results.Content!);
+}
+
+string modelPath = "D:\\VisionCATS_AI_Agent\\Development\\.cache\\models\\microsoft_Phi_4_multimodal_instruct_onnx-gpu_gpu_int4_rtn_block_32";
+
+IKernelBuilder builder = Kernel.CreateBuilder();
+builder.AddOnnxRuntimeGenAIChatCompletion(
+    modelPath: modelPath,
+    serviceId: "onnx",
+    providers: ["cuda"]
+);
+
+Kernel kernel = builder.Build();
+
+ChatHistory history = [];
+history.AddSystemMessage("""
+                         You are a helpful assistant.
+                         You are not restricted to using the provided plugins,
+                         and you can use information from your training.
+                         Please explain your reasoning with the response.
+                         """);
+
+IChatCompletionService chatCompletionService = kernel.GetRequiredService<IChatCompletionService>();
+OnnxRuntimeGenAIPromptExecutionSettings settings = new()
+{
+    FunctionChoiceBehavior = FunctionChoiceBehavior.Auto()
+};
+
+Console.WriteLine("""
+                  Ask questions or give instructions to the copilot such as:
+                  - change the alarm to 8
+                  - what is the current alarm set?
+                  - is the light on?
+                  - turn the light off please
+                  - set an alarm for 6:00 am
+                  """);
+
+await DoLoop(history, chatCompletionService, settings, kernel);
+
+if (chatCompletionService is OnnxRuntimeGenAIChatCompletionService onnxService)
+{
+    onnxService.Dispose();
+}

--- a/dotnet/samples/Demos/OnnxWithProviderChoice/Program.cs
+++ b/dotnet/samples/Demos/OnnxWithProviderChoice/Program.cs
@@ -46,13 +46,13 @@ async Task DoDemo(ChatHistory history, IChatCompletionService chatCompletionServ
     history.AddAssistantMessage(results.Content!);
 }
 
-string modelPath = "D:\\VisionCATS_AI_Agent\\Development\\.cache\\models\\microsoft_Phi_4_multimodal_instruct_onnx-gpu_gpu_int4_rtn_block_32";
+string modelPath = "D:\\VisionCATS_AI_Agent_experimental\\Development\\.cache\\models\\microsoft_Phi_4_mini_instruct_onnx-gpu_gpu_int4_rtn_block_32";
 
 IKernelBuilder builder = Kernel.CreateBuilder();
 builder.AddOnnxRuntimeGenAIChatCompletion(
     modelPath: modelPath,
     serviceId: "onnx",
-    providers: ["cuda"]
+    providers: [new Provider { Id = "cuda" }]
 );
 
 Kernel kernel = builder.Build();

--- a/dotnet/samples/Demos/OpenAIFunctionCalling/OpenAIFunctionCalling.csproj
+++ b/dotnet/samples/Demos/OpenAIFunctionCalling/OpenAIFunctionCalling.csproj
@@ -1,0 +1,19 @@
+﻿<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <OutputType>Exe</OutputType>
+    <TargetFramework>net8.0</TargetFramework>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+    <NoWarn>$(NoWarn);VSTHRD111,CA2007,CS8618,CS1591,CA1052,SKEXP0001</NoWarn>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Microsoft.Extensions.Configuration.EnvironmentVariables"/>
+    <PackageReference Include="Microsoft.Extensions.Configuration.UserSecrets"/>
+    <PackageReference Include="Microsoft.Extensions.Configuration.Binder"/>
+    <ProjectReference Include="..\..\..\src\Connectors\Connectors.AzureOpenAI\Connectors.AzureOpenAI.csproj"/>
+    <ProjectReference Include="..\..\..\src\SemanticKernel.Core\SemanticKernel.Core.csproj"/>
+  </ItemGroup>
+
+</Project>

--- a/dotnet/samples/Demos/OpenAIFunctionCalling/Plugins/MyAlarmPlugin.cs
+++ b/dotnet/samples/Demos/OpenAIFunctionCalling/Plugins/MyAlarmPlugin.cs
@@ -1,0 +1,34 @@
+﻿// Copyright (c) Microsoft. All rights reserved.
+
+using System.ComponentModel;
+using Microsoft.SemanticKernel;
+
+namespace OpenAIFunctionCalling.Plugins;
+
+/// <summary>
+/// Class that represents a controllable alarm.
+/// </summary>
+public class MyAlarmPlugin
+{
+    private string _hour;
+
+    public MyAlarmPlugin(string providedHour)
+    {
+        this._hour = providedHour;
+    }
+
+    [KernelFunction]
+    [Description("Sets an alarm at the provided time")]
+    public string SetAlarm(string time)
+    {
+        this._hour = time;
+        return GetCurrentAlarm();
+    }
+
+    [KernelFunction]
+    [Description("Get current alarm set")]
+    public string GetCurrentAlarm()
+    {
+        return $"Alarm set for {_hour}";
+    }
+}

--- a/dotnet/samples/Demos/OpenAIFunctionCalling/Plugins/MyAlarmPlugin.cs
+++ b/dotnet/samples/Demos/OpenAIFunctionCalling/Plugins/MyAlarmPlugin.cs
@@ -22,13 +22,13 @@ public class MyAlarmPlugin
     public string SetAlarm(string time)
     {
         this._hour = time;
-        return GetCurrentAlarm();
+        return this.GetCurrentAlarm();
     }
 
     [KernelFunction]
     [Description("Get current alarm set")]
     public string GetCurrentAlarm()
     {
-        return $"Alarm set for {_hour}";
+        return $"Alarm set for {this._hour}";
     }
 }

--- a/dotnet/samples/Demos/OpenAIFunctionCalling/Plugins/MyLightPlugin.cs
+++ b/dotnet/samples/Demos/OpenAIFunctionCalling/Plugins/MyLightPlugin.cs
@@ -1,0 +1,27 @@
+﻿// Copyright (c) Microsoft. All rights reserved.
+
+using System.ComponentModel;
+using Microsoft.SemanticKernel;
+
+namespace OpenAIFunctionCalling.Plugins;
+
+/// <summary>
+/// Class that represents a controllable light bulb.
+/// </summary>
+[Description("Represents a light bulb")]
+public class MyLightPlugin(bool turnedOn = false)
+{
+    private bool _turnedOn = turnedOn;
+
+    [KernelFunction]
+    [Description("Returns whether this light is on")]
+    public bool IsTurnedOn() => _turnedOn;
+
+    [KernelFunction]
+    [Description("Turn on this light")]
+    public void TurnOn() => _turnedOn = true;
+
+    [KernelFunction]
+    [Description("Turn off this light")]
+    public void TurnOff() => _turnedOn = false;
+}

--- a/dotnet/samples/Demos/OpenAIFunctionCalling/Plugins/MyLightPlugin.cs
+++ b/dotnet/samples/Demos/OpenAIFunctionCalling/Plugins/MyLightPlugin.cs
@@ -15,13 +15,13 @@ public class MyLightPlugin(bool turnedOn = false)
 
     [KernelFunction]
     [Description("Returns whether this light is on")]
-    public bool IsTurnedOn() => _turnedOn;
+    public bool IsTurnedOn() => this._turnedOn;
 
     [KernelFunction]
     [Description("Turn on this light")]
-    public void TurnOn() => _turnedOn = true;
+    public void TurnOn() => this._turnedOn = true;
 
     [KernelFunction]
     [Description("Turn off this light")]
-    public void TurnOff() => _turnedOn = false;
+    public void TurnOff() => this._turnedOn = false;
 }

--- a/dotnet/samples/Demos/OpenAIFunctionCalling/Plugins/MyTimePlugin.cs
+++ b/dotnet/samples/Demos/OpenAIFunctionCalling/Plugins/MyTimePlugin.cs
@@ -1,6 +1,5 @@
 ﻿// Copyright (c) Microsoft. All rights reserved.
 
-using System;
 using System.ComponentModel;
 using Microsoft.SemanticKernel;
 

--- a/dotnet/samples/Demos/OpenAIFunctionCalling/Plugins/MyTimePlugin.cs
+++ b/dotnet/samples/Demos/OpenAIFunctionCalling/Plugins/MyTimePlugin.cs
@@ -1,0 +1,17 @@
+﻿// Copyright (c) Microsoft. All rights reserved.
+
+using System;
+using System.ComponentModel;
+using Microsoft.SemanticKernel;
+
+namespace OpenAIFunctionCalling.Plugins;
+
+/// <summary>
+/// Simple plugin that just returns the time.
+/// </summary>
+public class MyTimePlugin
+{
+    [KernelFunction]
+    [Description("Get the current time")]
+    public DateTimeOffset Time() => DateTimeOffset.Now;
+}

--- a/dotnet/samples/Demos/OpenAIFunctionCalling/Program.cs
+++ b/dotnet/samples/Demos/OpenAIFunctionCalling/Program.cs
@@ -1,0 +1,80 @@
+﻿﻿using Microsoft.SemanticKernel;
+using Microsoft.SemanticKernel.ChatCompletion;
+using Microsoft.SemanticKernel.Connectors.OpenAI;
+using OpenAI;
+using OpenAIFunctionCalling.Plugins;
+
+async Task DoLoop(ChatHistory history, IChatCompletionService chatCompletionService, OpenAIPromptExecutionSettings settings, Kernel kernel)
+{
+    while (true)
+    {
+        Console.Write("User > ");
+        string userMessage = Console.ReadLine()!;
+        if (userMessage == "exit" || userMessage == "quit")
+        {
+            break;
+        }
+
+        if (string.IsNullOrEmpty(userMessage))
+        {
+            continue;
+        }
+
+        history.AddUserMessage(userMessage);
+
+        try
+        {
+            ChatMessageContent results = await chatCompletionService.GetChatMessageContentAsync(history, settings, kernel);
+            Console.WriteLine($"Assistant > {results.Content}");
+            history.AddAssistantMessage(results.Content!);
+        }
+        catch (Exception e)
+        {
+            Console.WriteLine(e.Message);
+        }
+    }
+}
+
+async Task DoDemo(ChatHistory history, IChatCompletionService chatCompletionService, OpenAIPromptExecutionSettings settings, Kernel kernel)
+{
+    string userMessage = "change the alarm to 8";
+    Console.WriteLine($"User > {userMessage}");
+    history.AddUserMessage(userMessage);
+    ChatMessageContent results = await chatCompletionService.GetChatMessageContentAsync(history, settings, kernel);
+    Console.WriteLine($"Assistant > {results.Content}");
+    history.AddAssistantMessage(results.Content!);
+}
+
+IKernelBuilder builder = Kernel.CreateBuilder();
+builder.AddOpenAIChatCompletion("o4-mini-2025-04-16", new OpenAIClient("API_KEY"));
+builder.Plugins
+    .AddFromType<MyTimePlugin>()
+    .AddFromObject(new MyLightPlugin(turnedOn: true))
+    .AddFromObject(new MyAlarmPlugin("11"));
+
+Kernel kernel = builder.Build();
+
+ChatHistory history = [];
+history.AddSystemMessage("""
+                         You are a helpful assistant.
+                         You are not restricted to using the provided plugins,
+                         and you can use information from your training.
+                         Please explain your reasoning with the response.
+                         """);
+
+IChatCompletionService chatCompletionService = kernel.GetRequiredService<IChatCompletionService>();
+OpenAIPromptExecutionSettings settings = new()
+{
+    FunctionChoiceBehavior = FunctionChoiceBehavior.Auto()
+};
+
+Console.WriteLine("""
+                  Ask questions or give instructions to the copilot such as:
+                  - change the alarm to 8
+                  - what is the current alarm set?
+                  - is the light on?
+                  - turn the light off please
+                  - set an alarm for 6:00 am
+                  """);
+
+await DoLoop(history, chatCompletionService, settings, kernel);

--- a/dotnet/samples/Demos/OpenAIFunctionCalling/Program.cs
+++ b/dotnet/samples/Demos/OpenAIFunctionCalling/Program.cs
@@ -1,4 +1,6 @@
-﻿﻿using Microsoft.SemanticKernel;
+﻿// Copyright (c) Microsoft. All rights reserved.
+
+using Microsoft.SemanticKernel;
 using Microsoft.SemanticKernel.ChatCompletion;
 using Microsoft.SemanticKernel.Connectors.OpenAI;
 using OpenAI;

--- a/dotnet/samples/GettingStartedWithAgents/GettingStartedWithAgents.csproj
+++ b/dotnet/samples/GettingStartedWithAgents/GettingStartedWithAgents.csproj
@@ -27,7 +27,7 @@
     <PackageReference Include="Microsoft.Extensions.Http" VersionOverride="9.0.1" />
     <PackageReference Include="Microsoft.Extensions.Http.Resilience" VersionOverride="9.1.0" />
     <PackageReference Include="Microsoft.Extensions.Logging" VersionOverride="9.0.5" />
-    <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" />
+    <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" VersionOverride="9.0.5"/>
     <PackageReference Include="Microsoft.Extensions.Logging.Console" />
     <PackageReference Include="OpenTelemetry.Exporter.Console" />
     <PackageReference Include="coverlet.collector" />

--- a/dotnet/src/Connectors/Connectors.Onnx/Connectors.Onnx.csproj
+++ b/dotnet/src/Connectors/Connectors.Onnx/Connectors.Onnx.csproj
@@ -6,12 +6,14 @@
     <RootNamespace>$(AssemblyName)</RootNamespace>
     <TargetFrameworks>net8.0;netstandard2.0</TargetFrameworks>
     <IsAotCompatible Condition="$([MSBuild]::IsTargetFrameworkCompatible('$(TargetFramework)', 'net7.0'))">true</IsAotCompatible>
-    <VersionSuffix>alpha</VersionSuffix>
     <NoWarn>$(NoWarn);SKEXP0001;SYSLIB1222</NoWarn>
   </PropertyGroup>
 
   <!-- IMPORT NUGET PACKAGE SHARED PROPERTIES -->
   <Import Project="$(RepoRoot)/dotnet/nuget/nuget-package.props" />
+  <PropertyGroup>
+    <PackageVersion>1.60.1</PackageVersion>
+  </PropertyGroup>
 
   <ItemGroup>
     <Compile Include="$(RepoRoot)/dotnet/src/InternalUtilities/src/Diagnostics/Verify.cs" Link="%(RecursiveDir)%(Filename)%(Extension)" />
@@ -44,5 +46,5 @@
     <PackageReference Include="Microsoft.ML.OnnxRuntimeGenAI.Cuda" Condition=" '$(Configuration)' == 'Debug_Cuda' OR '$(Configuration)' == 'Release_Cuda' " />
     <PackageReference Include="Microsoft.ML.OnnxRuntimeGenAI.DirectML" Condition=" '$(Configuration)' == 'Debug_DirectML' OR '$(Configuration)' == 'Release_DirectML' " />    
   </ItemGroup>
-
+  
 </Project>

--- a/dotnet/src/Connectors/Connectors.Onnx/Connectors.Onnx.csproj
+++ b/dotnet/src/Connectors/Connectors.Onnx/Connectors.Onnx.csproj
@@ -12,7 +12,7 @@
   <!-- IMPORT NUGET PACKAGE SHARED PROPERTIES -->
   <Import Project="$(RepoRoot)/dotnet/nuget/nuget-package.props" />
   <PropertyGroup>
-    <PackageVersion>1.60.1</PackageVersion>
+    <PackageVersion>1.60.0-camag-2</PackageVersion>
   </PropertyGroup>
 
   <ItemGroup>

--- a/dotnet/src/Connectors/Connectors.Onnx/Connectors.Onnx.csproj
+++ b/dotnet/src/Connectors/Connectors.Onnx/Connectors.Onnx.csproj
@@ -6,6 +6,7 @@
     <RootNamespace>$(AssemblyName)</RootNamespace>
     <TargetFrameworks>net8.0;netstandard2.0</TargetFrameworks>
     <IsAotCompatible Condition="$([MSBuild]::IsTargetFrameworkCompatible('$(TargetFramework)', 'net7.0'))">true</IsAotCompatible>
+    <VersionSuffix>alpha</VersionSuffix>
     <NoWarn>$(NoWarn);SKEXP0001;SYSLIB1222</NoWarn>
   </PropertyGroup>
 

--- a/dotnet/src/Connectors/Connectors.Onnx/Connectors.Onnx.csproj
+++ b/dotnet/src/Connectors/Connectors.Onnx/Connectors.Onnx.csproj
@@ -42,7 +42,7 @@
   <ItemGroup>
     <PackageReference Include="Microsoft.ML.OnnxRuntimeGenAI" Condition=" '$(Configuration)' == 'Debug' OR '$(Configuration)' == 'Release' " />
     <PackageReference Include="Microsoft.ML.OnnxRuntimeGenAI.Cuda" Condition=" '$(Configuration)' == 'Debug_Cuda' OR '$(Configuration)' == 'Release_Cuda' " />
-    <PackageReference Include="Microsoft.ML.OnnxRuntimeGenAI.DirectML" Condition=" '$(Configuration)' == 'Debug_DirectML' OR '$(Configuration)' == 'Release_DirectML' " />
+    <PackageReference Include="Microsoft.ML.OnnxRuntimeGenAI.DirectML" Condition=" '$(Configuration)' == 'Debug_DirectML' OR '$(Configuration)' == 'Release_DirectML' " />    
   </ItemGroup>
 
 </Project>

--- a/dotnet/src/Connectors/Connectors.Onnx/Connectors.Onnx.csproj
+++ b/dotnet/src/Connectors/Connectors.Onnx/Connectors.Onnx.csproj
@@ -11,9 +11,6 @@
 
   <!-- IMPORT NUGET PACKAGE SHARED PROPERTIES -->
   <Import Project="$(RepoRoot)/dotnet/nuget/nuget-package.props" />
-  <PropertyGroup>
-    <PackageVersion>1.60.0-camag-2</PackageVersion>
-  </PropertyGroup>
 
   <ItemGroup>
     <Compile Include="$(RepoRoot)/dotnet/src/InternalUtilities/src/Diagnostics/Verify.cs" Link="%(RecursiveDir)%(Filename)%(Extension)" />
@@ -44,7 +41,7 @@
   <ItemGroup>
     <PackageReference Include="Microsoft.ML.OnnxRuntimeGenAI" Condition=" '$(Configuration)' == 'Debug' OR '$(Configuration)' == 'Release' " />
     <PackageReference Include="Microsoft.ML.OnnxRuntimeGenAI.Cuda" Condition=" '$(Configuration)' == 'Debug_Cuda' OR '$(Configuration)' == 'Release_Cuda' " />
-    <PackageReference Include="Microsoft.ML.OnnxRuntimeGenAI.DirectML" Condition=" '$(Configuration)' == 'Debug_DirectML' OR '$(Configuration)' == 'Release_DirectML' " />    
+    <PackageReference Include="Microsoft.ML.OnnxRuntimeGenAI.DirectML" Condition=" '$(Configuration)' == 'Debug_DirectML' OR '$(Configuration)' == 'Release_DirectML' " />
   </ItemGroup>
-  
+
 </Project>

--- a/dotnet/src/Connectors/Connectors.Onnx/OnnxKernelBuilderExtensions.cs
+++ b/dotnet/src/Connectors/Connectors.Onnx/OnnxKernelBuilderExtensions.cs
@@ -35,7 +35,7 @@ public static class OnnxKernelBuilderExtensions
         string? modelId = null,
         ILoggerFactory? loggerFactory = null,
         JsonSerializerOptions? jsonSerializerOptions = null,
-        List<string>? providers = null
+        List<Provider>? providers = null
     )
     {
         Verify.NotNull(builder);

--- a/dotnet/src/Connectors/Connectors.Onnx/OnnxRuntimeGenAIChatCompletionService.cs
+++ b/dotnet/src/Connectors/Connectors.Onnx/OnnxRuntimeGenAIChatCompletionService.cs
@@ -40,7 +40,7 @@ public sealed class OnnxRuntimeGenAIChatCompletionService : IChatCompletionServi
         string? modelId = null,
         ILoggerFactory? loggerFactory = null,
         JsonSerializerOptions? jsonSerializerOptions = null,
-        List<string>? providers = null)
+        List<Provider>? providers = null)
     {
         Verify.NotNullOrWhiteSpace(modelPath);
         this._attributesInternal.Add(AIServiceExtensions.ModelIdKey, modelId);
@@ -48,9 +48,13 @@ public sealed class OnnxRuntimeGenAIChatCompletionService : IChatCompletionServi
         if (providers != null)
         {
             this._config.ClearProviders();
-            foreach (string provider in providers)
+            foreach (Provider provider in providers)
             {
-                this._config.AppendProvider(provider);
+                this._config.AppendProvider(provider.Id);
+                foreach (KeyValuePair<string, string> option in provider.Options)
+                {
+                    this._config.SetProviderOption(provider.Id, option.Key, option.Value);
+                }
             }
         }
 

--- a/dotnet/src/Connectors/Connectors.Onnx/OnnxServiceCollectionExtensions.cs
+++ b/dotnet/src/Connectors/Connectors.Onnx/OnnxServiceCollectionExtensions.cs
@@ -1,9 +1,9 @@
 ﻿// Copyright (c) Microsoft. All rights reserved.
 
 using System;
+using System.Collections.Generic;
 using System.IO;
 using System.Text.Json;
-using Microsoft.Extensions.AI;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Logging;
 using Microsoft.SemanticKernel.ChatCompletion;
@@ -18,27 +18,35 @@ namespace Microsoft.SemanticKernel;
 public static class OnnxServiceCollectionExtensions
 {
     /// <summary>
-    /// Add OnnxRuntimeGenAI Chat Completion services to the specified service collection.
+    /// Adds the OnnxRuntimeGenAI Chat Completion services to the specified <see cref="IServiceCollection"/>.
     /// </summary>
-    /// <param name="services">The service collection to add the OnnxRuntimeGenAI Text Generation service to.</param>
-    /// <param name="modelId">The name of the model.</param>
-    /// <param name="modelPath">The generative AI ONNX model path.</param>
-    /// <param name="serviceId">Optional service ID.</param>
-    /// <param name="jsonSerializerOptions">The <see cref="JsonSerializerOptions"/> to use for various aspects of serialization and deserialization required by the service.</param>
-    /// <returns>The updated service collection.</returns>
+    /// <param name="services">The <see cref="IServiceCollection"/> instance to augment.</param>
+    /// <param name="modelPath">The generative AI ONNX model path for the chat completion service.</param>
+    /// <param name="serviceId">A local identifier for the given AI service.</param>
+    /// <param name="modelId">Model Id.</param>
+    /// <param name="loggerFactory">Logger factory.</param>
+    /// <param name="jsonSerializerOptions">The <see cref="JsonSerializerOptions"/> to use for various aspects of serialization, such as function argument deserialization, function result serialization, logging, etc., of the service.</param>
+    /// <param name="providers">Providers</param>
+    /// <returns>The same instance as <paramref name="services"/>.</returns>
     public static IServiceCollection AddOnnxRuntimeGenAIChatCompletion(
         this IServiceCollection services,
-        string modelId,
         string modelPath,
-        string? serviceId = null,
-        JsonSerializerOptions? jsonSerializerOptions = null)
+        string serviceId,
+        string? modelId = null,
+        ILoggerFactory? loggerFactory = null,
+        JsonSerializerOptions? jsonSerializerOptions = null,
+        List<string>? providers = null
+    )
     {
-        services.AddKeyedSingleton<IChatCompletionService>(serviceId, (serviceProvider, _) =>
+        services.AddKeyedSingleton<IChatCompletionService>(serviceId, (_, _) =>
             new OnnxRuntimeGenAIChatCompletionService(
-                modelId,
-                modelPath,
-                loggerFactory: serviceProvider.GetService<ILoggerFactory>(),
-                jsonSerializerOptions));
+                modelPath: modelPath,
+                modelId: modelId,
+                loggerFactory: loggerFactory,
+                jsonSerializerOptions: jsonSerializerOptions,
+                providers: providers
+            )
+        );
 
         return services;
     }

--- a/dotnet/src/Connectors/Connectors.Onnx/OnnxServiceCollectionExtensions.cs
+++ b/dotnet/src/Connectors/Connectors.Onnx/OnnxServiceCollectionExtensions.cs
@@ -35,7 +35,7 @@ public static class OnnxServiceCollectionExtensions
         string? modelId = null,
         ILoggerFactory? loggerFactory = null,
         JsonSerializerOptions? jsonSerializerOptions = null,
-        List<string>? providers = null
+        List<Provider>? providers = null
     )
     {
         services.AddKeyedSingleton<IChatCompletionService>(serviceId, (_, _) =>

--- a/dotnet/src/Connectors/Connectors.Onnx/Provider.cs
+++ b/dotnet/src/Connectors/Connectors.Onnx/Provider.cs
@@ -1,0 +1,18 @@
+﻿// Copyright (c) Microsoft. All rights reserved.
+
+using System.Collections.Generic;
+
+namespace Microsoft.SemanticKernel.Connectors.Onnx;
+
+public class Provider
+{
+    /// <summary>
+    /// Id
+    /// </summary>
+    public string Id { get; set; }
+
+    /// <summary>
+    /// Options
+    /// </summary>
+    public Dictionary<string, string> Options { get; set; } = new();
+}


### PR DESCRIPTION
### Motivation and Context

<!-- Thank you for your contribution to the semantic-kernel repo!
Please help reviewers and future users, providing the following information:
  1. Why is this change required?
  2. What problem does it solve?
  3. What scenario does it contribute to?
  4. If it fixes an open issue, please link to the issue here.
-->

1. **Why is this change required?**
   Currently, users can configure ONNX execution providers only by manually creating a `genai_config.json` file next to the ONNX model. This approach is cumbersome and doesn't integrate well with Semantic Kernel's configuration patterns.

2. **What problem does it solve?**
   This change eliminates the need for manual JSON configuration files by providing a programmatic API for provider configuration, making it easier for developers to configure ONNX execution providers directly through code.

3. **What scenario does it contribute to?**
   This improves the developer experience when working with ONNX models in Semantic Kernel, particularly for scenarios where:
   - Developers want to dynamically select providers based on runtime conditions
   - Teams prefer code-based configuration over file-based configuration
   - Integration with existing Semantic Kernel configuration patterns is desired

4. **If it fixes an open issue, please link to the issue here.**
   Closes #12828

### Description

<!-- Describe your changes, the overall approach, the underlying design.
     These notes will help understanding how your code works. Thanks! -->

**Changes Made:**

- **New Provider Class**: Added `Provider` class to encapsulate provider configuration with `Id` and `Options` properties
- **Enhanced Chat Completion Service**: Extended `OnnxRuntimeGenAIChatCompletionService` to accept and configure providers programmatically
- **Updated Builder Extension**: Modified `OnnxKernelBuilderExtensions.AddOnnxRuntimeGenAIChatCompletion` to accept `List<Provider>` parameter
- **New Demo Project**: Created `OnnxWithProviderChoice` demo showcasing the new provider configuration API
- **Package Updates**: Updated Semantic Kernel packages to version 1.60.0 and removed deprecated demo project

**Design Approach:**

The implementation leverages ONNX Runtime GenAI's existing `Config` API to programmatically set providers and their options. The `Provider` class provides a clean abstraction for specifying provider ID (e.g., "cuda", "cpu") and custom options. During service initialization, the providers are configured using the underlying ONNX Runtime GenAI configuration system.

**Usage Example:**
```csharp
IKernelBuilder builder = Kernel.CreateBuilder();
builder.AddOnnxRuntimeGenAIChatCompletion(
    modelPath: "path/to/model",
    serviceId: "onnx",
    providers: [new Provider { Id = "cuda" }]
);
```

**Backward Compatibility:**
This change maintains full backward compatibility. Existing code continues to work without modification, and the manual `genai_config.json` approach remains supported.


### Contribution Checklist

<!-- Before submitting this PR, please make sure: -->

- [ X] The code builds clean without any errors or warnings
- [X ] The PR follows the [SK Contribution Guidelines](https://github.com/microsoft/semantic-kernel/blob/main/CONTRIBUTING.md) and the [pre-submission formatting script](https://github.com/microsoft/semantic-kernel/blob/main/CONTRIBUTING.md#development-scripts) raises no violations
- [X ] All unit tests pass, and I have added new tests where possible
- [ X] I didn't break anyone :smile:
