### PR TITLE
.Net: Fix whitespace formatting in PromptExecutionSettingsExtensions.cs

### DIFF
--- a/dotnet/src/SemanticKernel.Abstractions/AI/PromptExecutionSettingsExtensions.cs
+++ b/dotnet/src/SemanticKernel.Abstractions/AI/PromptExecutionSettingsExtensions.cs
@@ -175,13 +175,11 @@ public static class PromptExecutionSettingsExtensions
                 options.ToolMode = ChatToolMode.Auto;
                 options.AllowMultipleToolCalls = autoChoiceBehavior.Options?.AllowParallelCalls;
             }
-            else
-            if (settings.FunctionChoiceBehavior is NoneFunctionChoiceBehavior noneFunctionChoiceBehavior)
+            else if (settings.FunctionChoiceBehavior is NoneFunctionChoiceBehavior noneFunctionChoiceBehavior)
             {
                 options.ToolMode = ChatToolMode.None;
             }
-            else
-            if (settings.FunctionChoiceBehavior is RequiredFunctionChoiceBehavior requiredFunctionChoiceBehavior)
+            else if (settings.FunctionChoiceBehavior is RequiredFunctionChoiceBehavior requiredFunctionChoiceBehavior)
             {
                 options.ToolMode = ChatToolMode.RequireAny;
                 options.AllowMultipleToolCalls = requiredFunctionChoiceBehavior.Options?.AllowParallelCalls;


### PR DESCRIPTION
### Motivation and Context

The `PromptExecutionSettingsExtensions.cs` file had whitespace formatting errors (WHITESPACE and IDE0055 warnings) on lines 179-188 caused by `else` and `if` being split across separate lines instead of combined as `else if`.

### Description

Combined split `else` / `if` statements into single `else if` lines in `PromptExecutionSettingsExtensions.cs`, resolving 10 whitespace formatting errors and IDE0055 warnings.

### Contribution Checklist

- [x] The code builds clean without any errors or warnings
- [x] The PR follows the [SK Contribution Guidelines](https://github.com/microsoft/semantic-kernel/blob/main/CONTRIBUTING.md) and the [pre-submission formatting script](https://github.com/microsoft/semantic-kernel/blob/main/CONTRIBUTING.md#development-scripts) raises no violations
- [x] All unit tests pass, and I have added new tests where possible
- [x] I didn't break anyone :smile:
