### PR TITLE
Fixed sorting for negative DOT product

### DIFF
--- a/dotnet/src/VectorData/SqlServer/SqlServerCommandBuilder.cs
+++ b/dotnet/src/VectorData/SqlServer/SqlServerCommandBuilder.cs
@@ -657,8 +657,8 @@ internal static class SqlServerCommandBuilder
         DistanceFunction.CosineDistance => ("COSINE", "ASC"),
         // A value of 0 indicates that the vectors are identical, while larger values indicate greater dissimilarity.
         DistanceFunction.EuclideanDistance => ("EUCLIDEAN", "ASC"),
-        // A value closer to 0 indicates higher similarity, while more negative values indicate greater dissimilarity.
-        DistanceFunction.NegativeDotProductSimilarity => ("DOT", "DESC"),
+        // Smaller numbers indicate more similar vectors
+        DistanceFunction.NegativeDotProductSimilarity => ("DOT", "ASC"),
         _ => throw new NotSupportedException($"Distance function {name} is not supported.")
     };
 }


### PR DESCRIPTION
### Motivation and Context

When using negative dot product scoring, the more negative the value, the closer the vector is to the query vector.

### Description

Fixed the sorting used for negative dot product distance calculations

### Contribution Checklist

- [x] The code builds clean without any errors or warnings
- [x] The PR follows the [SK Contribution Guidelines](https://github.com/microsoft/semantic-kernel/blob/main/CONTRIBUTING.md) and the [pre-submission formatting script](https://github.com/microsoft/semantic-kernel/blob/main/CONTRIBUTING.md#development-scripts) raises no violations
- [x] All unit tests pass, and I have added new tests where possible
- [x] I didn't break anyone :smile:
