### PR TITLE
.Net: Updated encoding logic in prompt templates

### DIFF
--- a/dotnet/samples/Concepts/PromptTemplates/HandlebarsPrompts.cs
+++ b/dotnet/samples/Concepts/PromptTemplates/HandlebarsPrompts.cs
@@ -67,6 +67,14 @@ public class HandlebarsPrompts(ITestOutputHelper output) : BaseTest(output)
             Template = template,
             TemplateFormat = "handlebars",
             Name = "ContosoChatPrompt",
+            InputVariables = new()
+            {
+                // Set AllowDangerouslySetContent to 'true' only if arguments do not contain harmful content.
+                // Consider encoding for each argument to prevent prompt injection attacks.
+                // If argument value is string, encoding will be performed automatically.
+                new() { Name = "customer", AllowDangerouslySetContent = true },
+                new() { Name = "history", AllowDangerouslySetContent = true },
+            }
         };
 
         // Render the prompt
@@ -93,7 +101,14 @@ public class HandlebarsPrompts(ITestOutputHelper output) : BaseTest(output)
         var handlebarsPromptYaml = EmbeddedResource.Read("HandlebarsPrompt.yaml");
 
         // Create the prompt function from the YAML resource
-        var templateFactory = new HandlebarsPromptTemplateFactory();
+        var templateFactory = new HandlebarsPromptTemplateFactory()
+        {
+            // Set AllowDangerouslySetContent to 'true' only if arguments do not contain harmful content.
+            // Consider encoding for each argument to prevent prompt injection attacks.
+            // If argument value is string, encoding will be performed automatically.
+            AllowDangerouslySetContent = true
+        };
+
         var function = kernel.CreateFunctionFromPromptYaml(handlebarsPromptYaml, templateFactory);
 
         // Input data for the prompt rendering and execution

--- a/dotnet/samples/Concepts/PromptTemplates/LiquidPrompts.cs
+++ b/dotnet/samples/Concepts/PromptTemplates/LiquidPrompts.cs
@@ -67,6 +67,14 @@ public class LiquidPrompts(ITestOutputHelper output) : BaseTest(output)
             Template = template,
             TemplateFormat = "liquid",
             Name = "ContosoChatPrompt",
+            InputVariables = new()
+            {
+                // Set AllowDangerouslySetContent to 'true' only if arguments do not contain harmful content.
+                // Consider encoding for each argument to prevent prompt injection attacks.
+                // If argument value is string, encoding will be performed automatically.
+                new() { Name = "customer", AllowDangerouslySetContent = true },
+                new() { Name = "history", AllowDangerouslySetContent = true },
+            }
         };
 
         // Render the prompt
@@ -93,7 +101,14 @@ public class LiquidPrompts(ITestOutputHelper output) : BaseTest(output)
         var liquidPromptYaml = EmbeddedResource.Read("LiquidPrompt.yaml");
 
         // Create the prompt function from the YAML resource
-        var templateFactory = new LiquidPromptTemplateFactory();
+        var templateFactory = new LiquidPromptTemplateFactory()
+        {
+            // Set AllowDangerouslySetContent to 'true' only if arguments do not contain harmful content.
+            // Consider encoding for each argument to prevent prompt injection attacks.
+            // If argument value is string, encoding will be performed automatically.
+            AllowDangerouslySetContent = true
+        };
+
         var function = kernel.CreateFunctionFromPromptYaml(liquidPromptYaml, templateFactory);
 
         // Input data for the prompt rendering and execution

--- a/dotnet/src/Extensions/Extensions.UnitTests/PromptTemplates/Handlebars/HandlebarsPromptTemplateTestUtils.cs
+++ b/dotnet/src/Extensions/Extensions.UnitTests/PromptTemplates/Handlebars/HandlebarsPromptTemplateTestUtils.cs
@@ -1,5 +1,6 @@
 ﻿// Copyright (c) Microsoft. All rights reserved.
 
+using System.Collections.Generic;
 using Microsoft.SemanticKernel;
 using Microsoft.SemanticKernel.PromptTemplates.Handlebars;
 
