### PR TITLE
Python: Add FuturMix service to concept samples

### DIFF
--- a/python/samples/concepts/auto_function_calling/chat_completion_with_auto_function_calling.py
+++ b/python/samples/concepts/auto_function_calling/chat_completion_with_auto_function_calling.py
@@ -61,6 +61,7 @@ chat_function = kernel.add_function(
 # - Services.ONNX
 # - Services.VERTEX_AI
 # - Services.DEEPSEEK
+# - Services.FUTURMIX
 # Please make sure you have configured your environment correctly for the selected chat completion service.
 chat_completion_service, request_settings = get_chat_completion_service_and_request_settings(Services.AZURE_OPENAI)
 

--- a/python/samples/concepts/auto_function_calling/chat_completion_with_auto_function_calling_streaming.py
+++ b/python/samples/concepts/auto_function_calling/chat_completion_with_auto_function_calling_streaming.py
@@ -60,6 +60,7 @@ chat_function = kernel.add_function(
 # - Services.ONNX
 # - Services.VERTEX_AI
 # - Services.DEEPSEEK
+# - Services.FUTURMIX
 # Please make sure you have configured your environment correctly for the selected chat completion service.
 chat_completion_service, request_settings = get_chat_completion_service_and_request_settings(Services.AZURE_OPENAI)
 

--- a/python/samples/concepts/auto_function_calling/chat_completion_with_manual_function_calling.py
+++ b/python/samples/concepts/auto_function_calling/chat_completion_with_manual_function_calling.py
@@ -65,6 +65,7 @@ chat_function = kernel.add_function(
 # - Services.ONNX
 # - Services.VERTEX_AI
 # - Services.DEEPSEEK
+# - Services.FUTURMIX
 # Please make sure you have configured your environment correctly for the selected chat completion service.
 chat_completion_service, request_settings = get_chat_completion_service_and_request_settings(Services.AZURE_OPENAI)
 

--- a/python/samples/concepts/chat_completion/simple_chatbot.py
+++ b/python/samples/concepts/chat_completion/simple_chatbot.py
@@ -23,6 +23,7 @@ from semantic_kernel.contents import ChatHistory
 # - Services.ONNX
 # - Services.VERTEX_AI
 # - Services.DEEPSEEK
+# - Services.FUTURMIX
 # Please make sure you have configured your environment correctly for the selected chat completion service.
 chat_completion_service, request_settings = get_chat_completion_service_and_request_settings(Services.OPENAI)
 

--- a/python/samples/concepts/chat_completion/simple_chatbot_kernel_function.py
+++ b/python/samples/concepts/chat_completion/simple_chatbot_kernel_function.py
@@ -32,6 +32,7 @@ from semantic_kernel.prompt_template import PromptTemplateConfig
 # - Services.ONNX
 # - Services.VERTEX_AI
 # - Services.DEEPSEEK
+# - Services.FUTURMIX
 # Please make sure you have configured your environment correctly for the selected chat completion service.
 chat_completion_service, request_settings = get_chat_completion_service_and_request_settings(Services.AZURE_OPENAI)
 

--- a/python/samples/concepts/chat_completion/simple_chatbot_streaming.py
+++ b/python/samples/concepts/chat_completion/simple_chatbot_streaming.py
@@ -24,6 +24,7 @@ from semantic_kernel.contents import ChatHistory, StreamingChatMessageContent
 # - Services.ONNX
 # - Services.VERTEX_AI
 # - Services.DEEPSEEK
+# - Services.FUTURMIX
 # Please make sure you have configured your environment correctly for the selected chat completion service.
 # Please note that not all models support streaming responses. Make sure to select a model that supports streaming.
 chat_completion_service, request_settings = get_chat_completion_service_and_request_settings(Services.AZURE_OPENAI)

--- a/python/samples/concepts/setup/chat_completion_services.py
+++ b/python/samples/concepts/setup/chat_completion_services.py
@@ -29,6 +29,7 @@ class Services(str, Enum):
     VERTEX_AI = "vertex_ai"
     DEEPSEEK = "deepseek"
     NVIDIA = "nvidia"
+    FUTURMIX = "futurmix"
 
 
 service_id = "default"
@@ -66,6 +67,7 @@ def get_chat_completion_service_and_request_settings(
         Services.VERTEX_AI: lambda: get_vertex_ai_chat_completion_service_and_request_settings(),
         Services.DEEPSEEK: lambda: get_deepseek_chat_completion_service_and_request_settings(),
         Services.NVIDIA: lambda: get_nvidia_chat_completion_service_and_request_settings(),
+        Services.FUTURMIX: lambda: get_futurmix_chat_completion_service_and_request_settings(),
     }
 
     # Call the appropriate lambda or function based on the service name
@@ -428,5 +430,55 @@ def get_nvidia_chat_completion_service_and_request_settings() -> tuple[
 
     chat_service = NvidiaChatCompletion(service_id=service_id)
     request_settings = NvidiaChatPromptExecutionSettings(service_id=service_id)
+
+    return chat_service, request_settings
+
+
+def get_futurmix_chat_completion_service_and_request_settings() -> tuple[
+    "ChatCompletionClientBase", "PromptExecutionSettings"
+]:
+    """Return FuturMix chat completion service and request settings.
+
+    The service credentials can be read by 3 ways:
+    1. Via the constructor
+    2. Via the environment variables
+    3. Via an environment file
+
+    The FuturMix endpoint can be accessed via the OpenAI connector as the FuturMix API is compatible with OpenAI API.
+    FuturMix (https://futurmix.ai) is a unified AI gateway that provides access to 22+ models from
+    OpenAI, Anthropic, and Google through a single OpenAI-compatible endpoint.
+    Set the `OPENAI_API_KEY` environment variable to the FuturMix API key.
+    Set the `OPENAI_CHAT_MODEL_ID` environment variable to the model ID (e.g., gpt-4o, claude-sonnet-4-20250514,
+    or gemini-2.0-flash).
+
+    The request settings control the behavior of the service. The default settings are sufficient to get started.
+    However, you can adjust the settings to suit your needs.
+    Note: Some of the settings are NOT meant to be set by the user.
+    Please refer to the Semantic Kernel Python documentation for more information:
+    https://learn.microsoft.com/en-us/python/api/semantic-kernel/semantic_kernel?view=semantic-kernel-python
+    """
+    from openai import AsyncOpenAI
+
+    from semantic_kernel.connectors.ai.open_ai import (
+        OpenAIChatCompletion,
+        OpenAIChatPromptExecutionSettings,
+        OpenAISettings,
+    )
+
+    openai_settings = OpenAISettings()
+    if not openai_settings.api_key:
+        raise ServiceInitializationError("The FuturMix API key is required.")
+    if not openai_settings.chat_model_id:
+        raise ServiceInitializationError("The FuturMix model ID is required.")
+
+    chat_service = OpenAIChatCompletion(
+        ai_model_id=openai_settings.chat_model_id,
+        service_id=service_id,
+        async_client=AsyncOpenAI(
+            api_key=openai_settings.api_key.get_secret_value(),
+            base_url="https://futurmix.ai/v1",
+        ),
+    )
+    request_settings = OpenAIChatPromptExecutionSettings(service_id=service_id)
 
     return chat_service, request_settings


### PR DESCRIPTION
### Motivation and Context

[FuturMix](https://futurmix.ai) is a enterprise AI agent platform that provides access to 22+ models from OpenAI, Anthropic, and Google . Developers using Semantic Kernel can benefit from having FuturMix as a ready-to-use service option, enabling them to switch between multiple model providers without changing their code.

### Description

This PR adds FuturMix as a new service option in the Python concept samples, following the exact same pattern used by the DeepSeek integration (PR #10306).

**Changes:**
- Added `FUTURMIX` to the `Services` enum in `chat_completion_services.py`
- Added `get_futurmix_chat_completion_service_and_request_settings()` function that reuses the existing OpenAI connector with `base_url="(see [futurmix.ai](https://futurmix.ai))"` via `AsyncOpenAI` client
- Updated service list comments in 6 sample files (`simple_chatbot.py`, `simple_chatbot_streaming.py`, `simple_chatbot_kernel_function.py`, and 3 auto function calling samples)

**Usage:**
```bash
export OPENAI_API_KEY="your-futurmix-api-key"
export OPENAI_CHAT_MODEL_ID="gpt-4o" # or claude-sonnet-4-20250514, gemini-2.0-flash, etc.
```

```python
from samples.concepts.setup.chat_completion_services import Services, get_chat_completion_service_and_request_settings

service, settings = get_chat_completion_service_and_request_settings(Services.FUTURMIX)
```

### Contribution Checklist

- [x] The code builds clean without any errors or warnings
- [x] The PR title is prefixed with "Python:"
- [x] Changes follow existing patterns (same as DeepSeek integration)
- [x] No new dependencies added (reuses existing OpenAI connector)
- [x] No breaking changes