### PR TITLE
.Net: [MEVD] Support MemoryExtensions.Contains in LINQ filters

### DIFF
--- a/dotnet/src/VectorData/AzureAISearch/AzureAISearchFilterTranslator.cs
+++ b/dotnet/src/VectorData/AzureAISearch/AzureAISearchFilterTranslator.cs
@@ -187,8 +187,41 @@ internal class AzureAISearchFilterTranslator
                 this.TranslateContains(source, item);
                 return;
 
+            // C# 14 made changes to overload resolution to prefer Span-based overloads when those exist ("first-class spans");
+            // this makes MemoryExtensions.Contains() be resolved rather than Enumerable.Contains() (see above).
+            // MemoryExtensions.Contains() also accepts a Span argument for the source, adding an implicit cast we need to remove.
+            // See https://github.com/dotnet/runtime/issues/109757 for more context.
+            // Note that MemoryExtensions.Contains has an optional 3rd ComparisonType parameter; we only match when
+            // it's null.
+            case { Method.Name: nameof(MemoryExtensions.Contains), Arguments: [var spanArg, var item, ..] } contains
+                when contains.Method.DeclaringType == typeof(MemoryExtensions)
+                    && (contains.Arguments.Count is 2
+                        || (contains.Arguments.Count is 3 && contains.Arguments[2] is ConstantExpression { Value: null }))
+                    && TryUnwrapSpanImplicitCast(spanArg, out var source):
+                this.TranslateContains(source, item);
+                return;
+
             default:
                 throw new NotSupportedException($"Unsupported method call: {methodCall.Method.DeclaringType?.Name}.{methodCall.Method.Name}");
+        }
+
+        static bool TryUnwrapSpanImplicitCast(Expression expression, [NotNullWhen(true)] out Expression? result)
+        {
+            if (expression is UnaryExpression
+                {
+                    NodeType: ExpressionType.Convert,
+                    Method: { Name: "op_Implicit", DeclaringType: { IsGenericType: true } implicitCastDeclaringType },
+                    Operand: var unwrapped
+                }
+                && implicitCastDeclaringType.GetGenericTypeDefinition() is var genericTypeDefinition
+                && (genericTypeDefinition == typeof(Span<>) || genericTypeDefinition == typeof(ReadOnlySpan<>)))
+            {
+                result = unwrapped;
+                return true;
+            }
+
+            result = null;
+            return false;
         }
     }
 

--- a/dotnet/src/VectorData/CosmosMongoDB/CosmosMongoFilterTranslator.cs
+++ b/dotnet/src/VectorData/CosmosMongoDB/CosmosMongoFilterTranslator.cs
@@ -155,7 +155,8 @@ internal class CosmosMongoFilterTranslator
     }
 
     private BsonDocument TranslateMethodCall(MethodCallExpression methodCall)
-        => methodCall switch
+    {
+        return methodCall switch
         {
             // Enumerable.Contains()
             { Method.Name: nameof(Enumerable.Contains), Arguments: [var source, var item] } contains
@@ -171,10 +172,44 @@ internal class CosmosMongoFilterTranslator
                 },
                 Object: Expression source,
                 Arguments: [var item]
-            } when declaringType.GetGenericTypeDefinition() == typeof(List<>) => this.TranslateContains(source, item),
+            } when declaringType.GetGenericTypeDefinition() == typeof(List<>)
+                => this.TranslateContains(source, item),
+
+            // C# 14 made changes to overload resolution to prefer Span-based overloads when those exist ("first-class spans");
+            // this makes MemoryExtensions.Contains() be resolved rather than Enumerable.Contains() (see above).
+            // MemoryExtensions.Contains() also accepts a Span argument for the source, adding an implicit cast we need to remove.
+            // See https://github.com/dotnet/runtime/issues/109757 for more context.
+            // Note that MemoryExtensions.Contains has an optional 3rd ComparisonType parameter; we only match when
+            // it's null.
+            { Method.Name: nameof(MemoryExtensions.Contains), Arguments: [var spanArg, var item, ..] } contains
+                when contains.Method.DeclaringType == typeof(MemoryExtensions)
+                    && (contains.Arguments.Count is 2
+                        || (contains.Arguments.Count is 3 && contains.Arguments[2] is ConstantExpression { Value: null }))
+                    && TryUnwrapSpanImplicitCast(spanArg, out var source)
+                => this.TranslateContains(source, item),
 
             _ => throw new NotSupportedException($"Unsupported method call: {methodCall.Method.DeclaringType?.Name}.{methodCall.Method.Name}")
         };
+
+        static bool TryUnwrapSpanImplicitCast(Expression expression, [NotNullWhen(true)] out Expression? result)
+        {
+            if (expression is UnaryExpression
+                {
+                    NodeType: ExpressionType.Convert,
+                    Method: { Name: "op_Implicit", DeclaringType: { IsGenericType: true } implicitCastDeclaringType },
+                    Operand: var unwrapped
+                }
+                && implicitCastDeclaringType.GetGenericTypeDefinition() is var genericTypeDefinition
+                && (genericTypeDefinition == typeof(Span<>) || genericTypeDefinition == typeof(ReadOnlySpan<>)))
+            {
+                result = unwrapped;
+                return true;
+            }
+
+            result = null;
+            return false;
+        }
+    }
 
     private BsonDocument TranslateContains(Expression source, Expression item)
     {

--- a/dotnet/src/VectorData/CosmosNoSql/CosmosNoSqlFilterTranslator.cs
+++ b/dotnet/src/VectorData/CosmosNoSql/CosmosNoSqlFilterTranslator.cs
@@ -230,8 +230,41 @@ internal class CosmosNoSqlFilterTranslator
                 this.TranslateContains(source, item);
                 return;
 
+            // C# 14 made changes to overload resolution to prefer Span-based overloads when those exist ("first-class spans");
+            // this makes MemoryExtensions.Contains() be resolved rather than Enumerable.Contains() (see above).
+            // MemoryExtensions.Contains() also accepts a Span argument for the source, adding an implicit cast we need to remove.
+            // See https://github.com/dotnet/runtime/issues/109757 for more context.
+            // Note that MemoryExtensions.Contains has an optional 3rd ComparisonType parameter; we only match when
+            // it's null.
+            case { Method.Name: nameof(MemoryExtensions.Contains), Arguments: [var spanArg, var item, ..] } contains
+                when contains.Method.DeclaringType == typeof(MemoryExtensions)
+                    && (contains.Arguments.Count is 2
+                        || (contains.Arguments.Count is 3 && contains.Arguments[2] is ConstantExpression { Value: null }))
+                    && TryUnwrapSpanImplicitCast(spanArg, out var source):
+                this.TranslateContains(source, item);
+                return;
+
             default:
                 throw new NotSupportedException($"Unsupported method call: {methodCall.Method.DeclaringType?.Name}.{methodCall.Method.Name}");
+        }
+
+        static bool TryUnwrapSpanImplicitCast(Expression expression, [NotNullWhen(true)] out Expression? result)
+        {
+            if (expression is UnaryExpression
+                {
+                    NodeType: ExpressionType.Convert,
+                    Method: { Name: "op_Implicit", DeclaringType: { IsGenericType: true } implicitCastDeclaringType },
+                    Operand: var unwrapped
+                }
+                && implicitCastDeclaringType.GetGenericTypeDefinition() is var genericTypeDefinition
+                && (genericTypeDefinition == typeof(Span<>) || genericTypeDefinition == typeof(ReadOnlySpan<>)))
+            {
+                result = unwrapped;
+                return true;
+            }
+
+            result = null;
+            return false;
         }
     }
 

--- a/dotnet/src/VectorData/Directory.Build.props
+++ b/dotnet/src/VectorData/Directory.Build.props
@@ -3,6 +3,7 @@
   <Import Project="$([MSBuild]::GetPathOfFileAbove('Directory.Build.props', '$(MSBuildThisFileDirectory)../'))" />
 
   <PropertyGroup>
+    <LangVersion>latest</LangVersion>
     <NoWarn>$(NoWarn);MEVD9000,MEVD9001</NoWarn> <!-- Experimental MEVD connector-facing APIs -->
   </PropertyGroup>
 

--- a/dotnet/src/VectorData/MongoDB/MongoFilterTranslator.cs
+++ b/dotnet/src/VectorData/MongoDB/MongoFilterTranslator.cs
@@ -161,7 +161,8 @@ internal class MongoFilterTranslator
     }
 
     private BsonDocument TranslateMethodCall(MethodCallExpression methodCall)
-        => methodCall switch
+    {
+        return methodCall switch
         {
             // Enumerable.Contains()
             { Method.Name: nameof(Enumerable.Contains), Arguments: [var source, var item] } contains
@@ -179,8 +180,41 @@ internal class MongoFilterTranslator
                 Arguments: [var item]
             } when declaringType.GetGenericTypeDefinition() == typeof(List<>) => this.TranslateContains(source, item),
 
+            // C# 14 made changes to overload resolution to prefer Span-based overloads when those exist ("first-class spans");
+            // this makes MemoryExtensions.Contains() be resolved rather than Enumerable.Contains() (see above).
+            // MemoryExtensions.Contains() also accepts a Span argument for the source, adding an implicit cast we need to remove.
+            // See https://github.com/dotnet/runtime/issues/109757 for more context.
+            // Note that MemoryExtensions.Contains has an optional 3rd ComparisonType parameter; we only match when
+            // it's null.
+            { Method.Name: nameof(MemoryExtensions.Contains), Arguments: [var spanArg, var item, ..] } contains
+                when contains.Method.DeclaringType == typeof(MemoryExtensions)
+                    && (contains.Arguments.Count is 2
+                        || (contains.Arguments.Count is 3 && contains.Arguments[2] is ConstantExpression { Value: null }))
+                    && TryUnwrapSpanImplicitCast(spanArg, out var source)
+                => this.TranslateContains(source, item),
+
             _ => throw new NotSupportedException($"Unsupported method call: {methodCall.Method.DeclaringType?.Name}.{methodCall.Method.Name}")
         };
+
+        static bool TryUnwrapSpanImplicitCast(Expression expression, [NotNullWhen(true)] out Expression? result)
+        {
+            if (expression is UnaryExpression
+                {
+                    NodeType: ExpressionType.Convert,
+                    Method: { Name: "op_Implicit", DeclaringType: { IsGenericType: true } implicitCastDeclaringType },
+                    Operand: var unwrapped
+                }
+                && implicitCastDeclaringType.GetGenericTypeDefinition() is var genericTypeDefinition
+                && (genericTypeDefinition == typeof(Span<>) || genericTypeDefinition == typeof(ReadOnlySpan<>)))
+            {
+                result = unwrapped;
+                return true;
+            }
+
+            result = null;
+            return false;
+        }
+    }
 
     private BsonDocument TranslateContains(Expression source, Expression item)
     {

--- a/dotnet/src/VectorData/Pinecone/PineconeFilterTranslator.cs
+++ b/dotnet/src/VectorData/Pinecone/PineconeFilterTranslator.cs
@@ -158,7 +158,8 @@ internal class PineconeFilterTranslator
     }
 
     private Metadata TranslateMethodCall(MethodCallExpression methodCall)
-        => methodCall switch
+    {
+        return methodCall switch
         {
             // Enumerable.Contains()
             { Method.Name: nameof(Enumerable.Contains), Arguments: [var source, var item] } contains
@@ -176,8 +177,41 @@ internal class PineconeFilterTranslator
                 Arguments: [var item]
             } when declaringType.GetGenericTypeDefinition() == typeof(List<>) => this.TranslateContains(source, item),
 
+            // C# 14 made changes to overload resolution to prefer Span-based overloads when those exist ("first-class spans");
+            // this makes MemoryExtensions.Contains() be resolved rather than Enumerable.Contains() (see above).
+            // MemoryExtensions.Contains() also accepts a Span argument for the source, adding an implicit cast we need to remove.
+            // See https://github.com/dotnet/runtime/issues/109757 for more context.
+            // Note that MemoryExtensions.Contains has an optional 3rd ComparisonType parameter; we only match when
+            // it's null.
+            { Method.Name: nameof(MemoryExtensions.Contains), Arguments: [var spanArg, var item, ..] } contains
+                when contains.Method.DeclaringType == typeof(MemoryExtensions)
+                    && (contains.Arguments.Count is 2
+                        || (contains.Arguments.Count is 3 && contains.Arguments[2] is ConstantExpression { Value: null }))
+                    && TryUnwrapSpanImplicitCast(spanArg, out var source)
+                => this.TranslateContains(source, item),
+
             _ => throw new NotSupportedException($"Unsupported method call: {methodCall.Method.DeclaringType?.Name}.{methodCall.Method.Name}")
         };
+
+        static bool TryUnwrapSpanImplicitCast(Expression expression, [NotNullWhen(true)] out Expression? result)
+        {
+            if (expression is UnaryExpression
+                {
+                    NodeType: ExpressionType.Convert,
+                    Method: { Name: "op_Implicit", DeclaringType: { IsGenericType: true } implicitCastDeclaringType },
+                    Operand: var unwrapped
+                }
+                && implicitCastDeclaringType.GetGenericTypeDefinition() is var genericTypeDefinition
+                && (genericTypeDefinition == typeof(Span<>) || genericTypeDefinition == typeof(ReadOnlySpan<>)))
+            {
+                result = unwrapped;
+                return true;
+            }
+
+            result = null;
+            return false;
+        }
+    }
 
     private Metadata TranslateContains(Expression source, Expression item)
     {

--- a/dotnet/src/VectorData/Qdrant/QdrantFilterTranslator.cs
+++ b/dotnet/src/VectorData/Qdrant/QdrantFilterTranslator.cs
@@ -267,7 +267,8 @@ internal class QdrantFilterTranslator
     #endregion Logical operators
 
     private Filter TranslateMethodCall(MethodCallExpression methodCall)
-        => methodCall switch
+    {
+        return methodCall switch
         {
             // Enumerable.Contains()
             { Method.Name: nameof(Enumerable.Contains), Arguments: [var source, var item] } contains
@@ -286,8 +287,41 @@ internal class QdrantFilterTranslator
             } when declaringType.GetGenericTypeDefinition() == typeof(List<>)
                 => this.TranslateContains(source, item),
 
+            // C# 14 made changes to overload resolution to prefer Span-based overloads when those exist ("first-class spans");
+            // this makes MemoryExtensions.Contains() be resolved rather than Enumerable.Contains() (see above).
+            // MemoryExtensions.Contains() also accepts a Span argument for the source, adding an implicit cast we need to remove.
+            // See https://github.com/dotnet/runtime/issues/109757 for more context.
+            // Note that MemoryExtensions.Contains has an optional 3rd ComparisonType parameter; we only match when
+            // it's null.
+            { Method.Name: nameof(MemoryExtensions.Contains), Arguments: [var spanArg, var item, ..] } contains
+                when contains.Method.DeclaringType == typeof(MemoryExtensions)
+                    && (contains.Arguments.Count is 2
+                        || (contains.Arguments.Count is 3 && contains.Arguments[2] is ConstantExpression { Value: null }))
+                    && TryUnwrapSpanImplicitCast(spanArg, out var source)
+                => this.TranslateContains(source, item),
+
             _ => throw new NotSupportedException($"Unsupported method call: {methodCall.Method.DeclaringType?.Name}.{methodCall.Method.Name}")
         };
+
+        static bool TryUnwrapSpanImplicitCast(Expression expression, [NotNullWhen(true)] out Expression? result)
+        {
+            if (expression is UnaryExpression
+                {
+                    NodeType: ExpressionType.Convert,
+                    Method: { Name: "op_Implicit", DeclaringType: { IsGenericType: true } implicitCastDeclaringType },
+                    Operand: var unwrapped
+                }
+                && implicitCastDeclaringType.GetGenericTypeDefinition() is var genericTypeDefinition
+                && (genericTypeDefinition == typeof(Span<>) || genericTypeDefinition == typeof(ReadOnlySpan<>)))
+            {
+                result = unwrapped;
+                return true;
+            }
+
+            result = null;
+            return false;
+        }
+    }
 
     private Filter TranslateContains(Expression source, Expression item)
     {

--- a/dotnet/src/VectorData/Redis/RedisFilterTranslator.cs
+++ b/dotnet/src/VectorData/Redis/RedisFilterTranslator.cs
@@ -173,8 +173,41 @@ internal class RedisFilterTranslator
                 this.TranslateContains(source, item);
                 return;
 
+            // C# 14 made changes to overload resolution to prefer Span-based overloads when those exist ("first-class spans");
+            // this makes MemoryExtensions.Contains() be resolved rather than Enumerable.Contains() (see above).
+            // MemoryExtensions.Contains() also accepts a Span argument for the source, adding an implicit cast we need to remove.
+            // See https://github.com/dotnet/runtime/issues/109757 for more context.
+            // Note that MemoryExtensions.Contains has an optional 3rd ComparisonType parameter; we only match when
+            // it's null.
+            case { Method.Name: nameof(MemoryExtensions.Contains), Arguments: [var spanArg, var item, ..] } contains
+                when contains.Method.DeclaringType == typeof(MemoryExtensions)
+                    && (contains.Arguments.Count is 2
+                        || (contains.Arguments.Count is 3 && contains.Arguments[2] is ConstantExpression { Value: null }))
+                    && TryUnwrapSpanImplicitCast(spanArg, out var source):
+                this.TranslateContains(source, item);
+                return;
+
             default:
                 throw new NotSupportedException($"Unsupported method call: {methodCall.Method.DeclaringType?.Name}.{methodCall.Method.Name}");
+        }
+
+        static bool TryUnwrapSpanImplicitCast(Expression expression, [NotNullWhen(true)] out Expression? result)
+        {
+            if (expression is UnaryExpression
+                {
+                    NodeType: ExpressionType.Convert,
+                    Method: { Name: "op_Implicit", DeclaringType: { IsGenericType: true } implicitCastDeclaringType },
+                    Operand: var unwrapped
+                }
+                && implicitCastDeclaringType.GetGenericTypeDefinition() is var genericTypeDefinition
+                && (genericTypeDefinition == typeof(Span<>) || genericTypeDefinition == typeof(ReadOnlySpan<>)))
+            {
+                result = unwrapped;
+                return true;
+            }
+
+            result = null;
+            return false;
         }
     }
 

