### PR TITLE
Python: Description not set in OrchestrationHandoffs when adding agent by name

### DIFF
--- a/python/semantic_kernel/agents/orchestration/handoffs.py
+++ b/python/semantic_kernel/agents/orchestration/handoffs.py
@@ -87,7 +87,7 @@ class OrchestrationHandoffs(dict[str, AgentHandoffs]):
         return self._add(
             source_agent=source_agent if isinstance(source_agent, str) else source_agent.name,
             target_agent=target_agent if isinstance(target_agent, str) else target_agent.name,
-            description=description or target_agent.description or "" if isinstance(target_agent, Agent) else "",
+            description=description or (target_agent.description or "" if isinstance(target_agent, Agent) else ""),
         )
 
     def add_many(self, source_agent: str | Agent, target_agents: list[str | Agent] | AgentHandoffs) -> "Self":

--- a/python/tests/unit/agents/orchestration/test_handoff.py
+++ b/python/tests/unit/agents/orchestration/test_handoff.py
@@ -264,6 +264,9 @@ def test_orchestration_handoff_add():
     agent_a = MockAgent()
     agent_b = MockAgent()
 
+    agent_a.description = "Description Agent A"
+    agent_b.description = "Description Agent B"
+
     orchestration_handoffs = OrchestrationHandoffs().add(agent_a, agent_b).add(agent_b, agent_a)
 
     assert isinstance(orchestration_handoffs, OrchestrationHandoffs)
@@ -272,10 +275,48 @@ def test_orchestration_handoff_add():
     assert len(orchestration_handoffs[agent_b.name]) == 1
     for handoff_agent_name, handoff_description in orchestration_handoffs[agent_a.name].items():
         assert handoff_agent_name == agent_b.name
-        assert handoff_description == ""
+        assert handoff_description == "Description Agent B"
     for handoff_agent_name, handoff_description in orchestration_handoffs[agent_b.name].items():
         assert handoff_agent_name == agent_a.name
-        assert handoff_description == ""
+        assert handoff_description == "Description Agent A"
+
+
+def test_orchestration_handoff_add_with_description():
+    """Test the add method of the OrchestrationHandoffs."""
+    agent_a = MockAgent()
+    agent_b = MockAgent()
+
+    orchestration_handoffs = (
+        OrchestrationHandoffs()
+        .add(agent_a, agent_b, "Description from Agent A to Agent B")
+        .add(agent_b, agent_a, "Description from Agent B to Agent A")
+    )
+
+    for handoff_agent_name, handoff_description in orchestration_handoffs[agent_a.name].items():
+        assert handoff_agent_name == agent_b.name
+        assert handoff_description == "Description from Agent A to Agent B"
+    for handoff_agent_name, handoff_description in orchestration_handoffs[agent_b.name].items():
+        assert handoff_agent_name == agent_a.name
+        assert handoff_description == "Description from Agent B to Agent A"
+
+
+def test_orchestration_handoff_add_by_name_with_description():
+    """Test the add method of the OrchestrationHandoffs."""
+    agent_a = MockAgent()
+    agent_b = MockAgent()
+
+    orchestration_handoffs = (
+        OrchestrationHandoffs()
+        .add(agent_a.name, agent_b.name, "Description from Agent A to Agent B")
+        .add(agent_b.name, agent_a.name, "Description from Agent B to Agent A")
+    )
+
+    for handoff_agent_name, handoff_description in orchestration_handoffs[agent_a.name].items():
+        assert handoff_agent_name == agent_b.name
+        assert handoff_description == "Description from Agent A to Agent B"
+    for handoff_agent_name, handoff_description in orchestration_handoffs[agent_b.name].items():
+        assert handoff_agent_name == agent_a.name
+        assert handoff_description == "Description from Agent B to Agent A"
 
 
 def test_orchestration_handoff_add_many():


### PR DESCRIPTION
### Motivation and Context

When setting an OrchestrationHandoffs configuration using agent's name instead of the Agent instances, the description field is not taken into account.
This causes the description to not be part of the function definition sent to the LLM.

### Description

FIx Python construct used when generating the description to be used.

### Contribution Checklist

- [X] The code builds clean without any errors or warnings
- [X] The PR follows the [SK Contribution Guidelines](https://github.com/microsoft/semantic-kernel/blob/main/CONTRIBUTING.md) and the [pre-submission formatting script](https://github.com/microsoft/semantic-kernel/blob/main/CONTRIBUTING.md#development-scripts) raises no violations
- [X] All unit tests pass, and I have added new tests where possible
- [X] I didn't break anyone :smile:
