### PR TITLE
Python: fix(python/redis): fix FT.CREATE prefix format and silent delete failure

### DIFF
--- a/python/semantic_kernel/connectors/redis.py
+++ b/python/semantic_kernel/connectors/redis.py
@@ -278,7 +278,7 @@ class RedisCollection(
             raise VectorStoreOperationException("Invalid index type supplied.")
         fields = _definition_to_redis_fields(self.definition, self.collection_type)
         index_definition = IndexDefinition(
-            prefix=f"{self.collection_name}:", index_type=INDEX_TYPE_MAP[self.collection_type]
+            prefix=[f"{self.collection_name}:"], index_type=INDEX_TYPE_MAP[self.collection_type]
         )
         await self.redis_database.ft(self.collection_name).create_index(fields, definition=index_definition, **kwargs)
 
@@ -706,7 +706,7 @@ class RedisJsonCollection(RedisCollection[TKey, TModel], Generic[TKey, TModel]):
 
     @override
     async def _inner_delete(self, keys: Sequence[str], **kwargs: Any) -> None:
-        await asyncio.gather(*[self.redis_database.json().delete(key, **kwargs) for key in keys])
+        await asyncio.gather(*[self.redis_database.json().delete(self._get_redis_key(key), **kwargs) for key in keys])
 
     @override
     def _serialize_dicts_to_store_models(

--- a/python/tests/unit/connectors/memory/test_redis_store.py
+++ b/python/tests/unit/connectors/memory/test_redis_store.py
@@ -314,10 +314,19 @@ async def test_ensure_collection_deleted(collection_hash, mock_ensure_collection
 async def test_create_index(collection_hash, mock_ensure_collection_exists):
     await collection_hash.ensure_collection_exists()
 
-    # Check that the index definition has the correct prefix list format
-    # The second positional argument to create_index is usually 'definition' (keyword)
-    # but here we check kwargs
-    assert mock_ensure_collection_exists.call_args.kwargs["definition"].prefix == ["test:"]
+    index_definition = mock_ensure_collection_exists.call_args.kwargs["definition"]
+
+    # A bare string prefix is treated as an iterable by redis-py and becomes
+    # five one-character prefixes. Assert the generated command uses one prefix.
+    assert index_definition.args == ["ON", "HASH", "PREFIX", 1, "test:", "SCORE", 1.0]
+
+
+def test_create_index_prefix_must_be_sequence():
+    from redis.commands.search.index_definition import IndexDefinition, IndexType
+
+    index_definition = IndexDefinition(prefix="test:", index_type=IndexType.HASH)
+
+    assert index_definition.args == ["ON", "HASH", "PREFIX", 5, "t", "e", "s", "t", ":", "SCORE", 1.0]
 
 
 async def test_create_index_manual(collection_hash, mock_ensure_collection_exists):

--- a/python/tests/unit/connectors/memory/test_redis_store.py
+++ b/python/tests/unit/connectors/memory/test_redis_store.py
@@ -270,10 +270,30 @@ async def test_get(
     assert records is not None
 
 
+@mark.parametrize("prefix", [True, False])
 @mark.parametrize("type_", ["hashset", "json"])
-async def test_delete(collection_hash, collection_json, type_):
-    collection = collection_hash if type_ == "hashset" else collection_json
+async def test_delete(
+    collection_hash,
+    collection_json,
+    collection_with_prefix_hash,
+    collection_with_prefix_json,
+    mock_delete_hash,
+    mock_delete_json,
+    type_,
+    prefix,
+):
+    if prefix:
+        collection = collection_with_prefix_hash if type_ == "hashset" else collection_with_prefix_json
+    else:
+        collection = collection_hash if type_ == "hashset" else collection_json
+
     await collection._inner_delete(["id1"])
+
+    expected_key = "test:id1" if prefix else "id1"
+    if type_ == "hashset":
+        mock_delete_hash.assert_called_once_with(expected_key)
+    else:
+        mock_delete_json.assert_called_once_with(expected_key)
 
 
 async def test_collection_exists(collection_hash, mock_collection_exists):
@@ -294,12 +314,17 @@ async def test_ensure_collection_deleted(collection_hash, mock_ensure_collection
 async def test_create_index(collection_hash, mock_ensure_collection_exists):
     await collection_hash.ensure_collection_exists()
 
+    # Check that the index definition has the correct prefix list format
+    # The second positional argument to create_index is usually 'definition' (keyword)
+    # but here we check kwargs
+    assert mock_ensure_collection_exists.call_args.kwargs["definition"].prefix == ["test:"]
+
 
 async def test_create_index_manual(collection_hash, mock_ensure_collection_exists):
     from redis.commands.search.index_definition import IndexDefinition, IndexType
 
     fields = ["fields"]
-    index_definition = IndexDefinition(prefix="test:", index_type=IndexType.HASH)
+    index_definition = IndexDefinition(prefix=["test:"], index_type=IndexType.HASH)
     await collection_hash.ensure_collection_exists(index_definition=index_definition, fields=fields)
 
 


### PR DESCRIPTION
Fixes #13894
Fixes #13904

## Problem
The Python Redis connector in Semantic Kernel had two critical bugs:
1.  **Index Creation (#13894):** The `IndexDefinition` prefix was passed as a string instead of a list, causing Redis to malform the index prefix. This effectively broke vector search (RAG) on Redis.
2.  **Silent Delete Failure (#13904):** The `RedisJsonCollection._inner_delete` method used raw keys instead of calling `_get_redis_key()`. This caused deletion to silently fail when `prefix_collection_name_to_key_names` was enabled.

## Solution
1.  **Wrap Prefix:** Wrapped the collection prefix in a list for `IndexDefinition`.
2.  **Correct Key Prefixing:** Updated `_inner_delete` to use the `_get_redis_key()` helper for all keys.

## Changes
- `python/semantic_kernel/connectors/redis.py`: Fixed prefix formatting and key resolution in deletion logic.

## Verification
- Verified that `IndexDefinition` now receives a list of prefixes.
- Verified that deletion logic now correctly applies collection prefixes.