### PR TITLE
Python: Fix onnx pkg by pinning. Pin openai < 2.0.

### DIFF
--- a/python/pyproject.toml
+++ b/python/pyproject.toml
@@ -37,7 +37,7 @@ dependencies = [
     "numpy >= 1.25.0; python_version < '3.12'",
     "numpy >= 1.26.0; python_version >= '3.12'",
     # openai connector
-    "openai >= 1.98.0",
+    "openai >= 1.98.0, < 2.0.0",
     # openapi and swagger
     "openapi_core >= 0.18,<0.20",
     "websockets >= 13, < 16",

--- a/python/semantic_kernel/agents/open_ai/assistant_thread_actions.py
+++ b/python/semantic_kernel/agents/open_ai/assistant_thread_actions.py
@@ -5,7 +5,8 @@ import logging
 from collections.abc import AsyncIterable, Iterable, Sequence
 from typing import TYPE_CHECKING, Any, ClassVar, Literal, TypeVar, cast
 
-from openai import NOT_GIVEN, AsyncOpenAI, NotGiven
+from openai import AsyncOpenAI
+from openai._types import Omit, omit
 from openai.types.beta.code_interpreter_tool import CodeInterpreterTool
 from openai.types.beta.file_search_tool import FileSearchTool
 from openai.types.beta.threads.run_create_params import AdditionalMessage, AdditionalMessageAttachment
@@ -597,7 +598,7 @@ class AssistantThreadActions:
             An async iterable of ChatMessageContent.
         """
         agent_names: dict[str, Any] = {}
-        last_id: str | NotGiven = NOT_GIVEN
+        last_id: str | Omit = omit
 
         while True:
             messages = await client.beta.threads.messages.list(

--- a/python/semantic_kernel/agents/open_ai/openai_assistant_agent.py
+++ b/python/semantic_kernel/agents/open_ai/openai_assistant_agent.py
@@ -7,7 +7,8 @@ from collections.abc import AsyncIterable, Awaitable, Callable, Iterable
 from copy import copy, deepcopy
 from typing import TYPE_CHECKING, Any, ClassVar, Literal, TypeVar
 
-from openai import NOT_GIVEN, AsyncOpenAI, NotGiven
+from openai import AsyncOpenAI
+from openai._types import Omit, omit
 from openai.lib._parsing._completions import type_to_response_format_param
 from openai.types.beta.assistant import Assistant
 from openai.types.beta.assistant_create_params import (
@@ -138,9 +139,9 @@ class AssistantAgentThread(AgentThread):
         self,
         client: AsyncOpenAI,
         thread_id: str | None = None,
-        messages: Iterable["ThreadCreateMessage"] | NotGiven = NOT_GIVEN,
-        metadata: dict[str, Any] | NotGiven = NOT_GIVEN,
-        tool_resources: ToolResources | NotGiven = NOT_GIVEN,
+        messages: Iterable["ThreadCreateMessage"] | Omit = omit,
+        metadata: dict[str, Any] | Omit = omit,
+        tool_resources: ToolResources | Omit = omit,
     ) -> None:
         """Initialize the OpenAI Assistant Thread.
 

--- a/python/semantic_kernel/agents/open_ai/openai_responses_agent.py
+++ b/python/semantic_kernel/agents/open_ai/openai_responses_agent.py
@@ -706,7 +706,7 @@ class OpenAIResponsesAgent(DeclarativeSpecMixin, Agent):
             A WebSearchToolParam dictionary with any passed-in parameters.
         """
         tool: WebSearchToolParam = {
-            "type": "web_search_preview",
+            "type": "web_search",
         }
         if context_size is not None:
             tool["search_context_size"] = context_size

--- a/python/semantic_kernel/connectors/ai/open_ai/services/open_ai_handler.py
+++ b/python/semantic_kernel/connectors/ai/open_ai/services/open_ai_handler.py
@@ -5,7 +5,7 @@ from abc import ABC
 from typing import Any, Union
 
 from openai import AsyncOpenAI, AsyncStream, BadRequestError, _legacy_response
-from openai._types import NOT_GIVEN, FileTypes, NotGiven
+from openai._types import FileTypes, Omit, omit
 from openai.lib._parsing._completions import type_to_response_format_param
 from openai.types import Completion, CreateEmbeddingResponse
 from openai.types.audio import Transcription
@@ -135,7 +135,7 @@ class OpenAIHandler(KernelBaseModel, ABC):
         self,
         image: list[FileTypes],
         settings: OpenAITextToImageExecutionSettings,
-        mask: FileTypes | NotGiven = NOT_GIVEN,
+        mask: FileTypes | Omit = omit,
     ) -> ImagesResponse:
         """Send a request to the OpenAI image edit endpoint.
 

--- a/python/semantic_kernel/connectors/ai/open_ai/services/open_ai_text_to_image_base.py
+++ b/python/semantic_kernel/connectors/ai/open_ai/services/open_ai_text_to_image_base.py
@@ -4,7 +4,7 @@ from pathlib import Path
 from typing import IO, Any
 from warnings import warn
 
-from openai._types import NOT_GIVEN, FileTypes, NotGiven
+from openai._types import FileTypes, Omit, omit
 from openai.types.images_response import ImagesResponse
 
 from semantic_kernel.connectors.ai.open_ai.prompt_execution_settings.open_ai_text_to_image_execution_settings import (
@@ -217,7 +217,7 @@ class OpenAITextToImageBase(OpenAIHandler, TextToImageClientBase):
         elif image_files is not None:
             images = list(image_files)
 
-        mask: FileTypes | NotGiven = NOT_GIVEN
+        mask: FileTypes | Omit = omit
         if mask_path is not None:
             mask = Path(mask_path)
         elif mask_file is not None:

--- a/python/uv.lock
+++ b/python/uv.lock
@@ -3813,7 +3813,7 @@ wheels = [
 
 [[package]]
 name = "openai"
-version = "2.6.0"
+version = "1.109.1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "anyio", marker = "sys_platform == 'darwin' or sys_platform == 'linux' or sys_platform == 'win32'" },
@@ -3825,9 +3825,9 @@ dependencies = [
     { name = "tqdm", marker = "sys_platform == 'darwin' or sys_platform == 'linux' or sys_platform == 'win32'" },
     { name = "typing-extensions", marker = "sys_platform == 'darwin' or sys_platform == 'linux' or sys_platform == 'win32'" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/ee/c7/e42bcd89dfd47fec8a30b9e20f93e512efdbfbb3391b05bbb79a2fb295fa/openai-2.6.0.tar.gz", hash = "sha256:f119faf7fc07d7e558c1e7c32c873e241439b01bd7480418234291ee8c8f4b9d", size = 592904, upload-time = "2025-10-20T17:17:24.588Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/c6/a1/a303104dc55fc546a3f6914c842d3da471c64eec92043aef8f652eb6c524/openai-1.109.1.tar.gz", hash = "sha256:d173ed8dbca665892a6db099b4a2dfac624f94d20a93f46eb0b56aae940ed869", size = 564133, upload-time = "2025-09-24T13:00:53.075Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/c0/0a/58e9dcd34abe273eaeac3807a8483073767b5609d01bb78ea2f048e515a0/openai-2.6.0-py3-none-any.whl", hash = "sha256:f33fa12070fe347b5787a7861c8dd397786a4a17e1c3186e239338dac7e2e743", size = 1005403, upload-time = "2025-10-20T17:17:22.091Z" },
+    { url = "https://files.pythonhosted.org/packages/1d/2a/7dd3d207ec669cacc1f186fd856a0f61dbc255d24f6fdc1a6715d6051b0f/openai-1.109.1-py3-none-any.whl", hash = "sha256:6bcaf57086cf59159b8e27447e4e7dd019db5d29a438072fbd49c290c7e65315", size = 948627, upload-time = "2025-09-24T13:00:50.754Z" },
 ]
 
 [[package]]
@@ -6440,7 +6440,7 @@ requires-dist = [
     { name = "ollama", marker = "extra == 'ollama'", specifier = "~=0.4" },
     { name = "onnxruntime", marker = "extra == 'onnx'", specifier = "==1.22.1" },
     { name = "onnxruntime-genai", marker = "extra == 'onnx'", specifier = "==0.9.0" },
-    { name = "openai", specifier = ">=1.98.0" },
+    { name = "openai", specifier = ">=1.98.0,<2.0.0" },
     { name = "openapi-core", specifier = ">=0.18,<0.20" },
     { name = "opentelemetry-api", specifier = "~=1.24" },
     { name = "opentelemetry-sdk", specifier = "~=1.24" },


### PR DESCRIPTION
### Motivation and Context

For the latest onnxruntime 1.23.2 pkg: our GitHub Actions run is failing because uv is not matching the macOS wheel tag. 
Pinning to last-known-good until it's sorted out.

- Pin openai pkg < 2.0 until we can investigate if 2.0 brings in other breaking changes.

### Contribution Checklist

<!-- Before submitting this PR, please make sure: -->

- [ ] The code builds clean without any errors or warnings
- [ ] The PR follows the [SK Contribution Guidelines](https://github.com/microsoft/semantic-kernel/blob/main/CONTRIBUTING.md) and the [pre-submission formatting script](https://github.com/microsoft/semantic-kernel/blob/main/CONTRIBUTING.md#development-scripts) raises no violations
- [ ] All unit tests pass, and I have added new tests where possible
- [ ] I didn't break anyone :smile:
