### PR TITLE
Python: fix(redis): pass collection prefix as a list

### DIFF
--- a/python/semantic_kernel/connectors/redis.py
+++ b/python/semantic_kernel/connectors/redis.py
@@ -278,7 +278,7 @@ class RedisCollection(
             raise VectorStoreOperationException("Invalid index type supplied.")
         fields = _definition_to_redis_fields(self.definition, self.collection_type)
         index_definition = IndexDefinition(
-            prefix=f"{self.collection_name}:", index_type=INDEX_TYPE_MAP[self.collection_type]
+            prefix=[f"{self.collection_name}:"], index_type=INDEX_TYPE_MAP[self.collection_type]
         )
         await self.redis_database.ft(self.collection_name).create_index(fields, definition=index_definition, **kwargs)
 

--- a/python/tests/unit/connectors/memory/test_redis_store.py
+++ b/python/tests/unit/connectors/memory/test_redis_store.py
@@ -299,10 +299,40 @@ async def test_create_index_manual(collection_hash, mock_ensure_collection_exist
     from redis.commands.search.index_definition import IndexDefinition, IndexType
 
     fields = ["fields"]
-    index_definition = IndexDefinition(prefix="test:", index_type=IndexType.HASH)
+    index_definition = IndexDefinition(prefix=["test:"], index_type=IndexType.HASH)
     await collection_hash.ensure_collection_exists(index_definition=index_definition, fields=fields)
 
 
 async def test_create_index_fail(collection_hash, mock_ensure_collection_exists):
     with raises(VectorStoreOperationException, match="Invalid index type supplied."):
         await collection_hash.ensure_collection_exists(index_definition="index_definition", fields="fields")
+
+
+@mark.parametrize(
+    ("fixture_name", "expected_index_type"),
+    [
+        ("collection_hash", "hash"),
+        ("collection_json", "json"),
+    ],
+)
+async def test_create_index_uses_single_collection_prefix(
+    request,
+    fixture_name,
+    expected_index_type,
+    mock_ensure_collection_exists,
+):
+    collection = request.getfixturevalue(fixture_name)
+    from redis.commands.search.index_definition import IndexType
+
+    with patch("semantic_kernel.connectors.redis.IndexDefinition") as mock_index_definition:
+        definition = object()
+        mock_index_definition.return_value = definition
+
+        await collection.ensure_collection_exists()
+
+        mock_index_definition.assert_called_once_with(
+            prefix=["test:"],
+            index_type=IndexType(expected_index_type),
+        )
+        mock_ensure_collection_exists.assert_awaited_once()
+        assert mock_ensure_collection_exists.await_args.kwargs["definition"] is definition


### PR DESCRIPTION
## Summary
- pass Redis `IndexDefinition.prefix` as a single-item list instead of a plain string
- update the manual test fixture to match the correct `redis-py` API shape
- add a regression test that asserts the connector builds the index definition with exactly one collection prefix

Closes #13894

## Verification
- ran `git diff --check`
- added a focused unit test around `ensure_collection_exists()` prefix construction

## Notes
- I did not run the Python test suite locally because the required Redis/Python test dependencies were not installed in this environment.
