### PR TITLE
.Net: Remove MEVD components from SK-release.slnf

### DIFF
--- a/dotnet/SK-release.slnf
+++ b/dotnet/SK-release.slnf
@@ -32,22 +32,6 @@
       "src\\Connectors\\Connectors.Onnx\\Connectors.Onnx.csproj",
       "src\\Connectors\\Connectors.OpenAI\\Connectors.OpenAI.csproj",
 
-      "src\\VectorData\\AzureAISearch\\AzureAISearch.csproj",
-      "src\\VectorData\\Chroma\\Chroma.csproj",
-      "src\\VectorData\\CosmosMongoDB\\CosmosMongoDB.csproj",
-      "src\\VectorData\\CosmosNoSql\\CosmosNoSql.csproj",
-      "src\\VectorData\\InMemory\\InMemory.csproj",
-      "src\\VectorData\\Milvus\\Milvus.csproj",
-      "src\\VectorData\\MongoDB\\MongoDB.csproj",
-      "src\\VectorData\\PgVector\\PgVector.csproj",
-      "src\\VectorData\\Pinecone\\Pinecone.csproj",
-      "src\\VectorData\\Qdrant\\Qdrant.csproj",
-      "src\\VectorData\\Redis\\Redis.csproj",
-      "src\\VectorData\\SqliteVec\\SqliteVec.csproj",
-      "src\\VectorData\\SqlServer\\SqlServer.csproj",
-      "src\\VectorData\\VectorData.Abstractions\\VectorData.Abstractions.csproj",
-      "src\\VectorData\\Weaviate\\Weaviate.csproj",
-
       "src\\Experimental\\Orchestration.Flow\\Experimental.Orchestration.Flow.csproj",
 
       "src\\Experimental\\Process.Abstractions\\Process.Abstractions.csproj",


### PR DESCRIPTION
With the ongoing move of MEVD components out of the SK repo, this disables publishing them.