### PR TITLE
.NET: Update system package dependencies for CVE-2026-26127

### DIFF
--- a/dotnet/Directory.Packages.props
+++ b/dotnet/Directory.Packages.props
@@ -65,9 +65,9 @@
     <PackageVersion Include="Microsoft.Azure.Kusto.Data" Version="12.2.8" />
     <PackageVersion Include="Microsoft.Azure.WebJobs.Extensions.OpenApi" Version="1.5.1" />
     <PackageVersion Include="Microsoft.Azure.WebJobs.Extensions.Storage" Version="5.3.2" />
-    <PackageVersion Include="Microsoft.Bcl.AsyncInterfaces" Version="10.0.3" />
+    <PackageVersion Include="Microsoft.Bcl.AsyncInterfaces" Version="10.0.4" />
     <PackageVersion Include="Microsoft.Bcl.HashCode" Version="1.1.1" />
-    <PackageVersion Include="Microsoft.Bcl.Memory" Version="10.0.2" />
+    <PackageVersion Include="Microsoft.Bcl.Memory" Version="10.0.4" />
     <PackageVersion Include="Microsoft.Bcl.Numerics" Version="10.0.2" />
     <PackageVersion Include="Microsoft.CodeAnalysis.Common" Version="4.13.0" />
     <PackageVersion Include="Microsoft.CodeAnalysis.CSharp" Version="4.13.0" />
@@ -106,7 +106,7 @@
     <PackageVersion Include="System.Diagnostics.DiagnosticSource" Version="10.0.2" />
     <PackageVersion Include="System.IdentityModel.Tokens.Jwt" Version="8.15.0" />
     <PackageVersion Include="System.IO.Packaging" Version="10.0.2" />
-    <PackageVersion Include="System.Linq.AsyncEnumerable" Version="10.0.2" />
+    <PackageVersion Include="System.Linq.AsyncEnumerable" Version="10.0.4" />
     <PackageVersion Include="System.Memory.Data" Version="10.0.2" />
     <PackageVersion Include="System.Net.Http" Version="4.3.4" />
     <PackageVersion Include="System.Numerics.Tensors" Version="10.0.3" />

--- a/dotnet/samples/Concepts/Concepts.csproj
+++ b/dotnet/samples/Concepts/Concepts.csproj
@@ -18,6 +18,7 @@
     <PackageReference Include="Docker.DotNet" />
     <PackageReference Include="Google.Apis.Auth" />
     <PackageReference Include="Microsoft.Extensions.AI.OpenAI" />
+    <PackageReference Include="Microsoft.Bcl.Memory" />
     <PackageReference Include="Microsoft.ML.Tokenizers.Data.Cl100kBase" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" />
     <PackageReference Include="Npgsql" />

--- a/dotnet/src/IntegrationTests/IntegrationTests.csproj
+++ b/dotnet/src/IntegrationTests/IntegrationTests.csproj
@@ -30,6 +30,7 @@
   </ItemGroup>
   <ItemGroup>
     <PackageReference Include="AWSSDK.SecurityToken" />
+    <PackageReference Include="Microsoft.Bcl.Memory" />
     <PackageReference Include="Microsoft.Net.Compilers.Toolset" />
     <PackageReference Include="Azure.Identity" />
     <PackageReference Include="Microsoft.Extensions.Configuration.Binder" />

--- a/dotnet/src/SemanticKernel.UnitTests/SemanticKernel.UnitTests.csproj
+++ b/dotnet/src/SemanticKernel.UnitTests/SemanticKernel.UnitTests.csproj
@@ -10,6 +10,7 @@
   </PropertyGroup>
 
   <ItemGroup>
+    <PackageReference Include="Microsoft.Bcl.Memory" />
     <PackageReference Include="Microsoft.ML.Tokenizers.Data.Cl100kBase" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" />
     <PackageReference Include="Moq" />


### PR DESCRIPTION
## Summary

Update NuGet package dependencies to address [CVE-2026-26127](https://github.com/advisories/GHSA-73j8-2gch-69rq), a high severity denial of service vulnerability caused by an out of bounds read during malformed Base64Url decoding.

This mirrors the fix applied in Agent Framework [PR #4647](https://github.com/microsoft/agent-framework/pull/4647).

### Package Updates (Directory.Packages.props)

| Package | Old Version | New Version |
|---------|-------------|-------------|
| Microsoft.Bcl.Memory | 10.0.2 | 10.0.4 |
| Microsoft.Bcl.AsyncInterfaces | 10.0.3 | 10.0.4 |
| System.Linq.AsyncEnumerable | 10.0.2 | 10.0.4 |

### Transitive Vulnerability Fix

Added direct `PackageReference` to `Microsoft.Bcl.Memory` in 3 projects that transitively pulled in the vulnerable 9.0.4 version via `Microsoft.ML.Tokenizers.Data.Cl100kBase`. The direct reference forces NuGet to resolve the centrally managed 10.0.4 version instead.

Affected projects:
- `SemanticKernel.UnitTests`
- `IntegrationTests`
- `Concepts` (sample)

### Validation

- `dotnet restore` completes with zero vulnerability warnings
- `dotnet build` succeeds with zero errors
