### PR TITLE
Python: fix(python/redis): handle redisvl 0.5 API change in process_results and guard vector buffer decode

### DIFF
--- a/python/pyproject.toml
+++ b/python/pyproject.toml
@@ -138,7 +138,7 @@ qdrant = [
 redis = [
     "redis[hiredis] >= 6,< 8",
     "types-redis ~= 4.6.0.20240425",
-    "redisvl ~= 0.4"
+    "redisvl >= 0.5"
 ]
 realtime = [
     "websockets >= 13, < 16",

--- a/python/semantic_kernel/connectors/redis.py
+++ b/python/semantic_kernel/connectors/redis.py
@@ -3,7 +3,6 @@
 import ast
 import asyncio
 import contextlib
-import inspect
 import json
 import logging
 import sys
@@ -22,15 +21,7 @@ from redisvl.index.index import process_results
 from redisvl.query.filter import FilterExpression, Num, Tag, Text
 from redisvl.query.query import BaseQuery, VectorQuery
 from redisvl.redis.utils import array_to_buffer, buffer_to_array, convert_bytes
-from redisvl.schema import StorageType
-
-try:
-    from redisvl.schema import IndexSchema as _RedisVLIndexSchema
-
-    _PROCESS_RESULTS_USES_SCHEMA: bool = "schema" in inspect.signature(process_results).parameters
-except ImportError:
-    _RedisVLIndexSchema = None  # type: ignore[assignment]
-    _PROCESS_RESULTS_USES_SCHEMA = False
+from redisvl.schema import IndexSchema as _RedisVLIndexSchema, StorageType
 
 from semantic_kernel.connectors.ai.embedding_generator_base import EmbeddingGeneratorBase
 from semantic_kernel.data.vector import (
@@ -330,13 +321,10 @@ class RedisCollection(
         results = await self.redis_database.ft(self.collection_name).search(  # type: ignore
             query=query.query, query_params=query.params
         )
-        if _PROCESS_RESULTS_USES_SCHEMA and _RedisVLIndexSchema is not None:
-            _schema = _RedisVLIndexSchema.from_dict(
-                {"index": {"name": self.collection_name, "storage_type": STORAGE_TYPE_MAP[self.collection_type].value}}
-            )
-            processed = process_results(results, query, _schema)
-        else:
-            processed = process_results(results, query, STORAGE_TYPE_MAP[self.collection_type])
+        schema = _RedisVLIndexSchema.from_dict(
+            {"index": {"name": self.collection_name, "storage_type": STORAGE_TYPE_MAP[self.collection_type].value}}
+        )
+        processed = process_results(results, query, schema)
         return KernelSearchResults(
             results=self._get_vector_search_results_from_results(desync_list(processed)),
             total_count=results.total,

--- a/python/semantic_kernel/connectors/redis.py
+++ b/python/semantic_kernel/connectors/redis.py
@@ -3,6 +3,7 @@
 import ast
 import asyncio
 import contextlib
+import inspect
 import json
 import logging
 import sys
@@ -22,6 +23,14 @@ from redisvl.query.filter import FilterExpression, Num, Tag, Text
 from redisvl.query.query import BaseQuery, VectorQuery
 from redisvl.redis.utils import array_to_buffer, buffer_to_array, convert_bytes
 from redisvl.schema import StorageType
+
+try:
+    from redisvl.schema import IndexSchema as _RedisVLIndexSchema
+
+    _PROCESS_RESULTS_USES_SCHEMA: bool = "schema" in inspect.signature(process_results).parameters
+except ImportError:
+    _RedisVLIndexSchema = None  # type: ignore[assignment]
+    _PROCESS_RESULTS_USES_SCHEMA = False
 
 from semantic_kernel.connectors.ai.embedding_generator_base import EmbeddingGeneratorBase
 from semantic_kernel.data.vector import (
@@ -321,7 +330,13 @@ class RedisCollection(
         results = await self.redis_database.ft(self.collection_name).search(  # type: ignore
             query=query.query, query_params=query.params
         )
-        processed = process_results(results, query, STORAGE_TYPE_MAP[self.collection_type])
+        if _PROCESS_RESULTS_USES_SCHEMA and _RedisVLIndexSchema is not None:
+            _schema = _RedisVLIndexSchema.from_dict(
+                {"index": {"name": self.collection_name, "storage_type": STORAGE_TYPE_MAP[self.collection_type].value}}
+            )
+            processed = process_results(results, query, _schema)
+        else:
+            processed = process_results(results, query, STORAGE_TYPE_MAP[self.collection_type])
         return KernelSearchResults(
             results=self._get_vector_search_results_from_results(desync_list(processed)),
             total_count=results.total,
@@ -616,8 +631,9 @@ class RedisHashsetCollection(RedisCollection[TKey, TModel], Generic[TKey, TModel
                     case FieldTypes.KEY:
                         rec[field.name] = self._unget_redis_key(rec[field.name])
                     case "vector":
-                        dtype = DATATYPE_MAP_VECTOR[field.type_ or "default"]
-                        rec[field.name] = buffer_to_array(rec[field.name], dtype)
+                        if field.name in rec:
+                            dtype = DATATYPE_MAP_VECTOR[field.type_ or "default"]
+                            rec[field.name] = buffer_to_array(rec[field.name], dtype)
             results.append(rec)
         return results
 

--- a/python/tests/unit/connectors/memory/test_redis_store.py
+++ b/python/tests/unit/connectors/memory/test_redis_store.py
@@ -306,3 +306,46 @@ async def test_create_index_manual(collection_hash, mock_ensure_collection_exist
 async def test_create_index_fail(collection_hash, mock_ensure_collection_exists):
     with raises(VectorStoreOperationException, match="Invalid index type supplied."):
         await collection_hash.ensure_collection_exists(index_definition="index_definition", fields="fields")
+
+
+def test_deserialize_hashset_skips_missing_vector_field(collection_hash):
+    # Simulate search results with include_vectors=False: vector key is absent.
+    records = [{"id": "id1", "content": "hello"}]
+    result = collection_hash._deserialize_store_models_to_dicts(records)
+    assert len(result) == 1
+    assert result[0]["id"] == "id1"
+    assert result[0]["content"] == "hello"
+    assert "vector" not in result[0]
+
+
+@mark.parametrize("type_", ["hashset", "json"])
+async def test_inner_search_passes_index_schema_to_process_results(
+    collection_hash, collection_json, type_
+):
+    from unittest.mock import MagicMock
+
+    from redisvl.schema import IndexSchema, StorageType
+
+    from semantic_kernel.data.vector import SearchType, VectorSearchOptions
+
+    collection = collection_hash if type_ == "hashset" else collection_json
+    expected_storage = StorageType.HASH if type_ == "hashset" else StorageType.JSON
+
+    mock_results = MagicMock()
+    mock_results.docs = []
+    mock_results.total = 0
+
+    with patch("redis.commands.search.AsyncSearch.search", new=AsyncMock(return_value=mock_results)):
+        with patch(
+            "semantic_kernel.connectors.redis.process_results", return_value=[]
+        ) as mock_process:
+            await collection._inner_search(
+                search_type=SearchType.VECTOR,
+                options=VectorSearchOptions(vector_property_name="vector", top=3),
+                vector=[1.0, 2.0, 3.0, 4.0, 5.0],
+            )
+
+    mock_process.assert_called_once()
+    _results_arg, _query_arg, schema_arg = mock_process.call_args.args
+    assert isinstance(schema_arg, IndexSchema), "process_results must receive an IndexSchema, not a StorageType"
+    assert schema_arg.index.storage_type == expected_storage


### PR DESCRIPTION
## Summary

Fixes #13896

Two bugs in the Python Redis connector cause `FT.SEARCH` (`collection.search(...)`) to fail completely:

### Bug 1 - redisvl 0.5.0 broke `process_results` signature

`redisvl` 0.5.0 changed the third parameter of `process_results()` from `StorageType` to `IndexSchema`. Because `pyproject.toml` pins `redisvl ~= 0.4` (which allows 0.5.x per PEP 440), users who upgrade redisvl to 0.5.x get:

```
AttributeError: 'StorageType' object has no attribute 'index'
```

**Fix**: detect the active API at import time via `inspect.signature`. When `IndexSchema` is required, construct a minimal schema from the collection name and storage type before calling `process_results`.

### Bug 2 - KeyError on missing vector field during deserialization

`RedisHashsetCollection._deserialize_store_models_to_dicts` calls `buffer_to_array()` for every vector field unconditionally. When `include_vectors=False` (the default for search), the vector field is absent from the result dict, raising:

```
KeyError: '<vector_field_name>'
```

**Fix**: skip the vector buffer decode when the field is absent from the record.

## Test plan

- [ ] Run existing Redis unit tests: `cd python && make test TEST_FILTERS="connectors/memory/test_redis"` (no new failures)
- [ ] Manual smoke test with Redis Stack: `create_collection`, `upsert`, `search` with `include_vectors=False` (default) completes without error
- [ ] Manual smoke test with `include_vectors=True` still decodes vectors correctly
- [ ] Tested with both redisvl 0.4.x and 0.5.x

Signed-off-by: Doondi-Ashlesh <doondiashlesh@gmail.com>