### PR TITLE
.Net: Add ExtraBody to OpenAIPromptExecutionSettings (#12307)

### DIFF
--- a/dotnet/samples/Concepts/ChatCompletion/OpenAI_ChatCompletionExtraBody.cs
+++ b/dotnet/samples/Concepts/ChatCompletion/OpenAI_ChatCompletionExtraBody.cs
@@ -1,0 +1,79 @@
+﻿// Copyright (c) Microsoft. All rights reserved.
+
+using Microsoft.SemanticKernel.ChatCompletion;
+using Microsoft.SemanticKernel.Connectors.OpenAI;
+
+namespace ChatCompletion;
+
+#pragma warning disable SKEXP0010 // OpenAIPromptExecutionSettings.ExtraBody is experimental.
+
+/// <summary>
+/// <see cref="OpenAIPromptExecutionSettings.ExtraBody"/> is an escape hatch that injects additional fields
+/// into the request body sent to the OpenAI-compatible endpoint. Use it to pass vendor-specific or preview
+/// parameters that are not modeled by <see cref="OpenAIPromptExecutionSettings"/> (for example,
+/// Qwen3's <c>enable_thinking</c> flag, ChatGLM thinking modes, or NVIDIA NIM custom knobs).
+///
+/// <para>Key syntax:</para>
+/// <list type="bullet">
+/// <item><description>A plain key (without leading <c>$.</c>) is treated as a literal top-level field name.</description></item>
+/// <item><description>A key starting with <c>$.</c> is interpreted as a JSONPath expression and applied as a deep patch onto the request body.</description></item>
+/// </list>
+/// </summary>
+public class OpenAI_ChatCompletionExtraBody(ITestOutputHelper output) : BaseTest(output)
+{
+    /// <summary>
+    /// Adds a flat top-level field to the outgoing chat completion request:
+    /// <code>{ "messages": [...], "model": "qwen-plus", "enable_thinking": false, ... }</code>
+    /// </summary>
+    [Fact]
+    public async Task FlatFieldExampleAsync()
+    {
+        OpenAIChatCompletionService chatCompletionService = new(
+            TestConfiguration.OpenAI.ChatModelId,
+            TestConfiguration.OpenAI.ApiKey);
+
+        var settings = new OpenAIPromptExecutionSettings
+        {
+            ExtraBody = new Dictionary<string, object?>
+            {
+                // Required by Qwen3 open-source models for non-streaming calls.
+                ["enable_thinking"] = false,
+            },
+        };
+
+        var chatHistory = new ChatHistory("You are a helpful assistant.");
+        chatHistory.AddUserMessage("Who are you?");
+
+        var reply = await chatCompletionService.GetChatMessageContentAsync(chatHistory, settings);
+
+        Console.WriteLine(reply.Content);
+    }
+
+    /// <summary>
+    /// Uses a <c>$.</c>-prefixed JSONPath key to surgically patch a nested field in the request body
+    /// (for example, into <c>thinking.enabled</c>). This avoids having to specify the entire nested object.
+    /// </summary>
+    [Fact]
+    public async Task DeepPatchExampleAsync()
+    {
+        OpenAIChatCompletionService chatCompletionService = new(
+            TestConfiguration.OpenAI.ChatModelId,
+            TestConfiguration.OpenAI.ApiKey);
+
+        var settings = new OpenAIPromptExecutionSettings
+        {
+            ExtraBody = new Dictionary<string, object?>
+            {
+                // Emits { "thinking": { "enabled": false } } in the request body.
+                ["$.thinking.enabled"] = false,
+            },
+        };
+
+        var chatHistory = new ChatHistory("You are a helpful assistant.");
+        chatHistory.AddUserMessage("Summarize the plot of Hamlet in one sentence.");
+
+        var reply = await chatCompletionService.GetChatMessageContentAsync(chatHistory, settings);
+
+        Console.WriteLine(reply.Content);
+    }
+}

--- a/dotnet/src/Connectors/Connectors.AzureOpenAI.UnitTests/Services/AzureOpenAIChatCompletionExtraBodyTests.cs
+++ b/dotnet/src/Connectors/Connectors.AzureOpenAI.UnitTests/Services/AzureOpenAIChatCompletionExtraBodyTests.cs
@@ -2,7 +2,6 @@
 
 using System;
 using System.Collections.Generic;
-using System.IO;
 using System.Net;
 using System.Net.Http;
 using System.Text;
@@ -12,7 +11,6 @@ using Microsoft.SemanticKernel;
 using Microsoft.SemanticKernel.ChatCompletion;
 using Microsoft.SemanticKernel.Connectors.AzureOpenAI;
 using Microsoft.SemanticKernel.Connectors.OpenAI;
-using Xunit;
 
 namespace SemanticKernel.Connectors.AzureOpenAI.UnitTests.Services;
 

--- a/dotnet/src/Connectors/Connectors.AzureOpenAI.UnitTests/Services/AzureOpenAIChatCompletionExtraBodyTests.cs
+++ b/dotnet/src/Connectors/Connectors.AzureOpenAI.UnitTests/Services/AzureOpenAIChatCompletionExtraBodyTests.cs
@@ -1,0 +1,123 @@
+﻿// Copyright (c) Microsoft. All rights reserved.
+
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Net;
+using System.Net.Http;
+using System.Text;
+using System.Text.Json;
+using System.Threading.Tasks;
+using Microsoft.SemanticKernel;
+using Microsoft.SemanticKernel.ChatCompletion;
+using Microsoft.SemanticKernel.Connectors.AzureOpenAI;
+using Microsoft.SemanticKernel.Connectors.OpenAI;
+using Xunit;
+
+namespace SemanticKernel.Connectors.AzureOpenAI.UnitTests.Services;
+
+/// <summary>
+/// Unit tests verifying that <see cref="OpenAIPromptExecutionSettings.ExtraBody"/> is honored by
+/// the <see cref="AzureOpenAIChatCompletionService"/> classic path.
+/// </summary>
+public sealed class AzureOpenAIChatCompletionExtraBodyTests : IDisposable
+{
+    private readonly MultipleHttpMessageHandlerStub _messageHandlerStub;
+    private readonly HttpClient _httpClient;
+    private readonly ChatHistory _chatHistory = [new ChatMessageContent(AuthorRole.User, "test")];
+
+    public AzureOpenAIChatCompletionExtraBodyTests()
+    {
+        this._messageHandlerStub = new MultipleHttpMessageHandlerStub();
+        this._httpClient = new HttpClient(this._messageHandlerStub, false);
+    }
+
+    public void Dispose()
+    {
+        this._httpClient.Dispose();
+        this._messageHandlerStub.Dispose();
+    }
+
+    [Fact]
+    public async Task ExtraBodyFlatKeyAppearsAtTopLevelAsync()
+    {
+        // Arrange
+        var service = new AzureOpenAIChatCompletionService("deployment", "https://endpoint", "api-key", "model-id", this._httpClient);
+        this._messageHandlerStub.ResponsesToReturn.Add(new HttpResponseMessage(HttpStatusCode.OK)
+        {
+            Content = new StringContent(AzureOpenAITestHelper.GetTestResponse("chat_completion_test_response.json")),
+        });
+        var settings = new AzureOpenAIPromptExecutionSettings
+        {
+            ExtraBody = new Dictionary<string, object?>
+            {
+                ["enable_thinking"] = false,
+            },
+        };
+
+        // Act
+        await service.GetChatMessageContentsAsync(this._chatHistory, settings);
+
+        // Assert
+        var body = ParseRequestBody(this._messageHandlerStub.RequestContents[0]!);
+        Assert.True(body.TryGetProperty("enable_thinking", out var value));
+        Assert.False(value.GetBoolean());
+    }
+
+    [Fact]
+    public async Task ExtraBodyOverridesFirstClassPropertyAsync()
+    {
+        // Arrange - last-write-wins.
+        var service = new AzureOpenAIChatCompletionService("deployment", "https://endpoint", "api-key", "model-id", this._httpClient);
+        this._messageHandlerStub.ResponsesToReturn.Add(new HttpResponseMessage(HttpStatusCode.OK)
+        {
+            Content = new StringContent(AzureOpenAITestHelper.GetTestResponse("chat_completion_test_response.json")),
+        });
+        var settings = new AzureOpenAIPromptExecutionSettings
+        {
+            Temperature = 0.7,
+            ExtraBody = new Dictionary<string, object?>
+            {
+                ["temperature"] = 0.0,
+            },
+        };
+
+        // Act
+        await service.GetChatMessageContentsAsync(this._chatHistory, settings);
+
+        // Assert
+        var body = ParseRequestBody(this._messageHandlerStub.RequestContents[0]!);
+        Assert.Equal(0.0, body.GetProperty("temperature").GetDouble());
+    }
+
+    [Fact]
+    public async Task ExtraBodyJsonPathPrefixDoesDeepPatchAsync()
+    {
+        // Arrange
+        var service = new AzureOpenAIChatCompletionService("deployment", "https://endpoint", "api-key", "model-id", this._httpClient);
+        this._messageHandlerStub.ResponsesToReturn.Add(new HttpResponseMessage(HttpStatusCode.OK)
+        {
+            Content = new StringContent(AzureOpenAITestHelper.GetTestResponse("chat_completion_test_response.json")),
+        });
+        var settings = new AzureOpenAIPromptExecutionSettings
+        {
+            ExtraBody = new Dictionary<string, object?>
+            {
+                ["$.thinking.enabled"] = false,
+            },
+        };
+
+        // Act
+        await service.GetChatMessageContentsAsync(this._chatHistory, settings);
+
+        // Assert
+        var body = ParseRequestBody(this._messageHandlerStub.RequestContents[0]!);
+        Assert.False(body.GetProperty("thinking").GetProperty("enabled").GetBoolean());
+    }
+
+    private static JsonElement ParseRequestBody(byte[] requestContent)
+    {
+        var json = Encoding.UTF8.GetString(requestContent);
+        return JsonDocument.Parse(json).RootElement;
+    }
+}

--- a/dotnet/src/Connectors/Connectors.AzureOpenAI/Core/AzureClientCore.ChatCompletion.cs
+++ b/dotnet/src/Connectors/Connectors.AzureOpenAI/Core/AzureClientCore.ChatCompletion.cs
@@ -131,6 +131,8 @@ internal partial class AzureClientCore
             }
         }
 
+        OpenAIPromptExecutionSettings.ApplyExtraBody(options, executionSettings);
+
         return options;
     }
 

--- a/dotnet/src/Connectors/Connectors.OpenAI.UnitTests/Services/OpenAIChatCompletionExtraBodyTests.cs
+++ b/dotnet/src/Connectors/Connectors.OpenAI.UnitTests/Services/OpenAIChatCompletionExtraBodyTests.cs
@@ -7,10 +7,12 @@ using System.Net.Http;
 using System.Text;
 using System.Text.Json;
 using System.Threading.Tasks;
+using Microsoft.Extensions.AI;
 using Microsoft.SemanticKernel;
 using Microsoft.SemanticKernel.ChatCompletion;
 using Microsoft.SemanticKernel.Connectors.OpenAI;
 using Xunit;
+using ChatMessageContent = Microsoft.SemanticKernel.ChatMessageContent;
 
 namespace SemanticKernel.Connectors.OpenAI.UnitTests.Services;
 
@@ -288,6 +290,41 @@ public sealed class OpenAIChatCompletionExtraBodyTests : IDisposable
         var json = JsonDocument.Parse(serialized).RootElement;
         Assert.False(json.GetProperty("enable_thinking").GetBoolean());
         Assert.False(json.GetProperty("thinking").GetProperty("enabled").GetBoolean());
+    }
+
+    [Fact]
+    public async Task IChatClientPathPreservesStronglyTypedSettingsAlongsideExtraBodyAsync()
+    {
+        // Arrange - end-to-end IChatClient path: build an IChatClient via OpenAI SDK and send a request
+        // through M.E.AI. Verify both the strongly-typed property (Temperature) and the ExtraBody patch
+        // (enable_thinking) appear in the outgoing HTTP request body. Per M.E.AI ChatOptions.RawRepresentationFactory
+        // contract, the OpenAI bridge mutates the returned raw options with values from the strongly-typed
+        // ChatOptions properties before serialization.
+        var openAIClient = new global::OpenAI.OpenAIClient(
+            new global::System.ClientModel.ApiKeyCredential("NOKEY"),
+            new global::OpenAI.OpenAIClientOptions { Transport = new global::System.ClientModel.Primitives.HttpClientPipelineTransport(this._httpClient) });
+        global::Microsoft.Extensions.AI.IChatClient chatClient = openAIClient.GetChatClient("gpt-4o").AsIChatClient();
+
+        var settings = new OpenAIPromptExecutionSettings
+        {
+            Temperature = 0.7,
+            MaxTokens = 256,
+            ExtraBody = new Dictionary<string, object?>
+            {
+                ["enable_thinking"] = false,
+            },
+        };
+        var chatOptions = settings.ToChatOptions(kernel: null);
+
+        // Act
+        var messages = new[] { new global::Microsoft.Extensions.AI.ChatMessage(global::Microsoft.Extensions.AI.ChatRole.User, "hi") };
+        await chatClient.GetResponseAsync(messages, chatOptions);
+
+        // Assert
+        var body = ParseRequestBody(this._messageHandlerStub.RequestContent!);
+        Assert.Equal(0.7, body.GetProperty("temperature").GetDouble());
+        Assert.Equal(256, body.GetProperty("max_completion_tokens").GetInt32());
+        Assert.False(body.GetProperty("enable_thinking").GetBoolean());
     }
 
     private static JsonElement ParseRequestBody(byte[] requestContent)

--- a/dotnet/src/Connectors/Connectors.OpenAI.UnitTests/Services/OpenAIChatCompletionExtraBodyTests.cs
+++ b/dotnet/src/Connectors/Connectors.OpenAI.UnitTests/Services/OpenAIChatCompletionExtraBodyTests.cs
@@ -1,0 +1,318 @@
+﻿// Copyright (c) Microsoft. All rights reserved.
+
+using System;
+using System.Collections.Generic;
+using System.Net;
+using System.Net.Http;
+using System.Text;
+using System.Text.Json;
+using System.Threading.Tasks;
+using Microsoft.SemanticKernel;
+using Microsoft.SemanticKernel.ChatCompletion;
+using Microsoft.SemanticKernel.Connectors.OpenAI;
+using Xunit;
+
+namespace SemanticKernel.Connectors.OpenAI.UnitTests.Services;
+
+/// <summary>
+/// Unit tests for the <see cref="OpenAIPromptExecutionSettings.ExtraBody"/> property and its application to
+/// outgoing chat completion requests.
+/// </summary>
+public sealed class OpenAIChatCompletionExtraBodyTests : IDisposable
+{
+    private readonly HttpMessageHandlerStub _messageHandlerStub;
+    private readonly HttpClient _httpClient;
+    private readonly ChatHistory _chatHistory = [new ChatMessageContent(AuthorRole.User, "test")];
+
+    public OpenAIChatCompletionExtraBodyTests()
+    {
+        this._messageHandlerStub = new HttpMessageHandlerStub
+        {
+            ResponseToReturn = new HttpResponseMessage(HttpStatusCode.OK)
+            {
+                Content = new StringContent(ChatCompletionResponse),
+            },
+        };
+        this._httpClient = new HttpClient(this._messageHandlerStub, false);
+    }
+
+    public void Dispose()
+    {
+        this._httpClient.Dispose();
+        this._messageHandlerStub.Dispose();
+    }
+
+    [Fact]
+    public async Task ExtraBodyFlatKeyAppearsAtTopLevelAsync()
+    {
+        // Arrange
+        var service = new OpenAIChatCompletionService("gpt-4o", apiKey: "NOKEY", httpClient: this._httpClient);
+        var settings = new OpenAIPromptExecutionSettings
+        {
+            ExtraBody = new Dictionary<string, object?>
+            {
+                ["enable_thinking"] = false,
+            },
+        };
+
+        // Act
+        await service.GetChatMessageContentsAsync(this._chatHistory, settings);
+
+        // Assert
+        var body = ParseRequestBody(this._messageHandlerStub.RequestContent!);
+        Assert.True(body.TryGetProperty("enable_thinking", out var value));
+        Assert.False(value.GetBoolean());
+    }
+
+    [Fact]
+    public async Task ExtraBodyStreamingFlatKeyAppearsAtTopLevelAsync()
+    {
+        // Arrange
+        var streamBytes = Encoding.UTF8.GetBytes(ChatCompletionStreamingResponse);
+        this._messageHandlerStub.ResponseToReturn = new HttpResponseMessage(HttpStatusCode.OK)
+        {
+            Content = new StreamContent(new System.IO.MemoryStream(streamBytes)),
+        };
+        var service = new OpenAIChatCompletionService("gpt-4o", apiKey: "NOKEY", httpClient: this._httpClient);
+        var settings = new OpenAIPromptExecutionSettings
+        {
+            ExtraBody = new Dictionary<string, object?>
+            {
+                ["enable_thinking"] = false,
+            },
+        };
+
+        // Act
+        await foreach (var _ in service.GetStreamingChatMessageContentsAsync(this._chatHistory, settings))
+        {
+        }
+
+        // Assert
+        var body = ParseRequestBody(this._messageHandlerStub.RequestContent!);
+        Assert.True(body.TryGetProperty("enable_thinking", out var value));
+        Assert.False(value.GetBoolean());
+    }
+
+    [Fact]
+    public async Task ExtraBodyOverridesFirstClassPropertyAsync()
+    {
+        // Arrange - last-write-wins; ExtraBody value applied via JsonPatch overrides the strongly-typed property.
+        var service = new OpenAIChatCompletionService("gpt-4o", apiKey: "NOKEY", httpClient: this._httpClient);
+        var settings = new OpenAIPromptExecutionSettings
+        {
+            Temperature = 0.7,
+            ExtraBody = new Dictionary<string, object?>
+            {
+                ["temperature"] = 0.0,
+            },
+        };
+
+        // Act
+        await service.GetChatMessageContentsAsync(this._chatHistory, settings);
+
+        // Assert
+        var body = ParseRequestBody(this._messageHandlerStub.RequestContent!);
+        Assert.Equal(0.0, body.GetProperty("temperature").GetDouble());
+    }
+
+    [Fact]
+    public async Task ExtraBodyNestedDictionaryEmitsNestedJsonObjectAsync()
+    {
+        // Arrange
+        var service = new OpenAIChatCompletionService("gpt-4o", apiKey: "NOKEY", httpClient: this._httpClient);
+        var settings = new OpenAIPromptExecutionSettings
+        {
+            ExtraBody = new Dictionary<string, object?>
+            {
+                ["thinking"] = new Dictionary<string, object?> { ["enabled"] = false, ["budget"] = 100 },
+            },
+        };
+
+        // Act
+        await service.GetChatMessageContentsAsync(this._chatHistory, settings);
+
+        // Assert
+        var body = ParseRequestBody(this._messageHandlerStub.RequestContent!);
+        var thinking = body.GetProperty("thinking");
+        Assert.False(thinking.GetProperty("enabled").GetBoolean());
+        Assert.Equal(100, thinking.GetProperty("budget").GetInt32());
+    }
+
+    [Fact]
+    public async Task ExtraBodyJsonPathPrefixDoesDeepPatchAsync()
+    {
+        // Arrange - $.-prefixed key is interpreted as a JSONPath patch and creates the nested structure.
+        var service = new OpenAIChatCompletionService("gpt-4o", apiKey: "NOKEY", httpClient: this._httpClient);
+        var settings = new OpenAIPromptExecutionSettings
+        {
+            ExtraBody = new Dictionary<string, object?>
+            {
+                ["$.thinking.enabled"] = false,
+            },
+        };
+
+        // Act
+        await service.GetChatMessageContentsAsync(this._chatHistory, settings);
+
+        // Assert
+        var body = ParseRequestBody(this._messageHandlerStub.RequestContent!);
+        Assert.False(body.GetProperty("thinking").GetProperty("enabled").GetBoolean());
+    }
+
+    [Fact]
+    public async Task ExtraBodyLiteralDottedKeyEmitsLiteralFieldAsync()
+    {
+        // Arrange - keys without $. prefix are literal, even when they contain dots.
+        var service = new OpenAIChatCompletionService("gpt-4o", apiKey: "NOKEY", httpClient: this._httpClient);
+        var settings = new OpenAIPromptExecutionSettings
+        {
+            ExtraBody = new Dictionary<string, object?>
+            {
+                ["weird.key"] = "literal-value",
+            },
+        };
+
+        // Act
+        await service.GetChatMessageContentsAsync(this._chatHistory, settings);
+
+        // Assert
+        var body = ParseRequestBody(this._messageHandlerStub.RequestContent!);
+        Assert.True(body.TryGetProperty("weird.key", out var value));
+        Assert.Equal("literal-value", value.GetString());
+    }
+
+    [Fact]
+    public async Task ExtraBodyNullValueEmitsJsonNullAsync()
+    {
+        // Arrange
+        var service = new OpenAIChatCompletionService("gpt-4o", apiKey: "NOKEY", httpClient: this._httpClient);
+        var settings = new OpenAIPromptExecutionSettings
+        {
+            ExtraBody = new Dictionary<string, object?>
+            {
+                ["nullable_field"] = null,
+            },
+        };
+
+        // Act
+        await service.GetChatMessageContentsAsync(this._chatHistory, settings);
+
+        // Assert
+        var body = ParseRequestBody(this._messageHandlerStub.RequestContent!);
+        Assert.True(body.TryGetProperty("nullable_field", out var value));
+        Assert.Equal(JsonValueKind.Null, value.ValueKind);
+    }
+
+    [Fact]
+    public void FromExecutionSettingsRoundTripPreservesExtraBody()
+    {
+        // Arrange - deserializing through the base type (e.g. via PromptTemplateConfig) should preserve extra_body.
+        var jsonSettings = new PromptExecutionSettings
+        {
+            ExtensionData = new Dictionary<string, object>
+            {
+                ["temperature"] = 0.5,
+                ["extra_body"] = new Dictionary<string, object?> { ["enable_thinking"] = false },
+            },
+        };
+
+        // Act
+        var settings = OpenAIPromptExecutionSettings.FromExecutionSettings(jsonSettings);
+
+        // Assert
+        Assert.NotNull(settings.ExtraBody);
+        Assert.True(settings.ExtraBody.ContainsKey("enable_thinking"));
+    }
+
+    [Fact]
+    public void CloneCopiesExtraBodyShallowly()
+    {
+        // Arrange
+        var original = new OpenAIPromptExecutionSettings
+        {
+            ExtraBody = new Dictionary<string, object?> { ["a"] = 1 },
+        };
+
+        // Act
+        var clone = (OpenAIPromptExecutionSettings)original.Clone();
+        clone.ExtraBody!["b"] = 2;
+
+        // Assert - top-level shallow copy: adding to clone does not affect original.
+        Assert.False(original.ExtraBody!.ContainsKey("b"));
+        Assert.True(clone.ExtraBody.ContainsKey("a"));
+        Assert.True(clone.ExtraBody.ContainsKey("b"));
+    }
+
+    [Fact]
+    public void FreezeMakesExtraBodyReadOnly()
+    {
+        // Arrange
+        var settings = new OpenAIPromptExecutionSettings
+        {
+            ExtraBody = new Dictionary<string, object?> { ["a"] = 1 },
+        };
+
+        // Act
+        settings.Freeze();
+
+        // Assert
+        Assert.Throws<NotSupportedException>(() => settings.ExtraBody!["b"] = 2);
+    }
+
+    [Fact]
+    public void ToChatOptionsSetsRawRepresentationFactoryAndCleansAdditionalProperties()
+    {
+        // Arrange - exercises the IChatClient path: PrepareChatOptionsForRequest must
+        // wire ChatOptions.RawRepresentationFactory and remove the redundant extra_body entry from AdditionalProperties.
+        var settings = new OpenAIPromptExecutionSettings
+        {
+            ExtraBody = new Dictionary<string, object?>
+            {
+                ["enable_thinking"] = false,
+                ["$.thinking.enabled"] = false,
+            },
+        };
+
+        // Act
+        var chatOptions = settings.ToChatOptions(kernel: null);
+
+        // Assert
+        Assert.NotNull(chatOptions);
+        Assert.NotNull(chatOptions!.RawRepresentationFactory);
+        Assert.False(chatOptions.AdditionalProperties?.ContainsKey("extra_body") ?? false);
+
+        // Verify the factory produces a ChatCompletionOptions that serializes the patched fields.
+        var rawObj = chatOptions.RawRepresentationFactory.Invoke(null!);
+        var raw = Assert.IsType<global::OpenAI.Chat.ChatCompletionOptions>(rawObj);
+        var serialized = global::System.ClientModel.Primitives.ModelReaderWriter.Write(raw).ToString();
+        var json = JsonDocument.Parse(serialized).RootElement;
+        Assert.False(json.GetProperty("enable_thinking").GetBoolean());
+        Assert.False(json.GetProperty("thinking").GetProperty("enabled").GetBoolean());
+    }
+
+    private static JsonElement ParseRequestBody(byte[] requestContent)
+    {
+        var json = Encoding.UTF8.GetString(requestContent);
+        return JsonDocument.Parse(json).RootElement;
+    }
+
+    private const string ChatCompletionResponse = """
+        {
+          "id": "chatcmpl-123",
+          "object": "chat.completion",
+          "created": 1677652288,
+          "model": "gpt-4o",
+          "choices": [{
+            "index": 0,
+            "message": { "role": "assistant", "content": "Hello!" },
+            "finish_reason": "stop"
+          }],
+          "usage": { "prompt_tokens": 1, "completion_tokens": 1, "total_tokens": 2 }
+        }
+        """;
+
+    private const string ChatCompletionStreamingResponse =
+        "data: {\"id\":\"x\",\"object\":\"chat.completion.chunk\",\"created\":1,\"model\":\"gpt-4o\",\"choices\":[{\"index\":0,\"delta\":{\"role\":\"assistant\",\"content\":\"Hi\"},\"finish_reason\":null}]}\n\n" +
+        "data: {\"id\":\"x\",\"object\":\"chat.completion.chunk\",\"created\":1,\"model\":\"gpt-4o\",\"choices\":[{\"index\":0,\"delta\":{},\"finish_reason\":\"stop\"}]}\n\n" +
+        "data: [DONE]\n\n";
+}

--- a/dotnet/src/Connectors/Connectors.OpenAI/Core/ClientCore.ChatCompletion.cs
+++ b/dotnet/src/Connectors/Connectors.OpenAI/Core/ClientCore.ChatCompletion.cs
@@ -548,6 +548,8 @@ internal partial class ClientCore
             }
         }
 
+        OpenAIPromptExecutionSettings.ApplyExtraBody(options, executionSettings);
+
         return options;
     }
 

--- a/dotnet/src/Connectors/Connectors.OpenAI/Settings/OpenAIPromptExecutionSettings.cs
+++ b/dotnet/src/Connectors/Connectors.OpenAI/Settings/OpenAIPromptExecutionSettings.cs
@@ -447,6 +447,53 @@ public class OpenAIPromptExecutionSettings : PromptExecutionSettings
         }
     }
 
+    /// <summary>
+    /// Gets or sets a dictionary of additional fields to include in the request body sent to the OpenAI-compatible endpoint.
+    /// </summary>
+    /// <remarks>
+    /// <para>
+    /// This is an escape hatch for vendor-specific or preview parameters that are not modeled by
+    /// <see cref="OpenAIPromptExecutionSettings"/> (for example, Qwen3's <c>enable_thinking</c> or ChatGLM thinking-mode flags).
+    /// </para>
+    /// <para>
+    /// <b>Key syntax</b> (hybrid):
+    /// <list type="bullet">
+    /// <item><description>A plain key (without a leading <c>$.</c>) is treated as a literal top-level field name.
+    /// For example, <c>ExtraBody["enable_thinking"] = false</c> emits <c>{ "enable_thinking": false }</c>. Keys containing
+    /// dots, brackets, or other special characters are bracket-quoted automatically and remain literal.</description></item>
+    /// <item><description>A key starting with <c>$.</c> is interpreted as a JSONPath expression and applied as a deep patch
+    /// onto the request body, allowing surgical edits of nested objects and arrays produced by the SDK
+    /// (for example, <c>ExtraBody["$.stream_options.include_usage"] = true</c> or <c>ExtraBody["$.thinking.enabled"] = false</c>).</description></item>
+    /// </list>
+    /// </para>
+    /// <para>
+    /// <b>Collisions:</b> if a key targets the same JSON property as a strongly-typed setting (for example,
+    /// <c>ExtraBody["temperature"] = 0.0</c> with <see cref="Temperature"/> set to <c>0.7</c>), the <see cref="ExtraBody"/>
+    /// value wins because it is applied during request serialization (last-write-wins).
+    /// </para>
+    /// <para>
+    /// <b>Removal is not supported:</b> setting a value to <see langword="null"/> emits a JSON <c>null</c>; it does not remove
+    /// an SDK-injected field. Use a delegating HTTP handler if you need to remove fields from the outgoing body.
+    /// </para>
+    /// <para>
+    /// <b>Round-trip behavior:</b> when populated via YAML or JSON <c>PromptTemplateConfig</c> deserialization, values arrive
+    /// as <see cref="JsonElement"/> instances. Read accordingly.
+    /// </para>
+    /// </remarks>
+    [Experimental("SKEXP0010")]
+    [JsonPropertyName("extra_body")]
+    [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
+    public IDictionary<string, object?>? ExtraBody
+    {
+        get => this._extraBody;
+
+        set
+        {
+            this.ThrowIfFrozen();
+            this._extraBody = value;
+        }
+    }
+
     /// <inheritdoc/>
     public override void Freeze()
     {
@@ -470,6 +517,11 @@ public class OpenAIPromptExecutionSettings : PromptExecutionSettings
         if (this._metadata is not null)
         {
             this._metadata = new ReadOnlyDictionary<string, string>(this._metadata);
+        }
+
+        if (this._extraBody is not null)
+        {
+            this._extraBody = new ReadOnlyDictionary<string, object?>(this._extraBody);
         }
     }
 
@@ -543,6 +595,7 @@ public class OpenAIPromptExecutionSettings : PromptExecutionSettings
             WebSearchOptions = this.WebSearchOptions,
             Modalities = this.Modalities,
             Audio = this.Audio,
+            ExtraBody = this.ExtraBody is not null ? new Dictionary<string, object?>(this.ExtraBody) : null,
         };
     }
 
@@ -561,6 +614,75 @@ public class OpenAIPromptExecutionSettings : PromptExecutionSettings
         }
 
         return chatHistory;
+    }
+
+    /// <inheritdoc/>
+    protected override void PrepareChatOptionsForRequest(Microsoft.Extensions.AI.ChatOptions options)
+    {
+        base.PrepareChatOptionsForRequest(options);
+
+        if (this._extraBody is null || this._extraBody.Count == 0)
+        {
+            return;
+        }
+
+        var snapshot = new List<KeyValuePair<string, object?>>(this._extraBody);
+
+        options.RawRepresentationFactory = (_) =>
+        {
+            var raw = new ChatCompletionOptions();
+            foreach (var kvp in snapshot)
+            {
+                ApplyExtraBodyEntry(raw, kvp.Key, kvp.Value);
+            }
+            return raw;
+        };
+
+        // The base ToChatOptions catch-all writes ExtraBody into AdditionalProperties via JSON round-trip.
+        // The factory above is the canonical carrier, so remove the duplicate here.
+        options.AdditionalProperties?.Remove("extra_body");
+    }
+
+    /// <summary>
+    /// Applies a single <see cref="ExtraBody"/> entry to the supplied <see cref="ChatCompletionOptions"/> using its
+    /// <c>JsonPatch</c> facility. Plain keys become bracket-quoted top-level fields; keys starting with <c>$.</c> are
+    /// passed through as raw JSONPath patches.
+    /// </summary>
+    internal static void ApplyExtraBodyEntry(ChatCompletionOptions options, string key, object? value)
+    {
+        string path = key.StartsWith("$.", StringComparison.Ordinal)
+            ? key
+            : $"$[{JsonSerializer.Serialize(key)}]";
+
+        byte[] pathBytes = System.Text.Encoding.UTF8.GetBytes(path);
+
+#pragma warning disable SCME0001 // System.ClientModel JsonPatch is for evaluation purposes only.
+        if (value is null)
+        {
+            options.Patch.SetNull(pathBytes);
+            return;
+        }
+
+        // Serialize to raw JSON bytes so any value type (primitive, JsonElement, dictionary, complex object) is supported uniformly.
+        byte[] jsonBytes = JsonSerializer.SerializeToUtf8Bytes(value, value.GetType());
+        options.Patch.Set(pathBytes, BinaryData.FromBytes(jsonBytes));
+#pragma warning restore SCME0001
+    }
+
+    /// <summary>
+    /// Applies all entries from <paramref name="settings"/>.<see cref="ExtraBody"/> to <paramref name="options"/>.
+    /// </summary>
+    internal static void ApplyExtraBody(ChatCompletionOptions options, OpenAIPromptExecutionSettings settings)
+    {
+        if (settings._extraBody is null || settings._extraBody.Count == 0)
+        {
+            return;
+        }
+
+        foreach (var kvp in settings._extraBody)
+        {
+            ApplyExtraBodyEntry(options, kvp.Key, kvp.Value);
+        }
     }
 
     #region private ================================================================================
@@ -586,6 +708,7 @@ public class OpenAIPromptExecutionSettings : PromptExecutionSettings
     private IDictionary<string, string>? _metadata;
     private object? _responseModalities;
     private object? _audioOptions;
+    private IDictionary<string, object?>? _extraBody;
 
     #endregion
 }

--- a/dotnet/src/SemanticKernel.Abstractions/AI/PromptExecutionSettings.cs
+++ b/dotnet/src/SemanticKernel.Abstractions/AI/PromptExecutionSettings.cs
@@ -4,6 +4,7 @@ using System;
 using System.Collections.Generic;
 using System.Collections.ObjectModel;
 using System.Text.Json.Serialization;
+using Microsoft.Extensions.AI;
 using Microsoft.SemanticKernel.ChatCompletion;
 using Microsoft.SemanticKernel.TextGeneration;
 
@@ -182,6 +183,21 @@ public class PromptExecutionSettings
     /// <param name="chatHistory">Target chat history to prepare.</param>
     /// <returns>Prepared chat history.</returns>
     internal ChatHistory ChatClientPrepareChatHistoryForRequest(ChatHistory chatHistory) => this.PrepareChatHistoryForRequest(chatHistory);
+
+    /// <summary>
+    /// When some derived <see cref="PromptExecutionSettings"/> requires post-processing of the produced
+    /// <see cref="ChatOptions"/> (for example, setting <see cref="ChatOptions.RawRepresentationFactory"/>),
+    /// this method can be overridden. Called after the standard <c>ToChatOptions</c> conversion completes.
+    /// </summary>
+    /// <param name="options">The <see cref="ChatOptions"/> instance to prepare.</param>
+    protected virtual void PrepareChatOptionsForRequest(ChatOptions options) { }
+
+    /// <summary>
+    /// Internal bridge used by <c>PromptExecutionSettingsExtensions.ToChatOptions</c> without exposing
+    /// the protected <see cref="PrepareChatOptionsForRequest"/> publicly.
+    /// </summary>
+    /// <param name="options">Target <see cref="ChatOptions"/> to prepare.</param>
+    internal void ChatClientPrepareChatOptionsForRequest(ChatOptions options) => this.PrepareChatOptionsForRequest(options);
 
     #region private ================================================================================
 

--- a/dotnet/src/SemanticKernel.Abstractions/AI/PromptExecutionSettingsExtensions.cs
+++ b/dotnet/src/SemanticKernel.Abstractions/AI/PromptExecutionSettingsExtensions.cs
@@ -179,13 +179,11 @@ public static class PromptExecutionSettingsExtensions
                 options.ToolMode = ChatToolMode.Auto;
                 options.AllowMultipleToolCalls = autoChoiceBehavior.Options?.AllowParallelCalls;
             }
-            else
-            if (settings.FunctionChoiceBehavior is NoneFunctionChoiceBehavior noneFunctionChoiceBehavior)
+            else if (settings.FunctionChoiceBehavior is NoneFunctionChoiceBehavior noneFunctionChoiceBehavior)
             {
                 options.ToolMode = ChatToolMode.None;
             }
-            else
-            if (settings.FunctionChoiceBehavior is RequiredFunctionChoiceBehavior requiredFunctionChoiceBehavior)
+            else if (settings.FunctionChoiceBehavior is RequiredFunctionChoiceBehavior requiredFunctionChoiceBehavior)
             {
                 options.ToolMode = ChatToolMode.RequireAny;
                 options.AllowMultipleToolCalls = requiredFunctionChoiceBehavior.Options?.AllowParallelCalls;

--- a/dotnet/src/SemanticKernel.Abstractions/AI/PromptExecutionSettingsExtensions.cs
+++ b/dotnet/src/SemanticKernel.Abstractions/AI/PromptExecutionSettingsExtensions.cs
@@ -23,6 +23,10 @@ public static class PromptExecutionSettingsExtensions
             return null;
         }
 
+        // Preserve the original (potentially derived) settings instance so derived hooks can run after the
+        // base-type roundtrip below replaces 'settings' with a base PromptExecutionSettings.
+        PromptExecutionSettings derivedSettings = settings;
+
         if (settings.GetType() != typeof(PromptExecutionSettings))
         {
             var originalFunctionChoiceBehavior = settings.FunctionChoiceBehavior;
@@ -195,6 +199,11 @@ public static class PromptExecutionSettingsExtensions
                 options.Tools.Add(functionClone);
             }
         }
+
+        // Allow derived PromptExecutionSettings to perform post-processing on the produced ChatOptions
+        // (for example, setting ChatOptions.RawRepresentationFactory). Invoke on the original derived instance
+        // since 'settings' may have been replaced with a base-type clone above.
+        derivedSettings.ChatClientPrepareChatOptionsForRequest(options);
 
         // Enables usage of AutoFunctionInvocationFilters
         return kernel is null


### PR DESCRIPTION
### Motivation and Context

Closes #12307. Provides .NET parity with the Python fix in #11852 by adding an escape-hatch `ExtraBody` property to `OpenAIPromptExecutionSettings`. This allows callers to inject vendor-specific or preview parameters into the request body without waiting for SDK modeling. Use cases from the issue include:

- Qwen3 open-source models requiring `enable_thinking: false` for non-streaming calls
- ChatGLM thinking-mode flags
- Any OpenAI-compatible endpoint exposing fields not modeled by the SDK

### Description

Adds `IDictionary<string, object?>? ExtraBody` to `OpenAIPromptExecutionSettings` (inherited automatically by `AzureOpenAIPromptExecutionSettings`), marked `[Experimental("SKEXP0010")]`.

#### Hybrid key syntax (diverges intentionally from Python to leverage the OpenAI .NET SDK's `JsonPatch`)

- A plain key is treated as a literal top-level field name. Keys with dots, brackets, or other special characters are bracket-quoted automatically and remain literal.
  - `ExtraBody["enable_thinking"] = false` → `{ "enable_thinking": false }`
  - `ExtraBody["weird.key"] = "x"` → `{ "weird.key": "x" }`
- A key starting with `$.` is interpreted as a JSONPath expression and applied as a deep patch onto the request body.
  - `ExtraBody["$.thinking.enabled"] = false` → `{ "thinking": { "enabled": false } }`
  - `ExtraBody["$.tools[0].function.name"] = "x"` → patches into array elements
- Nested dictionaries are also supported via plain keys: `ExtraBody["thinking"] = new Dictionary<string,object?> { ["enabled"] = false }`.

#### Behavior

- **Last-write-wins on collisions** with strongly-typed properties (e.g. `Temperature`). Documented.
- **`null` values emit JSON `null`**. Field removal is not supported.
- **No input validation, no telemetry emission** of `ExtraBody` contents (Python parity).
- **Shallow `Clone()`**, `ReadOnlyDictionary` on `Freeze()`.

#### Wiring

- Classic path: `ClientCore.ChatCompletion.cs` and `AzureClientCore.ChatCompletion.cs` apply patches at the end of `CreateChatCompletionOptions`.
- `IChatClient` path: new `protected virtual PrepareChatOptionsForRequest(ChatOptions)` hook on `PromptExecutionSettings` (mirrors the existing `PrepareChatHistoryForRequest` pattern). The OpenAI override sets `ChatOptions.RawRepresentationFactory` and removes the redundant `AdditionalProperties["extra_body"]` entry produced by `ToChatOptions`'s round-trip.

#### Files changed

- `SemanticKernel.Abstractions/AI/PromptExecutionSettings.cs` — new hook + internal bridge
- `SemanticKernel.Abstractions/AI/PromptExecutionSettingsExtensions.cs` — invokes the hook on the original derived instance
- `Connectors.OpenAI/Settings/OpenAIPromptExecutionSettings.cs` — property, Freeze, Clone, `PrepareChatOptionsForRequest` override, `ApplyExtraBody`/`ApplyExtraBodyEntry` helpers
- `Connectors.OpenAI/Core/ClientCore.ChatCompletion.cs` — apply in classic path
- `Connectors.AzureOpenAI/Core/AzureClientCore.ChatCompletion.cs` — apply in Azure classic path
- `samples/Concepts/ChatCompletion/OpenAI_ChatCompletionExtraBody.cs` — concept sample (flat field + deep patch)

#### Tests (14 new, all passing)

`Connectors.OpenAI.UnitTests` (11): non-streaming flat key, streaming flat key, collision (last-write-wins), nested dict, `$.` deep patch, literal dotted key, `null` value, `FromExecutionSettings` round-trip, Clone shallow, Freeze read-only, `ToChatOptions` `RawRepresentationFactory` + `AdditionalProperties` cleanup.

`Connectors.AzureOpenAI.UnitTests` (3): flat key, collision, `$.` deep patch.

#### Regression

- `Connectors.OpenAI.UnitTests`: 485 passed
- `Connectors.AzureOpenAI.UnitTests`: 493 passed
- `SemanticKernel.UnitTests`: 1606 passed (verifies the new hook in Abstractions has no side effects)

### Contribution Checklist

- [x] The code builds clean without any errors or warnings
- [x] The PR follows the SK Contribution Guidelines and the pre-submission formatting script raises no violations
- [x] All unit tests pass, and I have added new tests where possible
- [x] I didn't break anyone 😄
