### PR TITLE
.Net: Add OpenApi parameter description to its schema

### DIFF
--- a/dotnet/src/Functions/Functions.UnitTests/OpenApi/OpenApiKernelPluginFactoryTests.cs
+++ b/dotnet/src/Functions/Functions.UnitTests/OpenApi/OpenApiKernelPluginFactoryTests.cs
@@ -716,6 +716,27 @@ public sealed class OpenApiKernelPluginFactoryTests
     }
 
     [Fact]
+    public async Task ItCanAddPropertyDescriptionToSchemaAsync()
+    {
+        // Act
+        var plugin = await OpenApiKernelPluginFactory.CreateFromOpenApiAsync("fakePlugin", this._openApiDocument, this._executionParameters);
+
+        // Assert
+        var setSecretFunction = plugin["SetSecret"];
+        Assert.NotNull(setSecretFunction);
+
+        var functionView = setSecretFunction.Metadata;
+        Assert.NotNull(functionView);
+
+        // Check if description is added to the parameter schema
+        var secretNameParameter = functionView.Parameters.First(p => p.Name == "secret_name");
+        Assert.Equal("The name of the secret", secretNameParameter.Description);
+
+        Assert.True(secretNameParameter.Schema!.RootElement.TryGetProperty("description", out var description));
+        Assert.Equal("The name of the secret", description.GetString());
+    }
+
+    [Fact]
     public void Dispose()
     {
         this._openApiDocument.Dispose();

--- a/dotnet/src/Functions/Functions.UnitTests/OpenApi/TestPlugins/documentV2_0.json
+++ b/dotnet/src/Functions/Functions.UnitTests/OpenApi/TestPlugins/documentV2_0.json
@@ -83,6 +83,7 @@
             "in": "path",
             "name": "secret-name",
             "required": true,
+            "description": "The name of the secret",
             "type": "string"
           },
           {

--- a/dotnet/src/Functions/Functions.UnitTests/OpenApi/TestPlugins/documentV3_0.json
+++ b/dotnet/src/Functions/Functions.UnitTests/OpenApi/TestPlugins/documentV3_0.json
@@ -88,6 +88,7 @@
             "name": "secret-name",
             "in": "path",
             "required": true,
+            "description": "The name of the secret",
             "schema": {
               "type": "string"
             }

--- a/dotnet/src/Functions/Functions.UnitTests/OpenApi/TestPlugins/documentV3_1.yaml
+++ b/dotnet/src/Functions/Functions.UnitTests/OpenApi/TestPlugins/documentV3_1.yaml
@@ -57,6 +57,7 @@ paths:
         - name: secret-name
           in: path
           required: true
+          description: The name of the secret
           schema:
             type: string
         - name: api-version


### PR DESCRIPTION
This PR adds OpenAPI parameter description to its schema to provide more details to ai model about it.