@@ -7,12 +8,15 @@ namespace Extensions.UnitTests.PromptTemplates.Handlebars;
 
 internal static class TestUtilities
 {
-    public static PromptTemplateConfig InitializeHbPromptConfig(string template)
+    public static PromptTemplateConfig InitializeHbPromptConfig(
+        string template,
+        List<InputVariable>? inputVariables = null)
     {
         return new PromptTemplateConfig()
         {
             TemplateFormat = HandlebarsPromptTemplateFactory.HandlebarsTemplateFormat,
-            Template = template
+            Template = template,
+            InputVariables = inputVariables ?? []
         };
     }
 }

--- a/dotnet/src/Extensions/Extensions.UnitTests/PromptTemplates/Handlebars/Helpers/KernelSystemHelpersTests.cs
+++ b/dotnet/src/Extensions/Extensions.UnitTests/PromptTemplates/Handlebars/Helpers/KernelSystemHelpersTests.cs
@@ -1,6 +1,7 @@
 ﻿// Copyright (c) Microsoft. All rights reserved.
 
 using System;
+using System.Collections.Generic;
 using System.Text.Json.Nodes;
 using System.Threading.Tasks;
 using System.Web;
@@ -60,8 +61,10 @@ public sealed class KernelSystemHelpersTests
                 { "person", json }
             };
 
+        var inputVariables = new List<InputVariable> { new() { Name = "person", AllowDangerouslySetContent = true } };
+
         // Act
-        var result = await this.RenderPromptTemplateAsync(template, arguments);
+        var result = await this.RenderPromptTemplateAsync(template, arguments, inputVariables);
 
         // Assert
         Assert.Equal("""{"name":"Alice","age":25}""", HttpUtility.HtmlDecode(result));
@@ -90,8 +93,10 @@ public sealed class KernelSystemHelpersTests
                 { "person", new { name = "Alice", age = 25 } }
             };
 
+        var inputVariables = new List<InputVariable> { new() { Name = "person", AllowDangerouslySetContent = true } };
+
         // Act
-        var result = await this.RenderPromptTemplateAsync(template, arguments);
+        var result = await this.RenderPromptTemplateAsync(template, arguments, inputVariables);
 
         // Assert  
         Assert.Equal("{ name = Alice, age = 25 }", result);
@@ -107,8 +112,10 @@ public sealed class KernelSystemHelpersTests
                 { "person", new { name = "Alice", age = 25 } }
             };
 
+        var inputVariables = new List<InputVariable> { new() { Name = "person", AllowDangerouslySetContent = true } };
+
         // Act
-        var result = await this.RenderPromptTemplateAsync(template, arguments);
+        var result = await this.RenderPromptTemplateAsync(template, arguments, inputVariables);
 
         // Assert
         Assert.Equal("Alice", result);
@@ -124,8 +131,10 @@ public sealed class KernelSystemHelpersTests
             { "person", new { Name = "Alice", Age = 25, Address = new { City = "New York", Country = "USA" } } }
         };
 
-        // Act  
-        var result = await this.RenderPromptTemplateAsync(template, arguments);
+        var inputVariables = new List<InputVariable> { new() { Name = "person", AllowDangerouslySetContent = true } };
+
+        // Act
+        var result = await this.RenderPromptTemplateAsync(template, arguments, inputVariables);
 
         // Assert  
         Assert.Equal("{ City = New York, Country = USA }", result);
@@ -155,8 +164,14 @@ public sealed class KernelSystemHelpersTests
             { "Address", new { City = "New York", Country = "USA"  } }
         };
 
+        var inputVariables = new List<InputVariable>
+        {
+            new() { Name = "person" },
+            new() { Name = "Address", AllowDangerouslySetContent = true },
+        };
+
         // Act
-        var result = await this.RenderPromptTemplateAsync(template, arguments);
+        var result = await this.RenderPromptTemplateAsync(template, arguments, inputVariables);
 
         // Assert
         Assert.Equal("hi, ,Alice,!,Welcome to, ,New York", result);
@@ -283,9 +298,12 @@ public sealed class KernelSystemHelpersTests
     private readonly Kernel _kernel;
     private readonly KernelArguments _arguments;
 
-    private async Task<string> RenderPromptTemplateAsync(string template, KernelArguments? args = null)
+    private async Task<string> RenderPromptTemplateAsync(
+        string template,
+        KernelArguments? args = null,
+        List<InputVariable>? inputVariables = null)
     {
-        var resultConfig = InitializeHbPromptConfig(template);
+        var resultConfig = InitializeHbPromptConfig(template, inputVariables);
         var target = (HandlebarsPromptTemplate)this._factory.Create(resultConfig);
 
         // Act

--- a/dotnet/src/Extensions/PromptTemplates.Handlebars/HandlebarsPromptTemplate.cs
+++ b/dotnet/src/Extensions/PromptTemplates.Handlebars/HandlebarsPromptTemplate.cs
@@ -1,5 +1,6 @@
 ﻿// Copyright (c) Microsoft. All rights reserved.
 
+using System;
 using System.Threading;
 using System.Threading.Tasks;
 using System.Web;
@@ -117,14 +118,7 @@ internal sealed class HandlebarsPromptTemplate : IPromptTemplate
             {
                 if (kvp.Value is not null)
                 {
-                    var value = kvp.Value;
-
-                    if (this.ShouldEncodeTags(this._promptModel, kvp.Key, kvp.Value))
-                    {
-                        value = HttpUtility.HtmlEncode(value.ToString());
-                    }
-
-                    result[kvp.Key] = value;
+                    result[kvp.Key] = this.GetEncodedValueOrDefault(this._promptModel, kvp.Key, kvp.Value);
                 }
             }
         }
@@ -132,22 +126,79 @@ internal sealed class HandlebarsPromptTemplate : IPromptTemplate
         return result;
     }
 
-    private bool ShouldEncodeTags(PromptTemplateConfig promptTemplateConfig, string propertyName, object? propertyValue)
+    /// <summary>
+    /// Encodes argument value if necessary, or throws an exception if encoding is not supported.
+    /// </summary>
+    /// <param name="promptTemplateConfig">The prompt template configuration.</param>
+    /// <param name="propertyName">The name of the property/argument.</param>
+    /// <param name="propertyValue">The value of the property/argument.</param>
+    private object GetEncodedValueOrDefault(PromptTemplateConfig promptTemplateConfig, string propertyName, object propertyValue)
     {
-        if (propertyValue is null || propertyValue is not string || this._allowDangerouslySetContent)
+        if (this._allowDangerouslySetContent)
         {
-            return false;
+            return propertyValue;
         }
 
         foreach (var inputVariable in promptTemplateConfig.InputVariables)
         {
             if (inputVariable.Name == propertyName)
             {
-                return !inputVariable.AllowDangerouslySetContent;
+                if (inputVariable.AllowDangerouslySetContent)
+                {
+                    return propertyValue;
+                }
+
+                break;
             }
         }
 
-        return true;
+        var valueType = propertyValue.GetType();
+
+        var underlyingType = Nullable.GetUnderlyingType(valueType) ?? valueType;
+
+        if (underlyingType == typeof(string))
+        {
+            var stringValue = (string)propertyValue;
+            return HttpUtility.HtmlEncode(stringValue);
+        }
+
+        if (this.IsSafeType(underlyingType))
+        {
+            return propertyValue;
+        }
+
+        // For complex types, throw an exception if dangerous content is not allowed
+        throw new NotSupportedException(
+            $"Argument '{propertyName}' has a value that could potentially be used for prompt injection. " +
+            $"Set {nameof(InputVariable.AllowDangerouslySetContent)} to 'true' for this input variable and implement custom encoding, " +
+            "or provide the value as a string.");
+    }
+
+    /// <summary>
+    /// Determines if a type is considered safe and doesn't require encoding.
+    /// </summary>
+    /// <param name="type">The type to check.</param>
+    /// <returns>True if the type is safe, false otherwise.</returns>
+    private bool IsSafeType(Type type)
+    {
+        return type == typeof(byte) ||
+               type == typeof(sbyte) ||
+               type == typeof(bool) ||
+               type == typeof(ushort) ||
+               type == typeof(short) ||
+               type == typeof(char) ||
+               type == typeof(uint) ||
+               type == typeof(int) ||
+               type == typeof(ulong) ||
+               type == typeof(long) ||
+               type == typeof(float) ||
+               type == typeof(double) ||
+               type == typeof(decimal) ||
+               type == typeof(TimeSpan) ||
+               type == typeof(DateTime) ||
+               type == typeof(DateTimeOffset) ||
+               type == typeof(Guid) ||
+               type.IsEnum;
     }
 
     #endregion

--- a/dotnet/src/Extensions/PromptTemplates.Handlebars/HandlebarsPromptTemplate.cs
+++ b/dotnet/src/Extensions/PromptTemplates.Handlebars/HandlebarsPromptTemplate.cs
@@ -169,8 +169,8 @@ internal sealed class HandlebarsPromptTemplate : IPromptTemplate
 
         // For complex types, throw an exception if dangerous content is not allowed
         throw new NotSupportedException(
-            $"Argument '{propertyName}' has a value that could potentially be used for prompt injection. " +
-            $"Set {nameof(InputVariable.AllowDangerouslySetContent)} to 'true' for this input variable and implement custom encoding, " +
+            $"Argument '{propertyName}' has a value that doesn't support automatic encoding. " +
+            $"Set {nameof(InputVariable.AllowDangerouslySetContent)} to 'true' for this argument and implement custom encoding, " +
             "or provide the value as a string.");
     }
 

--- a/dotnet/src/Extensions/PromptTemplates.Liquid/LiquidPromptTemplate.cs
+++ b/dotnet/src/Extensions/PromptTemplates.Liquid/LiquidPromptTemplate.cs
@@ -232,8 +232,8 @@ internal sealed partial class LiquidPromptTemplate : IPromptTemplate
 
         // For complex types, throw an exception if dangerous content is not allowed
         throw new NotSupportedException(
-            $"Argument '{propertyName}' has a value that could potentially be used for prompt injection. " +
-            $"Set {nameof(InputVariable.AllowDangerouslySetContent)} to 'true' for this input variable and implement custom encoding, " +
+            $"Argument '{propertyName}' has a value that doesn't support automatic encoding. " +
+            $"Set {nameof(InputVariable.AllowDangerouslySetContent)} to 'true' for this argument and implement custom encoding, " +
             "or provide the value as a string.");
     }
 


### PR DESCRIPTION
### Motivation and Context

<!-- Thank you for your contribution to the semantic-kernel repo!
Please help reviewers and future users, providing the following information:
  1. Why is this change required?
  2. What problem does it solve?
  3. What scenario does it contribute to?
  4. If it fixes an open issue, please link to the issue here.
-->

Today, the encoding of template arguments is performed only if argument type is `string`. In case of custom type, anonymous type or collection - the encoding is not performed.

This PR contains changes to throw an exception in case if encoding is enabled but complex type is used. In case of complex type, the encoding should be performed manually according to business logic and automatic encoding should be explicitly disabled. 

This enforces stricter, but more secure template rendering rules.

**Note**: this is a breaking change for customers who use Handlebars or Liquid template with complex types. Code changes are required when initializing template arguments.

Before:
```csharp
var arguments = new KernelArguments()
{
    { "customer", new
        {
            firstName = userInput.FirstName,
            lastName = userInput.LastName,
        }
    }
};

var templateFactory = new LiquidPromptTemplateFactory();
var promptTemplateConfig = new PromptTemplateConfig()
{
    TemplateFormat = "liquid"
};

var promptTemplate = templateFactory.Create(promptTemplateConfig);

// This will throw an exception now to prevent passing harmful content to the prompt template engine.
var renderedPrompt = await promptTemplate.RenderAsync(kernel, arguments); 
```

After:
```csharp
var arguments = new KernelArguments()
{
    // Encode each property of anonymous type.
    { "customer", new
        {
            firstName = HttpUtility.HtmlEncode(userInput.FirstName),
            lastName = HttpUtility.HtmlEncode(userInput.LastName),
        }
    }
};

var templateFactory = new LiquidPromptTemplateFactory();
var promptTemplateConfig = new PromptTemplateConfig()
{
    TemplateFormat = "liquid",
    InputVariables = new()
    {
        // We set AllowDangerouslySetContent to 'true' because each property of this argument is encoded manually. 
        new() { Name = "customer", AllowDangerouslySetContent = true },
    }
};

var promptTemplate = templateFactory.Create(promptTemplateConfig);
var renderedPrompt = await promptTemplate.RenderAsync(kernel, arguments); 
```

### Contribution Checklist

<!-- Before submitting this PR, please make sure: -->

- [x] The code builds clean without any errors or warnings
- [x] The PR follows the [SK Contribution Guidelines](https://github.com/microsoft/semantic-kernel/blob/main/CONTRIBUTING.md) and the [pre-submission formatting script](https://github.com/microsoft/semantic-kernel/blob/main/CONTRIBUTING.md#development-scripts) raises no violations
- [x] All unit tests pass, and I have added new tests where possible
- [x] I didn't break anyone :smile:
