### PR TITLE
Python: fix(python): normalize Azure AI agent response_format

### DIFF
--- a/python/semantic_kernel/agents/azure_ai/agent_thread_actions.py
+++ b/python/semantic_kernel/agents/azure_ai/agent_thread_actions.py
@@ -893,7 +893,7 @@ class AgentThreadActions:
         *,
         agent: "AzureAIAgent",
         model: str | None = None,
-        response_format: ResponseFormatJsonSchemaType | None = None,
+        response_format: str | ResponseFormatJsonSchemaType | dict[str, Any] | None = None,
         temperature: float | None = None,
         top_p: float | None = None,
         metadata: dict[str, str] | None = None,
@@ -919,8 +919,8 @@ class AgentThreadActions:
 
     @classmethod
     def _normalize_response_format(
-        cls: type[_T], response_format: ResponseFormatJsonSchemaType | dict[str, Any] | None
-    ) -> ResponseFormatJsonSchemaType | dict[str, Any] | None:
+        cls: type[_T], response_format: str | ResponseFormatJsonSchemaType | dict[str, Any] | None
+    ) -> str | ResponseFormatJsonSchemaType | None:
         """Normalize structured output response formats for Azure SDK consumers."""
         if response_format is None or isinstance(response_format, ResponseFormatJsonSchemaType):
             return response_format
@@ -928,7 +928,13 @@ class AgentThreadActions:
         if not isinstance(response_format, dict):
             return response_format
 
-        if response_format.get("type") != "json_schema":
+        # Map simple dict shapes to the string form the Azure SDK expects.
+        # {"type": "json_object"} / {"type": "text"} both have canonical string equivalents.
+        rf_type = response_format.get("type")
+        if rf_type in ("json_object", "text"):
+            return rf_type
+
+        if rf_type != "json_schema":
             return response_format
 
         json_schema = response_format.get("json_schema")

--- a/python/semantic_kernel/agents/azure_ai/agent_thread_actions.py
+++ b/python/semantic_kernel/agents/azure_ai/agent_thread_actions.py
@@ -13,6 +13,7 @@ from azure.ai.agents.models import (
     BaseAsyncAgentEventHandler,
     FunctionToolDefinition,
     RequiredMcpToolCall,
+    ResponseFormatJsonSchema,
     ResponseFormatJsonSchemaType,
     RunStep,
     RunStepAzureAISearchToolCall,
@@ -902,14 +903,46 @@ class AgentThreadActions:
 
         Run-level parameters take precedence.
         """
+        normalized_response_format = (
+            cls._normalize_response_format(response_format)
+            if response_format is not None
+            else cls._normalize_response_format(agent.definition.response_format)
+        )
         return {
             "model": model if model is not None else agent.definition.model,
-            "response_format": response_format if response_format is not None else agent.definition.response_format,
+            "response_format": normalized_response_format,
             "temperature": temperature if temperature is not None else None,
             "top_p": top_p if top_p is not None else None,
             "metadata": metadata if metadata is not None else agent.definition.metadata,
             **kwargs,
         }
+
+    @classmethod
+    def _normalize_response_format(
+        cls: type[_T], response_format: ResponseFormatJsonSchemaType | dict[str, Any] | None
+    ) -> ResponseFormatJsonSchemaType | dict[str, Any] | None:
+        """Normalize structured output response formats for Azure SDK consumers."""
+        if response_format is None or isinstance(response_format, ResponseFormatJsonSchemaType):
+            return response_format
+
+        if not isinstance(response_format, dict):
+            return response_format
+
+        if response_format.get("type") != "json_schema":
+            return response_format
+
+        json_schema = response_format.get("json_schema")
+        if not isinstance(json_schema, dict):
+            return response_format
+
+        return ResponseFormatJsonSchemaType(
+            json_schema=ResponseFormatJsonSchema(
+                name=json_schema.get("name"),
+                description=json_schema.get("description"),
+                schema=json_schema.get("schema"),
+                strict=json_schema.get("strict"),
+            )
+        )
 
     @classmethod
     def _generate_options(cls: type[_T], **kwargs: Any) -> dict[str, Any]:

--- a/python/tests/unit/agents/azure_ai_agent/test_agent_thread_actions.py
+++ b/python/tests/unit/agents/azure_ai_agent/test_agent_thread_actions.py
@@ -8,6 +8,7 @@ from azure.ai.agents.models import (
     MessageTextDetails,
     RequiredFunctionToolCall,
     RequiredFunctionToolCallDetails,
+    ResponseFormatJsonSchemaType,
     RunStep,
     RunStepCodeInterpreterToolCall,
     RunStepCodeInterpreterToolCallDetails,
@@ -78,6 +79,25 @@ async def test_agent_thread_actions_create_message_no_content():
     out = await AgentThreadActions.create_message(FakeClient(), "threadXYZ", message)
     assert out is None
     assert FakeAgentClient.create_message.await_count == 0
+
+
+def test_agent_thread_actions_generate_options_normalizes_dict_response_format(ai_agent_definition):
+    agent = AzureAIAgent(client=AsyncMock(spec=AIProjectClient), definition=ai_agent_definition)
+    agent.definition.response_format = {
+        "type": "json_schema",
+        "json_schema": {
+            "name": "planet_mass",
+            "description": "Extract planet mass.",
+            "schema": {"type": "object", "properties": {"mass": {"type": "number"}}},
+            "strict": True,
+        },
+    }
+
+    options = AgentThreadActions._generate_options(agent=agent)
+
+    assert isinstance(options["response_format"], ResponseFormatJsonSchemaType)
+    assert options["response_format"].json_schema.name == "planet_mass"
+    assert options["response_format"].json_schema.strict is True
 
 
 async def test_agent_thread_actions_invoke(ai_project_client: AIProjectClient, ai_agent_definition):


### PR DESCRIPTION
## Summary
- normalize dict-based structured output configs into Azure SDK ResponseFormatJsonSchemaType objects before creating runs
- avoid passing raw dict response_format values into Azure Monitor-instrumented agent clients
- add a focused unit test around the option generation path

## Testing
- python3 -m py_compile python/semantic_kernel/agents/azure_ai/agent_thread_actions.py python/tests/unit/agents/azure_ai_agent/test_agent_thread_actions.py
- python3 -m pytest tests/unit/agents/azure_ai_agent/test_agent_thread_actions.py -k response_format (fails locally because repo test setup imports openai, which is not installed in this environment)