### PR TITLE
.Net: Fix JSON enum deserialization mismatch in tool calls

### DIFF
--- a/dotnet/src/InternalUtilities/src/Schema/KernelJsonSchemaBuilder.cs
+++ b/dotnet/src/InternalUtilities/src/Schema/KernelJsonSchemaBuilder.cs
@@ -61,7 +61,7 @@ internal static class KernelJsonSchemaBuilder
 
     [RequiresUnreferencedCode("Uses JsonStringEnumConverter and DefaultJsonTypeInfoResolver classes, making it incompatible with AOT scenarios.")]
     [RequiresDynamicCode("Uses JsonStringEnumConverter and DefaultJsonTypeInfoResolver classes, making it incompatible with AOT scenarios.")]
-    private static JsonSerializerOptions GetDefaultOptions()
+    internal static JsonSerializerOptions GetDefaultOptions()
     {
         if (s_options is null)
         {

--- a/dotnet/src/SemanticKernel.Core/Functions/KernelFunctionFromMethod.cs
+++ b/dotnet/src/SemanticKernel.Core/Functions/KernelFunctionFromMethod.cs
@@ -738,7 +738,7 @@ internal sealed partial class KernelFunctionFromMethod : KernelFunction
                     return jsonStringParser(element.GetString()!);
                 }
 
-                if (value is not null && TryToDeserializeValue(value, type, jsonSerializerOptions, out var deserializedValue))
+                if (value is not null && TryToDeserializeValue(value, type, jsonSerializerOptions ?? KernelJsonSchemaBuilder.GetDefaultOptions(), out var deserializedValue))
                 {
                     return deserializedValue;
                 }

--- a/dotnet/src/SemanticKernel.UnitTests/Functions/KernelFunctionFromMethodTests1.cs
+++ b/dotnet/src/SemanticKernel.UnitTests/Functions/KernelFunctionFromMethodTests1.cs
@@ -755,6 +755,42 @@ public sealed class KernelFunctionFromMethodTests1
         Assert.Equal(expected, actual);
     }
 
+    [Theory]
+    [InlineData("\"Sunday\"", DayOfWeek.Sunday)]
+    [InlineData("\"Monday\"", DayOfWeek.Monday)]
+    [InlineData("\"Thursday\"", DayOfWeek.Thursday)]
+    [InlineData("\"Saturday\"", DayOfWeek.Saturday)]
+    public async Task ItSupportsConvertingStringJsonElementToEnumAsync(string json, DayOfWeek expected)
+    {
+        // Arrange
+        object? actual = null;
+        var function = KernelFunctionFactory.CreateFromMethod((DayOfWeek dow) => actual = dow);
+
+        // Act — simulate LLM returning a string enum value as a JsonElement
+        var result = await function.InvokeAsync(this._kernel, new() { ["dow"] = JsonDocument.Parse(json).RootElement });
+
+        // Assert
+        Assert.Equal(expected, actual);
+    }
+
+    [Fact]
+    public async Task ItSupportsConvertingStringEnumNestedInObjectFromJsonElementAsync()
+    {
+        // Arrange — matches the issue scenario: enum nested in an object, then in an array
+        TaskReminder[]? actual = null;
+        var function = KernelFunctionFactory.CreateFromMethod((TaskReminder[] reminders) => actual = reminders);
+        var json = """[{"unit":"Days","value":3}]""";
+
+        // Act — simulate LLM returning a JSON array with string enum values
+        var result = await function.InvokeAsync(this._kernel, new() { ["reminders"] = JsonDocument.Parse(json).RootElement });
+
+        // Assert
+        Assert.NotNull(actual);
+        Assert.Single(actual);
+        Assert.Equal(ReminderUnit.Days, actual[0].Unit);
+        Assert.Equal(3, actual[0].Value);
+    }
+
     [TypeConverter(typeof(MyCustomTypeConverter))]
     private sealed class MyCustomType
     {
@@ -1589,5 +1625,23 @@ public sealed class KernelFunctionFromMethodTests1
     private sealed class ThirdPartyJsonPrimitive(string jsonToReturn)
     {
         public override string ToString() => jsonToReturn;
+    }
+
+    private enum ReminderUnit
+    {
+        Minutes,
+        Hours,
+        Days,
+    }
+
+#pragma warning disable CA1812 // Avoid uninstantiated internal classes
+    private sealed class TaskReminder
+#pragma warning restore CA1812 // Avoid uninstantiated internal classes
+    {
+        [JsonPropertyName("unit")]
+        public ReminderUnit Unit { get; set; }
+
+        [JsonPropertyName("value")]
+        public int Value { get; set; }
     }
 }


### PR DESCRIPTION
## Motivation and Context

Closes #13589

`KernelJsonSchemaBuilder` uses `JsonStringEnumConverter` when generating tool parameter schemas, which tells LLMs to return enum values as strings (e.g. `"Thursday"` instead of `4`). However, `KernelFunctionFromMethod.TryToDeserializeValue` used the caller-provided `JsonSerializerOptions` (which may be `null`) for deserialization, falling back to `System.Text.Json` defaults that expect numeric enum values — causing a `JsonException` for any kernel function with enum parameters.

This was already acknowledged as a known issue in a [TODO comment](https://github.com/microsoft/semantic-kernel/blob/c086d0944259ab3f28ba16f1f984a3ab2fe4fc7d/dotnet/src/InternalUtilities/src/Schema/KernelJsonSchemaBuilder.cs#L16-L22) in `KernelJsonSchemaBuilder`.

## Description

- Changed `KernelJsonSchemaBuilder.GetDefaultOptions()` from `private` to `internal` so it can be reused by `KernelFunctionFromMethod` (already covered by `InternalsVisibleTo`)
- In `KernelFunctionFromMethod`, fall back to `KernelJsonSchemaBuilder.GetDefaultOptions()` when no explicit `JsonSerializerOptions` are provided to `TryToDeserializeValue`, ensuring deserialization uses the same converter configuration as schema generation

### Changes

| File | Change |
|------|--------|
| `KernelJsonSchemaBuilder.cs` | `GetDefaultOptions()`: `private` → `internal` |
| `KernelFunctionFromMethod.cs` | `TryToDeserializeValue` call: added `?? KernelJsonSchemaBuilder.GetDefaultOptions()` fallback |
| `KernelFunctionFromMethodTests1.cs` | Added 5 new tests for string enum deserialization |

## Contribution Checklist

- [x] The code builds clean without any errors or warnings
- [x] The PR follows the [SK Contribution Guidelines](https://github.com/microsoft/semantic-kernel/blob/main/CONTRIBUTING.md)
- [x] The code follows the [.NET coding conventions](https://learn.microsoft.com/en-us/dotnet/csharp/fundamentals/coding-style/coding-conventions)
- [x] All unit tests pass (`dotnet test` — 91/91 passed for `KernelFunctionFromMethod`, 3/3 passed for `KernelJsonSchema`)
- [x] New unit tests added to cover the fix