### PR TITLE
.Net: Support tuned models on Vertex AI

### DIFF
--- a/dotnet/src/Connectors/Connectors.Google/Core/Gemini/Clients/GeminiChatCompletionClient.cs
+++ b/dotnet/src/Connectors/Connectors.Google/Core/Gemini/Clients/GeminiChatCompletionClient.cs
@@ -122,6 +122,7 @@ internal sealed class GeminiChatCompletionClient : ClientBase
     /// <param name="location">The region to process the request</param>
     /// <param name="projectId">Project ID from google cloud</param>
     /// <param name="apiVersion">Version of the Vertex API</param>
+    /// <param name="isFineTunedModel">Whether this is a tuned model or not</param>
     /// <param name="logger">Logger instance used for logging (optional)</param>
     public GeminiChatCompletionClient(
         HttpClient httpClient,
@@ -130,6 +131,7 @@ internal sealed class GeminiChatCompletionClient : ClientBase
         string location,
         string projectId,
         VertexAIVersion apiVersion,
+        bool isFineTunedModel = false,
         ILogger? logger = null)
         : base(
             httpClient: httpClient,
@@ -144,8 +146,17 @@ internal sealed class GeminiChatCompletionClient : ClientBase
         string versionSubLink = GetApiVersionSubLink(apiVersion);
 
         this._modelId = modelId;
-        this._chatGenerationEndpoint = new Uri($"https://{location}-aiplatform.googleapis.com/{versionSubLink}/projects/{projectId}/locations/{location}/publishers/google/models/{this._modelId}:generateContent");
-        this._chatStreamingEndpoint = new Uri($"https://{location}-aiplatform.googleapis.com/{versionSubLink}/projects/{projectId}/locations/{location}/publishers/google/models/{this._modelId}:streamGenerateContent?alt=sse");
+
+        if (isFineTunedModel)
+        {
+            this._chatGenerationEndpoint = new Uri($"https://{location}-aiplatform.googleapis.com/{versionSubLink}/projects/{projectId}/locations/{location}/endpoints/{this._modelId}:generateContent");
+            this._chatStreamingEndpoint = new Uri($"https://{location}-aiplatform.googleapis.com/{versionSubLink}/projects/{projectId}/locations/{location}/endpoints/{this._modelId}:streamGenerateContent?alt=sse");
+        }
+        else
+        {
+            this._chatGenerationEndpoint = new Uri($"https://{location}-aiplatform.googleapis.com/{versionSubLink}/projects/{projectId}/locations/{location}/publishers/google/models/{this._modelId}:generateContent");
+            this._chatStreamingEndpoint = new Uri($"https://{location}-aiplatform.googleapis.com/{versionSubLink}/projects/{projectId}/locations/{location}/publishers/google/models/{this._modelId}:streamGenerateContent?alt=sse");
+        }
     }
 
     /// <summary>

--- a/dotnet/src/Connectors/Connectors.Google/Extensions/VertexAIKernelBuilderExtensions.cs
+++ b/dotnet/src/Connectors/Connectors.Google/Extensions/VertexAIKernelBuilderExtensions.cs
@@ -27,6 +27,7 @@ public static class VertexAIKernelBuilderExtensions
     /// <param name="location">The location to process the request</param>
     /// <param name="projectId">Your project ID</param>
     /// <param name="apiVersion">The version of the Vertex API.</param>
+    /// <param name="isFineTunedModel">Whether this is a tuned model or not</param>
     /// <param name="serviceId">The optional service ID.</param>
     /// <param name="httpClient">The optional custom HttpClient.</param>
     /// <returns>The updated kernel builder.</returns>
@@ -42,6 +43,7 @@ public static class VertexAIKernelBuilderExtensions
         string location,
         string projectId,
         VertexAIVersion apiVersion = VertexAIVersion.V1,
+        bool isFineTunedModel = false,
         string? serviceId = null,
         HttpClient? httpClient = null)
     {
@@ -58,6 +60,7 @@ public static class VertexAIKernelBuilderExtensions
                 location: location,
                 projectId: projectId,
                 apiVersion: apiVersion,
+                isFineTunedModel: isFineTunedModel,
                 httpClient: HttpClientProvider.GetHttpClient(httpClient, serviceProvider),
                 loggerFactory: serviceProvider.GetService<ILoggerFactory>()));
         return builder;

--- a/dotnet/src/Connectors/Connectors.Google/Services/VertexAIGeminiChatCompletionService.cs
+++ b/dotnet/src/Connectors/Connectors.Google/Services/VertexAIGeminiChatCompletionService.cs
@@ -29,6 +29,7 @@ public sealed class VertexAIGeminiChatCompletionService : IChatCompletionService
     /// <param name="location">The region to process the request</param>
     /// <param name="projectId">Your project ID</param>
     /// <param name="apiVersion">Version of the Vertex API</param>
+    /// <param name="isFineTunedModel">Whether this is a tuned model or not</param>
     /// <param name="httpClient">Optional HTTP client to be used for communication with the Gemini API.</param>
     /// <param name="loggerFactory">Optional logger factory to be used for logging.</param>
     public VertexAIGeminiChatCompletionService(
@@ -37,9 +38,10 @@ public sealed class VertexAIGeminiChatCompletionService : IChatCompletionService
         string location,
         string projectId,
         VertexAIVersion apiVersion = VertexAIVersion.V1,
+        bool isFineTunedModel = false,
         HttpClient? httpClient = null,
         ILoggerFactory? loggerFactory = null)
-        : this(modelId, () => new ValueTask<string>(bearerKey), location, projectId, apiVersion, httpClient, loggerFactory)
+        : this(modelId, () => new ValueTask<string>(bearerKey), location, projectId, apiVersion, isFineTunedModel, httpClient, loggerFactory)
     {
         Verify.NotNullOrWhiteSpace(bearerKey);
     }
@@ -52,6 +54,7 @@ public sealed class VertexAIGeminiChatCompletionService : IChatCompletionService
     /// <param name="location">The region to process the request</param>
     /// <param name="projectId">Your project ID</param>
     /// <param name="apiVersion">Version of the Vertex API</param>
+    /// <param name="isFineTunedModel">Whether this is a tuned model or not</param>
     /// <param name="httpClient">Optional HTTP client to be used for communication with the Gemini API.</param>
     /// <param name="loggerFactory">Optional logger factory to be used for logging.</param>
     /// <remarks>
@@ -65,6 +68,7 @@ public sealed class VertexAIGeminiChatCompletionService : IChatCompletionService
         string location,
         string projectId,
         VertexAIVersion apiVersion = VertexAIVersion.V1,
+        bool isFineTunedModel = false,
         HttpClient? httpClient = null,
         ILoggerFactory? loggerFactory = null)
     {
@@ -82,6 +86,7 @@ public sealed class VertexAIGeminiChatCompletionService : IChatCompletionService
             location: location,
             projectId: projectId,
             apiVersion: apiVersion,
+            isFineTunedModel: isFineTunedModel,
             logger: loggerFactory?.CreateLogger(typeof(VertexAIGeminiChatCompletionService)));
         this._attributesInternal.Add(AIServiceExtensions.ModelIdKey, modelId);
     }


### PR DESCRIPTION
### Motivation and Context

<!-- Thank you for your contribution to the semantic-kernel repo!
Please help reviewers and future users, providing the following information:
  1. Why is this change required?
  2. What problem does it solve?
  3. What scenario does it contribute to?
  4. If it fixes an open issue, please link to the issue here.
-->

Original issue is #12941.

The current GeminiChatCompletionClient implementation only supports publisher models using this format: `projects/{project}/locations/{location}/publishers/*/models/*`

However, according to the [Vertex AI REST API doc](https://cloud.google.com/vertex-ai/docs/reference/rest/v1/projects.locations.endpoints/generateContent), fine-tuned models must be accessed using the format: `projects/{project}/locations/{location}/endpoints/{endpoint}`

It means that, if I want to use standard models like gemini-2.0-flash, gemini-2.5-flash, gemini-2.5-pro, etc., then it will work. But if I fine-tune them, creating tuned models, on Vertex AI, then there is no way for me to use them with Semantic Kernel. Tuning models on Vertex AI is a big reason why I use Vertex AI in the first place.


### Description

<!-- Describe your changes, the overall approach, the underlying design.
     These notes will help understanding how your code works. Thanks! -->

I add `isFineTunedModel` bool parameter. It is optional and will be `false` by default. No breaking change with previous implementation. I also add the parameter to the upstream classes and extension methods so that I can do the following on the consuming side.

```csharp
using Microsoft.SemanticKernel;
using Google.Apis.Auth.OAuth2;
using Microsoft.SemanticKernel.ChatCompletion;

var builder = Kernel.CreateBuilder();
var modelId = "{endpointId}"; // Endpoint ID from Vertex AI
var credential = GoogleCredential.GetApplicationDefault()
    .CreateScoped("https://www.googleapis.com/auth/cloud-platform");
builder.AddVertexAIGeminiChatCompletion(
    modelId,
    () =>
    {
        var credential = GoogleCredential.GetApplicationDefault()
            .CreateScoped("https://www.googleapis.com/auth/cloud-platform");
        var token = credential
            .UnderlyingCredential
            .GetAccessTokenForRequestAsync().Result;
        return new ValueTask<string>(token);
    },
    "location",
    "endpointId",
    Microsoft.SemanticKernel.Connectors.Google.VertexAIVersion.V1,
    true);
var kernel = builder.Build();

var chatCompletionService = kernel.GetRequiredService<IChatCompletionService>();
var chatHistory = new ChatHistory();
chatHistory.AddUserMessage("What is capital of Italy?");

try
{
    var result = await chatCompletionService.GetChatMessageContentAsync(
        chatHistory,
        null,
        kernel);
    Console.WriteLine("Response:");
    Console.WriteLine(result.Content);
}
catch (Exception ex)
{
    Console.WriteLine($"Error: {ex.Message}");
}

Console.ReadLine();
```

### Contribution Checklist

<!-- Before submitting this PR, please make sure: -->

- [x] The code builds clean without any errors or warnings
- [x] The PR follows the [SK Contribution Guidelines](https://github.com/microsoft/semantic-kernel/blob/main/CONTRIBUTING.md) and the [pre-submission formatting script](https://github.com/microsoft/semantic-kernel/blob/main/CONTRIBUTING.md#development-scripts) raises no violations
- [x] All unit tests pass, and I have added new tests where possible
- [x] I didn't break anyone :smile:
