### PR TITLE
fix(huggingface): pass prompt as tuple to Thread args instead of a set

### DIFF
--- a/python/semantic_kernel/connectors/ai/hugging_face/services/hf_text_completion.py
+++ b/python/semantic_kernel/connectors/ai/hugging_face/services/hf_text_completion.py
@@ -132,7 +132,7 @@ class HuggingFaceTextCompletion(TextCompletionClientBase):
             streamer = TextIteratorStreamer(AutoTokenizer.from_pretrained(self.ai_model_id))
             # See https://github.com/huggingface/transformers/blob/main/src/transformers/generation/streamers.py#L159
             thread = Thread(
-                target=self.generator, args={prompt}, kwargs=settings.prepare_settings_dict(streamer=streamer)
+                target=self.generator, args=(prompt,), kwargs=settings.prepare_settings_dict(streamer=streamer)
             )
             thread.start()
 


### PR DESCRIPTION
## Summary

In `HuggingFaceTextCompletion._inner_get_streaming_text_contents`, the `threading.Thread` constructor was called with `args={prompt}` (a **set** literal) instead of `args=(prompt,)` (a **tuple**).

### Bug

```python
# Before (buggy): {prompt} creates a Python set, not a tuple
thread = Thread(
    target=self.generator, args={prompt}, kwargs=settings.prepare_settings_dict(streamer=streamer)
)
```

`threading.Thread` requires `args` to be a sequence (tuple or list) that is unpacked as positional arguments to the `target` callable. When a `set` is passed:

1. Sets have no guaranteed order (though for a single element this is moot).
2. More importantly, Python's `Thread` implementation internally calls `self._target(*self._args, **self._kwargs)`. When `_args` is a set containing a string like `"hello world"`, Python unpacks the set — but since `Thread` stores it and passes it directly to the target function with `*args`, passing a set actually works differently than a tuple. The `generator` (a HuggingFace `pipeline`) expects the prompt as its first positional argument. A set literal `{prompt}` evaluates to the set `{prompt}`, and when passed via `*args` unpacking is `generator({prompt})` — the generator receives the **set object** as its first argument rather than the string.

### Fix

```python
# After (fixed): (prompt,) is a tuple with one element
thread = Thread(
    target=self.generator, args=(prompt,), kwargs=settings.prepare_settings_dict(streamer=streamer)
)
```

## Files Changed

- `python/semantic_kernel/connectors/ai/hugging_face/services/hf_text_completion.py`

## Test plan

- [ ] Confirm that `HuggingFaceTextCompletion` streaming works correctly by passing the prompt string as the first positional argument to the pipeline
- [ ] Run existing HuggingFace unit tests

🤖 Generated with [Claude Code](https://claude.com/claude-code)