### PR TITLE
.Net: Support CollectionExistsAsync with redis alpine

### DIFF
--- a/dotnet/src/VectorData/Redis/RedisHashSetCollection.cs
+++ b/dotnet/src/VectorData/Redis/RedisHashSetCollection.cs
@@ -128,7 +128,9 @@ public class RedisHashSetCollection<TKey, TRecord> : VectorStoreCollection<TKey,
             await this._database.FT().InfoAsync(this.Name).ConfigureAwait(false);
             return true;
         }
-        catch (RedisServerException ex) when (ex.Message.Contains("Unknown index name"))
+        // "Unknown index name" is returned in Redis Stack
+        // "no such index" is returned in Redis Alpine
+        catch (RedisServerException ex) when (ex.Message.Contains("Unknown index name") || ex.Message.Contains("no such index"))
         {
             return false;
         }

--- a/dotnet/src/VectorData/Redis/RedisJsonCollection.cs
+++ b/dotnet/src/VectorData/Redis/RedisJsonCollection.cs
@@ -141,7 +141,9 @@ public class RedisJsonCollection<TKey, TRecord> : VectorStoreCollection<TKey, TR
             await this._database.FT().InfoAsync(this.Name).ConfigureAwait(false);
             return true;
         }
-        catch (RedisServerException ex) when (ex.Message.Contains("Unknown index name"))
+        // "Unknown index name" is returned in Redis Stack
+        // "no such index" is returned in Redis Alpine
+        catch (RedisServerException ex) when (ex.Message.Contains("Unknown index name") || ex.Message.Contains("no such index"))
         {
             return false;
         }


### PR DESCRIPTION
### Motivation and Context

#12734

Redis alpine produces a different error message for not found indices to redis stack.

### Description

- Support CollectionExistsAsync with redis alpine

### Contribution Checklist

<!-- Before submitting this PR, please make sure: -->

- [ ] The code builds clean without any errors or warnings
- [ ] The PR follows the [SK Contribution Guidelines](https://github.com/microsoft/semantic-kernel/blob/main/CONTRIBUTING.md) and the [pre-submission formatting script](https://github.com/microsoft/semantic-kernel/blob/main/CONTRIBUTING.md#development-scripts) raises no violations
- [ ] All unit tests pass, and I have added new tests where possible
- [ ] I didn't break anyone :smile:
