### PR TITLE
Python: fix(python/redis): wrap IndexDefinition prefix in a list

### DIFF
--- a/python/semantic_kernel/connectors/redis.py
+++ b/python/semantic_kernel/connectors/redis.py
@@ -278,7 +278,7 @@ class RedisCollection(
             raise VectorStoreOperationException("Invalid index type supplied.")
         fields = _definition_to_redis_fields(self.definition, self.collection_type)
         index_definition = IndexDefinition(
-            prefix=f"{self.collection_name}:", index_type=INDEX_TYPE_MAP[self.collection_type]
+            prefix=[f"{self.collection_name}:"], index_type=INDEX_TYPE_MAP[self.collection_type]
         )
         await self.redis_database.ft(self.collection_name).create_index(fields, definition=index_definition, **kwargs)
 

--- a/python/tests/unit/connectors/memory/test_redis_store.py
+++ b/python/tests/unit/connectors/memory/test_redis_store.py
@@ -291,15 +291,30 @@ async def test_ensure_collection_deleted(collection_hash, mock_ensure_collection
     await collection_hash.ensure_collection_deleted()
 
 
-async def test_create_index(collection_hash, mock_ensure_collection_exists):
-    await collection_hash.ensure_collection_exists()
+@mark.parametrize("type_", ["hashset", "json"])
+async def test_create_index(collection_hash, collection_json, mock_ensure_collection_exists, type_):
+    from redis.commands.search.index_definition import IndexDefinition, IndexType
+
+    collection = collection_hash if type_ == "hashset" else collection_json
+    expected_index_type = IndexType.HASH if type_ == "hashset" else IndexType.JSON
+
+    await collection.ensure_collection_exists()
+
+    mock_ensure_collection_exists.assert_called_once()
+    index_def = mock_ensure_collection_exists.call_args.kwargs["definition"]
+    assert isinstance(index_def, IndexDefinition)
+    # IndexDefinition._append_prefix iterates its argument. A bare string like "test:"
+    # produces PREFIX 5 t e s t : instead of PREFIX 1 test:. Comparing args against a
+    # reference built with a list catches this regression.
+    expected_def = IndexDefinition(prefix=[f"{collection.collection_name}:"], index_type=expected_index_type)
+    assert index_def.args == expected_def.args
 
 
 async def test_create_index_manual(collection_hash, mock_ensure_collection_exists):
     from redis.commands.search.index_definition import IndexDefinition, IndexType
 
     fields = ["fields"]
-    index_definition = IndexDefinition(prefix="test:", index_type=IndexType.HASH)
+    index_definition = IndexDefinition(prefix=["test:"], index_type=IndexType.HASH)
     await collection_hash.ensure_collection_exists(index_definition=index_definition, fields=fields)
 
 


### PR DESCRIPTION
## Summary

Fixes #13894

`redis-py`'s `IndexDefinition` expects `prefix` to be a `list` or `tuple`. In `python/semantic_kernel/connectors/redis.py:281` the prefix was passed as a bare string:

```python
# Before
index_definition = IndexDefinition(
    prefix=f"{self.collection_name}:", ...
)
```

Because Python iterates a string character-by-character, `redis-py` was building a `FT.CREATE PREFIX` command with each character as a separate prefix entry instead of the intended single prefix. This caused `create_collection` to fail with a malformed command.

## Change

```python
# After
index_definition = IndexDefinition(
    prefix=[f"{self.collection_name}:"], ...
)
```

Wrapping the string in a list ensures a single, correctly formed prefix is passed to `FT.CREATE`.

## Testing

- Existing unit tests in `python/tests/unit/connectors/memory/test_redis_store.py` continue to pass.
- Manually verified that `FT.CREATE` now receives the correct `PREFIX 1 <collection_name>:` argument.

Signed-off-by: Doondi-Ashlesh <doondiashlesh@gmail.com>