### PR TITLE
Python: fix(python): remove deprecated nest_asyncio dependency

### DIFF
--- a/python/pyproject.toml
+++ b/python/pyproject.toml
@@ -49,7 +49,6 @@ dependencies = [
     # templating
     "pybars4 ~= 0.9",
     "jinja2 ~= 3.1",
-    "nest-asyncio ~= 1.6",
     "scipy>=1.15.1",
     "websockets >= 13, < 16",
     "aiortc>=1.9.0",

--- a/python/samples/concepts/mcp/servers/menu_agent_server.py
+++ b/python/samples/concepts/mcp/servers/menu_agent_server.py
@@ -137,7 +137,6 @@ async def run(transport: Literal["sse", "stdio"] = "stdio", port: int | None = N
     server = agent.as_mcp_server()
 
     if transport == "sse" and port is not None:
-        import nest_asyncio
         import uvicorn
         from mcp.server.sse import SseServerTransport
         from starlette.applications import Starlette
@@ -159,7 +158,6 @@ async def run(transport: Literal["sse", "stdio"] = "stdio", port: int | None = N
                 Mount("/messages/", app=sse.handle_post_message),
             ],
         )
-        nest_asyncio.apply()
         uvicorn.run(starlette_app, host="0.0.0.0", port=port)  # nosec
     elif transport == "stdio":
         from mcp.server.stdio import stdio_server

--- a/python/samples/concepts/mcp/servers/restaurant_booking_agent_server.py
+++ b/python/samples/concepts/mcp/servers/restaurant_booking_agent_server.py
@@ -111,7 +111,6 @@ async def run(transport: Literal["sse", "stdio"] = "stdio", port: int | None = N
     server = agent.as_mcp_server()
 
     if transport == "sse" and port is not None:
-        import nest_asyncio
         import uvicorn
         from mcp.server.sse import SseServerTransport
         from starlette.applications import Starlette
@@ -133,7 +132,6 @@ async def run(transport: Literal["sse", "stdio"] = "stdio", port: int | None = N
                 Mount("/messages/", app=sse.handle_post_message),
             ],
         )
-        nest_asyncio.apply()
         uvicorn.run(starlette_app, host="0.0.0.0", port=port)  # nosec
     elif transport == "stdio":
         from mcp.server.stdio import stdio_server

--- a/python/samples/demos/mcp_server/agent_as_server.py
+++ b/python/samples/demos/mcp_server/agent_as_server.py
@@ -106,7 +106,6 @@ async def run(transport: Literal["sse", "stdio"] = "stdio", port: int | None = N
         server = agent.as_mcp_server()
 
         if transport == "sse" and port is not None:
-            import nest_asyncio
             import uvicorn
             from mcp.server.sse import SseServerTransport
             from starlette.applications import Starlette
@@ -128,7 +127,6 @@ async def run(transport: Literal["sse", "stdio"] = "stdio", port: int | None = N
                     Mount("/messages/", app=sse.handle_post_message),
                 ],
             )
-            nest_asyncio.apply()
             uvicorn.run(starlette_app, host="0.0.0.0", port=port)  # nosec
         elif transport == "stdio":
             from mcp.server.stdio import stdio_server

--- a/python/semantic_kernel/prompt_template/utils/template_function_helpers.py
+++ b/python/semantic_kernel/prompt_template/utils/template_function_helpers.py
@@ -1,12 +1,11 @@
 # Copyright (c) Microsoft. All rights reserved.
 
 import asyncio
+import concurrent.futures
 import logging
 from collections.abc import Callable
 from html import escape
 from typing import TYPE_CHECKING, Any
-
-import nest_asyncio
 
 from semantic_kernel.functions.kernel_arguments import KernelArguments
 from semantic_kernel.prompt_template.const import (
@@ -78,9 +77,6 @@ def _create_sync_template_helper_from_function(
     if template_format not in [JINJA2_TEMPLATE_FORMAT_NAME, HANDLEBARS_TEMPLATE_FORMAT_NAME]:
         raise ValueError(f"Invalid template format: {template_format}")
 
-    if not getattr(asyncio, "_nest_patched", False):
-        nest_asyncio.apply()
-
     def func(*args, **kwargs):
         arguments = KernelArguments()
         if base_arguments and base_arguments.execution_settings:
@@ -105,7 +101,15 @@ def _create_sync_template_helper_from_function(
             f"with args: {actual_args} and kwargs: {kwargs} and this: {this}."
         )
 
-        result = asyncio.run(function.invoke(kernel=kernel, arguments=arguments))
+        coro = function.invoke(kernel=kernel, arguments=arguments)
+        try:
+            asyncio.get_running_loop()
+            # Already in an event loop - run in a separate thread to avoid nested loop issues
+            with concurrent.futures.ThreadPoolExecutor() as executor:
+                result = executor.submit(asyncio.run, coro).result()
+        except RuntimeError:
+            # No event loop running - safe to use asyncio.run()
+            result = asyncio.run(coro)
         if allow_dangerously_set_content:
             return result
         return escape(str(result))


### PR DESCRIPTION
Fixes #13090

## Problem
The Python SDK depends on the archived `nest_asyncio` package, which does not support Python 3.12+`loop_factory` parameter, causing `TypeError: run() got an unexpected keyword argument 'loop_factory'`.

## Fix
- Removed `nest_asyncio` from `python/pyproject.toml`
- Removed all `nest_asyncio.apply()` call sites
- Refactored affected code to avoid nested event loop requirements