### PR TITLE
Python: Add directory allowlist configuration for SessionsPythonTool file

### DIFF
--- a/python/samples/getting_started_with_agents/chat_completion/step12_chat_completion_agent_code_interpreter.py
+++ b/python/samples/getting_started_with_agents/chat_completion/step12_chat_completion_agent_code_interpreter.py
@@ -29,8 +29,15 @@ async def handle_intermediate_steps(message: ChatMessageContent) -> None:
 async def main():
     credential = AzureCliCredential()
 
+    # Define the resources directory for file uploads
+    resources_dir = os.path.join(os.path.dirname(os.path.dirname(os.path.realpath(__file__))), "resources")
+
     # 1. Create the python code interpreter tool using the SessionsPythonTool
-    python_code_interpreter = SessionsPythonTool(credential=credential)
+    # allowed_upload_directories restricts which local directories can be accessed for uploads
+    python_code_interpreter = SessionsPythonTool(
+        credential=credential,
+        allowed_upload_directories=[resources_dir],
+    )
 
     # 2. Create the agent
     agent = ChatCompletionAgent(
@@ -41,7 +48,7 @@ async def main():
     )
 
     # 3. Upload a CSV file to the session
-    csv_file_path = os.path.join(os.path.dirname(os.path.dirname(os.path.realpath(__file__))), "resources", "sales.csv")
+    csv_file_path = os.path.join(resources_dir, "sales.csv")
     file_metadata = await python_code_interpreter.upload_file(local_file_path=csv_file_path)
 
     # 4. Invoke the agent for a response to a task

--- a/python/tests/unit/core_plugins/test_sessions_python_plugin.py
+++ b/python/tests/unit/core_plugins/test_sessions_python_plugin.py
@@ -863,4 +863,30 @@ def test_allowed_directories_accepts_list(aca_python_sessions_unit_test_env):
     assert plugin.allowed_download_directories == {"/path/three"}
 
 
+async def test_empty_set_denies_all_uploads(aca_python_sessions_unit_test_env, tmp_path):
+    """Test that an empty set for allowed_upload_directories denies all uploads."""
+    test_file = tmp_path / "test.txt"
+    test_file.write_text("content")
+
+    plugin = SessionsPythonTool(
+        auth_callback=lambda: "sample_token",
+        allowed_upload_directories=set(),  # Empty set - deny all
+    )
+
+    with pytest.raises(FunctionExecutionException, match="Access denied"):
+        await plugin.upload_file(local_file_path=str(test_file))
+
+
+def test_empty_strings_filtered_from_allowed_directories(aca_python_sessions_unit_test_env):
+    """Test that empty strings are filtered out from allowed directories."""
+    plugin = SessionsPythonTool(
+        auth_callback=lambda: "sample_token",
+        allowed_upload_directories=["", "/valid/path", ""],
+        allowed_download_directories=["", ""],
+    )
+
+    assert plugin.allowed_upload_directories == {"/valid/path"}
+    assert plugin.allowed_download_directories == set()  # All empty strings filtered out
+
+
 # endregion


### PR DESCRIPTION
### Motivation and Context

When `SessionsPythonTool` is used with an AI model, providing explicit directory boundaries for file operations gives developers fine-grained control over which parts of the filesystem the plugin can access. This follows the pattern established by `HttpPlugin.allowed_domains`.

- Add `allowed_upload_directories` parameter to control which local directories can be used for file uploads
- Add `allowed_download_directories` parameter for optional restrictions on file download destinations
- Implement path canonicalization to resolve symlinks and normalize paths

Usage:

```python
tool = SessionsPythonTool(
    credential=credential,
    allowed_upload_directories={"/app/data/uploads", "/app/user_files"},
    allowed_download_directories={"/app/data/downloads"},  # optional
)
```


<!-- Thank you for your contribution to the semantic-kernel repo!
Please help reviewers and future users, providing the following information:
  1. Why is this change required?
  2. What problem does it solve?
  3. What scenario does it contribute to?
  4. If it fixes an open issue, please link to the issue here.
-->

### Description

- `upload_file` now requires `allowed_upload_directories` to be configured (deny-by-default)
- `download_file` optionally supports `allowed_download_directories` (permissive-by-default, since it's not exposed as a kernel function)
- Both parameters accept `set[str]` or `list[str]` for convenience
- Paths are canonicalized using `os.path.realpath()` before validation

<!-- Describe your changes, the overall approach, the underlying design.
     These notes will help understanding how your code works. Thanks! -->

### Contribution Checklist

<!-- Before submitting this PR, please make sure: -->

- [X] The code builds clean without any errors or warnings
- [X] The PR follows the [SK Contribution Guidelines](https://github.com/microsoft/semantic-kernel/blob/main/CONTRIBUTING.md) and the [pre-submission formatting script](https://github.com/microsoft/semantic-kernel/blob/main/CONTRIBUTING.md#development-scripts) raises no violations
- [X] All unit tests pass, and I have added new tests where possible
- [ ] I didn't break anyone :smile:
