### PR TITLE
.Net: Allow the MongoDB VectorData tests to run without an image

### DIFF
--- a/dotnet/test/VectorData/MongoDB.ConformanceTests/MongoDB.ConformanceTests.csproj
+++ b/dotnet/test/VectorData/MongoDB.ConformanceTests/MongoDB.ConformanceTests.csproj
@@ -10,6 +10,9 @@
   </PropertyGroup>
 
   <ItemGroup>
+    <PackageReference Include="Microsoft.Extensions.Configuration" />
+    <PackageReference Include="Microsoft.Extensions.Configuration.EnvironmentVariables" />
+    <PackageReference Include="Microsoft.Extensions.Configuration.Json" />
     <PackageReference Include="xunit" />
     <PackageReference Include="xunit.runner.visualstudio">
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>

--- a/dotnet/test/VectorData/MongoDB.ConformanceTests/Support/MongoTestEnvironment.cs
+++ b/dotnet/test/VectorData/MongoDB.ConformanceTests/Support/MongoTestEnvironment.cs
@@ -1,0 +1,26 @@
+﻿// Copyright (c) Microsoft. All rights reserved.
+
+using Microsoft.Extensions.Configuration;
+
+namespace MongoDB.ConformanceTests.Support;
+
+#pragma warning disable CA1810 // Initialize all static fields when those fields are declared
+
+internal static class MongoTestEnvironment
+{
+    public static readonly string? ConnectionUrl;
+
+    public static bool IsConnectionInfoDefined => ConnectionUrl is not null;
+
+    static MongoTestEnvironment()
+    {
+        var configuration = new ConfigurationBuilder()
+            .AddJsonFile(path: "testsettings.json", optional: true)
+            .AddJsonFile(path: "testsettings.development.json", optional: true)
+            .AddEnvironmentVariables()
+            .Build();
+
+        var mongoSection = configuration.GetSection("MongoDB");
+        ConnectionUrl = mongoSection["ConnectionURL"];
+    }
+}

--- a/dotnet/test/VectorData/MongoDB.ConformanceTests/Support/MongoTestStore.cs
+++ b/dotnet/test/VectorData/MongoDB.ConformanceTests/Support/MongoTestStore.cs
@@ -13,9 +13,7 @@ internal sealed class MongoTestStore : TestStore
 {
     public static MongoTestStore Instance { get; } = new();
 
-    private readonly MongoDbContainer _container = new MongoDbBuilder()
-        .WithImage("mongodb/mongodb-atlas-local:7.0.6")
-        .Build();
+    private MongoDbContainer? _container;
 
     public MongoClient? _client { get; private set; }
     public IMongoDatabase? _database { get; private set; }
@@ -32,21 +30,40 @@ internal sealed class MongoTestStore : TestStore
 
     protected override async Task StartAsync()
     {
+        var clientSettings = MongoTestEnvironment.IsConnectionInfoDefined
+            ? MongoClientSettings.FromConnectionString(MongoTestEnvironment.ConnectionUrl)
+            : await this.StartMongoDbContainerAsync();
+
+        this._client = new MongoClient(clientSettings);
+        this._database = this._client.GetDatabase("VectorSearchTests");
+        this.DefaultVectorStore = new MongoVectorStore(this._database);
+    }
+
+    private async Task<MongoClientSettings> StartMongoDbContainerAsync()
+    {
+        this._container = new MongoDbBuilder()
+            .WithImage("mongodb/mongodb-atlas-local:7.0.6")
+            .Build();
+
         using CancellationTokenSource cts = new();
         cts.CancelAfter(TimeSpan.FromSeconds(60));
         await this._container.StartAsync(cts.Token);
 
-        this._client = new MongoClient(new MongoClientSettings
+        return new MongoClientSettings
         {
             Server = new MongoServerAddress(this._container.Hostname, this._container.GetMappedPublicPort(MongoDbBuilder.MongoDbPort)),
             DirectConnection = true,
             // ReadConcern = ReadConcern.Linearizable,
             // WriteConcern = WriteConcern.WMajority
-        });
-        this._database = this._client.GetDatabase("VectorSearchTests");
-        this.DefaultVectorStore = new MongoVectorStore(this._database);
+        };
     }
 
-    protected override Task StopAsync()
-        => this._container.StopAsync();
+    protected override async Task StopAsync()
+    {
+        if (this._container != null)
+        {
+            await this._container.StopAsync();
+            this._container = null;
+        }
+    }
 }

--- a/dotnet/test/VectorData/VectorData.ConformanceTests/Support/TestStore.cs
+++ b/dotnet/test/VectorData/VectorData.ConformanceTests/Support/TestStore.cs
@@ -96,7 +96,7 @@ public abstract class TestStore
 
         var vector = dummyVector ?? new ReadOnlyMemory<float>(Enumerable.Range(0, vectorSize ?? 3).Select(i => (float)i).ToArray());
 
-        for (var i = 0; i < 20; i++)
+        for (var i = 0; i < 200; i++)
         {
             var results = collection.SearchAsync(
                 vector,


### PR DESCRIPTION
### Motivation and Context

We are running the SK tests in our https://github.com/mongodb-labs/ai-ml-pipeline-testing repo and would like to also be able to run them against live MongoDB Atlas clusters for further verification rather than just the Docker image.

### Description

The PR adjusts the vector data tests (only as per @roji recommendation) so that if an environment variable named `MONGODB__CONNECTIONURL` exists then that is used to connect to MongoDB rather than using TestContainers to fire up a Docker image of MongoDB Atlas.

Additionally to improve reliability it was found that we need to increase the number of attempts to wait for the data to be ready after creating an index. (Bumped from 20 to 200). We're going to look at adding index status helper methods in the C# Driver going forward for a better experience.

Once this is done we should be able to fully enable the new tests on our repo and diagnose any further instabilities and then be able to submit a PR to fully-enable the image-based tests here.

### Contribution Checklist

<!-- Before submitting this PR, please make sure: -->

- [x] The code builds clean without any errors or warnings
- [x] The PR follows the [SK Contribution Guidelines](https://github.com/microsoft/semantic-kernel/blob/main/CONTRIBUTING.md) and the [pre-submission formatting script](https://github.com/microsoft/semantic-kernel/blob/main/CONTRIBUTING.md#development-scripts) raises no violations
- [x] All unit tests pass, and I have added new tests where possible
- [x] I didn't break anyone :smile:
