### PR TITLE
Fix C# 14 Contains translation for MEVD providers

### DIFF
--- a/dotnet/src/VectorData/Common/SqlFilterTranslator.cs
+++ b/dotnet/src/VectorData/Common/SqlFilterTranslator.cs
@@ -259,14 +259,41 @@ internal abstract class SqlFilterTranslator
 
         static bool TryUnwrapSpanImplicitCast(Expression expression, [NotNullWhen(true)] out Expression? result)
         {
-            if (expression is UnaryExpression
+            // Different versions of the compiler seem to generate slightly different expression tree representations for this
+            // implicit cast:
+            var (unwrapped, castDeclaringType) = expression switch
+            {
+                UnaryExpression
                 {
                     NodeType: ExpressionType.Convert,
                     Method: { Name: "op_Implicit", DeclaringType: { IsGenericType: true } implicitCastDeclaringType },
-                    Operand: var unwrapped
-                }
-                && implicitCastDeclaringType.GetGenericTypeDefinition() is var genericTypeDefinition
-                && (genericTypeDefinition == typeof(Span<>) || genericTypeDefinition == typeof(ReadOnlySpan<>)))
+                    Operand: var operand
+                } => (operand, implicitCastDeclaringType),
+
+                MethodCallExpression
+                {
+                    Method: { Name: "op_Implicit", DeclaringType: { IsGenericType: true } implicitCastDeclaringType },
+                    Arguments: [var firstArgument]
+                } => (firstArgument, implicitCastDeclaringType),
+
+                _ => (null, null)
+            };
+
+            // For the dynamic case, there's a Convert node representing an up-cast to object[]; unwrap that too.
+            if (unwrapped is UnaryExpression
+                {
+                    NodeType: ExpressionType.Convert,
+                    Method: null
+                } convert
+                && convert.Type == typeof(object[]))
+            {
+                result = convert.Operand;
+                return true;
+            }
+
+            if (unwrapped is not null
+                && castDeclaringType?.GetGenericTypeDefinition() is var genericTypeDefinition
+                    && (genericTypeDefinition == typeof(Span<>) || genericTypeDefinition == typeof(ReadOnlySpan<>)))
             {
                 result = unwrapped;
                 return true;

--- a/dotnet/src/VectorData/CosmosMongoDB/CosmosMongoFilterTranslator.cs
+++ b/dotnet/src/VectorData/CosmosMongoDB/CosmosMongoFilterTranslator.cs
@@ -196,14 +196,41 @@ internal class CosmosMongoFilterTranslator
 
         static bool TryUnwrapSpanImplicitCast(Expression expression, [NotNullWhen(true)] out Expression? result)
         {
-            if (expression is UnaryExpression
+            // Different versions of the compiler seem to generate slightly different expression tree representations for this
+            // implicit cast:
+            var (unwrapped, castDeclaringType) = expression switch
+            {
+                UnaryExpression
                 {
                     NodeType: ExpressionType.Convert,
                     Method: { Name: "op_Implicit", DeclaringType: { IsGenericType: true } implicitCastDeclaringType },
-                    Operand: var unwrapped
-                }
-                && implicitCastDeclaringType.GetGenericTypeDefinition() is var genericTypeDefinition
-                && (genericTypeDefinition == typeof(Span<>) || genericTypeDefinition == typeof(ReadOnlySpan<>)))
+                    Operand: var operand
+                } => (operand, implicitCastDeclaringType),
+
+                MethodCallExpression
+                {
+                    Method: { Name: "op_Implicit", DeclaringType: { IsGenericType: true } implicitCastDeclaringType },
+                    Arguments: [var firstArgument]
+                } => (firstArgument, implicitCastDeclaringType),
+
+                _ => (null, null)
+            };
+
+            // For the dynamic case, there's a Convert node representing an up-cast to object[]; unwrap that too.
+            if (unwrapped is UnaryExpression
+                {
+                    NodeType: ExpressionType.Convert,
+                    Method: null
+                } convert
+                && convert.Type == typeof(object[]))
+            {
+                result = convert.Operand;
+                return true;
+            }
+
+            if (unwrapped is not null
+                && castDeclaringType?.GetGenericTypeDefinition() is var genericTypeDefinition
+                    && (genericTypeDefinition == typeof(Span<>) || genericTypeDefinition == typeof(ReadOnlySpan<>)))
             {
                 result = unwrapped;
                 return true;

--- a/dotnet/src/VectorData/CosmosNoSql/CosmosNoSqlFilterTranslator.cs
+++ b/dotnet/src/VectorData/CosmosNoSql/CosmosNoSqlFilterTranslator.cs
@@ -250,14 +250,41 @@ internal class CosmosNoSqlFilterTranslator
 
         static bool TryUnwrapSpanImplicitCast(Expression expression, [NotNullWhen(true)] out Expression? result)
         {
-            if (expression is UnaryExpression
+            // Different versions of the compiler seem to generate slightly different expression tree representations for this
+            // implicit cast:
+            var (unwrapped, castDeclaringType) = expression switch
+            {
+                UnaryExpression
                 {
                     NodeType: ExpressionType.Convert,
                     Method: { Name: "op_Implicit", DeclaringType: { IsGenericType: true } implicitCastDeclaringType },
-                    Operand: var unwrapped
-                }
-                && implicitCastDeclaringType.GetGenericTypeDefinition() is var genericTypeDefinition
-                && (genericTypeDefinition == typeof(Span<>) || genericTypeDefinition == typeof(ReadOnlySpan<>)))
+                    Operand: var operand
+                } => (operand, implicitCastDeclaringType),
+
+                MethodCallExpression
+                {
+                    Method: { Name: "op_Implicit", DeclaringType: { IsGenericType: true } implicitCastDeclaringType },
+                    Arguments: [var firstArgument]
+                } => (firstArgument, implicitCastDeclaringType),
+
+                _ => (null, null)
+            };
+
+            // For the dynamic case, there's a Convert node representing an up-cast to object[]; unwrap that too.
+            if (unwrapped is UnaryExpression
+                {
+                    NodeType: ExpressionType.Convert,
+                    Method: null
+                } convert
+                && convert.Type == typeof(object[]))
+            {
+                result = convert.Operand;
+                return true;
+            }
+
+            if (unwrapped is not null
+                && castDeclaringType?.GetGenericTypeDefinition() is var genericTypeDefinition
+                    && (genericTypeDefinition == typeof(Span<>) || genericTypeDefinition == typeof(ReadOnlySpan<>)))
             {
                 result = unwrapped;
                 return true;

--- a/dotnet/src/VectorData/MongoDB/MongoFilterTranslator.cs
+++ b/dotnet/src/VectorData/MongoDB/MongoFilterTranslator.cs
@@ -201,14 +201,41 @@ internal class MongoFilterTranslator
 
         static bool TryUnwrapSpanImplicitCast(Expression expression, [NotNullWhen(true)] out Expression? result)
         {
-            if (expression is UnaryExpression
+            // Different versions of the compiler seem to generate slightly different expression tree representations for this
+            // implicit cast:
+            var (unwrapped, castDeclaringType) = expression switch
+            {
+                UnaryExpression
                 {
                     NodeType: ExpressionType.Convert,
                     Method: { Name: "op_Implicit", DeclaringType: { IsGenericType: true } implicitCastDeclaringType },
-                    Operand: var unwrapped
-                }
-                && implicitCastDeclaringType.GetGenericTypeDefinition() is var genericTypeDefinition
-                && (genericTypeDefinition == typeof(Span<>) || genericTypeDefinition == typeof(ReadOnlySpan<>)))
+                    Operand: var operand
+                } => (operand, implicitCastDeclaringType),
+
+                MethodCallExpression
+                {
+                    Method: { Name: "op_Implicit", DeclaringType: { IsGenericType: true } implicitCastDeclaringType },
+                    Arguments: [var firstArgument]
+                } => (firstArgument, implicitCastDeclaringType),
+
+                _ => (null, null)
+            };
+
+            // For the dynamic case, there's a Convert node representing an up-cast to object[]; unwrap that too.
+            if (unwrapped is UnaryExpression
+                {
+                    NodeType: ExpressionType.Convert,
+                    Method: null
+                } convert
+                && convert.Type == typeof(object[]))
+            {
+                result = convert.Operand;
+                return true;
+            }
+
+            if (unwrapped is not null
+                && castDeclaringType?.GetGenericTypeDefinition() is var genericTypeDefinition
+                    && (genericTypeDefinition == typeof(Span<>) || genericTypeDefinition == typeof(ReadOnlySpan<>)))
             {
                 result = unwrapped;
                 return true;

--- a/dotnet/src/VectorData/Pinecone/PineconeFilterTranslator.cs
+++ b/dotnet/src/VectorData/Pinecone/PineconeFilterTranslator.cs
@@ -203,14 +203,41 @@ internal class PineconeFilterTranslator
 
         static bool TryUnwrapSpanImplicitCast(Expression expression, [NotNullWhen(true)] out Expression? result)
         {
-            if (expression is UnaryExpression
+            // Different versions of the compiler seem to generate slightly different expression tree representations for this
+            // implicit cast:
+            var (unwrapped, castDeclaringType) = expression switch
+            {
+                UnaryExpression
                 {
                     NodeType: ExpressionType.Convert,
                     Method: { Name: "op_Implicit", DeclaringType: { IsGenericType: true } implicitCastDeclaringType },
-                    Operand: var unwrapped
-                }
-                && implicitCastDeclaringType.GetGenericTypeDefinition() is var genericTypeDefinition
-                && (genericTypeDefinition == typeof(Span<>) || genericTypeDefinition == typeof(ReadOnlySpan<>)))
+                    Operand: var operand
+                } => (operand, implicitCastDeclaringType),
+
+                MethodCallExpression
+                {
+                    Method: { Name: "op_Implicit", DeclaringType: { IsGenericType: true } implicitCastDeclaringType },
+                    Arguments: [var firstArgument]
+                } => (firstArgument, implicitCastDeclaringType),
+
+                _ => (null, null)
+            };
+
+            // For the dynamic case, there's a Convert node representing an up-cast to object[]; unwrap that too.
+            if (unwrapped is UnaryExpression
+                {
+                    NodeType: ExpressionType.Convert,
+                    Method: null
+                } convert
+                && convert.Type == typeof(object[]))
+            {
+                result = convert.Operand;
+                return true;
+            }
+
+            if (unwrapped is not null
+                && castDeclaringType?.GetGenericTypeDefinition() is var genericTypeDefinition
+                    && (genericTypeDefinition == typeof(Span<>) || genericTypeDefinition == typeof(ReadOnlySpan<>)))
             {
                 result = unwrapped;
                 return true;

--- a/dotnet/src/VectorData/Qdrant/QdrantFilterTranslator.cs
+++ b/dotnet/src/VectorData/Qdrant/QdrantFilterTranslator.cs
@@ -308,14 +308,41 @@ internal class QdrantFilterTranslator
 
         static bool TryUnwrapSpanImplicitCast(Expression expression, [NotNullWhen(true)] out Expression? result)
         {
-            if (expression is UnaryExpression
+            // Different versions of the compiler seem to generate slightly different expression tree representations for this
+            // implicit cast:
+            var (unwrapped, castDeclaringType) = expression switch
+            {
+                UnaryExpression
                 {
                     NodeType: ExpressionType.Convert,
                     Method: { Name: "op_Implicit", DeclaringType: { IsGenericType: true } implicitCastDeclaringType },
-                    Operand: var unwrapped
-                }
-                && implicitCastDeclaringType.GetGenericTypeDefinition() is var genericTypeDefinition
-                && (genericTypeDefinition == typeof(Span<>) || genericTypeDefinition == typeof(ReadOnlySpan<>)))
+                    Operand: var operand
+                } => (operand, implicitCastDeclaringType),
+
+                MethodCallExpression
+                {
+                    Method: { Name: "op_Implicit", DeclaringType: { IsGenericType: true } implicitCastDeclaringType },
+                    Arguments: [var firstArgument]
+                } => (firstArgument, implicitCastDeclaringType),
+
+                _ => (null, null)
+            };
+
+            // For the dynamic case, there's a Convert node representing an up-cast to object[]; unwrap that too.
+            if (unwrapped is UnaryExpression
+                {
+                    NodeType: ExpressionType.Convert,
+                    Method: null
+                } convert
+                && convert.Type == typeof(object[]))
+            {
+                result = convert.Operand;
+                return true;
+            }
+
+            if (unwrapped is not null
+                && castDeclaringType?.GetGenericTypeDefinition() is var genericTypeDefinition
+                    && (genericTypeDefinition == typeof(Span<>) || genericTypeDefinition == typeof(ReadOnlySpan<>)))
             {
                 result = unwrapped;
                 return true;

--- a/dotnet/src/VectorData/Redis/RedisFilterTranslator.cs
+++ b/dotnet/src/VectorData/Redis/RedisFilterTranslator.cs
@@ -201,14 +201,41 @@ internal class RedisFilterTranslator
 
         static bool TryUnwrapSpanImplicitCast(Expression expression, [NotNullWhen(true)] out Expression? result)
         {
-            if (expression is UnaryExpression
+            // Different versions of the compiler seem to generate slightly different expression tree representations for this
+            // implicit cast:
+            var (unwrapped, castDeclaringType) = expression switch
+            {
+                UnaryExpression
                 {
                     NodeType: ExpressionType.Convert,
                     Method: { Name: "op_Implicit", DeclaringType: { IsGenericType: true } implicitCastDeclaringType },
-                    Operand: var unwrapped
-                }
-                && implicitCastDeclaringType.GetGenericTypeDefinition() is var genericTypeDefinition
-                && (genericTypeDefinition == typeof(Span<>) || genericTypeDefinition == typeof(ReadOnlySpan<>)))
+                    Operand: var operand
+                } => (operand, implicitCastDeclaringType),
+
+                MethodCallExpression
+                {
+                    Method: { Name: "op_Implicit", DeclaringType: { IsGenericType: true } implicitCastDeclaringType },
+                    Arguments: [var firstArgument]
+                } => (firstArgument, implicitCastDeclaringType),
+
+                _ => (null, null)
+            };
+
+            // For the dynamic case, there's a Convert node representing an up-cast to object[]; unwrap that too.
+            if (unwrapped is UnaryExpression
+                {
+                    NodeType: ExpressionType.Convert,
+                    Method: null
+                } convert
+                && convert.Type == typeof(object[]))
+            {
+                result = convert.Operand;
+                return true;
+            }
+
+            if (unwrapped is not null
+                && castDeclaringType?.GetGenericTypeDefinition() is var genericTypeDefinition
+                    && (genericTypeDefinition == typeof(Span<>) || genericTypeDefinition == typeof(ReadOnlySpan<>)))
             {
                 result = unwrapped;
                 return true;

--- a/dotnet/src/VectorData/Weaviate/WeaviateFilterTranslator.cs
+++ b/dotnet/src/VectorData/Weaviate/WeaviateFilterTranslator.cs
@@ -241,14 +241,41 @@ internal class WeaviateFilterTranslator
 
         static bool TryUnwrapSpanImplicitCast(Expression expression, [NotNullWhen(true)] out Expression? result)
         {
-            if (expression is UnaryExpression
+            // Different versions of the compiler seem to generate slightly different expression tree representations for this
+            // implicit cast:
+            var (unwrapped, castDeclaringType) = expression switch
+            {
+                UnaryExpression
                 {
                     NodeType: ExpressionType.Convert,
                     Method: { Name: "op_Implicit", DeclaringType: { IsGenericType: true } implicitCastDeclaringType },
-                    Operand: var unwrapped
-                }
-                && implicitCastDeclaringType.GetGenericTypeDefinition() is var genericTypeDefinition
-                && (genericTypeDefinition == typeof(Span<>) || genericTypeDefinition == typeof(ReadOnlySpan<>)))
+                    Operand: var operand
+                } => (operand, implicitCastDeclaringType),
+
+                MethodCallExpression
+                {
+                    Method: { Name: "op_Implicit", DeclaringType: { IsGenericType: true } implicitCastDeclaringType },
+                    Arguments: [var firstArgument]
+                } => (firstArgument, implicitCastDeclaringType),
+
+                _ => (null, null)
+            };
+
+            // For the dynamic case, there's a Convert node representing an up-cast to object[]; unwrap that too.
+            if (unwrapped is UnaryExpression
+                {
+                    NodeType: ExpressionType.Convert,
+                    Method: null
+                } convert
+                && convert.Type == typeof(object[]))
+            {
+                result = convert.Operand;
+                return true;
+            }
+
+            if (unwrapped is not null
+                && castDeclaringType?.GetGenericTypeDefinition() is var genericTypeDefinition
+                    && (genericTypeDefinition == typeof(Span<>) || genericTypeDefinition == typeof(ReadOnlySpan<>)))
             {
                 result = unwrapped;
                 return true;


### PR DESCRIPTION
This fixes the failing Contains-related MEVD filter tests. I'm not quite sure what happened since I merged #13263 (at which point these were passing) - possibly #13395 - but these pass again.

Note that I still plan to go back and design the translators in a way which doesn't require the code to be duplicated, but we shouldn't block on that.