### PR TITLE
Python: Bump Python version to 1.35.3 for a release

### DIFF
--- a/python/semantic_kernel/__init__.py
+++ b/python/semantic_kernel/__init__.py
@@ -2,7 +2,7 @@
 
 from semantic_kernel.kernel import Kernel
 
-__version__ = "1.35.2"
+__version__ = "1.35.3"
 
 DEFAULT_RC_VERSION = f"{__version__}-rc9"
 


### PR DESCRIPTION
### Motivation and Context

Bump Python version to 1.35.3 for a release

<!-- Thank you for your contribution to the semantic-kernel repo!
Please help reviewers and future users, providing the following information:
  1. Why is this change required?
  2. What problem does it solve?
  3. What scenario does it contribute to?
  4. If it fixes an open issue, please link to the issue here.
-->

### Description

Bump Python version to 1.35.3 for a release

<!-- Describe your changes, the overall approach, the underlying design.
     These notes will help understanding how your code works. Thanks! -->

### Contribution Checklist

<!-- Before submitting this PR, please make sure: -->

- [X] The code builds clean without any errors or warnings
- [X] The PR follows the [SK Contribution Guidelines](https://github.com/microsoft/semantic-kernel/blob/main/CONTRIBUTING.md) and the [pre-submission formatting script](https://github.com/microsoft/semantic-kernel/blob/main/CONTRIBUTING.md#development-scripts) raises no violations
- [X] All unit tests pass, and I have added new tests where possible
- [X] I didn't break anyone :smile:
