### PR TITLE
.Net: Fix: Surface Ollama reasoning ("thinking") content in ChatMessageContent

### DIFF
--- a/dotnet/src/Connectors/Connectors.Ollama.UnitTests/Services/OllamaChatCompletionTests.cs
+++ b/dotnet/src/Connectors/Connectors.Ollama.UnitTests/Services/OllamaChatCompletionTests.cs
@@ -767,6 +767,28 @@ public sealed class OllamaChatCompletionTests : IDisposable
         Assert.Contains("\"result\":\"rainy\"", functionResult.GetProperty("content").GetString());
     }
 
+    [Fact]
+    public async Task GetChatMessageContentShouldIncludeThinkingWhenPresentInResponseAsync()
+    {
+        using var response = new HttpResponseMessage(System.Net.HttpStatusCode.OK)
+        {
+            Content = new StreamContent(File.OpenRead("TestData/chat_completion_with_thinking_response.txt"))
+        };
+
+        this._multiMessageHandlerStub.ResponsesToReturn = [response];
+
+        var sut = Kernel.CreateBuilder()
+            .AddOllamaChatCompletion("test-model", this._httpClient)
+            .Build()
+            .GetRequiredService<IChatCompletionService>();
+
+        // Act
+        var result = await sut.GetChatMessageContentAsync("test prompt");
+
+        // Assert
+        Assert.Contains("This is reasoning content", result.Content);
+    }
+    
     private sealed class AutoFunctionInvocationFilter : IAutoFunctionInvocationFilter
     {
         private readonly Func<AutoFunctionInvocationContext, Func<AutoFunctionInvocationContext, Task>, Task> _callback;

--- a/dotnet/src/Connectors/Connectors.Ollama.UnitTests/TestData/chat_completion_with_thinking_response.txt
+++ b/dotnet/src/Connectors/Connectors.Ollama.UnitTests/TestData/chat_completion_with_thinking_response.txt
@@ -1,0 +1,2 @@
+﻿{"model":"qwen3:0.6b","message":{"role":"assistant","content":"Final answer","thinking":"This is reasoning content"},"done":false}
+{"model":"qwen3:0.6b","message":{"role":"assistant","content":"","thinking":""},"done":true}

--- a/dotnet/src/InternalUtilities/meai/Extensions/ChatMessageExtensions.cs
+++ b/dotnet/src/InternalUtilities/meai/Extensions/ChatMessageExtensions.cs
@@ -23,6 +23,24 @@ internal static class ChatMessageExtensions
             Role = new AuthorRole(message.Role.Value),
         };
 
+        if (response?.RawRepresentation is not null)
+        {
+            var raw = response.RawRepresentation;
+            var messageProp = raw.GetType().GetProperty("Message");
+            var messageObj = messageProp?.GetValue(raw);
+            var thinkingProp = messageObj?.GetType().GetProperty("Thinking");
+            var thinking = thinkingProp?.GetValue(messageObj) as string;
+
+            if (!string.IsNullOrWhiteSpace(thinking))
+            {
+                result.Items.Add(new Microsoft.SemanticKernel.TextContent($"[THINKING]\n{thinking}")
+                {
+                    ModelId = response?.ModelId,
+                    InnerContent = raw
+                });
+            }
+        }
+
         foreach (AIContent content in message.Contents)
         {
 #pragma warning disable SKEXP0001 // Type is for evaluation purposes only and is subject to change or removal in future updates. Suppress this diagnostic to proceed.


### PR DESCRIPTION
## Summary
Fixes #13860
Ollama responses can include a `thinking` (reasoning) field, but this information is currently not exposed through `ChatMessageContent` in Semantic Kernel.

This PR adds support to surface reasoning content by extracting it from the underlying `RawRepresentation`.

---

## Changes

* Added a unit test demonstrating that reasoning (`thinking`) content is currently not propagated.
* Implemented a minimal fix to extract `thinking` from `RawRepresentation` and include it in `ChatMessageContent.Items` as `TextContent`.

---

## Behavior

Before:

* Only final response (`content`) is available.

After:

* Reasoning (`thinking`) is included alongside final response.

## Design Notes

* The fix uses `RawRepresentation` to avoid introducing a dependency on Ollama-specific types in `SemanticKernel.Abstractions`.
* This is intentionally a minimal and non-breaking change.

## Limitations / Future Work

* This highlights a broader gap in the current abstraction:

* The `Microsoft.Extensions.AI` model does not currently support reasoning/thinking as a first-class concept.
* Modern LLMs (Ollama, OpenAI reasoning models, etc.) are increasingly returning structured reasoning.

Potential improvements:

* Introduce a dedicated `ReasoningContent` type
* Or expose reasoning via standardized metadata

Happy to align with maintainers on preferred direction.

## Testing
Added unit test: `GetChatMessageContent_ShouldIncludeThinking_WhenPresentInResponseAsync`

