### PR TITLE
Python: make OpenAI omit sentinel import compatible across SDK versions

### DIFF
--- a/python/semantic_kernel/agents/open_ai/assistant_thread_actions.py
+++ b/python/semantic_kernel/agents/open_ai/assistant_thread_actions.py
@@ -6,7 +6,6 @@ from collections.abc import AsyncIterable, Iterable, Sequence
 from typing import TYPE_CHECKING, Any, ClassVar, Literal, TypeVar, cast
 
 from openai import AsyncOpenAI
-from openai._types import Omit, omit
 from openai.types.beta.code_interpreter_tool import CodeInterpreterTool
 from openai.types.beta.file_search_tool import FileSearchTool
 from openai.types.beta.threads.run_create_params import AdditionalMessage, AdditionalMessageAttachment
@@ -34,6 +33,7 @@ from semantic_kernel.agents.open_ai.assistant_content_generation import (
 from semantic_kernel.agents.open_ai.function_action_result import FunctionActionResult
 from semantic_kernel.agents.open_ai.run_polling_options import RunPollingOptions
 from semantic_kernel.connectors.ai.function_calling_utils import kernel_function_metadata_to_function_call_format
+from semantic_kernel.connectors.ai.open_ai._types_compat import Omit, omit
 from semantic_kernel.contents.file_reference_content import FileReferenceContent
 from semantic_kernel.contents.function_call_content import FunctionCallContent
 from semantic_kernel.contents.streaming_file_reference_content import StreamingFileReferenceContent
@@ -618,7 +618,7 @@ class AssistantThreadActions:
                     if agent.name and agent.name.strip():
                         agent_names[agent.id] = agent.name
 
-                assistant_name = agent_names.get(message.assistant_id or "", None) or message.assistant_id or message.id
+                assistant_name = agent_names.get(message.assistant_id or "") or message.assistant_id or message.id
                 content = generate_message_content(str(assistant_name), message)
 
                 if len(content.items) > 0:

--- a/python/semantic_kernel/agents/open_ai/openai_assistant_agent.py
+++ b/python/semantic_kernel/agents/open_ai/openai_assistant_agent.py
@@ -8,7 +8,6 @@ from copy import copy, deepcopy
 from typing import TYPE_CHECKING, Any, ClassVar, Literal, TypeVar
 
 from openai import AsyncOpenAI
-from openai._types import Omit, omit
 from openai.lib._parsing._completions import type_to_response_format_param
 from openai.types.beta.assistant import Assistant
 from openai.types.beta.assistant_create_params import (
@@ -35,6 +34,7 @@ from semantic_kernel.agents.channels.agent_channel import AgentChannel
 from semantic_kernel.agents.channels.open_ai_assistant_channel import OpenAIAssistantChannel
 from semantic_kernel.agents.open_ai.assistant_thread_actions import AssistantThreadActions
 from semantic_kernel.agents.open_ai.run_polling_options import RunPollingOptions
+from semantic_kernel.connectors.ai.open_ai._types_compat import Omit, omit
 from semantic_kernel.connectors.ai.open_ai.settings.open_ai_settings import OpenAISettings
 from semantic_kernel.connectors.utils.structured_output_schema import generate_structured_output_response_format_schema
 from semantic_kernel.contents.chat_message_content import ChatMessageContent

--- a/python/semantic_kernel/connectors/ai/open_ai/_types_compat.py
+++ b/python/semantic_kernel/connectors/ai/open_ai/_types_compat.py
@@ -1,0 +1,20 @@
+# Copyright (c) Microsoft. All rights reserved.
+
+"""Compatibility helpers for OpenAI client private type exports.
+
+Some OpenAI SDK 2.x releases expose ``omit`` while others only expose
+``NOT_GIVEN``. Semantic Kernel uses this sentinel for optional file/mask
+parameters, so we normalize both variants here.
+"""
+
+from openai._types import FileTypes
+
+try:
+    from openai._types import Omit, omit
+except ImportError:  # pragma: no cover - exercised via compatibility unit test
+    from openai._types import NOT_GIVEN, NotGiven
+
+    Omit = NotGiven
+    omit = NOT_GIVEN
+
+__all__ = ["FileTypes", "Omit", "omit"]

--- a/python/semantic_kernel/connectors/ai/open_ai/services/open_ai_handler.py
+++ b/python/semantic_kernel/connectors/ai/open_ai/services/open_ai_handler.py
@@ -5,7 +5,6 @@ from abc import ABC
 from typing import Any, Union
 
 from openai import AsyncOpenAI, AsyncStream, BadRequestError, _legacy_response
-from openai._types import FileTypes, Omit, omit
 from openai.lib._parsing._completions import type_to_response_format_param
 from openai.types import Completion, CreateEmbeddingResponse
 from openai.types.audio import Transcription
@@ -21,6 +20,7 @@ from semantic_kernel.connectors.ai.open_ai import (
     OpenAITextToAudioExecutionSettings,
     OpenAITextToImageExecutionSettings,
 )
+from semantic_kernel.connectors.ai.open_ai._types_compat import FileTypes, Omit, omit
 from semantic_kernel.connectors.ai.open_ai.exceptions.content_filter_ai_exception import ContentFilterAIException
 from semantic_kernel.connectors.ai.open_ai.services.open_ai_model_types import OpenAIModelTypes
 from semantic_kernel.connectors.ai.prompt_execution_settings import PromptExecutionSettings

--- a/python/semantic_kernel/connectors/ai/open_ai/services/open_ai_text_to_image_base.py
+++ b/python/semantic_kernel/connectors/ai/open_ai/services/open_ai_text_to_image_base.py
@@ -4,9 +4,9 @@ from pathlib import Path
 from typing import IO, Any
 from warnings import warn
 
-from openai._types import FileTypes, Omit, omit
 from openai.types.images_response import ImagesResponse
 
+from semantic_kernel.connectors.ai.open_ai._types_compat import FileTypes, Omit, omit
 from semantic_kernel.connectors.ai.open_ai.prompt_execution_settings.open_ai_text_to_image_execution_settings import (
     ImageSize,
     OpenAITextToImageExecutionSettings,

--- a/python/tests/unit/connectors/ai/open_ai/test_openai_types_compat.py
+++ b/python/tests/unit/connectors/ai/open_ai/test_openai_types_compat.py
@@ -1,0 +1,64 @@
+# Copyright (c) Microsoft. All rights reserved.
+
+import importlib.util
+import sys
+import types
+from pathlib import Path
+
+
+def _load_types_compat_module():
+    module_name = "sk_openai_types_compat_test_module"
+    module_path = (
+        Path(__file__).resolve().parents[5] / "semantic_kernel" / "connectors" / "ai" / "open_ai" / "_types_compat.py"
+    )
+    sys.modules.pop(module_name, None)
+    spec = importlib.util.spec_from_file_location(module_name, module_path)
+    assert spec is not None
+    assert spec.loader is not None
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+def test_openai_types_compat_uses_omit_when_available(monkeypatch):
+    fake_openai = types.ModuleType("openai")
+    fake_types = types.ModuleType("openai._types")
+
+    class DummyOmit:
+        pass
+
+    omit_marker = object()
+    fake_types.FileTypes = str
+    fake_types.Omit = DummyOmit
+    fake_types.omit = omit_marker
+    fake_openai._types = fake_types
+
+    monkeypatch.setitem(sys.modules, "openai", fake_openai)
+    monkeypatch.setitem(sys.modules, "openai._types", fake_types)
+
+    compat = _load_types_compat_module()
+
+    assert compat.Omit is DummyOmit
+    assert compat.omit is omit_marker
+
+
+def test_openai_types_compat_falls_back_to_not_given(monkeypatch):
+    fake_openai = types.ModuleType("openai")
+    fake_types = types.ModuleType("openai._types")
+
+    class DummyNotGiven:
+        pass
+
+    not_given_marker = object()
+    fake_types.FileTypes = str
+    fake_types.NotGiven = DummyNotGiven
+    fake_types.NOT_GIVEN = not_given_marker
+    fake_openai._types = fake_types
+
+    monkeypatch.setitem(sys.modules, "openai", fake_openai)
+    monkeypatch.setitem(sys.modules, "openai._types", fake_types)
+
+    compat = _load_types_compat_module()
+
+    assert compat.Omit is DummyNotGiven
+    assert compat.omit is not_given_marker


### PR DESCRIPTION
## Summary
Fixes import compatibility for OpenAI SDK variants where `openai._types` exports `NOT_GIVEN`/`NotGiven` but not `omit`/`Omit`.

This addresses the runtime import failure reported in #13525.

## Changes
- Added `python/semantic_kernel/connectors/ai/open_ai/_types_compat.py`:
  - Uses `Omit`/`omit` when available.
  - Falls back to `NotGiven`/`NOT_GIVEN` when `omit` is unavailable.
- Updated OpenAI integrations to import from the new compatibility module:
  - `python/semantic_kernel/connectors/ai/open_ai/services/open_ai_handler.py`
  - `python/semantic_kernel/connectors/ai/open_ai/services/open_ai_text_to_image_base.py`
  - `python/semantic_kernel/agents/open_ai/assistant_thread_actions.py`
  - `python/semantic_kernel/agents/open_ai/openai_assistant_agent.py`
- Added regression tests:
  - `python/tests/unit/connectors/ai/open_ai/test_openai_types_compat.py`
    - verifies normal path (`omit` available)
    - verifies fallback path (`NOT_GIVEN` only)

## Validation
- `uv run ruff check semantic_kernel/connectors/ai/open_ai/_types_compat.py semantic_kernel/connectors/ai/open_ai/services/open_ai_handler.py semantic_kernel/connectors/ai/open_ai/services/open_ai_text_to_image_base.py semantic_kernel/agents/open_ai/assistant_thread_actions.py semantic_kernel/agents/open_ai/openai_assistant_agent.py tests/unit/connectors/ai/open_ai/test_openai_types_compat.py`
- `env -u ALL_PROXY -u all_proxy -u HTTPS_PROXY -u https_proxy -u HTTP_PROXY -u http_proxy -u NO_PROXY -u no_proxy uv run --with pandas pytest -q tests/unit/connectors/ai/open_ai/test_openai_types_compat.py`
- `env -u ALL_PROXY -u all_proxy -u HTTPS_PROXY -u https_proxy -u HTTP_PROXY -u http_proxy -u NO_PROXY -u no_proxy uv run --with pandas pytest -q tests/unit/connectors/ai/open_ai/services/test_openai_text_to_image.py -k test_init`

