### PR TITLE
.Net: Fix weaviate collection name checking

### DIFF
--- a/dotnet/src/VectorData/Weaviate/WeaviateCollection.cs
+++ b/dotnet/src/VectorData/Weaviate/WeaviateCollection.cs
@@ -561,7 +561,7 @@ public class WeaviateCollection<TKey, TRecord> : VectorStoreCollection<TKey, TRe
         {
             if (!((character is >= 'a' and <= 'z') || (character is >= 'A' and <= 'Z') || (character is >= '0' and <= '9') || character is '_'))
             {
-                throw new ArgumentException("Collection name must contain only ASCII letters and digits.", nameof(collectionName));
+                throw new ArgumentException("Collection name must contain only ASCII letters and digits or underscores. The first character must be an upper case letter.", nameof(collectionName));
             }
         }
     }


### PR DESCRIPTION
### Motivation and Context

According to the weaviate document, the collection name allows the use of underscores

- [collections](https://docs.weaviate.io/weaviate/config-refs/collections#class): `The collection name validation regex is /^[A-Z][_0-9A-Za-z]*$/.`

### Description

Allow `_` in weaviate collection name.

### Contribution Checklist

<!-- Before submitting this PR, please make sure: -->

- [x] The code builds clean without any errors or warnings
- [x] The PR follows the [SK Contribution Guidelines](https://github.com/microsoft/semantic-kernel/blob/main/CONTRIBUTING.md) and the [pre-submission formatting script](https://github.com/microsoft/semantic-kernel/blob/main/CONTRIBUTING.md#development-scripts) raises no violations
- [x] All unit tests pass, and I have added new tests where possible
- [x] I didn't break anyone :smile:
