### PR TITLE
Python: Fix image integration tests that are now blocked due to bot policies

### DIFF
--- a/python/samples/concepts/chat_completion/simple_chatbot_with_image.py
+++ b/python/samples/concepts/chat_completion/simple_chatbot_with_image.py
@@ -34,7 +34,7 @@ from semantic_kernel.contents import AuthorRole, ChatHistory, ChatMessageContent
 # make sure to use a service that supports image input from a URI.
 chat_completion_service, request_settings = get_chat_completion_service_and_request_settings(Services.AZURE_OPENAI)
 
-IMAGE_URI = "https://upload.wikimedia.org/wikipedia/commons/d/d5/Half-timbered_mansion%2C_Zirkel%2C_East_view.jpg"
+IMAGE_URI = "https://raw.githubusercontent.com/microsoft/semantic-kernel/main/python/tests/assets/sample_image.jpg"
 IMAGE_PATH = "samples/concepts/resources/sample_image.jpg"
 
 # Create an image content with the image URI.

--- a/python/tests/integration/agents/chat_completion_agent/test_chat_completion_agent_integration.py
+++ b/python/tests/integration/agents/chat_completion_agent/test_chat_completion_agent_integration.py
@@ -251,7 +251,7 @@ class TestChatCompletionAgentIntegration:
     ):
         """Test function calling streaming."""
         IMAGE_URI = (
-            "https://upload.wikimedia.org/wikipedia/commons/d/d5/Half-timbered_mansion%2C_Zirkel%2C_East_view.jpg"
+            "https://raw.githubusercontent.com/microsoft/semantic-kernel/main/python/tests/assets/sample_image.jpg"
         )
         image_content_remote = ImageContent(uri=IMAGE_URI)
 

--- a/python/tests/integration/completions/test_chat_completion_with_image_input_text_output.py
+++ b/python/tests/integration/completions/test_chat_completion_with_image_input_text_output.py
@@ -26,6 +26,12 @@ from tests.integration.completions.chat_completion_test_base import (
 from tests.integration.completions.completion_test_base import ServiceType
 from tests.utils import retry
 
+# Use the repo's own sample image via raw GitHub URL for URI-based tests.
+# Previously this pointed to a 17.5 MB Wikimedia image that got blocked by
+# Wikimedia's User-Agent policy (Phabricator T400119), causing Azure's
+# server-side image fetcher to fail with HTTP 403.
+IMAGE_TEST_URL = "https://raw.githubusercontent.com/microsoft/semantic-kernel/main/python/tests/assets/sample_image.jpg"
+
 pytestmark = pytest.mark.parametrize(
     "service_id, execution_settings_kwargs, inputs, kwargs",
     [
@@ -37,15 +43,12 @@ pytestmark = pytest.mark.parametrize(
                     role=AuthorRole.USER,
                     items=[
                         TextContent(text="What is in this image?"),
-                        ImageContent(
-                            uri="https://upload.wikimedia.org/wikipedia/commons/d/d5/Half-timbered_mansion%2C_Zirkel%2C_East_view.jpg"
-                        ),
+                        ImageContent(uri=IMAGE_TEST_URL),
                     ],
                 ),
                 ChatMessageContent(role=AuthorRole.USER, items=[TextContent(text="Where was it made?")]),
             ],
             {},
-            marks=pytest.mark.xfail(reason="OpenAI service raise error for downloading image from URL"),
             id="openai_image_input_uri",
         ),
         pytest.param(
@@ -74,9 +77,7 @@ pytestmark = pytest.mark.parametrize(
                     role=AuthorRole.USER,
                     items=[
                         TextContent(text="What is in this image?"),
-                        ImageContent(
-                            uri="https://upload.wikimedia.org/wikipedia/commons/d/d5/Half-timbered_mansion%2C_Zirkel%2C_East_view.jpg"
-                        ),
+                        ImageContent(uri=IMAGE_TEST_URL),
                     ],
                 ),
                 ChatMessageContent(role=AuthorRole.USER, items=[TextContent(text="Where was it made?")]),
@@ -134,9 +135,7 @@ pytestmark = pytest.mark.parametrize(
                     role=AuthorRole.USER,
                     items=[
                         TextContent(text="What is in this image?"),
-                        ImageContent(
-                            uri="https://upload.wikimedia.org/wikipedia/commons/d/d5/Half-timbered_mansion%2C_Zirkel%2C_East_view.jpg"
-                        ),
+                        ImageContent(uri=IMAGE_TEST_URL),
                     ],
                 ),
                 ChatMessageContent(role=AuthorRole.USER, items=[TextContent(text="Where was it made?")]),


### PR DESCRIPTION
### Motivation and Context

Fix image integration tests that are now blocked due to bot policies

<!-- Thank you for your contribution to the semantic-kernel repo!
Please help reviewers and future users, providing the following information:
  1. Why is this change required?
  2. What problem does it solve?
  3. What scenario does it contribute to?
  4. If it fixes an open issue, please link to the issue here.
-->

### Description

Fix image integration tests that are now blocked due to bot policies

<!-- Describe your changes, the overall approach, the underlying design.
     These notes will help understanding how your code works. Thanks! -->

### Contribution Checklist

<!-- Before submitting this PR, please make sure: -->

- [X] The code builds clean without any errors or warnings
- [X] The PR follows the [SK Contribution Guidelines](https://github.com/microsoft/semantic-kernel/blob/main/CONTRIBUTING.md) and the [pre-submission formatting script](https://github.com/microsoft/semantic-kernel/blob/main/CONTRIBUTING.md#development-scripts) raises no violations
- [X] All unit tests pass, and I have added new tests where possible
- [ ] I didn't break anyone :smile:
