### PR TITLE
Input & output attributes in invoke_agent span

### DIFF
--- a/dotnet/samples/Demos/TelemetryWithAppInsights/Program.cs
+++ b/dotnet/samples/Demos/TelemetryWithAppInsights/Program.cs
@@ -18,11 +18,13 @@ using Microsoft.SemanticKernel.Connectors.HuggingFace;
 using Microsoft.SemanticKernel.Connectors.MistralAI;
 using Microsoft.SemanticKernel.Connectors.OpenAI;
 using Microsoft.SemanticKernel.Services;
+using Microsoft.SemanticKernel.Agents;
 using OpenTelemetry;
 using OpenTelemetry.Logs;
 using OpenTelemetry.Metrics;
 using OpenTelemetry.Resources;
 using OpenTelemetry.Trace;
+using Microsoft.SemanticKernel.ChatCompletion;
 
 /// <summary>
 /// Example of telemetry in Semantic Kernel using Application Insights within console application.
@@ -100,6 +102,13 @@ public sealed class Program
         using (var _ = s_activitySource.StartActivity("ToolCalls"))
         {
             await RunAzureOpenAIToolCallsAsync(kernel);
+            Console.WriteLine();
+        }
+
+        Console.WriteLine("Run ChatCompletion Agent.");
+        using (var _ = s_activitySource.StartActivity("Agent"))
+        {
+            await RunChatCompletionAgentAsync(kernel);
             Console.WriteLine();
         }
     }
@@ -305,6 +314,40 @@ public sealed class Program
 
         Console.WriteLine(result);
     }
+    #endregion
+
+    #region Agent
+
+    private static async Task RunChatCompletionAgentAsync(Kernel kernel)
+    {
+        Console.WriteLine("============= ChatCompletion Agent =============");
+
+        if (TestConfiguration.AzureOpenAI is null)
+        {
+            Console.WriteLine("Azure OpenAI is not configured. Skipping.");
+            return;
+        }
+
+        SetTargetService(kernel, AzureOpenAIServiceKey);
+
+        // Define the agent
+        ChatCompletionAgent agent =
+            new()
+            {
+                Name = "TestAgent",
+                Instructions = "You are a helpful assistant.",
+                Kernel = kernel
+            };
+
+        ChatMessageContent message = new(AuthorRole.User, "Write a poem about John Doe.");
+        Console.WriteLine($"User: {message.Content}");
+
+        await foreach (AgentResponseItem<ChatMessageContent> response in agent.InvokeAsync(message))
+        {
+            Console.WriteLine($"Agent: {response.Message.Content}");
+        }
+    }
+
     #endregion
 
     private static Kernel GetKernel(ILoggerFactory loggerFactory)

--- a/dotnet/samples/Demos/TelemetryWithAppInsights/TelemetryWithAppInsights.csproj
+++ b/dotnet/samples/Demos/TelemetryWithAppInsights/TelemetryWithAppInsights.csproj
@@ -25,6 +25,7 @@
     <ProjectReference Include="..\..\..\src\Connectors\Connectors.Google\Connectors.Google.csproj" />
     <ProjectReference Include="..\..\..\src\Connectors\Connectors.HuggingFace\Connectors.HuggingFace.csproj" />
     <ProjectReference Include="..\..\..\src\SemanticKernel.Core\SemanticKernel.Core.csproj" />
+    <ProjectReference Include="..\..\..\src\Agents\Core\Agents.Core.csproj" />
     <ProjectReference Include="..\..\..\src\Plugins\Plugins.Core\Plugins.Core.csproj" />
     <ProjectReference Include="..\..\..\src\Plugins\Plugins.Web\Plugins.Web.csproj" />
   </ItemGroup>

--- a/dotnet/src/Agents/AzureAI/AzureAIAgent.cs
+++ b/dotnet/src/Agents/AzureAI/AzureAIAgent.cs
@@ -162,7 +162,7 @@ public sealed partial class AzureAIAgent : Agent
             new AzureAIAgentInvokeOptions(options) { AdditionalInstructions = mergedAdditionalInstructions };
 
         var invokeResults = ActivityExtensions.RunWithActivityAsync(
-            () => ModelDiagnostics.StartAgentInvocationActivity(this.Id, this.GetDisplayName(), this.Description),
+            () => ModelDiagnostics.StartAgentInvocationActivity(this.Id, this.GetDisplayName(), this.Description, messages),
             () => InternalInvokeAsync(),
             cancellationToken);
 
@@ -268,7 +268,7 @@ public sealed partial class AzureAIAgent : Agent
         // a chat history to receive complete messages.
         ChatHistory newMessagesReceiver = [];
         var invokeResults = ActivityExtensions.RunWithActivityAsync(
-            () => ModelDiagnostics.StartAgentInvocationActivity(this.Id, this.GetDisplayName(), this.Description),
+            () => ModelDiagnostics.StartAgentInvocationActivity(this.Id, this.GetDisplayName(), this.Description, messages),
             () => AgentThreadActions.InvokeStreamingAsync(
                 this,
                 this.Client,

--- a/dotnet/src/Agents/AzureAI/AzureAIChannel.cs
+++ b/dotnet/src/Agents/AzureAI/AzureAIChannel.cs
@@ -45,7 +45,7 @@ internal sealed class AzureAIChannel(PersistentAgentsClient client, string threa
         CancellationToken cancellationToken)
     {
         return ActivityExtensions.RunWithActivityAsync(
-            () => ModelDiagnostics.StartAgentInvocationActivity(agent.Id, agent.GetDisplayName(), agent.Description),
+            () => ModelDiagnostics.StartAgentInvocationActivity(agent.Id, agent.GetDisplayName(), agent.Description, []),
             () => AgentThreadActions.InvokeAsync(agent, client, threadId, invocationOptions: null, this.Logger, agent.Kernel, agent.Arguments, cancellationToken),
             cancellationToken);
     }
@@ -54,7 +54,7 @@ internal sealed class AzureAIChannel(PersistentAgentsClient client, string threa
     protected override IAsyncEnumerable<StreamingChatMessageContent> InvokeStreamingAsync(AzureAIAgent agent, IList<ChatMessageContent> messages, CancellationToken cancellationToken = default)
     {
         return ActivityExtensions.RunWithActivityAsync(
-            () => ModelDiagnostics.StartAgentInvocationActivity(agent.Id, agent.GetDisplayName(), agent.Description),
+            () => ModelDiagnostics.StartAgentInvocationActivity(agent.Id, agent.GetDisplayName(), agent.Description, messages),
             () => AgentThreadActions.InvokeStreamingAsync(agent, client, threadId, messages, invocationOptions: null, this.Logger, agent.Kernel, agent.Arguments, cancellationToken),
             cancellationToken);
     }

--- a/dotnet/src/Agents/Bedrock/BedrockAgent.cs
+++ b/dotnet/src/Agents/Bedrock/BedrockAgent.cs
@@ -107,7 +107,6 @@ public sealed class BedrockAgent : Agent
         AgentInvokeOptions? options = null,
         [EnumeratorCancellation] CancellationToken cancellationToken = default)
     {
-        Verify.NotNull(messages, nameof(messages));
         if (messages.Count == 0)
         {
             throw new InvalidOperationException("The Bedrock agent requires a message to be invoked.");
@@ -145,15 +144,21 @@ public sealed class BedrockAgent : Agent
             };
         });
 
+        using var activity = ModelDiagnostics.StartAgentInvocationActivity(this.Id, this.GetDisplayName(), this.Description, messages);
+
         // Invoke the agent
         var invokeResults = this.InvokeInternalAsync(invokeAgentRequest, options?.KernelArguments, cancellationToken);
+        List<ChatMessageContent>? chatMessageContents = activity is not null ? [] : null;
 
         // Return the results to the caller in AgentResponseItems.
         await foreach (var result in invokeResults.ConfigureAwait(false))
         {
             await this.NotifyThreadOfNewMessage(bedrockThread, result, cancellationToken).ConfigureAwait(false);
             yield return new(result, bedrockThread);
+            chatMessageContents?.Add(result);
         }
+
+        activity?.SetAgentResponse(messages);
     }
 
     /// <summary>
@@ -206,6 +211,9 @@ public sealed class BedrockAgent : Agent
         invokeAgentRequest.SessionId = bedrockThread.Id;
         invokeAgentRequest = this.ConfigureAgentRequest(options, () => invokeAgentRequest);
 
+        using var activity = ModelDiagnostics.StartAgentInvocationActivity(this.Id, this.GetDisplayName(), this.Description, []);
+        List<ChatMessageContent>? chatMessageContents = activity is not null ? [] : null;
+
         // Invoke the agent
         var invokeResults = this.InvokeInternalAsync(invokeAgentRequest, options?.KernelArguments, cancellationToken);
 
@@ -214,7 +222,10 @@ public sealed class BedrockAgent : Agent
         {
             await this.NotifyThreadOfNewMessage(bedrockThread, result, cancellationToken).ConfigureAwait(false);
             yield return new(result, bedrockThread);
+            chatMessageContents?.Add(result);
         }
+
+        activity?.SetAgentResponse(chatMessageContents);
     }
 
     #endregion
@@ -286,6 +297,9 @@ public sealed class BedrockAgent : Agent
             };
         });
 
+        using var activity = ModelDiagnostics.StartAgentInvocationActivity(this.Id, this.GetDisplayName(), this.Description, []);
+        List<StreamingChatMessageContent>? streamedContents = activity is not null ? [] : null;
+
         // Invoke the agent
         var invokeResults = this.InvokeStreamingInternalAsync(invokeAgentRequest, bedrockThread, options?.KernelArguments, cancellationToken);
 
@@ -293,7 +307,10 @@ public sealed class BedrockAgent : Agent
         await foreach (var result in invokeResults.ConfigureAwait(false))
         {
             yield return new(result, bedrockThread);
+            streamedContents?.Add(result);
         }
+
+        activity?.EndAgentStreamingResponse(streamedContents);
     }
 
     /// <summary>
@@ -348,6 +365,9 @@ public sealed class BedrockAgent : Agent
         invokeAgentRequest.SessionId = bedrockThread.Id;
         invokeAgentRequest = this.ConfigureAgentRequest(options, () => invokeAgentRequest);
 
+        using var activity = ModelDiagnostics.StartAgentInvocationActivity(this.Id, this.GetDisplayName(), this.Description, []);
+        List<StreamingChatMessageContent>? streamedContents = activity is not null ? [] : null;
+
         var invokeResults = this.InvokeStreamingInternalAsync(invokeAgentRequest, bedrockThread, options?.KernelArguments, cancellationToken);
 
         // The Bedrock agent service has the same API for both streaming and non-streaming responses.
@@ -364,7 +384,10 @@ public sealed class BedrockAgent : Agent
                     Metadata = chatMessageContent.Metadata,
                 },
                 thread: bedrockThread);
+            streamedContents?.Add(chatMessageContent);
         }
+
+        activity?.EndAgentStreamingResponse(streamedContents);
     }
 
     #endregion
@@ -409,10 +432,7 @@ public sealed class BedrockAgent : Agent
     {
         return invokeAgentRequest.StreamingConfigurations != null && (invokeAgentRequest.StreamingConfigurations.StreamFinalResponse ?? false)
             ? throw new ArgumentException("The streaming configuration must be null for non-streaming responses.")
-            : ActivityExtensions.RunWithActivityAsync(
-                () => ModelDiagnostics.StartAgentInvocationActivity(this.Id, this.GetDisplayName(), this.Description, []),
-                InvokeInternal,
-                cancellationToken);
+            : InvokeInternal();
 
         // Collect all responses from the agent and return them as a single chat message content since this
         // is a non-streaming API.

--- a/dotnet/src/Agents/Bedrock/BedrockAgent.cs
+++ b/dotnet/src/Agents/Bedrock/BedrockAgent.cs
@@ -410,7 +410,7 @@ public sealed class BedrockAgent : Agent
         return invokeAgentRequest.StreamingConfigurations != null && (invokeAgentRequest.StreamingConfigurations.StreamFinalResponse ?? false)
             ? throw new ArgumentException("The streaming configuration must be null for non-streaming responses.")
             : ActivityExtensions.RunWithActivityAsync(
-                () => ModelDiagnostics.StartAgentInvocationActivity(this.Id, this.GetDisplayName(), this.Description),
+                () => ModelDiagnostics.StartAgentInvocationActivity(this.Id, this.GetDisplayName(), this.Description, []),
                 InvokeInternal,
                 cancellationToken);
 
@@ -472,7 +472,7 @@ public sealed class BedrockAgent : Agent
         }
 
         return ActivityExtensions.RunWithActivityAsync(
-            () => ModelDiagnostics.StartAgentInvocationActivity(this.Id, this.GetDisplayName(), this.Description),
+            () => ModelDiagnostics.StartAgentInvocationActivity(this.Id, this.GetDisplayName(), this.Description, []),
             InvokeInternal,
             cancellationToken);
 

--- a/dotnet/src/Agents/Core/ChatCompletionAgent.cs
+++ b/dotnet/src/Agents/Core/ChatCompletionAgent.cs
@@ -238,16 +238,13 @@ public sealed class ChatCompletionAgent : ChatHistoryAgent
     {
         string agentName = this.GetDisplayName();
 
-        return ActivityExtensions.RunWithActivityAsync(
-            () => ModelDiagnostics.StartAgentInvocationActivity(this.Id, agentName, this.Description, history),
-            () => this.InternalInvokeStreamingAsync(
-                agentName,
-                history,
-                (newMessage) => Task.CompletedTask,
-                arguments,
-                kernel,
-                null,
-                cancellationToken),
+        return this.InternalInvokeStreamingAsync(
+            agentName,
+            history,
+            (newMessage) => Task.CompletedTask,
+            arguments,
+            kernel,
+            null,
             cancellationToken);
     }
 

--- a/dotnet/src/Agents/OpenAI/OpenAIAssistantAgent.cs
+++ b/dotnet/src/Agents/OpenAI/OpenAIAssistantAgent.cs
@@ -158,10 +158,17 @@ public sealed partial class OpenAIAssistantAgent : Agent
         kernel.Plugins.AddFromAIContext(providersContext, "Tools");
 #pragma warning restore SKEXP0110, SKEXP0130 // Type is for evaluation purposes only and is subject to change or removal in future updates. Suppress this diagnostic to proceed.
 
-        var invokeResults = ActivityExtensions.RunWithActivityAsync(
-            () => ModelDiagnostics.StartAgentInvocationActivity(this.Id, this.GetDisplayName(), this.Description, messages),
-            () => InternalInvokeAsync(),
-            cancellationToken);
+        using var activity = ModelDiagnostics.StartAgentInvocationActivity(this.Id, this.GetDisplayName(), this.Description, messages);
+        List<ChatMessageContent>? chatMessageContents = activity is not null ? [] : null;
+
+        // Notify the thread of new messages and return them to the caller.
+        await foreach (var result in InternalInvokeAsync().ConfigureAwait(false))
+        {
+            yield return new(result, openAIAssistantAgentThread);
+            chatMessageContents?.Add(result);
+        }
+
+        activity?.SetAgentResponse(messages);
 
         async IAsyncEnumerable<ChatMessageContent> InternalInvokeAsync()
         {
@@ -188,12 +195,6 @@ public sealed partial class OpenAIAssistantAgent : Agent
                     yield return message;
                 }
             }
-        }
-
-        // Notify the thread of new messages and return them to the caller.
-        await foreach (var result in invokeResults.ConfigureAwait(false))
-        {
-            yield return new(result, openAIAssistantAgentThread);
         }
     }
 
@@ -266,11 +267,11 @@ public sealed partial class OpenAIAssistantAgent : Agent
         });
 
 #pragma warning disable SKEXP0001 // ModelDiagnostics is marked experimental.
+        using var activity = ModelDiagnostics.StartAgentInvocationActivity(this.Id, this.GetDisplayName(), this.Description, messages);
+        List<StreamingChatMessageContent>? streamedContents = activity is not null ? [] : null;
+
         ChatHistory newMessagesReceiver = [];
-        var invokeResults = ActivityExtensions.RunWithActivityAsync(
-            () => ModelDiagnostics.StartAgentInvocationActivity(this.Id, this.GetDisplayName(), this.Description, messages),
-            () => InternalInvokeStreamingAsync(),
-            cancellationToken);
+        var invokeResults = InternalInvokeStreamingAsync();
 #pragma warning restore SKEXP0001 // ModelDiagnostics is marked experimental.
 
         IAsyncEnumerable<StreamingChatMessageContent> InternalInvokeStreamingAsync()
@@ -296,10 +297,13 @@ public sealed partial class OpenAIAssistantAgent : Agent
             await NotifyMessagesAsync().ConfigureAwait(false);
 
             yield return new(result, openAIAssistantAgentThread);
+            streamedContents?.Add(result);
         }
 
         // Notify the thread of any remaining messages that were assembled from the streaming response after all iterations are complete.
         await NotifyMessagesAsync().ConfigureAwait(false);
