### PR TITLE
.Net: fix key-type validation compatibility regression in InMemory/Qdrant

### DIFF
--- a/dotnet/src/VectorData/InMemory/InMemoryModelBuilder.cs
+++ b/dotnet/src/VectorData/InMemory/InMemoryModelBuilder.cs
@@ -28,6 +28,14 @@ internal class InMemoryModelBuilder() : CollectionModelBuilder(ValidationOptions
         }
     }
 
+    protected override bool IsKeyPropertyTypeValid(Type type, [NotNullWhen(false)] out string? supportedTypes)
+    {
+        supportedTypes = null;
+
+        // All .NET key types are supported by the InMemory provider.
+        return true;
+    }
+
     protected override bool IsDataPropertyTypeValid(Type type, [NotNullWhen(false)] out string? supportedTypes)
     {
         supportedTypes = "";

--- a/dotnet/src/VectorData/Qdrant/QdrantModelBuilder.cs
+++ b/dotnet/src/VectorData/Qdrant/QdrantModelBuilder.cs
@@ -24,11 +24,23 @@ internal class QdrantModelBuilder(bool hasNamedVectors) : CollectionModelBuilder
     {
         var type = keyProperty.Type;
 
-        if (type != typeof(ulong) && type != typeof(Guid))
+        if (!this.IsKeyPropertyTypeValid(type, out _))
         {
             throw new NotSupportedException(
                 $"Property '{keyProperty.ModelName}' has unsupported type '{type.Name}'. Key properties must be either ulong or Guid.");
         }
+    }
+
+    protected override bool IsKeyPropertyTypeValid(Type type, [NotNullWhen(false)] out string? supportedTypes)
+    {
+        if (type == typeof(ulong) || type == typeof(Guid))
+        {
+            supportedTypes = null;
+            return true;
+        }
+
+        supportedTypes = "ulong, Guid";
+        return false;
     }
 
     protected override bool IsDataPropertyTypeValid(Type type, [NotNullWhen(false)] out string? supportedTypes)

--- a/dotnet/src/VectorData/VectorData.Abstractions/ProviderServices/CollectionModelBuilder.cs
+++ b/dotnet/src/VectorData/VectorData.Abstractions/ProviderServices/CollectionModelBuilder.cs
@@ -540,6 +540,28 @@ public abstract class CollectionModelBuilder
     /// <summary>
     /// Validates that the .NET type for a key property is supported by the provider.
     /// </summary>
+    /// <remarks>
+    /// This compatibility hook allows providers to expose key-type support as a boolean check,
+    /// while existing providers can continue using <see cref="ValidateKeyProperty(KeyPropertyModel)"/>.
+    /// </remarks>
+    protected virtual bool IsKeyPropertyTypeValid(Type type, [NotNullWhen(false)] out string? supportedTypes)
+    {
+        try
+        {
+            this.ValidateKeyProperty(new KeyPropertyModel(nameof(type), type));
+            supportedTypes = null;
+            return true;
+        }
+        catch (NotSupportedException)
+        {
+            supportedTypes = "Provider-specific key type constraints are not satisfied.";
+            return false;
+        }
+    }
+
+    /// <summary>
+    /// Validates that the .NET type for a key property is supported by the provider.
+    /// </summary>
     /// <returns><c>true</c> if the provider supports auto-generating keys of the specified type; otherwise, <c>false</c>.</returns>
     protected abstract void ValidateKeyProperty(KeyPropertyModel keyProperty);
 

--- a/dotnet/test/VectorData/InMemory.UnitTests/InMemoryVectorStoreTests.cs
+++ b/dotnet/test/VectorData/InMemory.UnitTests/InMemoryVectorStoreTests.cs
@@ -1,6 +1,7 @@
 ﻿// Copyright (c) Microsoft. All rights reserved.
 
 using System;
+using System.Reflection;
 using System.Threading.Tasks;
 using Microsoft.Extensions.VectorData;
 using Microsoft.SemanticKernel.Connectors.InMemory;
@@ -41,6 +42,25 @@ public class InMemoryVectorStoreTests
         // Assert.
         Assert.NotNull(actual);
         Assert.IsType<InMemoryCollection<int, SinglePropsModel<int>>>(actual);
+    }
+
+    [Fact]
+    public void InMemoryModelBuilderExposesKeyTypeValidationCompatibilityMethod()
+    {
+        // Arrange.
+        var method = typeof(InMemoryModelBuilder).GetMethod(
+            "IsKeyPropertyTypeValid",
+            BindingFlags.Instance | BindingFlags.NonPublic | BindingFlags.DeclaredOnly);
+        var sut = new InMemoryModelBuilder();
+        var args = new object?[] { typeof(string), null };
+
+        // Act.
+        var isSupported = (bool?)method?.Invoke(sut, args);
+
+        // Assert.
+        Assert.NotNull(method);
+        Assert.True(isSupported);
+        Assert.Null(args[1]);
     }
 
     [Fact]

--- a/dotnet/test/VectorData/Qdrant.UnitTests/QdrantVectorStoreTests.cs
+++ b/dotnet/test/VectorData/Qdrant.UnitTests/QdrantVectorStoreTests.cs
@@ -2,6 +2,7 @@
 
 using System;
 using System.Linq;
+using System.Reflection;
 using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.Extensions.VectorData;
@@ -48,6 +49,29 @@ public class QdrantVectorStoreTests
 
         // Act & Assert.
         Assert.Throws<NotSupportedException>(() => sut.GetCollection<string, SinglePropsModel<string>>(TestCollectionName));
+    }
+
+    [Fact]
+    public void QdrantModelBuilderExposesKeyTypeValidationCompatibilityMethod()
+    {
+        // Arrange.
+        var method = typeof(QdrantModelBuilder).GetMethod(
+            "IsKeyPropertyTypeValid",
+            BindingFlags.Instance | BindingFlags.NonPublic | BindingFlags.DeclaredOnly);
+        var sut = new QdrantModelBuilder(hasNamedVectors: false);
+        var validArgs = new object?[] { typeof(ulong), null };
+        var invalidArgs = new object?[] { typeof(string), null };
+
+        // Act.
+        var validResult = (bool?)method?.Invoke(sut, validArgs);
+        var invalidResult = (bool?)method?.Invoke(sut, invalidArgs);
+
+        // Assert.
+        Assert.NotNull(method);
+        Assert.True(validResult);
+        Assert.Null(validArgs[1]);
+        Assert.False(invalidResult);
+        Assert.Equal("ulong, Guid", invalidArgs[1]);
     }
 
     [Fact]


### PR DESCRIPTION
## Summary
This change addresses a runtime compatibility regression affecting InMemory and Qdrant connectors where model builder type loading fails due to missing `IsKeyPropertyTypeValid` implementation.

## What changed
- Added a compatibility hook to `CollectionModelBuilder`:
  - `IsKeyPropertyTypeValid(Type, out string?)` with a safe default implementation.
- Implemented explicit overrides in:
  - `InMemoryModelBuilder`
  - `QdrantModelBuilder`
- Updated Qdrant key validation path to use the compatibility hook.
- Added regression unit tests for both connectors to verify the compatibility method is present and behaves correctly.

## Why this helps
- Prevents runtime type-load failures in the reported scenarios.
- Keeps existing key-validation behavior intact.
- Adds a stable compatibility surface for provider key-type validation.

## Validation
- `dotnet test test/VectorData/InMemory.UnitTests/InMemory.UnitTests.csproj --configuration Release`
- `dotnet test test/VectorData/Qdrant.UnitTests/Qdrant.UnitTests.csproj --configuration Release`

Fixes #13562
Fixes #13563
