### PR TITLE
Python: Add semantic-kernel User-Agent to google-genai Client

### DIFF
--- a/python/semantic_kernel/connectors/ai/google/google_ai/services/google_ai_chat_completion.py
+++ b/python/semantic_kernel/connectors/ai/google/google_ai/services/google_ai_chat_completion.py
@@ -29,6 +29,7 @@ from semantic_kernel.connectors.ai.google.shared_utils import (
     filter_system_message,
     format_gemini_function_name_to_kernel_function_fully_qualified_name,
 )
+from semantic_kernel.const import USER_AGENT
 from semantic_kernel.contents.chat_history import ChatHistory
 from semantic_kernel.contents.chat_message_content import CMC_ITEM_TYPES, ChatMessageContent
 from semantic_kernel.contents.function_call_content import FunctionCallContent
@@ -46,6 +47,7 @@ from semantic_kernel.utils.telemetry.model_diagnostics.decorators import (
     trace_chat_completion,
     trace_streaming_chat_completion,
 )
+from semantic_kernel.utils.telemetry.user_agent import SEMANTIC_KERNEL_USER_AGENT
 
 if sys.version_info >= (3, 12):
     from typing import override  # pragma: no cover
@@ -169,10 +171,14 @@ class GoogleAIChatCompletion(GoogleAIBase, ChatCompletionClientBase):
                 vertexai=True,
                 project=self.service_settings.cloud_project_id,
                 location=self.service_settings.cloud_region,
+                http_options={"headers": {USER_AGENT: SEMANTIC_KERNEL_USER_AGENT}},
             ) as client:
                 response: GenerateContentResponse = await _generate_content(client)  # type: ignore[no-redef]
         else:
-            with Client(api_key=self.service_settings.api_key.get_secret_value()) as client:  # type: ignore[union-attr]
+            with Client(
+                api_key=self.service_settings.api_key.get_secret_value(),
+                http_options={"headers": {USER_AGENT: SEMANTIC_KERNEL_USER_AGENT}},
+            ) as client:  # type: ignore[union-attr]
                 response: GenerateContentResponse = await _generate_content(client)  # type: ignore[no-redef]
 
         return [self._create_chat_message_content(response, candidate) for candidate in response.candidates]  # type: ignore
@@ -216,6 +222,7 @@ class GoogleAIChatCompletion(GoogleAIBase, ChatCompletionClientBase):
                 vertexai=True,
                 project=self.service_settings.cloud_project_id,
                 location=self.service_settings.cloud_region,
+                http_options={"headers": {USER_AGENT: SEMANTIC_KERNEL_USER_AGENT}},
             ) as client:
                 async for chunk in _generate_content_stream(client):
                     yield [
@@ -223,7 +230,10 @@ class GoogleAIChatCompletion(GoogleAIBase, ChatCompletionClientBase):
                         for candidate in chunk.candidates  # type: ignore
                     ]
         else:
-            with Client(api_key=self.service_settings.api_key.get_secret_value()) as client:  # type: ignore[union-attr]
+            with Client(
+                api_key=self.service_settings.api_key.get_secret_value(),
+                http_options={"headers": {USER_AGENT: SEMANTIC_KERNEL_USER_AGENT}},
+            ) as client:  # type: ignore[union-attr]
                 async for chunk in _generate_content_stream(client):
                     yield [
                         self._create_streaming_chat_message_content(chunk, candidate, function_invoke_attempt)

--- a/python/semantic_kernel/connectors/ai/google/google_ai/services/google_ai_text_completion.py
+++ b/python/semantic_kernel/connectors/ai/google/google_ai/services/google_ai_text_completion.py
@@ -15,6 +15,7 @@ from semantic_kernel.connectors.ai.google.google_ai.google_ai_prompt_execution_s
 from semantic_kernel.connectors.ai.google.google_ai.google_ai_settings import GoogleAISettings
 from semantic_kernel.connectors.ai.google.google_ai.services.google_ai_base import GoogleAIBase
 from semantic_kernel.connectors.ai.text_completion_client_base import TextCompletionClientBase
+from semantic_kernel.const import USER_AGENT
 from semantic_kernel.contents import TextContent
 from semantic_kernel.contents.streaming_text_content import StreamingTextContent
 from semantic_kernel.exceptions.service_exceptions import ServiceInitializationError
@@ -22,6 +23,7 @@ from semantic_kernel.utils.telemetry.model_diagnostics.decorators import (
     trace_streaming_text_completion,
     trace_text_completion,
 )
+from semantic_kernel.utils.telemetry.user_agent import SEMANTIC_KERNEL_USER_AGENT
 
 if TYPE_CHECKING:
     from semantic_kernel.connectors.ai.prompt_execution_settings import PromptExecutionSettings
@@ -135,10 +137,14 @@ class GoogleAITextCompletion(GoogleAIBase, TextCompletionClientBase):
                 vertexai=True,
                 project=self.service_settings.cloud_project_id,
                 location=self.service_settings.cloud_region,
+                http_options={"headers": {USER_AGENT: SEMANTIC_KERNEL_USER_AGENT}},
             ) as client:
                 response: GenerateContentResponse = await _generate_content(client)  # type: ignore[no-redef]
         else:
-            with Client(api_key=self.service_settings.api_key.get_secret_value()) as client:  # type: ignore[union-attr]
+            with Client(
+                api_key=self.service_settings.api_key.get_secret_value(),
+                http_options={"headers": {USER_AGENT: SEMANTIC_KERNEL_USER_AGENT}},
+            ) as client:  # type: ignore[union-attr]
                 response: GenerateContentResponse = await _generate_content(client)  # type: ignore[no-redef]
 
         return [self._create_text_content(response, candidate) for candidate in response.candidates]  # type: ignore
@@ -173,11 +179,15 @@ class GoogleAITextCompletion(GoogleAIBase, TextCompletionClientBase):
                 vertexai=True,
                 project=self.service_settings.cloud_project_id,
                 location=self.service_settings.cloud_region,
+                http_options={"headers": {USER_AGENT: SEMANTIC_KERNEL_USER_AGENT}},
             ) as client:
                 async for chunk in _generate_content_stream(client):
                     yield [self._create_streaming_text_content(chunk, candidate) for candidate in chunk.candidates]  # type: ignore
         else:
-            with Client(api_key=self.service_settings.api_key.get_secret_value()) as client:  # type: ignore[union-attr]
+            with Client(
+                api_key=self.service_settings.api_key.get_secret_value(),
+                http_options={"headers": {USER_AGENT: SEMANTIC_KERNEL_USER_AGENT}},
+            ) as client:  # type: ignore[union-attr]
                 async for chunk in _generate_content_stream(client):
                     yield [self._create_streaming_text_content(chunk, candidate) for candidate in chunk.candidates]  # type: ignore
 

--- a/python/semantic_kernel/connectors/ai/google/google_ai/services/google_ai_text_embedding.py
+++ b/python/semantic_kernel/connectors/ai/google/google_ai/services/google_ai_text_embedding.py
@@ -15,7 +15,9 @@ from semantic_kernel.connectors.ai.google.google_ai.google_ai_prompt_execution_s
 from semantic_kernel.connectors.ai.google.google_ai.google_ai_settings import GoogleAISettings
 from semantic_kernel.connectors.ai.google.google_ai.services.google_ai_base import GoogleAIBase
 from semantic_kernel.connectors.ai.prompt_execution_settings import PromptExecutionSettings
+from semantic_kernel.const import USER_AGENT
 from semantic_kernel.exceptions.service_exceptions import ServiceInitializationError
+from semantic_kernel.utils.telemetry.user_agent import SEMANTIC_KERNEL_USER_AGENT
 
 if sys.version_info >= (3, 12):
     from typing import override  # pragma: no cover
@@ -131,10 +133,14 @@ class GoogleAITextEmbedding(GoogleAIBase, EmbeddingGeneratorBase):
                 vertexai=True,
                 project=self.service_settings.cloud_project_id,
                 location=self.service_settings.cloud_region,
+                http_options={"headers": {USER_AGENT: SEMANTIC_KERNEL_USER_AGENT}},
             ) as client:
                 response: EmbedContentResponse = await _embed_content(client)  # type: ignore[no-redef]
         else:
-            with Client(api_key=self.service_settings.api_key.get_secret_value()) as client:  # type: ignore[union-attr]
+            with Client(
+                api_key=self.service_settings.api_key.get_secret_value(),
+                http_options={"headers": {USER_AGENT: SEMANTIC_KERNEL_USER_AGENT}},
+            ) as client:  # type: ignore[union-attr]
                 response: EmbedContentResponse = await _embed_content(client)  # type: ignore[no-redef]
 
         return [embedding.values for embedding in response.embeddings]  # type: ignore


### PR DESCRIPTION
### Motivation and Context

Currently, the Python connectors for Google AI and Vertex AI don't pass the standard semantic-kernel user agent string. This PR adds the user agent header so that the Google API calls properly identify Semantic Kernel.

This aligns with the dotnet implementation, and our (Google DeepMind's) [best practices](https://ai.google.dev/gemini-api/docs/partner-integration).

### Description

Sends the `User-Agent` header conditionally in `GoogleAIChatCompletion`, `GoogleAITextCompletion`, and `GoogleAITextEmbedding`, matching the OpenAI implementation as much as possible (gated behind telemetry flag, using `SEMANTIC_KERNEL_USER_AGENT`).

### Contribution Checklist

- [x] The code builds clean without any errors or warnings
- [x] The PR follows the [SK Contribution Guidelines](https://github.com/microsoft/semantic-kernel/blob/main/CONTRIBUTING.md) and the [pre-submission formatting script](https://github.com/microsoft/semantic-kernel/blob/main/CONTRIBUTING.md#development-scripts) raises no violations
- [x] All unit tests pass, and I have added new tests where possible
- [x] I didn't break anyone :smile:.