### PR TITLE
Python: fix(anthropic): preserve tool definitions after max auto-invo…

### DIFF
--- a/python/semantic_kernel/connectors/ai/anthropic/prompt_execution_settings/anthropic_prompt_execution_settings.py
+++ b/python/semantic_kernel/connectors/ai/anthropic/prompt_execution_settings/anthropic_prompt_execution_settings.py
@@ -5,7 +5,9 @@ from typing import Annotated, Any
 
 from pydantic import Field, model_validator
 
+from semantic_kernel.connectors.ai.function_choice_type import FunctionChoiceType
 from semantic_kernel.connectors.ai.prompt_execution_settings import PromptExecutionSettings
+from semantic_kernel.exceptions import ServiceInvalidExecutionSettingsError
 
 logger = logging.getLogger(__name__)
 
@@ -44,5 +46,25 @@ class AnthropicChatPromptExecutionSettings(AnthropicPromptExecutionSettings):
 
     @model_validator(mode="after")
     def validate_tool_choice(self) -> "AnthropicChatPromptExecutionSettings":
-        """Validate tool choice payload."""
+        """Validate tool choice payload.
+
+        Anthropic supports disabling tool calls by setting {"type": "none"},
+        which is used when auto-invocation attempts are exhausted.
+        """
+        if self.tool_choice is None:
+            return self
+
+        allowed_tool_choice_types = {
+            FunctionChoiceType.AUTO.value,
+            FunctionChoiceType.NONE.value,
+            FunctionChoiceType.REQUIRED.value,
+            "any",
+            "tool",
+        }
+        tool_choice_type = self.tool_choice.get("type")
+        if tool_choice_type not in allowed_tool_choice_types:
+            raise ServiceInvalidExecutionSettingsError(
+                f"Invalid Anthropic tool_choice type '{tool_choice_type}'. "
+                f"Expected one of: {sorted(allowed_tool_choice_types)}."
+            )
         return self

--- a/python/semantic_kernel/connectors/ai/anthropic/services/anthropic_chat_completion.py
+++ b/python/semantic_kernel/connectors/ai/anthropic/services/anthropic_chat_completion.py
@@ -144,6 +144,8 @@ class AnthropicChatCompletion(ChatCompletionClientBase):
     @override
     def _reset_function_choice_settings(self, settings: "PromptExecutionSettings") -> None:
         if hasattr(settings, "tool_choice") and getattr(settings, "tools", None):
+            # Anthropic supports disabling tool calls while keeping tool definitions:
+            # https://docs.anthropic.com/en/api/messages#body-tool_choice
             settings.tool_choice = {"type": FunctionChoiceType.NONE.value}
 
     @override
@@ -302,7 +304,7 @@ class AnthropicChatCompletion(ChatCompletionClientBase):
                     id=tool_use_block.id,
                     index=stream_event.index,
                     name=tool_use_block.name,
-                    arguments=json.dumps(tool_use_block.input) if tool_use_block.input else None,
+                    arguments=json.dumps(tool_use_block.input) if tool_use_block.input is not None else None,
                 )
             )
         elif isinstance(stream_event, RawMessageDeltaEvent):

--- a/python/tests/unit/connectors/ai/anthropic/services/test_anthropic_chat_completion.py
+++ b/python/tests/unit/connectors/ai/anthropic/services/test_anthropic_chat_completion.py
@@ -645,3 +645,33 @@ def test_get_tool_calls_from_message_serializes_arguments(
 
     assert len(tool_calls) == 1
     assert tool_calls[0].arguments == '{"input": 3, "amount": 3}'
+
+
+def test_get_tool_calls_from_message_serializes_empty_arguments_dict(
+    mock_anthropic_client_completion: MagicMock,
+):
+    chat_completion = AnthropicChatCompletion(
+        ai_model_id="test_model_id", service_id="test", api_key="", async_client=mock_anthropic_client_completion
+    )
+    message = Message(
+        id="test_message_id",
+        content=[
+            ToolUseBlock(
+                id="test_tool_use_block_id",
+                input={},
+                name="math-Add",
+                type="tool_use",
+            ),
+        ],
+        model="claude-3-opus-20240229",
+        role="assistant",
+        stop_reason="tool_use",
+        stop_sequence=None,
+        type="message",
+        usage=Usage(input_tokens=100, output_tokens=100),
+    )
+
+    tool_calls = chat_completion._get_tool_calls_from_message(message)
+
+    assert len(tool_calls) == 1
+    assert tool_calls[0].arguments == "{}"

--- a/python/tests/unit/connectors/ai/anthropic/test_anthropic_request_settings.py
+++ b/python/tests/unit/connectors/ai/anthropic/test_anthropic_request_settings.py
@@ -1,10 +1,13 @@
 # Copyright (c) Microsoft. All rights reserved.
 
+import pytest
+
 from semantic_kernel.connectors.ai.anthropic.prompt_execution_settings.anthropic_prompt_execution_settings import (
     AnthropicChatPromptExecutionSettings,
 )
 from semantic_kernel.connectors.ai.function_choice_behavior import FunctionChoiceBehavior
 from semantic_kernel.connectors.ai.prompt_execution_settings import PromptExecutionSettings
+from semantic_kernel.exceptions import ServiceInvalidExecutionSettingsError
 
 
 def test_default_anthropic_chat_prompt_execution_settings():
@@ -124,3 +127,14 @@ def test_tool_choice_none():
         function_choice_behavior=FunctionChoiceBehavior.NoneInvoke(),
     )
     assert settings.tool_choice == {"type": "none"}
+
+
+def test_tool_choice_invalid_type_raises():
+    with pytest.raises(ServiceInvalidExecutionSettingsError, match="Invalid Anthropic tool_choice type"):
+        AnthropicChatPromptExecutionSettings(
+            service_id="test_service",
+            extension_data={
+                "tool_choice": {"type": "invalid"},
+                "messages": [{"role": "system", "content": "Hello"}],
+            },
+        )


### PR DESCRIPTION
…ke and fix unhashable arguments

### Motivation and Context

<!-- Thank you for your contribution to the semantic-kernel repo!
Please help reviewers and future users, providing the following information:
  1. Why is this change required?
  2. What problem does it solve?
  3. What scenario does it contribute to?
  4. If it fixes an open issue, please link to the issue here.
-->

### Description

<!-- Describe your changes, the overall approach, the underlying design.
     These notes will help understanding how your code works. Thanks! -->

### Contribution Checklist

<!-- Before submitting this PR, please make sure: -->

- [ ] The code builds clean without any errors or warnings
- [ ] The PR follows the [SK Contribution Guidelines](https://github.com/microsoft/semantic-kernel/blob/main/CONTRIBUTING.md) and the [pre-submission formatting script](https://github.com/microsoft/semantic-kernel/blob/main/CONTRIBUTING.md#development-scripts) raises no violations
- [ ] All unit tests pass, and I have added new tests where possible
- [ ] I didn't break anyone :smile:
