### PR TITLE
Processes: Local Runtime persistence update - enabling rehydrating process if stopped/resumed

### DIFF
--- a/dotnet/samples/GettingStartedWithProcesses/Step04/Step04_AgentOrchestration.cs
+++ b/dotnet/samples/GettingStartedWithProcesses/Step04/Step04_AgentOrchestration.cs
@@ -74,7 +74,7 @@ public class Step04_AgentOrchestration : BaseTest
 
         // Cleaning up created agents
         var processState = await localProcess.GetStateAsync();
-        var agentState = (KernelProcessStepState<KernelProcessAgentExecutorState>)processState.Steps.Where(step => step.State.Id == "Student").FirstOrDefault()!.State;
+        var agentState = (KernelProcessStepState<KernelProcessAgentExecutorState>)processState.Steps.Where(step => step.State.StepId == "Student").FirstOrDefault()!.State;
         var agentId = agentState?.State?.AgentId;
         if (agentId != null)
         {

--- a/dotnet/src/Experimental/Process.Abstractions/KernelProcess.cs
+++ b/dotnet/src/Experimental/Process.Abstractions/KernelProcess.cs
@@ -47,7 +47,7 @@ public sealed record KernelProcess : KernelProcessStepInfo
         : base(typeof(KernelProcess), state, edges ?? [])
     {
         Verify.NotNull(steps);
-        Verify.NotNullOrWhiteSpace(state.Name);
+        Verify.NotNullOrWhiteSpace(state.StepId);
 
         this.Steps = [.. steps];
     }

--- a/dotnet/src/Experimental/Process.Abstractions/KernelProcessMap.cs
+++ b/dotnet/src/Experimental/Process.Abstractions/KernelProcessMap.cs
@@ -23,8 +23,8 @@ public sealed record KernelProcessMap : KernelProcessStepInfo
         : base(typeof(KernelProcessMap), state, edges)
     {
         Verify.NotNull(operation, nameof(operation));
-        Verify.NotNullOrWhiteSpace(state.Name, $"{nameof(state)}.{nameof(KernelProcessMapState.Name)}");
-        Verify.NotNullOrWhiteSpace(state.Id, $"{nameof(state)}.{nameof(KernelProcessMapState.Id)}");
+        Verify.NotNullOrWhiteSpace(state.StepId, $"{nameof(state)}.{nameof(KernelProcessMapState.StepId)}");
+        Verify.NotNullOrWhiteSpace(state.RunId, $"{nameof(state)}.{nameof(KernelProcessMapState.RunId)}");
 
         this.Operation = operation;
     }

--- a/dotnet/src/Experimental/Process.Abstractions/KernelProcessProxy.cs
+++ b/dotnet/src/Experimental/Process.Abstractions/KernelProcessProxy.cs
@@ -23,7 +23,7 @@ public sealed record KernelProcessProxy : KernelProcessStepInfo
     public KernelProcessProxy(KernelProcessStepState state, Dictionary<string, List<KernelProcessEdge>> edges)
         : base(typeof(KernelProxyStep), state, edges)
     {
-        Verify.NotNullOrWhiteSpace(state.Name, $"{nameof(state)}.{nameof(KernelProcessStepState.Name)}");
-        Verify.NotNullOrWhiteSpace(state.Id, $"{nameof(state)}.{nameof(KernelProcessStepState.Id)}");
+        Verify.NotNullOrWhiteSpace(state.StepId, $"{nameof(state)}.{nameof(KernelProcessStepState.StepId)}");
+        Verify.NotNullOrWhiteSpace(state.RunId, $"{nameof(state)}.{nameof(KernelProcessStepState.RunId)}");
     }
 }

--- a/dotnet/src/Experimental/Process.Core/ProcessExporter.cs
+++ b/dotnet/src/Experimental/Process.Core/ProcessExporter.cs
@@ -23,7 +23,7 @@ public sealed class ProcessExporter
 
         Workflow workflow = new()
         {
-            Name = process.State.Name,
+            Name = process.State.StepId,
             Description = process.Description,
             FormatVersion = "1.0",
             WorkflowVersion = process.State.Version,
@@ -50,7 +50,7 @@ public sealed class ProcessExporter
         {
             var agentNode = new Node()
             {
-                Id = agentStep.State.Id ?? throw new KernelException("All steps must have an Id."),
+                Id = agentStep.State.RunId ?? throw new KernelException("All steps must have an Id."),
                 Description = agentStep.Description,
                 Type = "agent",
                 Inputs = agentStep.Inputs.ToDictionary((kvp) => kvp.Key, (kvp) =>

--- a/dotnet/src/Experimental/Process.Core/Tools/ProcessVisualizationExtensions.cs
+++ b/dotnet/src/Experimental/Process.Core/Tools/ProcessVisualizationExtensions.cs
@@ -64,10 +64,10 @@ public static class ProcessVisualizationExtensions
 
         // Dictionary to map step IDs to step names
         var stepNames = process.Steps
-            .Where(step => step.State.Id != null && step.State.Name != null)
+            .Where(step => step.State.RunId != null && step.State.StepId != null)
             .ToDictionary(
-                step => step.State.Id!,
-                step => step.State.Name!
+                step => step.State.RunId!,
+                step => step.State.StepId!
             );
 
         // Add Start and End nodes only if this is not a sub-process
@@ -80,8 +80,8 @@ public static class ProcessVisualizationExtensions
         // Process each step
         foreach (var step in process.Steps)
         {
-            var stepId = step.State.Id;
-            var stepName = step.State.Name;
+            var stepId = step.State.RunId;
+            var stepName = step.State.StepId;
 
             // Check if the step is a nested process (sub-process)
             if (step is KernelProcess nestedProcess && level < maxLevel)
@@ -115,7 +115,7 @@ public static class ProcessVisualizationExtensions
                     var stepEdges = kvp.Value;
 
                     // Skip drawing edges that point to a nested process as an entry point
-                    if (stepNames.ContainsKey(eventId) && process.Steps.Any(s => s.State.Name == eventId && s is KernelProcess))
+                    if (stepNames.ContainsKey(eventId) && process.Steps.Any(s => s.State.StepId == eventId && s is KernelProcess))
                     {
                         continue;
                     }
@@ -156,8 +156,8 @@ public static class ProcessVisualizationExtensions
         // Connect Start to the first step and the last step to End (only for the main process)
         if (!isSubProcess && process.Steps.Count > 0)
         {
-            var firstStepName = process.Steps.First().State.Name;
-            var lastStepName = process.Steps.Last().State.Name;
+            var firstStepName = process.Steps.First().State.StepId;
+            var lastStepName = process.Steps.Last().State.StepId;
 
             sb.AppendLine($"{indentation}Start --> {firstStepName}[\"{firstStepName}\"]");
             sb.AppendLine($"{indentation}{lastStepName}[\"{lastStepName}\"] --> End");

--- a/dotnet/src/Experimental/Process.Core/Workflow/WorkflowBuilder.cs
+++ b/dotnet/src/Experimental/Process.Core/Workflow/WorkflowBuilder.cs
@@ -325,10 +325,10 @@ internal class WorkflowBuilder
 
         Workflow workflow = new()
         {
-            Id = process.State.Id ?? throw new KernelException("The process must have an Id set"),
+            Id = process.State.RunId ?? throw new KernelException("The process must have an Id set"),
             Description = process.Description,
             FormatVersion = "1.0",
-            Name = process.State.Name,
+            Name = process.State.StepId,
             Nodes = [new Node { Id = "End", Type = "declarative", Version = "1.0", Description = "Terminal state" }],
             Variables = [],
         };
@@ -403,7 +403,7 @@ internal class WorkflowBuilder
 
     private static Node BuildNode(KernelProcessStepInfo step, List<OrchestrationStep> orchestrationSteps)
     {
-        Verify.NotNullOrWhiteSpace(step?.State?.Id, nameof(step.State.Id));
+        Verify.NotNullOrWhiteSpace(step?.State?.RunId, nameof(step.State.RunId));
 
         if (step is KernelProcessAgentStep agentStep)
         {
@@ -418,12 +418,12 @@ internal class WorkflowBuilder
 
         var node = new Node()
         {
-            Id = step.State.Id,
+            Id = step.State.RunId,
             Type = "dotnet",
             Agent = new AgentDefinition()
             {
                 Type = innerStepTypeString,
-                Id = step.State.Id
+                Id = step.State.RunId
             }
         };
 
@@ -433,7 +433,7 @@ internal class WorkflowBuilder
             {
                 ListenFor = new ListenCondition()
                 {
-                    From = step.State.Id,
+                    From = step.State.RunId,
                     Event = edge.Key,
                     Condition = edge.Value.FirstOrDefault()?.Condition.DeclarativeDefinition
                 },
@@ -465,14 +465,14 @@ internal class WorkflowBuilder
     {
         Verify.NotNull(agentStep);
 
-        if (agentStep.AgentDefinition is null || string.IsNullOrWhiteSpace(agentStep.State?.Id) || string.IsNullOrWhiteSpace(agentStep.AgentDefinition.Type))
+        if (agentStep.AgentDefinition is null || string.IsNullOrWhiteSpace(agentStep.State?.RunId) || string.IsNullOrWhiteSpace(agentStep.AgentDefinition.Type))
         {
             throw new InvalidOperationException("Attempt to build a workflow node from step with no Id");
         }
 
         var node = new Node()
         {
-            Id = agentStep.State.Id!,
+            Id = agentStep.State.RunId!,
             Type = agentStep.AgentDefinition.Type!,
             Agent = agentStep.AgentDefinition,
             HumanInLoopType = agentStep.HumanInLoopMode,
@@ -511,7 +511,7 @@ internal class WorkflowBuilder
             {
                 ListenFor = new ListenCondition()
                 {
-                    From = agentStep.State.Id,
+                    From = agentStep.State.RunId,
                     Event = ResolveEventName(edge.Key.key),
                     Condition = edge.Key.DeclarativeDefinition
                 },

--- a/dotnet/src/Experimental/Process.IntegrationTestRunner.Dapr/DaprTestProcessContext.cs
+++ b/dotnet/src/Experimental/Process.IntegrationTestRunner.Dapr/DaprTestProcessContext.cs
@@ -17,13 +17,13 @@ internal sealed class DaprTestProcessContext : KernelProcessContext
 
     internal DaprTestProcessContext(KernelProcess process, HttpClient httpClient)
     {
-        if (string.IsNullOrWhiteSpace(process.State.Id))
+        if (string.IsNullOrWhiteSpace(process.State.RunId))
         {
-            process = process with { State = process.State with { Id = Guid.NewGuid().ToString() } };
+            process = process with { State = process.State with { RunId = Guid.NewGuid().ToString() } };
         }
 
         this._process = process;
-        this._processId = process.State.Id;
+        this._processId = process.State.RunId;
         this._httpClient = httpClient;
 
         this._serializerOptions = new JsonSerializerOptions()
@@ -80,5 +80,5 @@ internal sealed class DaprTestProcessContext : KernelProcessContext
         };
     }
 
-    public override Task<string> GetProcessIdAsync() => Task.FromResult(this._process.State.Id!);
+    public override Task<string> GetProcessIdAsync() => Task.FromResult(this._process.State.RunId!);
 }

--- a/dotnet/src/Experimental/Process.IntegrationTests.Shared/ProcessCycleTests.cs
+++ b/dotnet/src/Experimental/Process.IntegrationTests.Shared/ProcessCycleTests.cs
@@ -74,7 +74,7 @@ public class ProcessCycleTests : IClassFixture<ProcessTestFixture>
         var processContext = await this._fixture.StartProcessAsync(kernelProcess, kernel, new KernelProcessEvent() { Id = CommonEvents.StartProcess, Data = "foo" });
 
         var processState = await processContext.GetStateAsync();
-        var cStepState = processState.Steps.Where(s => s.State.Name == "CStep").FirstOrDefault()?.State as KernelProcessStepState<CStepState>;
+        var cStepState = processState.Steps.Where(s => s.State.StepId == "CStep").FirstOrDefault()?.State as KernelProcessStepState<CStepState>;
 
         Assert.NotNull(cStepState?.State);
         Assert.Equal(3, cStepState.State.CurrentCycle);

--- a/dotnet/src/Experimental/Process.IntegrationTests.Shared/ProcessMapTests.cs
+++ b/dotnet/src/Experimental/Process.IntegrationTests.Shared/ProcessMapTests.cs
@@ -65,7 +65,7 @@ public class ProcessMapTests : IClassFixture<ProcessTestFixture>
 
         // Assert
         KernelProcess processState = await processContext.GetStateAsync();
-        KernelProcessStepState<UnionState> unionState = (KernelProcessStepState<UnionState>)processState.Steps.Where(s => s.State.Name == "Union").Single().State;
+        KernelProcessStepState<UnionState> unionState = (KernelProcessStepState<UnionState>)processState.Steps.Where(s => s.State.StepId == "Union").Single().State;
 
         Assert.NotNull(unionState?.State);
         Assert.Equal(55L, unionState.State.SquareResult);
@@ -106,7 +106,7 @@ public class ProcessMapTests : IClassFixture<ProcessTestFixture>
         // Act
         KernelProcessContext processContext =
             await this._fixture.StartProcessAsync(
-                processInstance with { State = processInstance.State with { Id = Guid.NewGuid().ToString() } },
+                processInstance with { State = processInstance.State with { RunId = Guid.NewGuid().ToString() } },
                 kernel,
                 new KernelProcessEvent()
                 {
@@ -116,7 +116,7 @@ public class ProcessMapTests : IClassFixture<ProcessTestFixture>
 
         // Assert
         KernelProcess processState = await processContext.GetStateAsync();
-        KernelProcessStepState<UnionState> unionState = (KernelProcessStepState<UnionState>)processState.Steps.Where(s => s.State.Name == "Union").Single().State;
+        KernelProcessStepState<UnionState> unionState = (KernelProcessStepState<UnionState>)processState.Steps.Where(s => s.State.StepId == "Union").Single().State;
 
         Assert.NotNull(unionState?.State);
         Assert.Equal(55L, unionState.State.SquareResult);

--- a/dotnet/src/Experimental/Process.IntegrationTests.Shared/ProcessTests.cs
+++ b/dotnet/src/Experimental/Process.IntegrationTests.Shared/ProcessTests.cs
@@ -96,7 +96,7 @@ public sealed class ProcessTests : IClassFixture<ProcessTestFixture>
         var processInfo = await processHandle.GetStateAsync();
 
         // Assert
-        var innerProcess = processInfo.Steps.Where(s => s.State.Name == "Inner").Single() as KernelProcess;
+        var innerProcess = processInfo.Steps.Where(s => s.State.StepId == "Inner").Single() as KernelProcess;
         Assert.NotNull(innerProcess);
         this.AssertStepStateLastMessage(innerProcess, nameof(RepeatStep), expectedLastMessage: string.Join(" ", Enumerable.Repeat(testInput, 4)));
     }
@@ -251,7 +251,7 @@ public sealed class ProcessTests : IClassFixture<ProcessTestFixture>
         var processInfo = await processHandle.GetStateAsync();
 
         // Assert
-        var subprocessStepInfo = processInfo.Steps.Where(s => s.State.Name == fanInStepName)?.FirstOrDefault() as KernelProcess;
+        var subprocessStepInfo = processInfo.Steps.Where(s => s.State.StepId == fanInStepName)?.FirstOrDefault() as KernelProcess;
         Assert.NotNull(subprocessStepInfo);
         this.AssertStepStateLastMessage(subprocessStepInfo, nameof(FanInStep), expectedLastMessage: $"{testInput}-{testInput} {testInput}");
     }
@@ -464,7 +464,7 @@ public sealed class ProcessTests : IClassFixture<ProcessTestFixture>
     #region Assert Utils
     private void AssertStepStateLastMessage(KernelProcess processInfo, string stepName, string? expectedLastMessage, int? expectedInvocationCount = null)
     {
-        KernelProcessStepInfo? stepInfo = processInfo.Steps.FirstOrDefault(s => s.State.Name == stepName);
+        KernelProcessStepInfo? stepInfo = processInfo.Steps.FirstOrDefault(s => s.State.StepId == stepName);
         Assert.NotNull(stepInfo);
         var outputStepResult = stepInfo.State as KernelProcessStepState<StepState>;
         Assert.NotNull(outputStepResult?.State);

--- a/dotnet/src/Experimental/Process.LocalRuntime/LocalAgentStep.cs
+++ b/dotnet/src/Experimental/Process.LocalRuntime/LocalAgentStep.cs
@@ -27,7 +27,7 @@ internal class LocalAgentStep : LocalStep
     protected override ValueTask InitializeStepAsync()
     {
         this._stepInstance = new KernelProcessAgentExecutorInternal(this._stepInfo, this._agentThread, this._processStateManager);
-        var kernelPlugin = KernelPluginFactory.CreateFromObject(this._stepInstance, pluginName: this._stepInfo.State.Name);
+        var kernelPlugin = KernelPluginFactory.CreateFromObject(this._stepInstance, pluginName: this._stepInfo.State.StepId);
 
         // Load the kernel functions
         foreach (KernelFunction f in kernelPlugin)

--- a/dotnet/src/Experimental/Process.LocalRuntime/LocalMap.cs
+++ b/dotnet/src/Experimental/Process.LocalRuntime/LocalMap.cs
@@ -27,7 +27,7 @@ internal sealed class LocalMap : LocalStep
         : base(map, kernel)
     {
         this._map = map;
-        this._logger = this._kernel.LoggerFactory?.CreateLogger(this._map.State.Name) ?? new NullLogger<LocalStep>();
+        this._logger = this._kernel.LoggerFactory?.CreateLogger(this._map.State.StepId) ?? new NullLogger<LocalStep>();
         this._mapEvents = [.. map.Edges.Keys.Select(key => key.Split(ProcessConstants.EventIdSeparator).Last())];
     }
 

--- a/dotnet/src/Experimental/Process.LocalRuntime/LocalProcess.cs
+++ b/dotnet/src/Experimental/Process.LocalRuntime/LocalProcess.cs
@@ -247,14 +247,14 @@ internal sealed class LocalProcess : LocalStep, System.IAsyncDisposable
             LocalStep? localStep = null;
 
             // The current step should already have a name.
-            Verify.NotNull(step.State?.Name);
+            Verify.NotNull(step.State?.StepId);
 
             if (step is KernelProcess processStep)
             {
                 // The process will only have an Id if its already been executed.
-                if (string.IsNullOrWhiteSpace(processStep.State.Id))
+                if (string.IsNullOrWhiteSpace(processStep.State.RunId))
                 {
-                    processStep = processStep with { State = processStep.State with { Id = Guid.NewGuid().ToString() } };
+                    processStep = processStep with { State = processStep.State with { RunId = Guid.NewGuid().ToString() } };
                 }
 
                 localStep =
@@ -296,7 +296,7 @@ internal sealed class LocalProcess : LocalStep, System.IAsyncDisposable
             else
             {
                 // The current step should already have an Id.
-                Verify.NotNull(step.State?.Id);
+                Verify.NotNull(step.State?.RunId);
 
                 localStep =
                     new LocalStep(step, this._kernel)
@@ -453,7 +453,7 @@ internal sealed class LocalProcess : LocalStep, System.IAsyncDisposable
         {
             foreach (KernelProcessEdge edge in defaultConditionedEdges)
             {
-                ProcessMessage message = ProcessMessageFactory.CreateFromEdge(edge, this._process.State.Id!, null, null);
+                ProcessMessage message = ProcessMessageFactory.CreateFromEdge(edge, this._process.State.RunId!, null, null);
                 messageChannel.Enqueue(message);
 
                 // TODO: Handle state here as well
@@ -482,7 +482,7 @@ internal sealed class LocalProcess : LocalStep, System.IAsyncDisposable
             var processEvent = new ProcessEvent
             {
                 Namespace = this.Name,
-                SourceId = this._process.State.Id!,
+                SourceId = this._process.State.RunId!,
                 Data = null,
                 Visibility = KernelProcessEventVisibility.Internal
             };

--- a/dotnet/src/Experimental/Process.LocalRuntime/LocalProxy.cs
+++ b/dotnet/src/Experimental/Process.LocalRuntime/LocalProxy.cs
@@ -27,7 +27,7 @@ internal sealed class LocalProxy : LocalStep
         : base(proxy, kernel)
     {
         this._proxy = proxy;
-        this._logger = this._kernel.LoggerFactory?.CreateLogger(this._proxy.State.Name) ?? new NullLogger<LocalStep>();
+        this._logger = this._kernel.LoggerFactory?.CreateLogger(this._proxy.State.StepId) ?? new NullLogger<LocalStep>();
     }
 
     internal override void AssignStepFunctionParameterValues(ProcessMessage message)

--- a/dotnet/src/Experimental/Process.LocalRuntime/LocalStep.cs
+++ b/dotnet/src/Experimental/Process.LocalRuntime/LocalStep.cs
@@ -46,12 +46,12 @@ internal class LocalStep : IKernelProcessMessageChannel
         Verify.NotNull(stepInfo, nameof(stepInfo));
 
         // This special handling will be removed with the refactoring of KernelProcessState
-        if (string.IsNullOrEmpty(stepInfo.State.Id) && stepInfo is KernelProcess)
+        if (string.IsNullOrEmpty(stepInfo.State.RunId) && stepInfo is KernelProcess)
         {
-            stepInfo = stepInfo with { State = stepInfo.State with { Id = Guid.NewGuid().ToString() } };
+            stepInfo = stepInfo with { State = stepInfo.State with { RunId = Guid.NewGuid().ToString() } };
         }
 
-        Verify.NotNull(stepInfo.State.Id);
+        Verify.NotNull(stepInfo.State.RunId);
 
         this.ParentProcessId = parentProcessId;
         this._kernel = kernel;
@@ -72,12 +72,12 @@ internal class LocalStep : IKernelProcessMessageChannel
     /// <summary>
     /// The name of the step.
     /// </summary>
-    internal string Name => this._stepInfo.State.Name!;
+    internal string Name => this._stepInfo.State.StepId!;
 
     /// <summary>
     /// The Id of the step.
     /// </summary>
-    internal string Id => this._stepInfo.State.Id!;
+    internal string Id => this._stepInfo.State.RunId!;
 
     /// <summary>
     /// An event proxy that can be used to intercept events emitted by the step.
@@ -277,7 +277,7 @@ internal class LocalStep : IKernelProcessMessageChannel
     {
         // Instantiate an instance of the inner step object
         this._stepInstance = (KernelProcessStep)ActivatorUtilities.CreateInstance(this._kernel.Services, this._stepInfo.InnerStepType);
-        var kernelPlugin = KernelPluginFactory.CreateFromObject(this._stepInstance, pluginName: this._stepInfo.State.Name);
+        var kernelPlugin = KernelPluginFactory.CreateFromObject(this._stepInstance, pluginName: this._stepInfo.State.StepId);
 
         // Load the kernel functions
         foreach (KernelFunction f in kernelPlugin)

--- a/dotnet/src/Experimental/Process.Runtime.Dapr/Actors/MapActor.cs
+++ b/dotnet/src/Experimental/Process.Runtime.Dapr/Actors/MapActor.cs
@@ -75,7 +75,7 @@ internal sealed class MapActor : StepActor, IMap
     /// <summary>
     /// The name of the step.
     /// </summary>
-    protected override string Name => this._mapInfo?.State.Name ?? throw new KernelException("The Map must be initialized before accessing the Name property.");
+    protected override string Name => this._mapInfo?.State.StepId ?? throw new KernelException("The Map must be initialized before accessing the Name property.");
 
     #endregion
 
@@ -91,7 +91,7 @@ internal sealed class MapActor : StepActor, IMap
         List<Task> mapOperations = [];
         foreach (var value in inputValues)
         {
-            KernelProcess mapProcess = mapOperation with { State = mapOperation.State with { Id = $"{this.Name}-{mapOperations.Count}-{Guid.NewGuid():N}" } };
+            KernelProcess mapProcess = mapOperation with { State = mapOperation.State with { RunId = $"{this.Name}-{mapOperations.Count}-{Guid.NewGuid():N}" } };
             DaprKernelProcessContext processContext = new(mapProcess);
             Task processTask =
                 processContext.StartWithEventAsync(
@@ -172,9 +172,9 @@ internal sealed class MapActor : StepActor, IMap
         this._mapInfo = mapInfo;
         this._map = mapInfo.ToKernelProcessMap();
         this.ParentProcessId = parentProcessId;
-        this._logger = this._kernel.LoggerFactory?.CreateLogger(this._mapInfo.State.Name) ?? new NullLogger<MapActor>();
+        this._logger = this._kernel.LoggerFactory?.CreateLogger(this._mapInfo.State.StepId) ?? new NullLogger<MapActor>();
         this._outputEdges = this._mapInfo.Edges.ToDictionary(kvp => kvp.Key, kvp => kvp.Value.ToList());
-        this._eventNamespace = $"{this._mapInfo.State.Name}_{this._mapInfo.State.Id}";
+        this._eventNamespace = $"{this._mapInfo.State.StepId}_{this._mapInfo.State.RunId}";
 
         // Capture the events that the map is interested in as hashtable for performant lookup
         this._mapEvents = [.. this._mapInfo.Edges.Keys.Select(key => key.Split(ProcessConstants.EventIdSeparator).Last())];

--- a/dotnet/src/Experimental/Process.Runtime.Dapr/Actors/ProcessActor.cs
+++ b/dotnet/src/Experimental/Process.Runtime.Dapr/Actors/ProcessActor.cs
@@ -184,7 +184,7 @@ internal sealed class ProcessActor : StepActor, IProcess, IDisposable
     /// <summary>
     /// The name of the step.
     /// </summary>
-    protected override string Name => this._process?.State.Name ?? throw new KernelException("The Process must be initialized before accessing the Name property.").Log(this._logger);
+    protected override string Name => this._process?.State.StepId ?? throw new KernelException("The Process must be initialized before accessing the Name property.").Log(this._logger);
 
     #endregion
 
@@ -238,7 +238,7 @@ internal sealed class ProcessActor : StepActor, IProcess, IDisposable
         this.ParentProcessId = parentProcessId;
         this._process = processInfo;
         this._stepsInfos = [.. this._process.Steps];
-        this._logger = this._kernel.LoggerFactory?.CreateLogger(this._process.State.Name) ?? new NullLogger<ProcessActor>();
+        this._logger = this._kernel.LoggerFactory?.CreateLogger(this._process.State.StepId) ?? new NullLogger<ProcessActor>();
         if (!string.IsNullOrWhiteSpace(eventProxyStepId))
         {
             this.EventProxyStepId = new ActorId(eventProxyStepId);
@@ -253,18 +253,18 @@ internal sealed class ProcessActor : StepActor, IProcess, IDisposable
             IStep? stepActor = null;
 
             // The current step should already have a name.
-            Verify.NotNull(step.State?.Name);
+            Verify.NotNull(step.State?.StepId);
 
             if (step is DaprProcessInfo processStep)
             {
                 // The process will only have an Id if its already been executed.
-                if (string.IsNullOrWhiteSpace(processStep.State.Id))
+                if (string.IsNullOrWhiteSpace(processStep.State.RunId))
                 {
-                    processStep = processStep with { State = processStep.State with { Id = Guid.NewGuid().ToString() } };
+                    processStep = processStep with { State = processStep.State with { RunId = Guid.NewGuid().ToString() } };
                 }
 
                 // Initialize the step as a process.
-                var scopedProcessId = this.ScopedActorId(new ActorId(processStep.State.Id!));
+                var scopedProcessId = this.ScopedActorId(new ActorId(processStep.State.RunId!));
                 var processActor = this.ProxyFactory.CreateActorProxy<IProcess>(scopedProcessId, nameof(ProcessActor));
                 await processActor.InitializeProcessAsync(processStep, this.Id.GetId(), eventProxyStepId).ConfigureAwait(false);
                 stepActor = this.ProxyFactory.CreateActorProxy<IStep>(scopedProcessId, nameof(ProcessActor));
@@ -272,7 +272,7 @@ internal sealed class ProcessActor : StepActor, IProcess, IDisposable
             else if (step is DaprMapInfo mapStep)
             {
                 // Initialize the step as a map.
-                ActorId scopedMapId = this.ScopedActorId(new ActorId(mapStep.State.Id!));
+                ActorId scopedMapId = this.ScopedActorId(new ActorId(mapStep.State.RunId!));
                 IMap mapActor = this.ProxyFactory.CreateActorProxy<IMap>(scopedMapId, nameof(MapActor));
                 await mapActor.InitializeMapAsync(mapStep, this.Id.GetId()).ConfigureAwait(false);
                 stepActor = this.ProxyFactory.CreateActorProxy<IStep>(scopedMapId, nameof(MapActor));
@@ -280,7 +280,7 @@ internal sealed class ProcessActor : StepActor, IProcess, IDisposable
             else if (step is DaprProxyInfo proxyStep)
             {
                 // Initialize the step as a proxy
-                ActorId scopedProxyId = this.ScopedActorId(new ActorId(proxyStep.State.Id!));
+                ActorId scopedProxyId = this.ScopedActorId(new ActorId(proxyStep.State.RunId!));
                 IProxy proxyActor = this.ProxyFactory.CreateActorProxy<IProxy>(scopedProxyId, nameof(ProxyActor));
                 await proxyActor.InitializeProxyAsync(proxyStep, this.Id.GetId()).ConfigureAwait(false);
                 stepActor = this.ProxyFactory.CreateActorProxy<IStep>(scopedProxyId, nameof(ProxyActor));
@@ -288,9 +288,9 @@ internal sealed class ProcessActor : StepActor, IProcess, IDisposable
             else
             {
                 // The current step should already have an Id.
-                Verify.NotNull(step.State?.Id);
+                Verify.NotNull(step.State?.RunId);
 
-                var scopedStepId = this.ScopedActorId(new ActorId(step.State.Id!));
+                var scopedStepId = this.ScopedActorId(new ActorId(step.State.RunId!));
                 stepActor = this.ProxyFactory.CreateActorProxy<IStep>(scopedStepId, nameof(StepActor));
                 await stepActor.InitializeStepAsync(step, this.Id.GetId(), eventProxyStepId).ConfigureAwait(false);
             }
@@ -516,7 +516,7 @@ internal sealed class ProcessActor : StepActor, IProcess, IDisposable
     private ProcessEvent ScopedEvent(ProcessEvent daprEvent)
     {
         Verify.NotNull(daprEvent);
-        return daprEvent with { Namespace = $"{this.Name}_{this._process!.State.Id}" };
+        return daprEvent with { Namespace = $"{this.Name}_{this._process!.State.RunId}" };
     }
 
     #endregion

--- a/dotnet/src/Experimental/Process.Runtime.Dapr/Actors/StepActor.cs
+++ b/dotnet/src/Experimental/Process.Runtime.Dapr/Actors/StepActor.cs
@@ -107,7 +107,7 @@ internal class StepActor : Actor, IStep, IKernelProcessMessageChannel
         this._stepState = this._stepInfo.State;
         this._logger = this._kernel.LoggerFactory?.CreateLogger(this._innerStepType) ?? new NullLogger<StepActor>();
         this._outputEdges = this._stepInfo.Edges.ToDictionary(kvp => kvp.Key, kvp => kvp.Value.ToList());
-        this._eventNamespace = $"{this._stepInfo.State.Name}_{this._stepInfo.State.Id}";
+        this._eventNamespace = $"{this._stepInfo.State.StepId}_{this._stepInfo.State.RunId}";
 
         if (!string.IsNullOrWhiteSpace(eventProxyStepId))
         {
@@ -203,7 +203,7 @@ internal class StepActor : Actor, IStep, IKernelProcessMessageChannel
     /// <summary>
     /// The name of the step.
     /// </summary>
-    protected virtual string Name => this._stepInfo?.State.Name ?? throw new KernelException("The Step must be initialized before accessing the Name property.").Log(this._logger);
+    protected virtual string Name => this._stepInfo?.State.StepId ?? throw new KernelException("The Step must be initialized before accessing the Name property.").Log(this._logger);
 
     /// <summary>
     /// Emits an event from the step.
@@ -352,7 +352,7 @@ internal class StepActor : Actor, IStep, IKernelProcessMessageChannel
 
         // Instantiate an instance of the inner step object
         KernelProcessStep stepInstance = (KernelProcessStep)ActivatorUtilities.CreateInstance(this._kernel.Services, this._innerStepType!);
-        var kernelPlugin = KernelPluginFactory.CreateFromObject(stepInstance, pluginName: this._stepInfo.State.Name);
+        var kernelPlugin = KernelPluginFactory.CreateFromObject(stepInstance, pluginName: this._stepInfo.State.StepId);
 
         // Load the kernel functions
         foreach (KernelFunction f in kernelPlugin)

--- a/dotnet/src/Experimental/Process.Runtime.Dapr/DaprKernelProcessContext.cs
+++ b/dotnet/src/Experimental/Process.Runtime.Dapr/DaprKernelProcessContext.cs
@@ -20,15 +20,15 @@ public class DaprKernelProcessContext : KernelProcessContext
     internal DaprKernelProcessContext(KernelProcess process, IActorProxyFactory? actorProxyFactory = null)
     {
         Verify.NotNull(process);
-        Verify.NotNullOrWhiteSpace(process.State?.Name);
+        Verify.NotNullOrWhiteSpace(process.State?.StepId);
 
-        if (string.IsNullOrWhiteSpace(process.State.Id))
+        if (string.IsNullOrWhiteSpace(process.State.RunId))
         {
-            process = process with { State = process.State with { Id = Guid.NewGuid().ToString() } };
+            process = process with { State = process.State with { RunId = Guid.NewGuid().ToString() } };
         }
 
         this._process = process;
-        var processId = new ActorId(process.State.Id);
+        var processId = new ActorId(process.State.RunId);
 
         // For a non-dependency-injected application, the static methods on ActorProxy are used.
         // Since the ActorProxy methods are error prone, try to avoid using them when using
@@ -89,6 +89,6 @@ public class DaprKernelProcessContext : KernelProcessContext
     public override async Task<string> GetProcessIdAsync()
     {
         var processInfo = await this._daprProcess.GetProcessInfoAsync().ConfigureAwait(false);
-        return processInfo.State.Id!;
+        return processInfo.State.RunId!;
     }
 }

--- a/dotnet/src/Experimental/Process.Runtime.Dapr/DaprKernelProcessFactory.cs
+++ b/dotnet/src/Experimental/Process.Runtime.Dapr/DaprKernelProcessFactory.cs
@@ -20,13 +20,13 @@ public static class DaprKernelProcessFactory
     public static async Task<DaprKernelProcessContext> StartAsync(this KernelProcess process, KernelProcessEvent initialEvent, string? processId = null, IActorProxyFactory? actorProxyFactory = null)
     {
         Verify.NotNull(process);
-        Verify.NotNullOrWhiteSpace(process.State?.Name);
+        Verify.NotNullOrWhiteSpace(process.State?.StepId);
         Verify.NotNull(initialEvent);
 
         // Assign the process Id if one is provided and the processes does not already have an Id.
-        if (!string.IsNullOrWhiteSpace(processId) && string.IsNullOrWhiteSpace(process.State.Id))
+        if (!string.IsNullOrWhiteSpace(processId) && string.IsNullOrWhiteSpace(process.State.RunId))
         {
-            process = process with { State = process.State with { Id = processId } };
+            process = process with { State = process.State with { RunId = processId } };
         }
 
         DaprKernelProcessContext processContext = new(process, actorProxyFactory);

--- a/dotnet/src/Experimental/Process.Runtime.Dapr/DaprMapInfo.cs
+++ b/dotnet/src/Experimental/Process.Runtime.Dapr/DaprMapInfo.cs
@@ -27,7 +27,7 @@ public sealed record DaprMapInfo : DaprStepInfo
         KernelProcessStepInfo processStepInfo = this.ToKernelProcessStepInfo();
         if (this.State is not KernelProcessMapState state)
         {
-            throw new KernelException($"Unable to read state from map with name '{this.State.Name}' and Id '{this.State.Id}'.");
+            throw new KernelException($"Unable to read state from map with name '{this.State.StepId}' and Id '{this.State.RunId}'.");
         }
 
         KernelProcessStepInfo operationStep =

--- a/dotnet/src/Experimental/Process.Runtime.Dapr/DaprProcessInfo.cs
+++ b/dotnet/src/Experimental/Process.Runtime.Dapr/DaprProcessInfo.cs
@@ -30,7 +30,7 @@ public sealed record DaprProcessInfo : DaprStepInfo
         var processStepInfo = this.ToKernelProcessStepInfo();
         if (this.State is not KernelProcessState state)
         {
-            throw new KernelException($"Unable to read state from process with name '{this.State.Name}' and Id '{this.State.Id}'.");
+            throw new KernelException($"Unable to read state from process with name '{this.State.StepId}' and Id '{this.State.RunId}'.");
         }
 
         List<KernelProcessStepInfo> steps = [];

--- a/dotnet/src/Experimental/Process.Runtime.Dapr/DaprProxyInfo.cs
+++ b/dotnet/src/Experimental/Process.Runtime.Dapr/DaprProxyInfo.cs
@@ -27,7 +27,7 @@ public sealed record DaprProxyInfo : DaprStepInfo
         KernelProcessStepInfo processStepInfo = this.ToKernelProcessStepInfo();
         if (this.State is not KernelProcessStepState state)
         {
-            throw new KernelException($"Unable to read state from proxy with name '{this.State.Name}', Id '{this.State.Id}' and type {this.State.GetType()}.");
+            throw new KernelException($"Unable to read state from proxy with name '{this.State.StepId}', Id '{this.State.RunId}' and type {this.State.GetType()}.");
         }
 
         return new KernelProcessProxy(state, this.Edges)

--- a/dotnet/src/Experimental/Process.UnitTests/Core/ProcessBuilderTests.cs
+++ b/dotnet/src/Experimental/Process.UnitTests/Core/ProcessBuilderTests.cs
@@ -143,7 +143,7 @@ public class ProcessBuilderTests
 
         // Assert
         Assert.NotNull(kernelProcess);
-        Assert.Equal(ProcessName, kernelProcess.State.Name);
+        Assert.Equal(ProcessName, kernelProcess.State.StepId);
         Assert.Single(kernelProcess.Steps);
     }
 

--- a/dotnet/src/Experimental/Process.UnitTests/Core/ProcessMapBuilderTests.cs
+++ b/dotnet/src/Experimental/Process.UnitTests/Core/ProcessMapBuilderTests.cs
@@ -129,8 +129,8 @@ public class ProcessMapBuilderTests
         // Assert
         Assert.NotNull(processMap);
         Assert.IsType<KernelProcessMap>(processMap);
-        Assert.Equal(map.Name, processMap.State.Name);
-        Assert.Equal(map.Id, processMap.State.Id);
+        Assert.Equal(map.Name, processMap.State.StepId);
+        Assert.Equal(map.Id, processMap.State.RunId);
     }
 
     /// <summary>

--- a/dotnet/src/Experimental/Process.UnitTests/Core/ProcessProxyBuilderTests.cs
+++ b/dotnet/src/Experimental/Process.UnitTests/Core/ProcessProxyBuilderTests.cs
@@ -78,8 +78,8 @@ public class ProcessProxyBuilderTests
         // Assert
         Assert.NotNull(proxyInfo);
         Assert.IsType<KernelProcessProxy>(proxyInfo);
-        Assert.Equal(proxy.Name, proxyInfo.State.Name);
-        Assert.Equal(proxy.Id, proxyInfo.State.Id);
+        Assert.Equal(proxy.Name, proxyInfo.State.StepId);
+        Assert.Equal(proxy.Id, proxyInfo.State.RunId);
         var processProxy = (KernelProcessProxy)proxyInfo;
         Assert.NotNull(processProxy?.ProxyMetadata);
         Assert.Equal(proxy._eventMetadata, processProxy.ProxyMetadata.EventMetadata);

--- a/dotnet/src/Experimental/Process.UnitTests/KernelProcessSerializationTests.cs
+++ b/dotnet/src/Experimental/Process.UnitTests/KernelProcessSerializationTests.cs
@@ -124,7 +124,7 @@ public class KernelProcessSerializationTests
 
     private static void AssertProcess(KernelProcess expectedProcess, KernelProcess anotherProcess)
     {
-        Assert.Equal(expectedProcess.State.Name, anotherProcess.State.Name);
+        Assert.Equal(expectedProcess.State.StepId, anotherProcess.State.StepId);
         Assert.Equal(expectedProcess.State.Version, anotherProcess.State.Version);
         Assert.Equal(expectedProcess.Steps.Count, anotherProcess.Steps.Count);
 
@@ -137,7 +137,7 @@ public class KernelProcessSerializationTests
     private static void AssertStep(KernelProcessStepInfo expectedStep, KernelProcessStepInfo actualStep)
     {
         Assert.Equal(expectedStep.InnerStepType, actualStep.InnerStepType);
-        Assert.Equal(expectedStep.State.Name, actualStep.State.Name);
+        Assert.Equal(expectedStep.State.StepId, actualStep.State.StepId);
         Assert.Equal(expectedStep.State.Version, actualStep.State.Version);
 
         if (expectedStep is KernelProcessMap mapStep)
@@ -163,8 +163,8 @@ public class KernelProcessSerializationTests
     private static void AssertProcessState(KernelProcess process, KernelProcessStateMetadata? savedProcess)
     {
         Assert.NotNull(savedProcess);
-        Assert.Equal(process.State.Id, savedProcess.Id);
-        Assert.Equal(process.State.Name, savedProcess.Name);
+        Assert.Equal(process.State.RunId, savedProcess.Id);
+        Assert.Equal(process.State.StepId, savedProcess.Name);
         Assert.Equal(process.State.Version, savedProcess.VersionInfo);
         Assert.NotNull(savedProcess.StepsState);
         Assert.Equal(process.Steps.Count, savedProcess.StepsState.Count);
@@ -177,10 +177,10 @@ public class KernelProcessSerializationTests
 
     private static void AssertStepState(KernelProcessStepInfo step, Dictionary<string, KernelProcessStepStateMetadata> savedSteps)
     {
-        Assert.True(savedSteps.ContainsKey(step.State.Name));
-        KernelProcessStepStateMetadata savedStep = savedSteps[step.State.Name];
-        Assert.Equal(step.State.Id, savedStep.Id);
-        Assert.Equal(step.State.Name, savedStep.Name);
+        Assert.True(savedSteps.ContainsKey(step.State.StepId));
+        KernelProcessStepStateMetadata savedStep = savedSteps[step.State.StepId];
+        Assert.Equal(step.State.RunId, savedStep.Id);
+        Assert.Equal(step.State.StepId, savedStep.Name);
         Assert.Equal(step.State.Version, savedStep.VersionInfo);
 
         if (step is KernelProcessMap mapStep)

--- a/dotnet/src/Experimental/Process.UnitTests/KernelProcessStateTests.cs
+++ b/dotnet/src/Experimental/Process.UnitTests/KernelProcessStateTests.cs
@@ -24,8 +24,8 @@ public class KernelProcessStateTests
         KernelProcessState state = new(name, "v1", id);
 
         // Assert
-        Assert.Equal(name, state.Name);
-        Assert.Equal(id, state.Id);
+        Assert.Equal(name, state.StepId);
+        Assert.Equal(id, state.RunId);
     }
 
     /// <summary>
@@ -41,8 +41,8 @@ public class KernelProcessStateTests
         KernelProcessState state = new(name, version: "v1");
 
         // Assert
-        Assert.Equal(name, state.Name);
-        Assert.Null(state.Id);
+        Assert.Equal(name, state.StepId);
+        Assert.Null(state.RunId);
     }
 
     /// <summary>

--- a/dotnet/src/Experimental/Process.UnitTests/ProcessSerializationTests.cs
+++ b/dotnet/src/Experimental/Process.UnitTests/ProcessSerializationTests.cs
@@ -47,10 +47,10 @@ public class ProcessSerializationTests
         // Assert
         Assert.NotNull(process);
 
-        var stepKickoff = process.Steps.FirstOrDefault(s => s.State.Id == "kickoff");
-        var stepA = process.Steps.FirstOrDefault(s => s.State.Id == "a_step");
-        var stepB = process.Steps.FirstOrDefault(s => s.State.Id == "b_step");
-        var stepC = process.Steps.FirstOrDefault(s => s.State.Id == "c_step");
+        var stepKickoff = process.Steps.FirstOrDefault(s => s.State.RunId == "kickoff");
+        var stepA = process.Steps.FirstOrDefault(s => s.State.RunId == "a_step");
+        var stepB = process.Steps.FirstOrDefault(s => s.State.RunId == "b_step");
+        var stepC = process.Steps.FirstOrDefault(s => s.State.RunId == "c_step");
 
         Assert.NotNull(stepKickoff);
         Assert.NotNull(stepA);
@@ -139,8 +139,8 @@ public class ProcessSerializationTests
 
         // Assert
         Assert.NotNull(process);
-        Assert.Contains(process.Steps, step => step.State.Id == "GetProductInfo");
-        Assert.Contains(process.Steps, step => step.State.Id == "Summarize");
+        Assert.Contains(process.Steps, step => step.State.RunId == "GetProductInfo");
+        Assert.Contains(process.Steps, step => step.State.RunId == "Summarize");
     }
 
     private KernelProcess GetProcess()

--- a/dotnet/src/Experimental/Process.UnitTests/Runtime.Local/LocalMapTests.cs
+++ b/dotnet/src/Experimental/Process.UnitTests/Runtime.Local/LocalMapTests.cs
@@ -387,7 +387,7 @@ public class LocalMapTests
     private static async Task<UnionState> GetUnionStateAsync(LocalKernelProcessContext processContext)
     {
         KernelProcess processState = await processContext.GetStateAsync();
-        KernelProcessStepState<UnionState> unionState = (KernelProcessStepState<UnionState>)processState.Steps.Single(s => s.State.Name == "Union").State;
+        KernelProcessStepState<UnionState> unionState = (KernelProcessStepState<UnionState>)processState.Steps.Single(s => s.State.StepId == "Union").State;
         Assert.NotNull(unionState);
         Assert.NotNull(unionState.State);
         return unionState.State;

--- a/dotnet/src/Experimental/Process.Utilities.UnitTests/CloneTests.cs
+++ b/dotnet/src/Experimental/Process.Utilities.UnitTests/CloneTests.cs
@@ -139,8 +139,8 @@ public class CloneTests
 
     private static void VerifyProcess(KernelProcess expected, KernelProcess actual)
     {
-        Assert.Equal(expected.State.Id, actual.State.Id);
-        Assert.Equal(expected.State.Name, actual.State.Name);
+        Assert.Equal(expected.State.RunId, actual.State.RunId);
+        Assert.Equal(expected.State.StepId, actual.State.StepId);
         Assert.Equal(expected.State.Version, actual.State.Version);
         Assert.Equal(expected.InnerStepType, actual.InnerStepType);
         Assert.Equivalent(expected.Edges, actual.Edges);

--- a/dotnet/src/InternalUtilities/process/Abstractions/KernelProcessStateMetadataFactory.cs
+++ b/dotnet/src/InternalUtilities/process/Abstractions/KernelProcessStateMetadataFactory.cs
@@ -15,15 +15,15 @@ internal static class ProcessStateMetadataFactory
     {
         KernelProcessStateMetadata metadata = new()
         {
-            Name = kernelProcess.State.Name,
-            Id = kernelProcess.State.Id,
+            Name = kernelProcess.State.StepId,
+            Id = kernelProcess.State.RunId,
             VersionInfo = kernelProcess.State.Version,
             StepsState = [],
         };
 
         foreach (KernelProcessStepInfo step in kernelProcess.Steps)
         {
-            metadata.StepsState.Add(step.State.Name, step.ToProcessStateMetadata());
+            metadata.StepsState.Add(step.State.StepId, step.ToProcessStateMetadata());
         }
 
         return metadata;
@@ -52,8 +52,8 @@ internal static class ProcessStateMetadataFactory
         return
             new()
             {
-                Name = stepMap.State.Name,
-                Id = stepMap.State.Id,
+                Name = stepMap.State.StepId,
+                Id = stepMap.State.RunId,
                 VersionInfo = stepMap.State.Version,
                 OperationState = ToProcessStateMetadata(stepMap.Operation),
             };
@@ -63,8 +63,8 @@ internal static class ProcessStateMetadataFactory
     {
         return new()
         {
-            Name = stepProxy.State.Name,
-            Id = stepProxy.State.Id,
+            Name = stepProxy.State.StepId,
+            Id = stepProxy.State.RunId,
             VersionInfo = stepProxy.State.Version,
             PublishTopics = stepProxy.ProxyMetadata?.PublishTopics ?? [],
             EventMetadata = stepProxy.ProxyMetadata?.EventMetadata ?? [],
@@ -79,8 +79,8 @@ internal static class ProcessStateMetadataFactory
     {
         KernelProcessStepStateMetadata metadata = new()
         {
-            Name = stepInfo.State.Name,
-            Id = stepInfo.State.Id,
+            Name = stepInfo.State.StepId,
+            Id = stepInfo.State.RunId,
             VersionInfo = stepInfo.State.Version
         };
 

--- a/dotnet/src/InternalUtilities/process/Abstractions/MapExtensions.cs
+++ b/dotnet/src/InternalUtilities/process/Abstractions/MapExtensions.cs
@@ -8,7 +8,7 @@ internal static class MapExtensions
 {
     public static KernelProcessMap CloneMap(this KernelProcessMap map, ILogger logger)
     {
-        KernelProcessMapState newState = new(map.State.Name, map.State.Version, map.State.Id!);
+        KernelProcessMapState newState = new(map.State.StepId, map.State.Version, map.State.RunId!);
 
         KernelProcessMap copy =
             new(

--- a/dotnet/src/InternalUtilities/process/Abstractions/ProcessExtensions.cs
+++ b/dotnet/src/InternalUtilities/process/Abstractions/ProcessExtensions.cs
@@ -11,7 +11,7 @@ internal static class ProcessExtensions
     {
         KernelProcess copy =
             new(
-                new KernelProcessState(process.State.Name, process.State.Version, process.State.Id),
+                new KernelProcessState(process.State.StepId, process.State.Version, process.State.RunId),
                 process.Steps.Select(s => s.Clone(logger)).ToArray(),
                 process.Edges.ToDictionary(kvp => kvp.Key, kvp => kvp.Value.ToList()));
 

--- a/dotnet/src/InternalUtilities/process/Abstractions/StepExtensions.cs
+++ b/dotnet/src/InternalUtilities/process/Abstractions/StepExtensions.cs
@@ -38,10 +38,10 @@ internal static class StepExtensions
     // Exposed for testing
     public static KernelProcessStepState Clone(this KernelProcessStepState sourceState, Type stateType, Type? userStateType, ILogger logger)
     {
-        KernelProcessStepState? newState = (KernelProcessStepState?)Activator.CreateInstance(stateType, sourceState.Name, sourceState.Version, sourceState.Id);
+        KernelProcessStepState? newState = (KernelProcessStepState?)Activator.CreateInstance(stateType, sourceState.StepId, sourceState.Version, sourceState.RunId);
         if (newState == null)
         {
-            throw new KernelException($"Failed to instantiate state: {stateType.Name} [{sourceState.Id}].").Log(logger);
+            throw new KernelException($"Failed to instantiate state: {stateType.Name} [{sourceState.RunId}].").Log(logger);
         }
 
         if (userStateType != null)

--- a/dotnet/src/InternalUtilities/process/Runtime/MapExtensions.cs
+++ b/dotnet/src/InternalUtilities/process/Runtime/MapExtensions.cs
@@ -37,9 +37,9 @@ internal static class MapExtensions
             string proxyId = Guid.NewGuid().ToString("N");
             mapOperation =
                 new KernelProcess(
-                    new KernelProcessState($"Map{map.Operation.State.Name}", map.Operation.State.Version, proxyId),
+                    new KernelProcessState($"Map{map.Operation.State.StepId}", map.Operation.State.Version, proxyId),
                     [map.Operation],
-                    new() { { ProcessConstants.MapEventId, [new KernelProcessEdge(proxyId, new KernelProcessFunctionTarget(map.Operation.State.Id!, message.FunctionName, parameterName))] } });
+                    new() { { ProcessConstants.MapEventId, [new KernelProcessEdge(proxyId, new KernelProcessFunctionTarget(map.Operation.State.RunId!, message.FunctionName, parameterName))] } });
         }
 
         return (inputValues, mapOperation, startEventId);
@@ -110,7 +110,7 @@ internal static class MapExtensions
         // Fails when zero or multiple candidate edges exist.  No reason a map-operation should be irrational.
         return
             mapOperation.Edges.SingleOrDefault(kvp => kvp.Value.Any(e => (e.OutputTarget as KernelProcessFunctionTarget)!.FunctionName == message.FunctionName)).Key ??
-            throw new InvalidOperationException($"The map operation does not have an input edge that matches the message destination: {mapOperation.State.Name}/{mapOperation.State.Id}.");
+            throw new InvalidOperationException($"The map operation does not have an input edge that matches the message destination: {mapOperation.State.StepId}/{mapOperation.State.RunId}.");
     }
 
     private static bool IsEqual(IEnumerable targetData, object? possibleValue)


### PR DESCRIPTION
### Description

<!-- Describe your changes, the overall approach, the underlying design.
     These notes will help understanding how your code works. Thanks! -->

This is a long one, trying to break down the changes by commit in the most part:

- Renaming `step.name` -> `step.Stepid`, `step.id` -> `step.RunId`. 
- Updating namespace from `SemanticKernel.xxxx` to `Microsoft.SemanticKernel.xxx`

### Contribution Checklist

<!-- Before submitting this PR, please make sure: -->

- [ ] The code builds clean without any errors or warnings
- [ ] The PR follows the [SK Contribution Guidelines](https://github.com/microsoft/semantic-kernel/blob/main/CONTRIBUTING.md) and the [pre-submission formatting script](https://github.com/microsoft/semantic-kernel/blob/main/CONTRIBUTING.md#development-scripts) raises no violations
- [ ] All unit tests pass, and I have added new tests where possible
- [ ] I didn't break anyone :smile:
