### PR TITLE
Python: fix GoogleAIChatCompletion requiring api_key when use_vertexai is True

### DIFF
--- a/python/semantic_kernel/connectors/ai/google/google_ai/services/google_ai_chat_completion.py
+++ b/python/semantic_kernel/connectors/ai/google/google_ai/services/google_ai_chat_completion.py
@@ -119,7 +119,7 @@ class GoogleAIChatCompletion(GoogleAIBase, ChatCompletionClientBase):
         if not client:
             if google_ai_settings.use_vertexai and not google_ai_settings.cloud_project_id:
                 raise ServiceInitializationError("Project ID must be provided when use_vertexai is True.")
-            if not google_ai_settings.api_key:
+            if not google_ai_settings.use_vertexai and not google_ai_settings.api_key:
                 raise ServiceInitializationError("The API key is required when use_vertexai is False.")
 
         super().__init__(


### PR DESCRIPTION
## Summary

Fix `ServiceInitializationError: The API key is required when use_vertexai is False` being raised even when `use_vertexai=True`.

Fixes #13483.

## Problem

In `GoogleAIChatCompletion.__init__`, the api_key check on line 122 runs unconditionally:

```python
if not client:
    if google_ai_settings.use_vertexai and not google_ai_settings.cloud_project_id:
        raise ServiceInitializationError("Project ID must be provided when use_vertexai is True.")
    if not google_ai_settings.api_key:  # <-- runs even when use_vertexai=True
        raise ServiceInitializationError("The API key is required when use_vertexai is False.")
```

When `use_vertexai=True`, authentication is via ADC (Application Default Credentials), not an API key. The api_key should not be required.

## Fix

Guard the api_key check with `not google_ai_settings.use_vertexai`:

```python
if not google_ai_settings.use_vertexai and not google_ai_settings.api_key:
    raise ServiceInitializationError("The API key is required when use_vertexai is False.")
```

This is consistent with the error message itself ("when use_vertexai is False") and with `_inner_get_chat_message_contents` which does not use `api_key` when Vertex AI is enabled.

> This PR was authored by Claude Opus 4.6 (AI). Human partner: @MaxwellCalkin
