### PR TITLE
docs(typing): add return type and docstring to store_results in utils/chat.py

### DIFF
--- a/python/semantic_kernel/utils/chat.py
+++ b/python/semantic_kernel/utils/chat.py
@@ -8,8 +8,18 @@ if TYPE_CHECKING:
     from semantic_kernel.contents.chat_message_content import ChatMessageContent
 
 
-def store_results(chat_history: ChatHistory, results: list["ChatMessageContent"]):
-    """Stores specific results in the context and chat prompt."""
+def store_results(
+        chat_history: ChatHistory, 
+        results: list["ChatMessageContent"]) -> ChatHistory:
+    """Stores specific results in the context and chat prompt.
+
+    Args:
+        chat_history(ChatHistory): The current chat history instance.
+        results(list["ChatMessageContent"]): Messages to be stored in the history.
+
+    Returns:
+        ChatHistory: Updated chat history containing the new messages.
+    """
     for message in results:
         chat_history.add_message(message=message)
     return chat_history


### PR DESCRIPTION
## Summary
- Added explicit return type `-> ChatHistory` to `store_results`.
- Added detailed docstring explaining parameters, return type, and behavior.

## Why
- Improves static analysis, IDE support, and code readability.
- Makes the function self-documenting for new contributors.

## Testing
- No changes to runtime behavior.
- Existing test suite passes locally.

### Motivation and Context

<!-- Thank you for your contribution to the semantic-kernel repo!
Please help reviewers and future users, providing the following information:
  1. Why is this change required?
  2. What problem does it solve?
  3. What scenario does it contribute to?
  4. If it fixes an open issue, please link to the issue here.
-->

### Description

<!-- Describe your changes, the overall approach, the underlying design.
     These notes will help understanding how your code works. Thanks! -->

### Contribution Checklist

<!-- Before submitting this PR, please make sure: -->

- [ ] The code builds clean without any errors or warnings
- [ ] The PR follows the [SK Contribution Guidelines](https://github.com/microsoft/semantic-kernel/blob/main/CONTRIBUTING.md) and the [pre-submission formatting script](https://github.com/microsoft/semantic-kernel/blob/main/CONTRIBUTING.md#development-scripts) raises no violations
- [ ] All unit tests pass, and I have added new tests where possible
- [ ] I didn't break anyone :smile:
