### PR TITLE
Python: Fix Redis FT.CREATE PREFIX sending one prefix per character of collec…

### DIFF
--- a/python/semantic_kernel/connectors/redis.py
+++ b/python/semantic_kernel/connectors/redis.py
@@ -278,7 +278,7 @@ class RedisCollection(
             raise VectorStoreOperationException("Invalid index type supplied.")
         fields = _definition_to_redis_fields(self.definition, self.collection_type)
         index_definition = IndexDefinition(
-            prefix=f"{self.collection_name}:", index_type=INDEX_TYPE_MAP[self.collection_type]
+            prefix=[f"{self.collection_name}:"], index_type=INDEX_TYPE_MAP[self.collection_type]
         )
         await self.redis_database.ft(self.collection_name).create_index(fields, definition=index_definition, **kwargs)
 

--- a/python/tests/unit/connectors/memory/test_redis_store.py
+++ b/python/tests/unit/connectors/memory/test_redis_store.py
@@ -295,11 +295,22 @@ async def test_create_index(collection_hash, mock_ensure_collection_exists):
     await collection_hash.ensure_collection_exists()
 
 
+async def test_create_index_prefix_is_list(collection_hash, mock_ensure_collection_exists):
+    """Verify prefix is passed as a list, not a string (#13894)."""
+    await collection_hash.ensure_collection_exists()
+    mock_ensure_collection_exists.assert_called_once()
+    definition = mock_ensure_collection_exists.call_args.kwargs.get("definition")
+    assert definition is not None
+    prefix_idx = definition.args.index("PREFIX")
+    assert definition.args[prefix_idx + 1] == 1
+    assert definition.args[prefix_idx + 2] == f"{collection_hash.collection_name}:"
+
+
 async def test_create_index_manual(collection_hash, mock_ensure_collection_exists):
     from redis.commands.search.index_definition import IndexDefinition, IndexType
 
     fields = ["fields"]
-    index_definition = IndexDefinition(prefix="test:", index_type=IndexType.HASH)
+    index_definition = IndexDefinition(prefix=["test:"], index_type=IndexType.HASH)
     await collection_hash.ensure_collection_exists(index_definition=index_definition, fields=fields)
 
 


### PR DESCRIPTION
Fixes #13894.

The Python Redis connector was passing a plain string to `redis-py`'s `IndexDefinition(prefix=...)`. `redis-py` treats that argument as an iterable of prefixes and iterates the string character-by-character. As a result, `FT.CREATE` was registering one prefix per character of the collection name instead of one prefix equal to `"<collection_name>:"`.

Observed on the wire for collection `redis_json_list_data_model`:

```
FT.CREATE redis_json_list_data_model ON JSON
  PREFIX 27 r e d i s _ j s o n _ l i s t _ d a t a _ m o d e l :
  SCORE 1.0 SCHEMA ...
```

Expected:

```
FT.CREATE redis_json_list_data_model ON JSON
  PREFIX 1 redis_json_list_data_model:
  SCORE 1.0 SCHEMA ...
```
RediSearch on Redis Stack silently accepts the malformed command, so the bug has been latent for single-collection users.
  
### Contribution Checklist

<!-- Before submitting this PR, please make sure: -->

- [x] The code builds clean without any errors or warnings
- [x] The PR follows the [SK Contribution Guidelines](https://github.com/microsoft/semantic-kernel/blob/main/CONTRIBUTING.md) and the [pre-submission formatting script](https://github.com/microsoft/semantic-kernel/blob/main/CONTRIBUTING.md#development-scripts) raises no violations
- [x] All unit tests pass, and I have added new tests where possible
- [x] I didn't break anyone :smile:
