### PR TITLE
fix(azure-ai-inference): guard against IndexError when tool message items list is empty

### DIFF
--- a/python/semantic_kernel/connectors/ai/azure_ai_inference/services/utils.py
+++ b/python/semantic_kernel/connectors/ai/azure_ai_inference/services/utils.py
@@ -134,6 +134,9 @@ def _format_tool_message(message: ChatMessageContent) -> ToolMessage:
     Returns:
         The formatted tool message.
     """
+    if len(message.items) == 0:
+        raise ValueError("Tool message has no items; expected exactly one FunctionResultContent item.")
+
     if len(message.items) != 1:
         logger.warning(
             "Unsupported number of items in Tool message while formatting chat history for Azure AI"


### PR DESCRIPTION
## Summary

In `_format_tool_message` within the Azure AI Inference utilities, when a `ChatMessageContent` with role `TOOL` has an **empty** `items` list, the existing guard only checks `len(message.items) != 1` and logs a warning — but then immediately proceeds to access `message.items[0]`, raising an unhandled `IndexError`.

### Bug

```python
def _format_tool_message(message: ChatMessageContent) -> ToolMessage:
    if len(message.items) != 1:
        # This logs a warning for items==0, but does NOT stop execution
        logger.warning("Unsupported number of items ...")

    # IndexError: list index out of range when message.items is empty
    if not isinstance(message.items[0], FunctionResultContent):
        raise ValueError("No FunctionResultContent found in the message items")
```

When `message.items` is an empty list, `message.items[0]` raises `IndexError: list index out of range`, which is an opaque error that obscures the real problem.

### Fix

Add an explicit guard for the empty-items case before the length-mismatch warning, raising a descriptive `ValueError`:

```python
def _format_tool_message(message: ChatMessageContent) -> ToolMessage:
    if len(message.items) == 0:
        raise ValueError("Tool message has no items; expected exactly one FunctionResultContent item.")

    if len(message.items) != 1:
        logger.warning("Unsupported number of items ...")

    if not isinstance(message.items[0], FunctionResultContent):
        raise ValueError("No FunctionResultContent found in the message items")
```

## Files Changed

- `python/semantic_kernel/connectors/ai/azure_ai_inference/services/utils.py`

## Test plan

- [ ] Pass a `ChatMessageContent(role=AuthorRole.TOOL, items=[])` to `_format_tool_message` and confirm it raises `ValueError` with a clear message instead of `IndexError`
- [ ] Run existing Azure AI Inference unit tests to verify no regression

🤖 Generated with [Claude Code](https://claude.com/claude-code)