### PR TITLE
Python: Don't return code output via on_intermediate_msg callback

### DIFF
--- a/python/semantic_kernel/agents/open_ai/assistant_thread_actions.py
+++ b/python/semantic_kernel/agents/open_ai/assistant_thread_actions.py
@@ -483,7 +483,7 @@ class AssistantThreadActions:
                                     tool_content = generate_streaming_code_interpreter_content(agent.name, step_details)
                                     content_is_visible = True
                                 if tool_content:
-                                    if output_messages is not None:
+                                    if output_messages is not None and not content_is_visible:
                                         output_messages.append(tool_content)
                                     if content_is_visible:
                                         yield tool_content


### PR DESCRIPTION
### Motivation and Context

Current, while using an OpenAIAssistantAgent, we are returning code output via the on_intermediate_message callback. This shouldn't be happening right now, as all other agents return code via TextContent with a metadata `{"code": True}` key-value pair in the dictionary.

<!-- Thank you for your contribution to the semantic-kernel repo!
Please help reviewers and future users, providing the following information:
  1. Why is this change required?
  2. What problem does it solve?
  3. What scenario does it contribute to?
  4. If it fixes an open issue, please link to the issue here.
-->

### Description

- Closes #12956

<!-- Describe your changes, the overall approach, the underlying design.
     These notes will help understanding how your code works. Thanks! -->

### Contribution Checklist

<!-- Before submitting this PR, please make sure: -->

- [X] The code builds clean without any errors or warnings
- [X] The PR follows the [SK Contribution Guidelines](https://github.com/microsoft/semantic-kernel/blob/main/CONTRIBUTING.md) and the [pre-submission formatting script](https://github.com/microsoft/semantic-kernel/blob/main/CONTRIBUTING.md#development-scripts) raises no violations
- [X] All unit tests pass, and I have added new tests where possible
- [X] I didn't break anyone :smile:
