### PR TITLE
Python: Fix responses agent kernel args bug

### DIFF
--- a/python/semantic_kernel/agents/open_ai/responses_agent_thread_actions.py
+++ b/python/semantic_kernel/agents/open_ai/responses_agent_thread_actions.py
@@ -256,7 +256,7 @@ class ResponsesAgentThreadActions:
                     kernel.invoke_function_call(
                         function_call=function_call,
                         chat_history=override_history,
-                        arguments=kwargs.get("arguments"),
+                        arguments=arguments,
                         execution_settings=None,
                         function_call_count=fc_count,
                         request_index=request_index,
@@ -561,7 +561,7 @@ class ResponsesAgentThreadActions:
                     kernel.invoke_function_call(
                         function_call=function_call,
                         chat_history=override_history,
-                        arguments=kwargs.get("arguments"),
+                        arguments=arguments,
                         is_streaming=True,
                         execution_settings=None,
                         function_call_count=fc_count,

--- a/python/tests/unit/agents/openai_responses/test_openai_responses_thread_actions.py
+++ b/python/tests/unit/agents/openai_responses/test_openai_responses_thread_actions.py
@@ -68,7 +68,6 @@ def mock_thread():
     return thread
 
 
-@pytest.mark.asyncio
 async def test_invoke_no_function_calls(mock_agent, mock_response, mock_chat_history, mock_thread):
     async def mock_get_response(*args, **kwargs):
         return mock_response
@@ -90,7 +89,6 @@ async def test_invoke_no_function_calls(mock_agent, mock_response, mock_chat_his
     assert final_msg.role == AuthorRole.ASSISTANT
 
 
-@pytest.mark.asyncio
 async def test_invoke_raises_on_failed_response(mock_agent, mock_chat_history, mock_thread):
     mock_failed_response = MagicMock(spec=Response)
     mock_failed_response.status = "failed"
@@ -116,7 +114,6 @@ async def test_invoke_raises_on_failed_response(mock_agent, mock_chat_history, m
             pass
 
 
-@pytest.mark.asyncio
 async def test_invoke_reaches_maximum_attempts(mock_agent, mock_chat_history, mock_thread):
     call_counter = 0
 
@@ -174,7 +171,6 @@ async def test_invoke_reaches_maximum_attempts(mock_agent, mock_chat_history, mo
         assert messages is not None
 
 
-@pytest.mark.asyncio
 async def test_invoke_with_function_calls(mock_agent, mock_chat_history, mock_thread):
     initial_response = MagicMock(spec=Response)
     initial_response.status = "completed"
@@ -228,7 +224,6 @@ async def test_invoke_with_function_calls(mock_agent, mock_chat_history, mock_th
         assert len(messages) == 3, f"Expected exactly 3 messages, got {len(messages)}"
 
 
-@pytest.mark.asyncio
 async def test_invoke_passes_kernel_arguments_to_kernel(mock_agent, mock_chat_history, mock_thread):
     # Prepare a response that triggers a function call
     initial_response = MagicMock(spec=Response)
@@ -288,7 +283,6 @@ async def test_invoke_passes_kernel_arguments_to_kernel(mock_agent, mock_chat_hi
         assert len(collected) >= 2
 
 
-@pytest.mark.asyncio
 async def test_invoke_stream_passes_kernel_arguments_to_kernel(mock_agent, mock_chat_history, mock_thread):
     class MockStream(AsyncStream[ResponseStreamEvent]):
         def __init__(self, events):
@@ -429,7 +423,6 @@ async def test_invoke_stream_no_function_calls(mock_agent, mock_chat_history, mo
         assert collected_stream_messages[0].role == AuthorRole.ASSISTANT
 
 
-@pytest.mark.asyncio
 async def test_invoke_stream_with_tool_calls(mock_agent, mock_chat_history, mock_thread):
     class MockStream(AsyncStream[ResponseStreamEvent]):
         def __init__(self, events):


### PR DESCRIPTION
### Motivation and Context

The `arguments: KernelArguments` are not getting handled properly for the Responses Agent invoke. Use the provided `arguments` instead of trying to get them from the kwargs.

<!-- Thank you for your contribution to the semantic-kernel repo!
Please help reviewers and future users, providing the following information:
  1. Why is this change required?
  2. What problem does it solve?
  3. What scenario does it contribute to?
  4. If it fixes an open issue, please link to the issue here.
-->

### Description

- Closes #13053
- Adds unit test coverage. 

<!-- Describe your changes, the overall approach, the underlying design.
     These notes will help understanding how your code works. Thanks! -->

### Contribution Checklist

<!-- Before submitting this PR, please make sure: -->

- [X] The code builds clean without any errors or warnings
- [X] The PR follows the [SK Contribution Guidelines](https://github.com/microsoft/semantic-kernel/blob/main/CONTRIBUTING.md) and the [pre-submission formatting script](https://github.com/microsoft/semantic-kernel/blob/main/CONTRIBUTING.md#development-scripts) raises no violations
- [X] All unit tests pass, and I have added new tests where possible
- [X] I didn't break anyone :smile:
