### PR TITLE
Add download_file function to sessions_python_plugin

### DIFF
--- a/python/semantic_kernel/core_plugins/sessions_python_tool/sessions_python_plugin.py
+++ b/python/semantic_kernel/core_plugins/sessions_python_tool/sessions_python_plugin.py
@@ -301,6 +301,7 @@ class SessionsPythonTool(KernelBaseModel):
                 f"List files failed with status code {e.response.status_code} and error: {error_message}"
             ) from e
 
+    @kernel_function(name="download_file", description="Downloads a file from the current Session ID")
     async def download_file(
         self,
         *,


### PR DESCRIPTION
### Motivation and Context

<!-- Thank you for your contribution to the semantic-kernel repo!
Please help reviewers and future users, providing the following information:
  1. Why is this change required? : Added @kernel_method line for download_file method.
  2. What problem does it solve?: Earlier it was download_file key error.
  3. What scenario does it contribute to? It fixes download_file key error.
  4. If it fixes an open issue, please link to the issue here.
-->

### Description

<!-- Describe your changes, the overall approach, the underlying design.
     These notes will help understanding how your code works. Thanks! -->

### Contribution Checklist

<!-- Before submitting this PR, please make sure: -->

- [x] The code builds clean without any errors or warnings
- [x] The PR follows the [SK Contribution Guidelines](https://github.com/microsoft/semantic-kernel/blob/main/CONTRIBUTING.md) and the [pre-submission formatting script](https://github.com/microsoft/semantic-kernel/blob/main/CONTRIBUTING.md#development-scripts) raises no violations
- [x] All unit tests pass, and I have added new tests where possible
- [x] I didn't break anyone :smile:
