### PR TITLE
Fix: emit streaming usage once at final chunk for OpenAI/Azure

### DIFF
--- a/dotnet/src/Connectors/Connectors.OpenAI/Core/ClientCore.ChatCompletion.cs
+++ b/dotnet/src/Connectors/Connectors.OpenAI/Core/ClientCore.ChatCompletion.cs
@@ -270,6 +270,7 @@ internal partial class ClientCore
             ChatFinishReason finishReason = default;
             ChatToolCall[]? toolCalls = null;
             FunctionCallContent[]? functionCallContents = null;
+            ChatTokenUsage? finalUsage = null;
 
             using (var activity = this.StartCompletionActivity(chatHistory, chatExecutionSettings))
             {
@@ -309,6 +310,11 @@ internal partial class ClientCore
                         streamedRole ??= chatCompletionUpdate.Role;
                         //streamedName ??= update.AuthorName;
                         finishReason = chatCompletionUpdate.FinishReason ?? default;
+
+                        if (chatCompletionUpdate.Usage is not null)
+                        {
+                            finalUsage = chatCompletionUpdate.Usage;
+                        }
 
                         // If we're intending to invoke function calls, we need to consume that function call information.
                         if (functionCallingConfig.AutoInvoke)
@@ -354,6 +360,11 @@ internal partial class ClientCore
                         }
                         streamedContents?.Add(openAIStreamingChatMessageContent);
                         yield return openAIStreamingChatMessageContent;
+                    }
+
+                    if (finalUsage is not null)
+                    {
+                        this.LogUsage(finalUsage);
                     }
 
                     // Translate all entries into ChatCompletionsFunctionToolCall instances.


### PR DESCRIPTION
Motivation and Context
For non‑streaming chat completions, the OpenAI / Azure OpenAI connector already logs token usage via LogUsage, which allows downstream systems to track prompt/completion/total tokens and costs.

For streaming chat completions, however, the .NET OpenAI connector currently never logs usage, even when the OpenAI API is called with stream_options: { "include_usage": true } and sends a final usage‑only chunk. As a result, consumers that rely on these metrics (e.g., for cost and token‑usage tracking) see no usage data at all for streaming calls, while non‑streaming calls behave as expected.

This PR fixes that gap and aligns the .NET connector’s behavior with both the OpenAI API semantics and the existing Python Semantic Kernel fix for streaming usage reporting.

Description
OpenAI’s chat completions API, when used with stream_options: { "include_usage": true }, emits:

normal streaming chunks with choices populated and usage == null, and
a final chunk where choices is empty and usage contains the final token counts.
The non‑streaming path in the .NET OpenAI connector already calls LogUsage(chatCompletion.Usage). The streaming path, however, did not call LogUsage at all, so usage was never reported for streaming completions.

This change updates ClientCore.ChatCompletion.GetStreamingChatMessageContentsAsync as follows:

Introduces a ChatTokenUsage? finalUsage local variable alongside the existing streaming state.
On each StreamingChatCompletionUpdate, if chatCompletionUpdate.Usage is non‑null, it overwrites finalUsage with that value.
After the streaming loop completes, if finalUsage is not null, it calls this.LogUsage(finalUsage) once.
There are no changes to the public API surface and no behavior changes for the non‑streaming path. The fix is intentionally minimal and makes the streaming path emit a single, consolidated usage event, consistent with:

the non‑streaming behavior in .NET,
the OpenAI API’s final usage‑only chunk semantics, and
the previously merged Python Semantic Kernel fix for streaming usage.

Contribution Checklist
[x] The code builds clean without any errors or warnings
[x] The PR follows the [SK Contribution Guidelines](https://github.com/microsoft/semantic-kernel/blob/main/CONTRIBUTING.md) and the [pre-submission formatting script](https://github.com/microsoft/semantic-kernel/blob/main/CONTRIBUTING.md#development-scripts) raises no violations
[x] All unit tests pass
[x] I didn't break anyone today :smile: