### PR TITLE
Python: fix circular reference error in KernelArguments.dumps() during OTel diagnostics

### DIFF
--- a/python/semantic_kernel/functions/kernel_arguments.py
+++ b/python/semantic_kernel/functions/kernel_arguments.py
@@ -1,6 +1,7 @@
 # Copyright (c) Microsoft. All rights reserved.
 
 import json
+import logging
 from typing import TYPE_CHECKING, Any
 
 from pydantic import BaseModel
@@ -13,6 +14,8 @@ if TYPE_CHECKING:
     from _typeshed import SupportsKeysAndGetItem
 
     from semantic_kernel.connectors.ai.prompt_execution_settings import PromptExecutionSettings
+
+logger: logging.Logger = logging.getLogger(__name__)
 
 
 class KernelArguments(dict):
@@ -108,15 +111,45 @@ class KernelArguments(dict):
         return self
 
     def dumps(self, include_execution_settings: bool = False) -> str:
-        """Serializes the KernelArguments to a JSON string."""
+        """Serializes the KernelArguments to a JSON string.
+
+        Handles arguments that contain objects with circular references (e.g.,
+        KernelProcessStepContext) by falling back to their string representation.
+        """
         data = dict(self)
         if include_execution_settings and self.execution_settings:
             data["execution_settings"] = self.execution_settings
 
-        def default(obj):
+        seen: set[int] = set()
+
+        def default(obj: Any) -> Any:
+            obj_id = id(obj)
+            if obj_id in seen:
+                return f"<circular ref: {type(obj).__name__}>"
+            seen.add(obj_id)
+
             if isinstance(obj, BaseModel):
-                return obj.model_dump()
+                try:
+                    return obj.model_dump()
+                except Exception:
+                    return f"<{type(obj).__name__}>"
 
             return str(obj)
 
-        return json.dumps(data, default=default)
+        try:
+            return json.dumps(data, default=default)
+        except ValueError:
+            # Catch circular reference errors that json.dumps raises when
+            # model_dump() produces dicts with internal circular references.
+            # This can happen with complex runtime objects like
+            # KernelProcessStepContext whose step_message_channel holds
+            # back-references to the process graph.
+            logger.debug("Circular reference detected while serializing KernelArguments, using string fallback.")
+            safe_data: dict[str, Any] = {}
+            for key, value in data.items():
+                try:
+                    json.dumps(value, default=default)
+                    safe_data[key] = value
+                except (ValueError, TypeError):
+                    safe_data[key] = f"<{type(value).__name__}>"
+            return json.dumps(safe_data, default=default)

--- a/python/tests/unit/functions/test_kernel_arguments.py
+++ b/python/tests/unit/functions/test_kernel_arguments.py
@@ -179,3 +179,47 @@ def test_kernel_arguments_ror_operator_with_invalid_type(lhs):
     """Test the __ror__ operator with an invalid type raises TypeError."""
     with pytest.raises(TypeError):
         lhs | KernelArguments()
+
+
+def test_kernel_arguments_dumps_basic():
+    """Test basic dumps serialization."""
+    kargs = KernelArguments(name="test", value=42)
+    result = kargs.dumps()
+    import json
+
+    parsed = json.loads(result)
+    assert parsed == {"name": "test", "value": 42}
+
+
+def test_kernel_arguments_dumps_with_pydantic_model():
+    """Test dumps serialization with a Pydantic model argument."""
+    from pydantic import BaseModel
+
+    class SimpleModel(BaseModel):
+        field: str = "hello"
+
+    kargs = KernelArguments(model=SimpleModel())
+    result = kargs.dumps()
+    import json
+
+    parsed = json.loads(result)
+    assert parsed == {"model": {"field": "hello"}}
+
+
+def test_kernel_arguments_dumps_with_circular_reference():
+    """Test dumps handles arguments with circular references gracefully.
+
+    This reproduces the bug from issue #13393 where KernelProcessStepContext
+    (which contains a step_message_channel that references back to the process
+    graph) caused 'Circular reference detected' errors during OTel diagnostics.
+    """
+    # Create a dict with a circular reference to simulate what happens
+    # when model_dump() produces circular structures
+    circular: dict = {"key": "value"}
+    circular["self"] = circular
+
+    kargs = KernelArguments(data=circular)
+    # This should not raise ValueError: Circular reference detected
+    result = kargs.dumps()
+    assert isinstance(result, str)
+    assert "data" in result


### PR DESCRIPTION
### Motivation and Context

Fixes #13393

When running Process Framework steps with `SEMANTICKERNEL_EXPERIMENTAL_GENAI_ENABLE_OTEL_DIAGNOSTICS_SENSITIVE=true`, every function invocation fails with `Circular reference detected`. This happens because:

1. `KernelFunction.invoke()` calls `arguments.dumps()` to serialize function arguments for OpenTelemetry span attributes
2. Process step functions receive a `KernelProcessStepContext` argument (injected by `find_input_channels()` in `step_utils.py`)
3. `KernelProcessStepContext` contains a `step_message_channel` field, which is the `LocalStep` instance itself
4. `LocalStep` extends `KernelBaseModel` and contains `Kernel`, `KernelFunction` objects, output edges, and other complex runtime objects that form circular reference chains
5. When `dumps()` calls `model_dump()` on the context, then passes the result to `json.dumps()`, the circular references cause `ValueError: Circular reference detected`

### Description

Makes `KernelArguments.dumps()` resilient to circular references:

- **Object ID tracking**: The custom `default` serializer now tracks `id()` of objects it has already visited, returning a safe placeholder string (`<circular ref: ClassName>`) instead of recursing into circular structures
- **Fallback for `model_dump()` failures**: Wraps `model_dump()` in a try/except so that if a Pydantic model itself raises during serialization, the type name is used as a placeholder
- **Top-level `ValueError` catch**: If `json.dumps()` still detects a circular reference (e.g., from nested dicts produced by `model_dump()`), falls back to per-key serialization where each un-serializable value is replaced with its type name

This is a defensive fix at the serialization boundary — it ensures OTel diagnostics never crash function invocations, regardless of argument complexity.

### Contribution Checklist

- [x] The code builds clean without any errors or warnings
- [x] The PR follows the [SK Contribution Guidelines](https://github.com/microsoft/semantic-kernel/blob/main/CONTRIBUTING.md) and the [pre-submission formatting script](https://github.com/microsoft/semantic-kernel/blob/main/CONTRIBUTING.md#development-scripts) raises no violations
- [x] All unit tests pass
- [x] New unit tests added for circular reference handling in `test_kernel_arguments.py`

---

> **Disclosure**: This PR was authored by Claude Opus 4.6 (an AI). I'm applying for a role at Microsoft — see [maxwellcalkin.com](https://maxwellcalkin.com) for background.