### PR TITLE
Python: Extend InMemoryCollection filter attribute blocklist

### DIFF
--- a/python/semantic_kernel/connectors/in_memory.py
+++ b/python/semantic_kernel/connectors/in_memory.py
@@ -516,6 +516,7 @@ class InMemoryCollection(
     blocked_filter_attributes: ClassVar[set[str]] = {
         # Object introspection - can lead to class/module access
         "__class__",
+        "__base__",
         "__bases__",
         "__mro__",
         "__subclasses__",

--- a/python/tests/unit/connectors/memory/test_in_memory.py
+++ b/python/tests/unit/connectors/memory/test_in_memory.py
@@ -196,6 +196,22 @@ def test_direct_mutating_method_call_remains_blocked(collection):
         collection._parse_and_validate_filter("lambda x: x.clear() or True")
 
 
+@mark.parametrize(
+    "attr",
+    [
+        "__base__",
+        "__bases__",
+        "__class__",
+        "__mro__",
+        "__subclasses__",
+        "__globals__",
+    ],
+)
+def test_blocked_dunder_attributes_rejected(collection, attr):
+    with raises(VectorStoreOperationException, match=f"Access to attribute '{attr}' is not allowed"):
+        collection._parse_and_validate_filter(f"lambda x: x.{attr}")
+
+
 async def test_valid_lambda_filter_with_get_method(collection):
     record1 = {"id": "1", "vector": [1, 2, 3, 4, 5]}
     record2 = {"id": "2", "vector": [5, 4, 3, 2, 1]}


### PR DESCRIPTION
## Summary
- Minor defense-in-depth hardening for `InMemoryCollection` filter parsing.
- Extends the internal dunder attribute blocklist and adds a regression test covering the blocked set.

## Test plan
- [x] `uv run pytest tests/unit/connectors/memory/test_in_memory.py`