+
+        activity?.EndAgentStreamingResponse(streamedContents);
 
         async Task NotifyMessagesAsync()
         {

--- a/dotnet/src/Agents/OpenAI/OpenAIAssistantAgent.cs
+++ b/dotnet/src/Agents/OpenAI/OpenAIAssistantAgent.cs
@@ -159,7 +159,7 @@ public sealed partial class OpenAIAssistantAgent : Agent
 #pragma warning restore SKEXP0110, SKEXP0130 // Type is for evaluation purposes only and is subject to change or removal in future updates. Suppress this diagnostic to proceed.
 
         var invokeResults = ActivityExtensions.RunWithActivityAsync(
-            () => ModelDiagnostics.StartAgentInvocationActivity(this.Id, this.GetDisplayName(), this.Description),
+            () => ModelDiagnostics.StartAgentInvocationActivity(this.Id, this.GetDisplayName(), this.Description, messages),
             () => InternalInvokeAsync(),
             cancellationToken);
 
@@ -268,7 +268,7 @@ public sealed partial class OpenAIAssistantAgent : Agent
 #pragma warning disable SKEXP0001 // ModelDiagnostics is marked experimental.
         ChatHistory newMessagesReceiver = [];
         var invokeResults = ActivityExtensions.RunWithActivityAsync(
-            () => ModelDiagnostics.StartAgentInvocationActivity(this.Id, this.GetDisplayName(), this.Description),
+            () => ModelDiagnostics.StartAgentInvocationActivity(this.Id, this.GetDisplayName(), this.Description, messages),
             () => InternalInvokeStreamingAsync(),
             cancellationToken);
 #pragma warning restore SKEXP0001 // ModelDiagnostics is marked experimental.

--- a/dotnet/src/Agents/OpenAI/OpenAIAssistantChannel.cs
+++ b/dotnet/src/Agents/OpenAI/OpenAIAssistantChannel.cs
@@ -50,7 +50,7 @@ internal sealed class OpenAIAssistantChannel(AssistantClient client, string thre
         CancellationToken cancellationToken)
     {
         return ActivityExtensions.RunWithActivityAsync(
-            () => ModelDiagnostics.StartAgentInvocationActivity(agent.Id, agent.GetDisplayName(), agent.Description),
+            () => ModelDiagnostics.StartAgentInvocationActivity(agent.Id, agent.GetDisplayName(), agent.Description, []),
             () => AssistantThreadActions.InvokeAsync(agent, this._client, this._threadId, invocationOptions: null, providersAdditionalInstructions: null, this.Logger, agent.Kernel, agent.Arguments, cancellationToken),
             cancellationToken);
     }
@@ -59,7 +59,7 @@ internal sealed class OpenAIAssistantChannel(AssistantClient client, string thre
     protected override IAsyncEnumerable<StreamingChatMessageContent> InvokeStreamingAsync(OpenAIAssistantAgent agent, IList<ChatMessageContent> messages, CancellationToken cancellationToken = default)
     {
         return ActivityExtensions.RunWithActivityAsync(
-            () => ModelDiagnostics.StartAgentInvocationActivity(agent.Id, agent.GetDisplayName(), agent.Description),
+            () => ModelDiagnostics.StartAgentInvocationActivity(agent.Id, agent.GetDisplayName(), agent.Description, messages),
             () => AssistantThreadActions.InvokeStreamingAsync(agent, this._client, this._threadId, messages, invocationOptions: null, providersAdditionalInstructions: null, this.Logger, agent.Kernel, agent.Arguments, cancellationToken),
             cancellationToken);
     }


### PR DESCRIPTION
### Motivation and Context

<!-- Thank you for your contribution to the semantic-kernel repo!
Please help reviewers and future users, providing the following information:
  1. Why is this change required?
  2. What problem does it solve?
  3. What scenario does it contribute to?
  4. If it fixes an open issue, please link to the issue here.
-->
The OTel workgroup has been thinking about enhancing tracing for agents. This is a proposal from our tracing team: https://github.com/open-telemetry/semantic-conventions/pull/2528. This PR implements part of the proposal so that when the proposal gets merged, we can quickly follow.

This is a follow-up PR after the Python PR #12834 
### Description

<!-- Describe your changes, the overall approach, the underlying design.
     These notes will help understanding how your code works. Thanks! -->

Two new attributes are added to the invoke_agent span, namely the `gen_ai.agent.invocation_input` and `gen_ai.agent.invocation_output`.

<img width="870" height="384" alt="image" src="https://github.com/user-attachments/assets/c2cf069a-af00-4ae2-8fed-745c166d9cbc" />

### Contribution Checklist

<!-- Before submitting this PR, please make sure: -->

- [ ] The code builds clean without any errors or warnings
- [ ] The PR follows the [SK Contribution Guidelines](https://github.com/microsoft/semantic-kernel/blob/main/CONTRIBUTING.md) and the [pre-submission formatting script](https://github.com/microsoft/semantic-kernel/blob/main/CONTRIBUTING.md#development-scripts) raises no violations
- [ ] All unit tests pass, and I have added new tests where possible
- [ ] I didn't break anyone :smile:
