### PR TITLE
.Net: fixed bug in TextSearchExtensions.cs: CreateGetSearchResults will not…

### DIFF
--- a/dotnet/src/SemanticKernel.Core/Data/TextSearch/TextSearchExtensions.cs
+++ b/dotnet/src/SemanticKernel.Core/Data/TextSearch/TextSearchExtensions.cs
@@ -314,7 +314,15 @@ public static class TextSearchExtensions
                 return [];
             }
 
-            var parameters = function.Metadata.Parameters;
+            if (arguments.TryGetValue("count", out var countObj) && countObj is int countVal and > 0)
+            {
+                count = countVal;
+            }
+
+            if (arguments.TryGetValue("skip", out var skipObj) && skipObj is int skipVal and >= 0)
+            {
+                skip = skipVal;
+            }
 
             searchOptions ??= new()
             {
@@ -351,7 +359,15 @@ public static class TextSearchExtensions
                 return [];
             }
 
-            var parameters = function.Metadata.Parameters;
+            if (arguments.TryGetValue("count", out var countObj) && countObj is int countVal and > 0)
+            {
+                count = countVal;
+            }
+
+            if (arguments.TryGetValue("skip", out var skipObj) && skipObj is int skipVal and >= 0)
+            {
+                skip = skipVal;
+            }
 
             searchOptions ??= new()
             {


### PR DESCRIPTION
… take use of param "count" and "skip" by tool calls.

### Motivation and Context

Fixed bug: method 'CreateGetSearchResults' has a bug that it could not take use of param "count" and "skip" by tool calls.

### Description

I add following lines to capture params:

```csharp
if (arguments.TryGetValue("count", out var countObj) && countObj is int countVal and > 0)
            {
                count = countVal;
            }

            if (arguments.TryGetValue("skip", out var skipObj) && skipObj is int skipVal and >= 0)
            {
                skip = skipVal;
            }
```

### Contribution Checklist

- [x] The code builds clean without any errors or warnings
- [x] The PR follows the [SK Contribution Guidelines](https://github.com/microsoft/semantic-kernel/blob/main/CONTRIBUTING.md) and the [pre-submission formatting script](https://github.com/microsoft/semantic-kernel/blob/main/CONTRIBUTING.md#development-scripts) raises no violations
- [x] All unit tests pass, and I have added new tests where possible
- [x] I didn't break anyone :smile:
