### PR TITLE
Python: .Net: Magentic orchestration to return the last agent message when limits reached

### DIFF
--- a/dotnet/src/Agents/UnitTests/Magentic/MagenticOrchestrationTests.cs
+++ b/dotnet/src/Agents/UnitTests/Magentic/MagenticOrchestrationTests.cs
@@ -248,7 +248,7 @@ public class MagenticOrchestrationTests
         StandardMagenticManager manager = new(chatServiceMock.Object, settings)
         {
             MaximumResetCount = 1, // Fast failure for testing but at least one response
-            MaximumStallCount = 2,
+            MaximumStallCount = 2, // Allow some stalls for at least one response
         };
 
         MagenticOrchestration orchestration = new(manager, [mockAgent1, mockAgent2, mockAgent3]);

--- a/dotnet/src/Agents/UnitTests/Magentic/MagenticOrchestrationTests.cs
+++ b/dotnet/src/Agents/UnitTests/Magentic/MagenticOrchestrationTests.cs
@@ -55,6 +55,216 @@ public class MagenticOrchestrationTests
         Assert.Equal(0, mockAgent3.InvokeCount);
     }
 
+    [Fact]
+    public async Task MagenticOrchestrationMaxInvocationCountReached_WithoutPartialResultAsync()
+    {
+        // Arrange
+        await using InProcessRuntime runtime = new();
+
+        MockAgent mockAgent1 = CreateMockAgent(1, "abc");
+        MockAgent mockAgent2 = CreateMockAgent(2, "xyz");
+        MockAgent mockAgent3 = CreateMockAgent(3, "lmn");
+
+        string jsonStatus =
+            $$"""
+            {
+                "Name": "{{mockAgent1.Name}}",
+                "Instruction":"Proceed",
+                "Reason":"TestReason",
+                "IsTaskComplete": {
+                  "Result": false,
+                  "Reason": "Test"
+                },
+                "IsTaskProgressing": {
+                  "Result": true,
+                  "Reason": "Test"
+                },
+                "IsTaskInLoop": {
+                  "Result": false,
+                  "Reason": "Test"
+                }
+            }
+            """;
+        Mock<IChatCompletionService> chatServiceMock = CreateMockChatCompletionService(jsonStatus);
+
+        FakePromptExecutionSettings settings = new();
+        StandardMagenticManager manager = new(chatServiceMock.Object, settings)
+        {
+            MaximumInvocationCount = 1, // Fast failure for testing
+        };
+
+        MagenticOrchestration orchestration = new(manager, [mockAgent1, mockAgent2, mockAgent3]);
+
+        // Act
+        await runtime.StartAsync();
+
+        const string InitialInput = "123";
+        OrchestrationResult<string> result = await orchestration.InvokeAsync(InitialInput, runtime);
+        string response = await result.GetValueAsync(TimeSpan.FromSeconds(20));
+
+        // Assert
+        Assert.NotNull(response);
+        Assert.Contains("No partial result available.", response);
+    }
+
+    [Fact]
+    public async Task MagenticOrchestrationMaxInvocationCountReached_WithPartialResultAsync()
+    {
+        // Arrange
+        await using InProcessRuntime runtime = new();
+
+        MockAgent mockAgent1 = CreateMockAgent(1, "abc");
+        MockAgent mockAgent2 = CreateMockAgent(2, "xyz");
+        MockAgent mockAgent3 = CreateMockAgent(3, "lmn");
+
+        string jsonStatus =
+            $$"""
+            {
+                "Name": "{{mockAgent1.Name}}",
+                "Instruction":"Proceed",
+                "Reason":"TestReason",
+                "IsTaskComplete": {
+                  "Result": false,
+                  "Reason": "Test"
+                },
+                "IsTaskProgressing": {
+                  "Result": true,
+                  "Reason": "Test"
+                },
+                "IsTaskInLoop": {
+                  "Result": false,
+                  "Reason": "Test"
+                }
+            }
+            """;
+        Mock<IChatCompletionService> chatServiceMock = CreateMockChatCompletionService(jsonStatus);
+
+        FakePromptExecutionSettings settings = new();
+        StandardMagenticManager manager = new(chatServiceMock.Object, settings)
+        {
+            MaximumInvocationCount = 2, // Fast failure for testing but at least one invocation
+        };
+
+        MagenticOrchestration orchestration = new(manager, [mockAgent1, mockAgent2, mockAgent3]);
+
+        // Act
+        await runtime.StartAsync();
+
+        const string InitialInput = "123";
+        OrchestrationResult<string> result = await orchestration.InvokeAsync(InitialInput, runtime);
+        string response = await result.GetValueAsync(TimeSpan.FromSeconds(20));
+
+        // Assert
+        Assert.NotNull(response);
+        Assert.Equal("abc", response);
+    }
+
+    [Fact]
+    public async Task MagenticOrchestrationMaxResetCountReached_WithoutPartialResultAsync()
+    {
+        // Arrange
+        await using InProcessRuntime runtime = new();
+
+        MockAgent mockAgent1 = CreateMockAgent(1, "abc");
+        MockAgent mockAgent2 = CreateMockAgent(2, "xyz");
+        MockAgent mockAgent3 = CreateMockAgent(3, "lmn");
+
+        string jsonStatus =
+            $$"""
+            {
+                "Name": "{{mockAgent1.Name}}",
+                "Instruction":"Proceed",
+                "Reason":"TestReason",
+                "IsTaskComplete": {
+                  "Result": false,
+                  "Reason": "Test"
+                },
+                "IsTaskProgressing": {
+                  "Result": false,
+                  "Reason": "Test"
+                },
+                "IsTaskInLoop": {
+                  "Result": true,
+                  "Reason": "Test"
+                }
+            }
+            """;
+        Mock<IChatCompletionService> chatServiceMock = CreateMockChatCompletionService(jsonStatus);
+
+        FakePromptExecutionSettings settings = new();
+        StandardMagenticManager manager = new(chatServiceMock.Object, settings)
+        {
+            MaximumResetCount = 1, // Fast failure for testing
+            MaximumStallCount = 0, // No stalls allowed
+        };
+
+        MagenticOrchestration orchestration = new(manager, [mockAgent1, mockAgent2, mockAgent3]);
+
+        // Act
+        await runtime.StartAsync();
+
+        const string InitialInput = "123";
+        OrchestrationResult<string> result = await orchestration.InvokeAsync(InitialInput, runtime);
+        string response = await result.GetValueAsync(TimeSpan.FromSeconds(20));
+
+        // Assert
+        Assert.NotNull(response);
+        Assert.Contains("No partial result available.", response);
+    }
+
+    [Fact]
+    public async Task MagenticOrchestrationMaxResetCountReached_WithPartialResultAsync()
+    {
+        // Arrange
+        await using InProcessRuntime runtime = new();
+
+        MockAgent mockAgent1 = CreateMockAgent(1, "abc");
+        MockAgent mockAgent2 = CreateMockAgent(2, "xyz");
+        MockAgent mockAgent3 = CreateMockAgent(3, "lmn");
+
+        string jsonStatus =
+            $$"""
+            {
+                "Name": "{{mockAgent1.Name}}",
+                "Instruction":"Proceed",
+                "Reason":"TestReason",
+                "IsTaskComplete": {
+                  "Result": false,
+                  "Reason": "Test"
+                },
+                "IsTaskProgressing": {
+                  "Result": false,
+                  "Reason": "Test"
+                },
+                "IsTaskInLoop": {
+                  "Result": true,
+                  "Reason": "Test"
+                }
+            }
+            """;
+        Mock<IChatCompletionService> chatServiceMock = CreateMockChatCompletionService(jsonStatus);
+
+        FakePromptExecutionSettings settings = new();
+        StandardMagenticManager manager = new(chatServiceMock.Object, settings)
+        {
+            MaximumResetCount = 1, // Fast failure for testing but at least one response
+            MaximumStallCount = 2,
+        };
+
+        MagenticOrchestration orchestration = new(manager, [mockAgent1, mockAgent2, mockAgent3]);
+
+        // Act
+        await runtime.StartAsync();
+
+        const string InitialInput = "123";
+        OrchestrationResult<string> result = await orchestration.InvokeAsync(InitialInput, runtime);
+        string response = await result.GetValueAsync(TimeSpan.FromSeconds(20));
+
+        // Assert
+        Assert.NotNull(response);
+        Assert.Contains("abc", response);
+    }
+
     private async Task<string> ExecuteOrchestrationAsync(InProcessRuntime runtime, string answer, params Agent[] mockAgents)
     {
         // Act
@@ -81,6 +291,7 @@ public class MagenticOrchestrationTests
     {
         return new()
         {
+            Name = $"MockAgent{index}",
             Description = $"test {index}",
             Response = [new(AuthorRole.Assistant, response)]
         };
@@ -129,5 +340,30 @@ public class MagenticOrchestrationTests
                 this._isComplete = true;
             }
         }
+    }
+
+    private static Mock<IChatCompletionService> CreateMockChatCompletionService(string response)
+    {
+        Mock<IChatCompletionService> chatServiceMock = new(MockBehavior.Strict);
+
+        chatServiceMock.Setup(
+            (service) => service.GetChatMessageContentsAsync(
+                It.IsAny<ChatHistory>(),
+                It.IsAny<PromptExecutionSettings>(),
+                null,
+                It.IsAny<CancellationToken>()))
+            .ReturnsAsync([new ChatMessageContent(AuthorRole.Assistant, response)]);
+
+        return chatServiceMock;
+    }
+
+    private sealed class FakePromptExecutionSettings : PromptExecutionSettings
+    {
+        public override PromptExecutionSettings Clone()
+        {
+            return this;
+        }
+
+        public object? ResponseFormat { get; set; }
     }
 }

--- a/python/semantic_kernel/agents/orchestration/magentic.py
+++ b/python/semantic_kernel/agents/orchestration/magentic.py
@@ -660,7 +660,7 @@ class MagenticManagerActor(ActorBase):
 
         if hit_round_limit or hit_reset_limit:
             limit_type = "round" if hit_round_limit else "reset"
-            logger.debug(f"Max {limit_type} count reached.")
+            logger.error(f"Max {limit_type} count reached.")
 
             # Retrieve the latest assistant content produced so far
             partial_result = next(


### PR DESCRIPTION
### Motivation and Context

<!-- Thank you for your contribution to the semantic-kernel repo!
Please help reviewers and future users, providing the following information:
  1. Why is this change required?
  2. What problem does it solve?
  3. What scenario does it contribute to?
  4. If it fixes an open issue, please link to the issue here.
-->
Related to #12687
Related to #12656 

Currently, the Magentic orchestration returns a static message if the max reset limit or the max invocation limit is reached.

### Description

<!-- Describe your changes, the overall approach, the underlying design.
     These notes will help understanding how your code works. Thanks! -->
Return the last agent response if either of the limit is reached.

### Contribution Checklist

<!-- Before submitting this PR, please make sure: -->

- [x] The code builds clean without any errors or warnings
- [x] The PR follows the [SK Contribution Guidelines](https://github.com/microsoft/semantic-kernel/blob/main/CONTRIBUTING.md) and the [pre-submission formatting script](https://github.com/microsoft/semantic-kernel/blob/main/CONTRIBUTING.md#development-scripts) raises no violations
- [x] All unit tests pass, and I have added new tests where possible
- [x] I didn't break anyone :smile:
