### PR TITLE
docs: add OpenTelemetry GenAI instrumentation sample

### DIFF
--- a/docs/OPENTELEMETRY_GENAI.md
+++ b/docs/OPENTELEMETRY_GENAI.md
@@ -1,0 +1,28 @@
+# OpenTelemetry GenAI instrumentation sample
+
+The community project [otel-genai-bridges](https://github.com/dineshkumarkummara/otel-genai-bridges) includes a .NET library (`SkOtel`) and sample (`dotnet/samples/sk-chat`) that instrument Semantic Kernel applications using the [OpenTelemetry Generative AI semantic conventions](https://github.com/open-telemetry/semantic-conventions/tree/main/docs/gen-ai).
+
+## Highlights
+
+- `AddSemanticKernelTelemetry` extension registers telemetry options, middleware, and a DelegatingHandler.
+- Middleware captures prompts, completions, tool invocations, latency, token usage, cost, and RAG retrieval latency.
+- Docker Compose stack (OpenTelemetry Collector → Tempo/Prometheus → Grafana) and dashboards are provided out of the box.
+
+## Quick start
+
+```bash
+# Clone the repository
+git clone https://github.com/dineshkumarkummara/otel-genai-bridges.git
+cd otel-genai-bridges
+
+# Launch the collector, Tempo, Prometheus, Grafana, and both sample apps
+./scripts/run_all.sh
+```
+
+The Semantic Kernel sample listens on `http://localhost:7080`. Send prompts to `/chat` or `/rag` with `curl` to generate telemetry.
+
+![Grafana token throughput panel](https://github.com/dineshkumarkummara/otel-genai-bridges/raw/main/docs/screenshots/grafana-tokens.png)
+
+The Grafana dashboard (http://localhost:3000/d/genai-overview) surfaces latency, token usage, error rates, tool-call counts, and RAG retrieval latency. Tempo provides trace waterfalls showing prompt/response events and tool execution spans.
+
+For more details or to contribute, visit the repository: https://github.com/dineshkumarkummara/otel-genai-bridges.


### PR DESCRIPTION
### Motivation and Context

<!-- Thank you for your contribution to the semantic-kernel repo!
Please help reviewers and future users, providing the following information:
  1. Why is this change required?
  2. What problem does it solve?
  3. What scenario does it contribute to?
  4. If it fixes an open issue, please link to the issue here.
-->

Currently, Semantic Kernel does not ship an example of how to adopt the new [OpenTelemetry GenAI semantic conventions](https://opentelemetry.io/docs/specs/semconv/gen-ai/).  
This makes it difficult for developers to instrument SK-based applications with end-to-end observability (latency, token usage, error rates, tool-call spans, and retrieval latency).

This PR contributes a **documentation/sample entry** showing how to instrument SK with OpenTelemetry using the [`SkOtel` library](https://github.com/dineshkumarkummara/otel-genai-bridges).  
The goal is to provide the community with a ready-to-run reference that aligns with the OTel GenAI spec.

---

### Description

<!-- Describe your changes, the overall approach, the underlying design.
     These notes will help understanding how your code works. Thanks! -->

- Adds a docs page under `samples/` demonstrating OTel GenAI instrumentation for SK.  
- Shows how to register `AddSemanticKernelTelemetry` middleware and a DelegatingHandler.  
- Provides runnable example (`sk-chat`) plus Dockerized Collector → Tempo → Prometheus → Grafana stack.  
- Includes screenshot of a Grafana token throughput panel to illustrate expected telemetry output.  

This contribution is **docs/sample only** — no changes are made to SK core runtime code.

---

### Contribution Checklist

<!-- Before submitting this PR, please make sure: -->

- [x] The docs build clean without any errors or warnings  
- [x] The sample code runs successfully and emits OTel telemetry  
- [x] The PR follows the [SK Contribution Guidelines](https://github.com/microsoft/semantic-kernel/blob/main/CONTRIBUTING.md)  
- [x] Screenshots and snippets are verified against the live repo example  
- [x] This is a docs/sample addition — no breaking changes introduced  