### PR TITLE
Python: fix: replace 2 bare except clauses with except Exception

### DIFF
--- a/python/semantic_kernel/agents/runtime/in_process/queue.py
+++ b/python/semantic_kernel/agents/runtime/in_process/queue.py
@@ -132,7 +132,7 @@ class Queue(_LoopBoundMixin, Generic[T]):
             self._putters.append(putter)
             try:
                 await putter
-            except:
+            except Exception:
                 putter.cancel()  # Just in case putter is not done yet.
                 try:  # noqa: SIM105
                     # Clean self._putters from canceled putters.
@@ -179,7 +179,7 @@ class Queue(_LoopBoundMixin, Generic[T]):
             self._getters.append(getter)
             try:
                 await getter
-            except:
+            except Exception:
                 getter.cancel()  # Just in case getter is not done yet.
                 try:  # noqa: SIM105
                     # Clean self._getters from canceled getters.


### PR DESCRIPTION
## What
Replace 2 bare `except:` clauses with `except Exception:`.

## Why
Bare `except:` catches `BaseException`, including `KeyboardInterrupt` and `SystemExit`, which can prevent clean process shutdown and mask critical errors.