### PR TITLE
Python: fix(redis): wrap prefix string in list for IndexDefinition

### DIFF
--- a/python/semantic_kernel/connectors/redis.py
+++ b/python/semantic_kernel/connectors/redis.py
@@ -278,7 +278,7 @@ class RedisCollection(
             raise VectorStoreOperationException("Invalid index type supplied.")
         fields = _definition_to_redis_fields(self.definition, self.collection_type)
         index_definition = IndexDefinition(
-            prefix=f"{self.collection_name}:", index_type=INDEX_TYPE_MAP[self.collection_type]
+            prefix=[f"{self.collection_name}:"], index_type=INDEX_TYPE_MAP[self.collection_type]
         )
         await self.redis_database.ft(self.collection_name).create_index(fields, definition=index_definition, **kwargs)
 


### PR DESCRIPTION
## Summary

The Redis connector passes a plain string to `IndexDefinition(prefix=...)`, but redis-py treats the `prefix` argument as an iterable. This causes each character of the collection name to become a separate key-space prefix.

For a collection named `redis_json_list_data_model`, the wire output becomes:
```
PREFIX 27 r e d i s _ j s o n _ l i s t _ d a t a _ m o d e l :
```

Instead of the expected:
```
PREFIX 1 redis_json_list_data_model:
```

## Fix

Wrap the prefix string in a list so redis-py receives a single-element iterable.

**Before:** `prefix=f"{self.collection_name}:"`  
**After:** `prefix=[f"{self.collection_name}:"]`

Fixes #13894