### PR TITLE
fix(mistral): remove accidental tuple wrapping of CompletionUsage in metadata

### DIFF
--- a/python/semantic_kernel/connectors/ai/mistral_ai/services/mistral_ai_chat_completion.py
+++ b/python/semantic_kernel/connectors/ai/mistral_ai/services/mistral_ai_chat_completion.py
@@ -251,11 +251,9 @@ class MistralAIChatCompletion(MistralAIBase, ChatCompletionClientBase):
         }
         # Check if usage exists and has a value, then add it to the metadata
         if hasattr(response, "usage") and response.usage is not None:
-            metadata["usage"] = (
-                CompletionUsage(
-                    prompt_tokens=response.usage.prompt_tokens,
-                    completion_tokens=response.usage.completion_tokens,
-                ),
+            metadata["usage"] = CompletionUsage(
+                prompt_tokens=response.usage.prompt_tokens,
+                completion_tokens=response.usage.completion_tokens,
             )
 
         return metadata


### PR DESCRIPTION
## Summary

In `MistralAIChatCompletion._get_metadata_from_response`, the `CompletionUsage` object is accidentally wrapped in a single-element tuple due to a trailing comma after the closing parenthesis of the constructor call.

### Bug

```python
# Before (buggy): metadata["usage"] is a tuple, not a CompletionUsage instance
metadata["usage"] = (
    CompletionUsage(
        prompt_tokens=response.usage.prompt_tokens,
        completion_tokens=response.usage.completion_tokens,
    ),   # <-- trailing comma creates a tuple
)
```

Any code that reads `metadata["usage"].prompt_tokens` or `metadata["usage"].completion_tokens` will get an `AttributeError` at runtime because tuples don't have those attributes.

### Fix

```python
# After (fixed): metadata["usage"] is a CompletionUsage instance
metadata["usage"] = CompletionUsage(
    prompt_tokens=response.usage.prompt_tokens,
    completion_tokens=response.usage.completion_tokens,
)
```

## Files Changed

- `python/semantic_kernel/connectors/ai/mistral_ai/services/mistral_ai_chat_completion.py`

## Test plan

- [ ] Verify that `metadata["usage"]` is a `CompletionUsage` instance (not a tuple) after a MistralAI chat completion response
- [ ] Confirm `metadata["usage"].prompt_tokens` and `metadata["usage"].completion_tokens` are accessible without error
- [ ] Run existing MistralAI unit tests

🤖 Generated with [Claude Code](https://claude.com/claude-code)