### PR TITLE
Python: Fix the Responses agent msg chaining with reasoning models

### DIFF
--- a/python/tests/unit/agents/openai_responses/test_openai_responses_thread_actions.py
+++ b/python/tests/unit/agents/openai_responses/test_openai_responses_thread_actions.py
@@ -405,7 +405,7 @@ def test_prepare_chat_history_multiple_images_no_duplication():
     chat_history.add_message(message)
 
     # Call the method that was causing duplication
-    result = ResponsesAgentThreadActions._prepare_chat_history_for_request(chat_history)
+    result = ResponsesAgentThreadActions._prepare_chat_history_for_request(chat_history, True)
 
     # Verify we have exactly one message in the result
     assert len(result) == 1, f"Expected 1 message, got {len(result)}"


### PR DESCRIPTION
### Motivation and Context

When running a reasoning model with the OpenAI responses agent, it was producing 400s due to the way we were either including or not including FCC related to tool calls. This PR fixes it for both the default (store_enabled=True) and the case where uses don't want to use OpenAI's previous response id as a pseudo-thread (store_enabled=False).

<!-- Thank you for your contribution to the semantic-kernel repo!
Please help reviewers and future users, providing the following information:
  1. Why is this change required?
  2. What problem does it solve?
  3. What scenario does it contribute to?
  4. If it fixes an open issue, please link to the issue here.
-->

### Description

- Closes #12843

<!-- Describe your changes, the overall approach, the underlying design.
     These notes will help understanding how your code works. Thanks! -->

### Contribution Checklist

<!-- Before submitting this PR, please make sure: -->

- [X] The code builds clean without any errors or warnings
- [X] The PR follows the [SK Contribution Guidelines](https://github.com/microsoft/semantic-kernel/blob/main/CONTRIBUTING.md) and the [pre-submission formatting script](https://github.com/microsoft/semantic-kernel/blob/main/CONTRIBUTING.md#development-scripts) raises no violations
- [X] All unit tests pass, and I have added new tests where possible
- [X] I didn't break anyone :smile:
