### PR TITLE
Python: Docs: Add Microsoft Agent Framework successor callout to READMEs

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,6 +7,10 @@
 [![Nuget package](https://img.shields.io/nuget/vpre/Microsoft.SemanticKernel)](https://www.nuget.org/packages/Microsoft.SemanticKernel/)
 [![Discord](https://img.shields.io/discord/1063152441819942922?label=Discord&logo=discord&logoColor=white&color=d82679)](https://aka.ms/SKDiscord)
 
+> [!IMPORTANT]
+> **Semantic Kernel's successor SDK is [Microsoft Agent Framework (MAF)](https://github.com/microsoft/agent-framework).** MAF is an open, multi-language framework for building **production-grade AI agents and multi-agent workflows** in **.NET and Python** — and is where major development is now happening.
+>
+> Please use MAF for the latest abstractions to build agents, workflows, and multi-agent orchestrations. Semantic Kernel will continue to receive minimal security and bug fixes only.
 
 ## What is Semantic Kernel?
 

--- a/README.md
+++ b/README.md
@@ -1,16 +1,16 @@
 # Semantic Kernel
 
+> [!IMPORTANT]
+> Semantic Kernel is now [Microsoft Agent Framework](https://github.com/microsoft/agent-framework)! Microsoft Agent Framework (MAF) is the enterprise‑ready successor to Semantic Kernel. Microsoft Agent Framework is now available at version 1.0 as a production-ready release: stable APIs, and a commitment to long-term support. Whether you're building a single assistant or orchestrating a fleet of specialized agents, Microsoft Agent Framework 1.0 gives you enterprise-grade multi-agent orchestration, multi-provider model support, and cross-runtime interoperability via A2A and MCP.
+>
+> Learn more about Semantic Kernel and Agent Framework here: [Semantic Kernel and Microsoft Agent Framework on the Agent Framework blog](https://devblogs.microsoft.com/agent-framework/semantic-kernel-and-microsoft-agent-framework/), and try out the [Semantic Kernel migration guide](https://learn.microsoft.com/en-us/agent-framework/migration-guide/from-semantic-kernel).
+
 **Build intelligent AI agents and multi-agent systems with this enterprise-ready orchestration framework**
 
 [![License: MIT](https://img.shields.io/github/license/microsoft/semantic-kernel)](https://github.com/microsoft/semantic-kernel/blob/main/LICENSE)
 [![Python package](https://img.shields.io/pypi/v/semantic-kernel)](https://pypi.org/project/semantic-kernel/)
 [![Nuget package](https://img.shields.io/nuget/vpre/Microsoft.SemanticKernel)](https://www.nuget.org/packages/Microsoft.SemanticKernel/)
 [![Discord](https://img.shields.io/discord/1063152441819942922?label=Discord&logo=discord&logoColor=white&color=d82679)](https://aka.ms/SKDiscord)
-
-> [!IMPORTANT]
-> **Semantic Kernel's successor SDK is [Microsoft Agent Framework (MAF)](https://github.com/microsoft/agent-framework).** MAF is an open, multi-language framework for building **production-grade AI agents and multi-agent workflows** in **.NET and Python** — and is where major development is now happening.
->
-> Please use MAF for the latest abstractions to build agents, workflows, and multi-agent orchestrations. Semantic Kernel will continue to receive minimal security and bug fixes only.
 
 ## What is Semantic Kernel?
 

--- a/dotnet/README.md
+++ b/dotnet/README.md
@@ -1,5 +1,10 @@
 # Get Started with Semantic Kernel ⚡
 
+> [!IMPORTANT]
+> **Semantic Kernel's successor SDK is [Microsoft Agent Framework (MAF)](https://github.com/microsoft/agent-framework).** MAF is an open, multi-language framework for building **production-grade AI agents and multi-agent workflows** in **.NET and Python** — and is where major development is now happening.
+>
+> Please use MAF for the latest abstractions to build agents, workflows, and multi-agent orchestrations. Semantic Kernel will continue to receive minimal security and bug fixes only.
+
 ## OpenAI / Azure OpenAI API keys
 
 To run the LLM prompts and semantic functions in the examples below, make sure

--- a/dotnet/README.md
+++ b/dotnet/README.md
@@ -1,9 +1,9 @@
 # Get Started with Semantic Kernel ⚡
 
 > [!IMPORTANT]
-> **Semantic Kernel's successor SDK is [Microsoft Agent Framework (MAF)](https://github.com/microsoft/agent-framework).** MAF is an open, multi-language framework for building **production-grade AI agents and multi-agent workflows** in **.NET and Python** — and is where major development is now happening.
+> Semantic Kernel is now [Microsoft Agent Framework](https://github.com/microsoft/agent-framework)! Microsoft Agent Framework (MAF) is the enterprise‑ready successor to Semantic Kernel. Microsoft Agent Framework is now available at version 1.0 as a production-ready release: stable APIs, and a commitment to long-term support. Whether you're building a single assistant or orchestrating a fleet of specialized agents, Microsoft Agent Framework 1.0 gives you enterprise-grade multi-agent orchestration, multi-provider model support, and cross-runtime interoperability via A2A and MCP.
 >
-> Please use MAF for the latest abstractions to build agents, workflows, and multi-agent orchestrations. Semantic Kernel will continue to receive minimal security and bug fixes only.
+> Learn more about Semantic Kernel and Agent Framework here: [Semantic Kernel and Microsoft Agent Framework on the Agent Framework blog](https://devblogs.microsoft.com/agent-framework/semantic-kernel-and-microsoft-agent-framework/), and try out the [Semantic Kernel migration guide](https://learn.microsoft.com/en-us/agent-framework/migration-guide/from-semantic-kernel).
 
 ## OpenAI / Azure OpenAI API keys
 

--- a/python/README.md
+++ b/python/README.md
@@ -1,9 +1,9 @@
 # Get Started with Semantic Kernel Python
 
 > [!IMPORTANT]
-> **Semantic Kernel's successor SDK is [Microsoft Agent Framework (MAF)](https://github.com/microsoft/agent-framework).** MAF is an open, multi-language framework for building **production-grade AI agents and multi-agent workflows** in **.NET and Python** — and is where major development is now happening.
+> Semantic Kernel is now [Microsoft Agent Framework](https://github.com/microsoft/agent-framework)! Microsoft Agent Framework (MAF) is the enterprise‑ready successor to Semantic Kernel. Microsoft Agent Framework is now available at version 1.0 as a production-ready release: stable APIs, and a commitment to long-term support. Whether you're building a single assistant or orchestrating a fleet of specialized agents, Microsoft Agent Framework 1.0 gives you enterprise-grade multi-agent orchestration, multi-provider model support, and cross-runtime interoperability via A2A and MCP.
 >
-> Please use MAF for the latest abstractions to build agents, workflows, and multi-agent orchestrations. Semantic Kernel will continue to receive minimal security and bug fixes only.
+> Learn more about Semantic Kernel and Agent Framework here: [Semantic Kernel and Microsoft Agent Framework on the Agent Framework blog](https://devblogs.microsoft.com/agent-framework/semantic-kernel-and-microsoft-agent-framework/), and try out the [Semantic Kernel migration guide](https://learn.microsoft.com/en-us/agent-framework/migration-guide/from-semantic-kernel).
 
 Highlights
 - Flexible Agent Framework: build, orchestrate, and deploy AI agents and multi-agent systems
@@ -131,6 +131,7 @@ from semantic_kernel.agents import ChatCompletionAgent
 from semantic_kernel.connectors.ai.open_ai import AzureChatCompletion, OpenAIChatPromptExecutionSettings
 from semantic_kernel.functions import kernel_function, KernelArguments
 
+
 class MenuPlugin:
     @kernel_function(description="Provides a list of specials from the menu.")
     def get_specials(self) -> Annotated[str, "Returns the specials from the menu."]:
@@ -146,10 +147,12 @@ class MenuPlugin:
     ) -> Annotated[str, "Returns the price of the menu item."]:
         return "$9.99"
 
+
 class MenuItem(BaseModel):
     # Used for structured outputs
     price: float
     name: str
+
 
 async def main():
     # Configure structured outputs format
@@ -162,7 +165,7 @@ async def main():
         name="SK-Assistant",
         instructions="You are a helpful assistant.",
         plugins=[MenuPlugin()],
-        arguments=KernelArguments(settings)
+        arguments=KernelArguments(settings),
     )
 
     response = await agent.get_response("What is the price of the soup special?")
@@ -171,7 +174,8 @@ async def main():
     # Output:
     # The price of the Clam Chowder, which is the soup special, is $9.99.
 
-asyncio.run(main()) 
+
+asyncio.run(main())
 ```
 
 You can explore additional getting started agent samples [here](https://github.com/microsoft/semantic-kernel/tree/main/python/samples/getting_started_with_agents).
@@ -186,6 +190,7 @@ from semantic_kernel.agents import ChatCompletionAgent, GroupChatOrchestration, 
 from semantic_kernel.agents.runtime import InProcessRuntime
 from semantic_kernel.connectors.ai.open_ai import AzureChatCompletion
 
+
 def get_agents():
     return [
         ChatCompletionAgent(
@@ -199,6 +204,7 @@ def get_agents():
             service=AzureChatCompletion(),
         ),
     ]
+
 
 async def main():
     agents = get_agents()
@@ -219,6 +225,7 @@ async def main():
     # Final Slogan: "Feel the Charge: Adventure Meets Affordability in Your New Electric SUV!"
 
     await runtime.stop_when_idle()
+
 
 if __name__ == "__main__":
     asyncio.run(main())

--- a/python/README.md
+++ b/python/README.md
@@ -1,5 +1,10 @@
 # Get Started with Semantic Kernel Python
 
+> [!IMPORTANT]
+> **Semantic Kernel's successor SDK is [Microsoft Agent Framework (MAF)](https://github.com/microsoft/agent-framework).** MAF is an open, multi-language framework for building **production-grade AI agents and multi-agent workflows** in **.NET and Python** — and is where major development is now happening.
+>
+> Please use MAF for the latest abstractions to build agents, workflows, and multi-agent orchestrations. Semantic Kernel will continue to receive minimal security and bug fixes only.
+
 Highlights
 - Flexible Agent Framework: build, orchestrate, and deploy AI agents and multi-agent systems
 - Multi-Agent Systems: Model workflows and collaboration between AI specialists


### PR DESCRIPTION
## Motivation and Context

Now that **Microsoft Agent Framework (MAF)** is the successor SDK to Semantic Kernel, the top-level and per-language READMEs should direct community members — especially newcomers landing here from search, GitHub, PyPI, or NuGet — to MAF for new work, and clearly state SK's ongoing maintenance posture.

## Description

Adds a prominent GitHub `> [!IMPORTANT]` callout, placed directly under the existing title/badges block, to:

- `README.md` (top-level)
- `python/README.md`
- `dotnet/README.md`

Each callout:

- Names MAF as Semantic Kernel's successor SDK and links to https://github.com/microsoft/agent-framework.
- Describes MAF as "an open, multi-language framework for building production-grade AI agents and multi-agent workflows in .NET and Python".
- Asks readers to use MAF for the latest abstractions to build agents, workflows, and multi-agent orchestrations.
- States that Semantic Kernel will continue to receive minimal security and bug fixes only.

No other README content is modified; SK identity, badges, install steps, and quickstart samples are preserved.

## Contribution Checklist

- [x] The code builds clean without any errors or warnings — docs-only change.
- [x] I didn't break anyone — additive callout only.
- [x] All relevant CONTRIBUTING.md sections were followed.