--- a/dotnet/src/VectorData/Weaviate/WeaviateFilterTranslator.cs
+++ b/dotnet/src/VectorData/Weaviate/WeaviateFilterTranslator.cs
@@ -213,8 +213,41 @@ internal class WeaviateFilterTranslator
                 this.TranslateContains(source, item);
                 return;
 
+            // C# 14 made changes to overload resolution to prefer Span-based overloads when those exist ("first-class spans");
+            // this makes MemoryExtensions.Contains() be resolved rather than Enumerable.Contains() (see above).
+            // MemoryExtensions.Contains() also accepts a Span argument for the source, adding an implicit cast we need to remove.
+            // See https://github.com/dotnet/runtime/issues/109757 for more context.
+            // Note that MemoryExtensions.Contains has an optional 3rd ComparisonType parameter; we only match when
+            // it's null.
+            case { Method.Name: nameof(MemoryExtensions.Contains), Arguments: [var spanArg, var item, ..] } contains
+                when contains.Method.DeclaringType == typeof(MemoryExtensions)
+                    && (contains.Arguments.Count is 2
+                        || (contains.Arguments.Count is 3 && contains.Arguments[2] is ConstantExpression { Value: null }))
+                    && TryUnwrapSpanImplicitCast(spanArg, out var source):
+                this.TranslateContains(source, item);
+                return;
+
             default:
                 throw new NotSupportedException($"Unsupported method call: {methodCall.Method.DeclaringType?.Name}.{methodCall.Method.Name}");
+        }
+
+        static bool TryUnwrapSpanImplicitCast(Expression expression, [NotNullWhen(true)] out Expression? result)
+        {
+            if (expression is UnaryExpression
+                {
+                    NodeType: ExpressionType.Convert,
+                    Method: { Name: "op_Implicit", DeclaringType: { IsGenericType: true } implicitCastDeclaringType },
+                    Operand: var unwrapped
+                }
+                && implicitCastDeclaringType.GetGenericTypeDefinition() is var genericTypeDefinition
+                && (genericTypeDefinition == typeof(Span<>) || genericTypeDefinition == typeof(ReadOnlySpan<>)))
+            {
+                result = unwrapped;
+                return true;
+            }
+
+            result = null;
+            return false;
         }
     }
 

--- a/dotnet/test/VectorData/Directory.Build.props
+++ b/dotnet/test/VectorData/Directory.Build.props
@@ -3,6 +3,8 @@
   <Import Project="$([MSBuild]::GetPathOfFileAbove('Directory.Build.props', '$(MSBuildThisFileDirectory)../'))" />
 
   <PropertyGroup>
+    <LangVersion>latest</LangVersion>
+
     <NoWarn>$(NoWarn);MEVD9000,MEVD9001</NoWarn> <!-- Experimental MEVD connector-facing APIs -->
     <NoWarn>$(NoWarn);CA1515</NoWarn> <!-- Because an application's API isn't typically referenced from outside the assembly, types can be made internal -->
     <NoWarn>$(NoWarn);CA1707</NoWarn> <!-- Remove the underscores from member name -->

--- a/dotnet/test/VectorData/Redis.ConformanceTests/Filter/RedisBasicFilterTests.cs
+++ b/dotnet/test/VectorData/Redis.ConformanceTests/Filter/RedisBasicFilterTests.cs
@@ -123,6 +123,19 @@ public class RedisHashSetCollectionBasicFilterTests(RedisHashSetCollectionBasicF
     public override Task Contains_over_field_string_List()
         => Assert.ThrowsAsync<InvalidOperationException>(() => base.Contains_over_field_string_List());
 
+    public override Task Contains_with_Enumerable_Contains()
+        => Assert.ThrowsAsync<InvalidOperationException>(() => base.Contains_with_Enumerable_Contains());
+
+#if !NETFRAMEWORK
+    public override Task Contains_with_MemoryExtensions_Contains()
+        => Assert.ThrowsAsync<InvalidOperationException>(() => base.Contains_with_MemoryExtensions_Contains());
+#endif
+
+#if NET10_0_OR_GREATER
+    public override Task Contains_with_MemoryExtensions_Contains_with_null_comparer()
+        => Assert.ThrowsAsync<InvalidOperationException>(() => base.Contains_with_MemoryExtensions_Contains_with_null_comparer());
+#endif
+
     [Obsolete("Legacy filter support")]
     public override Task Legacy_AnyTagEqualTo_array()
         => Assert.ThrowsAsync<InvalidOperationException>(() => base.Legacy_AnyTagEqualTo_array());

--- a/dotnet/test/VectorData/Redis.ConformanceTests/Filter/RedisBasicQueryTests.cs
+++ b/dotnet/test/VectorData/Redis.ConformanceTests/Filter/RedisBasicQueryTests.cs
@@ -123,6 +123,19 @@ public class RedisHashSetCollectionBasicQueryTests(RedisHashSetCollectionBasicQu
     public override Task Contains_over_field_string_List()
         => Assert.ThrowsAsync<InvalidOperationException>(() => base.Contains_over_field_string_List());
 
+    public override Task Contains_with_Enumerable_Contains()
+        => Assert.ThrowsAsync<InvalidOperationException>(() => base.Contains_with_Enumerable_Contains());
+
+#if !NETFRAMEWORK
+    public override Task Contains_with_MemoryExtensions_Contains()
+        => Assert.ThrowsAsync<InvalidOperationException>(() => base.Contains_with_MemoryExtensions_Contains());
+#endif
+
+#if NET10_0_OR_GREATER
+    public override Task Contains_with_MemoryExtensions_Contains_with_null_comparer()
+        => Assert.ThrowsAsync<InvalidOperationException>(() => base.Contains_with_MemoryExtensions_Contains_with_null_comparer());
+#endif
+
     public new class Fixture : BasicQueryTests<string>.QueryFixture
     {
         public override TestStore TestStore => RedisTestStore.HashSetInstance;

--- a/dotnet/test/VectorData/SqlServer.ConformanceTests/Filter/SqlServerBasicFilterTests.cs
+++ b/dotnet/test/VectorData/SqlServer.ConformanceTests/Filter/SqlServerBasicFilterTests.cs
@@ -42,6 +42,19 @@ public class SqlServerBasicFilterTests(SqlServerBasicFilterTests.Fixture fixture
     public override Task Contains_over_field_string_List()
         => Assert.ThrowsAsync<InvalidOperationException>(() => base.Contains_over_field_string_List());
 
+    public override Task Contains_with_Enumerable_Contains()
+        => Assert.ThrowsAsync<InvalidOperationException>(() => base.Contains_with_Enumerable_Contains());
+
+#if !NETFRAMEWORK
+    public override Task Contains_with_MemoryExtensions_Contains()
+        => Assert.ThrowsAsync<InvalidOperationException>(() => base.Contains_with_MemoryExtensions_Contains());
+#endif
+
+#if NET10_0_OR_GREATER
+    public override Task Contains_with_MemoryExtensions_Contains_with_null_comparer()
+        => Assert.ThrowsAsync<InvalidOperationException>(() => base.Contains_with_MemoryExtensions_Contains_with_null_comparer());
+#endif
+
     [Fact(Skip = "Not supported")]
     [Obsolete("Legacy filters are not supported")]
     public override Task Legacy_And() => throw new NotSupportedException();

--- a/dotnet/test/VectorData/SqlServer.ConformanceTests/Filter/SqlServerBasicQueryTests.cs
+++ b/dotnet/test/VectorData/SqlServer.ConformanceTests/Filter/SqlServerBasicQueryTests.cs
@@ -42,6 +42,19 @@ public class SqlServerBasicQueryTests(SqlServerBasicQueryTests.Fixture fixture)
     public override Task Contains_over_field_string_List()
         => Assert.ThrowsAsync<InvalidOperationException>(() => base.Contains_over_field_string_List());
 
+    public override Task Contains_with_Enumerable_Contains()
+        => Assert.ThrowsAsync<InvalidOperationException>(() => base.Contains_with_Enumerable_Contains());
+
+#if !NETFRAMEWORK
+    public override Task Contains_with_MemoryExtensions_Contains()
+        => Assert.ThrowsAsync<InvalidOperationException>(() => base.Contains_with_MemoryExtensions_Contains());
+#endif
+
+#if NET10_0_OR_GREATER
+    public override Task Contains_with_MemoryExtensions_Contains_with_null_comparer()
+        => Assert.ThrowsAsync<InvalidOperationException>(() => base.Contains_with_MemoryExtensions_Contains_with_null_comparer());
+#endif
+
     public new class Fixture : BasicQueryTests<int>.QueryFixture
     {
         private static readonly string s_uniqueName = Guid.NewGuid().ToString();

--- a/dotnet/test/VectorData/VectorData.ConformanceTests/Filter/BasicFilterTests.cs
+++ b/dotnet/test/VectorData/VectorData.ConformanceTests/Filter/BasicFilterTests.cs
@@ -333,6 +333,37 @@ public abstract class BasicFilterTests<TKey>(BasicFilterTests<TKey>.Fixture fixt
             r => array.Contains(r["String"]));
     }
 
+#pragma warning disable RCS1196 // Call extension method as instance method
+
+    // C# 14 made changes to overload resolution to prefer Span-based overloads when those exist ("first-class spans");
+    // this makes MemoryExtensions.Contains() be resolved rather than Enumerable.Contains() (see above).
+    // See https://github.com/dotnet/runtime/issues/109757 for more context.
+    // The following tests the various Contains variants directly, without using extension syntax, to ensure everything's
+    // properly supported.
+    [ConditionalFact]
+    public virtual Task Contains_with_Enumerable_Contains()
+        => this.TestFilterAsync(
+            r => Enumerable.Contains(r.StringArray, "x"),
+            r => ((string[])r["StringArray"]!).Contains("x"));
+
+#if !NETFRAMEWORK
+    [ConditionalFact]
+    public virtual Task Contains_with_MemoryExtensions_Contains()
+        => this.TestFilterAsync(
+            r => MemoryExtensions.Contains(r.StringArray, "x"),
+            r => ((string[])r["StringArray"]!).Contains("x"));
+#endif
+
+#if NET10_0_OR_GREATER
+    [ConditionalFact]
+    public virtual Task Contains_with_MemoryExtensions_Contains_with_null_comparer()
+        => this.TestFilterAsync(
+            r => MemoryExtensions.Contains(r.StringArray, "x", comparer: null),
+            r => ((string[])r["StringArray"]!).Contains("x"));
+#endif
+
+#pragma warning restore RCS1196 // Call extension method as instance method
+
     #endregion Contains
 
     #region Variable types


### PR DESCRIPTION
This makes the provider filters compatible with C# 14 (see #12504, and https://github.com/dotnet/runtime/issues/109757 on the runtime side). Note that this changes the entire repo to build with dotnet SDK 10.0 (rc2) - that's probably a good idea regardless to test with the latest, ensure compatibility etc. (but if this is problematic, let me know - it's only truly necessary for test coverage and can be reverted).

I'm not happy to have the implementation duplicated across the implementations: we have FilterTranslationPreprocessor for common LINQ filter preprocessing, and that would be the ideal place for this. However, rewriting MemoryExtensions.Contains to Enumerable.Contains would require doing MethodInfo.MakeGenericMethod which is incompatible with NativeAOT. I considered have a fake, non-invocable MethodInfo implementation to represent the closed generic MethodInfo to Enumerable.Contains (MethodInfo and Type are abstract, so we can create custom implementations compatible with NativeAOT), but that's quite involved/complicated. The better story here is probably to have a base class implementation for the provider filter processors, which recognizes specific patterns and dispatches to abstract handlers which specific implementations override; it would take care of recognizing the various Contains variants.

Note also that we already have duplication around Enumerable.Contains and List.Contains (the instance method), so this just adds another variant (for now). I'll think about cleaning this up.

Fixes #12504