### PR TITLE
.Net: preserve root $defs/definitions when wrapping AIFunction tools

### DIFF
--- a/dotnet/src/SemanticKernel.Abstractions/AI/ChatCompletion/AIFunctionKernelFunction.cs
+++ b/dotnet/src/SemanticKernel.Abstractions/AI/ChatCompletion/AIFunctionKernelFunction.cs
@@ -17,6 +17,7 @@ namespace Microsoft.SemanticKernel.ChatCompletion;
 internal sealed class AIFunctionKernelFunction : KernelFunction
 {
     private readonly AIFunction _aiFunction;
+    private readonly JsonElement _jsonSchema;
 
     public AIFunctionKernelFunction(AIFunction aiFunction) :
         base(
@@ -33,13 +34,18 @@ internal sealed class AIFunctionKernelFunction : KernelFunction
     {
         // Kernel functions created from AI functions are always fully qualified
         this._aiFunction = aiFunction;
+        this._jsonSchema = aiFunction.JsonSchema.Clone();
     }
 
     private AIFunctionKernelFunction(AIFunctionKernelFunction other, string? pluginName) :
         base(other.Name, pluginName, other.Description, other.Metadata.Parameters, AbstractionsJsonContext.Default.Options, other.Metadata.ReturnParameter)
     {
         this._aiFunction = other._aiFunction;
+        this._jsonSchema = other._jsonSchema;
     }
+
+    /// <inheritdoc />
+    public override JsonElement JsonSchema => this._jsonSchema;
 
     public override KernelFunction Clone(string? pluginName = null)
     {


### PR DESCRIPTION
### Summary
Preserves root-level JSON schema definitions (`$defs` / `definitions`) when wrapping `AIFunction` tools as `KernelFunction`.

Fixes #13447.

### Problem
`AIFunctionKernelFunction` currently builds schema metadata from parameter properties. During that conversion, root-level schema sections like `$defs` / `definitions` are dropped.

When a property schema still contains `$ref` (for example `#/$defs/Node`), this produces an incomplete tool schema for model calls.

### Changes
- `AIFunctionKernelFunction` now stores and returns the original `aiFunction.JsonSchema`.
- Added regression test to verify root-level `$defs` are preserved.
- Added streaming invocation test for the wrapper behavior path.

### Validation
- `GITHUB_ACTIONS=1 dotnet test dotnet/src/SemanticKernel.UnitTests/SemanticKernel.UnitTests.csproj --configuration Release --filter FullyQualifiedName~AIFunctionKernelFunctionTests`
  - Passed: 14, Failed: 0
- `GITHUB_ACTIONS=1 dotnet test dotnet/src/SemanticKernel.UnitTests/SemanticKernel.UnitTests.csproj --configuration Release --no-build --filter FullyQualifiedName~AIFunctionKernelFunctionTests --collect:"XPlat Code Coverage"`
  - `AIFunctionKernelFunction` line-rate: `1.0` (100%)
