### PR TITLE
Python: Add Perplexity connector (chat completion)

### DIFF
--- a/python/samples/concepts/setup/ALL_SETTINGS.md
+++ b/python/samples/concepts/setup/ALL_SETTINGS.md
@@ -38,6 +38,7 @@
 |  | [OllamaTextEmbedding](../../../semantic_kernel/connectors/ai/ollama/services/ollama_text_embedding.py) | ai_model_id, <br> host | OLLAMA_EMBEDDING_MODEL_ID, <br> OLLAMA_HOST | Yes, <br> No |  |
 | Onnx | [OnnxGenAIChatCompletion](../../../semantic_kernel/connectors/ai/onnx/services/onnx_gen_ai_chat_completion.py) | template, <br> ai_model_path | N/A, <br> ONNX_GEN_AI_CHAT_MODEL_FOLDER | Yes, <br> Yes | [OnnxGenAISettings](../../../semantic_kernel/connectors/ai/onnx/onnx_gen_ai_settings.py) |
 |  | [OnnxGenAITextCompletion](../../../semantic_kernel/connectors/ai/onnx/services/onnx_gen_ai_text_completion.py) | ai_model_path | ONNX_GEN_AI_TEXT_MODEL_FOLDER | Yes |  |
+| Perplexity | [PerplexityChatCompletion](../../../semantic_kernel/connectors/ai/perplexity/services/perplexity_chat_completion.py) | ai_model_id, <br> api_key, <br> base_url | PERPLEXITY_CHAT_MODEL_ID, <br> PERPLEXITY_API_KEY, <br> PERPLEXITY_BASE_URL | Yes (default: sonar-pro), <br> Yes, <br> No | [PerplexitySettings](../../../semantic_kernel/connectors/ai/perplexity/settings/perplexity_settings.py) |
 
 ## Agent Framework Settings used across SK
 

--- a/python/samples/concepts/setup/chat_completion_services.py
+++ b/python/samples/concepts/setup/chat_completion_services.py
@@ -29,6 +29,7 @@ class Services(str, Enum):
     VERTEX_AI = "vertex_ai"
     DEEPSEEK = "deepseek"
     NVIDIA = "nvidia"
+    PERPLEXITY = "perplexity"
 
 
 service_id = "default"
@@ -66,6 +67,7 @@ def get_chat_completion_service_and_request_settings(
         Services.VERTEX_AI: lambda: get_vertex_ai_chat_completion_service_and_request_settings(),
         Services.DEEPSEEK: lambda: get_deepseek_chat_completion_service_and_request_settings(),
         Services.NVIDIA: lambda: get_nvidia_chat_completion_service_and_request_settings(),
+        Services.PERPLEXITY: lambda: get_perplexity_chat_completion_service_and_request_settings(),
     }
 
     # Call the appropriate lambda or function based on the service name
@@ -428,5 +430,32 @@ def get_nvidia_chat_completion_service_and_request_settings() -> tuple[
 
     chat_service = NvidiaChatCompletion(service_id=service_id)
     request_settings = NvidiaChatPromptExecutionSettings(service_id=service_id)
+
+    return chat_service, request_settings
+
+
+def get_perplexity_chat_completion_service_and_request_settings() -> tuple[
+    "ChatCompletionClientBase", "PromptExecutionSettings"
+]:
+    """Return Perplexity chat completion service and request settings.
+
+    The service credentials can be read in 3 ways:
+    1. Via the constructor
+    2. Via the environment variables (PERPLEXITY_API_KEY, PERPLEXITY_CHAT_MODEL_ID)
+    3. Via an environment file
+
+    Perplexity exposes an OpenAI-compatible chat completions endpoint at
+    https://api.perplexity.ai/chat/completions. The default model is ``sonar-pro``.
+
+    The request settings control the behavior of the service. The default settings are sufficient to get started.
+    However, you can adjust the settings to suit your needs.
+    """
+    from semantic_kernel.connectors.ai.perplexity import (
+        PerplexityChatCompletion,
+        PerplexityChatPromptExecutionSettings,
+    )
+
+    chat_service = PerplexityChatCompletion(service_id=service_id)
+    request_settings = PerplexityChatPromptExecutionSettings(service_id=service_id)
 
     return chat_service, request_settings

--- a/python/semantic_kernel/connectors/ai/perplexity/__init__.py
+++ b/python/semantic_kernel/connectors/ai/perplexity/__init__.py
@@ -1,0 +1,15 @@
+# Copyright (c) Microsoft. All rights reserved.
+
+from semantic_kernel.connectors.ai.perplexity.prompt_execution_settings.perplexity_prompt_execution_settings import (
+    PerplexityChatPromptExecutionSettings,
+    PerplexityPromptExecutionSettings,
+)
+from semantic_kernel.connectors.ai.perplexity.services.perplexity_chat_completion import PerplexityChatCompletion
+from semantic_kernel.connectors.ai.perplexity.settings.perplexity_settings import PerplexitySettings
+
+__all__ = [
+    "PerplexityChatCompletion",
+    "PerplexityChatPromptExecutionSettings",
+    "PerplexityPromptExecutionSettings",
+    "PerplexitySettings",
+]

--- a/python/semantic_kernel/connectors/ai/perplexity/__init__.py
+++ b/python/semantic_kernel/connectors/ai/perplexity/__init__.py
@@ -4,8 +4,12 @@ from semantic_kernel.connectors.ai.perplexity.prompt_execution_settings.perplexi
     PerplexityChatPromptExecutionSettings,
     PerplexityPromptExecutionSettings,
 )
-from semantic_kernel.connectors.ai.perplexity.services.perplexity_chat_completion import PerplexityChatCompletion
-from semantic_kernel.connectors.ai.perplexity.settings.perplexity_settings import PerplexitySettings
+from semantic_kernel.connectors.ai.perplexity.services.perplexity_chat_completion import (
+    PerplexityChatCompletion,
+)
+from semantic_kernel.connectors.ai.perplexity.settings.perplexity_settings import (
+    PerplexitySettings,
+)
 
 __all__ = [
     "PerplexityChatCompletion",

--- a/python/semantic_kernel/connectors/ai/perplexity/prompt_execution_settings/__init__.py
+++ b/python/semantic_kernel/connectors/ai/perplexity/prompt_execution_settings/__init__.py
@@ -1,0 +1,1 @@
+# Copyright (c) Microsoft. All rights reserved.

--- a/python/semantic_kernel/connectors/ai/perplexity/prompt_execution_settings/perplexity_prompt_execution_settings.py
+++ b/python/semantic_kernel/connectors/ai/perplexity/prompt_execution_settings/perplexity_prompt_execution_settings.py
@@ -1,0 +1,47 @@
+# Copyright (c) Microsoft. All rights reserved.
+
+from typing import Annotated, Any, Literal
+
+from pydantic import BaseModel, Field
+
+from semantic_kernel.connectors.ai.prompt_execution_settings import PromptExecutionSettings
+
+
+class PerplexityPromptExecutionSettings(PromptExecutionSettings):
+    """Common settings for Perplexity prompt execution."""
+
+    format: Literal["json"] | None = None
+    options: dict[str, Any] | None = None
+
+
+class PerplexityChatPromptExecutionSettings(PerplexityPromptExecutionSettings):
+    """Settings for Perplexity chat prompt execution.
+
+    Mirrors the OpenAI chat parameter shape (the Perplexity Agent API is OpenAI-compatible),
+    plus a small set of Perplexity-specific search controls that are passed through as
+    top-level fields on the request body.
+    """
+
+    messages: list[dict[str, Any]] | None = None
+    ai_model_id: Annotated[str | None, Field(serialization_alias="model")] = None
+    temperature: Annotated[float | None, Field(ge=0.0, le=2.0)] = None
+    top_p: Annotated[float | None, Field(ge=0.0, le=1.0)] = None
+    top_k: Annotated[int | None, Field(ge=0)] = None
+    n: Annotated[int | None, Field(ge=1)] = None
+    stream: bool = False
+    stop: str | list[str] | None = None
+    max_tokens: Annotated[int | None, Field(ge=1)] = None
+    presence_penalty: Annotated[float | None, Field(ge=-2.0, le=2.0)] = None
+    frequency_penalty: Annotated[float | None, Field(ge=-2.0, le=2.0)] = None
+    response_format: (
+        dict[Literal["type"], Literal["text", "json_object"]] | dict[str, Any] | type[BaseModel] | type | None
+    ) = None
+    user: str | None = None
+    extra_headers: dict | None = None
+    extra_body: dict | None = None
+    timeout: float | None = None
+    # Perplexity-specific search parameters
+    search_domain_filter: list[str] | None = None
+    search_recency_filter: Literal["hour", "day", "week", "month", "year"] | None = None
+    return_images: bool | None = None
+    return_related_questions: bool | None = None

--- a/python/semantic_kernel/connectors/ai/perplexity/prompt_execution_settings/perplexity_prompt_execution_settings.py
+++ b/python/semantic_kernel/connectors/ai/perplexity/prompt_execution_settings/perplexity_prompt_execution_settings.py
@@ -2,9 +2,11 @@
 
 from typing import Annotated, Any, Literal
 
-from pydantic import BaseModel, Field
+from pydantic import Field
 
-from semantic_kernel.connectors.ai.prompt_execution_settings import PromptExecutionSettings
+from semantic_kernel.connectors.ai.prompt_execution_settings import (
+    PromptExecutionSettings,
+)
 
 
 class PerplexityPromptExecutionSettings(PromptExecutionSettings):
@@ -27,15 +29,13 @@ class PerplexityChatPromptExecutionSettings(PerplexityPromptExecutionSettings):
     temperature: Annotated[float | None, Field(ge=0.0, le=2.0)] = None
     top_p: Annotated[float | None, Field(ge=0.0, le=1.0)] = None
     top_k: Annotated[int | None, Field(ge=0)] = None
-    n: Annotated[int | None, Field(ge=1)] = None
+    number_of_responses: Annotated[int | None, Field(ge=1, serialization_alias="n")] = None
     stream: bool = False
     stop: str | list[str] | None = None
     max_tokens: Annotated[int | None, Field(ge=1)] = None
     presence_penalty: Annotated[float | None, Field(ge=-2.0, le=2.0)] = None
     frequency_penalty: Annotated[float | None, Field(ge=-2.0, le=2.0)] = None
-    response_format: (
-        dict[Literal["type"], Literal["text", "json_object"]] | dict[str, Any] | type[BaseModel] | type | None
-    ) = None
+    response_format: dict[Literal["type"], Literal["text", "json_object"]] | None = None
     user: str | None = None
     extra_headers: dict | None = None
     extra_body: dict | None = None

--- a/python/semantic_kernel/connectors/ai/perplexity/services/__init__.py
+++ b/python/semantic_kernel/connectors/ai/perplexity/services/__init__.py
@@ -1,0 +1,1 @@
+# Copyright (c) Microsoft. All rights reserved.

--- a/python/semantic_kernel/connectors/ai/perplexity/services/perplexity_chat_completion.py
+++ b/python/semantic_kernel/connectors/ai/perplexity/services/perplexity_chat_completion.py
@@ -1,0 +1,299 @@
+# Copyright (c) Microsoft. All rights reserved.
+
+import logging
+import sys
+from collections.abc import AsyncGenerator, Mapping
+from copy import copy
+from typing import Any
+
+from openai import AsyncOpenAI, AsyncStream
+from openai.types.chat.chat_completion import ChatCompletion, Choice
+from openai.types.chat.chat_completion_chunk import ChatCompletionChunk
+from openai.types.chat.chat_completion_chunk import Choice as ChunkChoice
+from pydantic import ValidationError
+
+from semantic_kernel import __version__ as semantic_kernel_version
+from semantic_kernel.connectors.ai.chat_completion_client_base import ChatCompletionClientBase
+from semantic_kernel.connectors.ai.completion_usage import CompletionUsage
+from semantic_kernel.connectors.ai.perplexity.prompt_execution_settings.perplexity_prompt_execution_settings import (
+    PerplexityChatPromptExecutionSettings,
+)
+from semantic_kernel.connectors.ai.perplexity.settings.perplexity_settings import PerplexitySettings
+from semantic_kernel.connectors.ai.prompt_execution_settings import PromptExecutionSettings
+from semantic_kernel.const import USER_AGENT
+from semantic_kernel.contents import (
+    AuthorRole,
+    ChatMessageContent,
+    FinishReason,
+    StreamingChatMessageContent,
+    StreamingTextContent,
+    TextContent,
+)
+from semantic_kernel.contents.chat_history import ChatHistory
+from semantic_kernel.exceptions.service_exceptions import ServiceInitializationError, ServiceResponseException
+from semantic_kernel.utils.feature_stage_decorator import experimental
+from semantic_kernel.utils.telemetry.model_diagnostics.decorators import (
+    trace_chat_completion,
+    trace_streaming_chat_completion,
+)
+from semantic_kernel.utils.telemetry.user_agent import APP_INFO, prepend_semantic_kernel_to_user_agent
+
+if sys.version_info >= (3, 12):
+    from typing import override  # pragma: no cover
+else:
+    from typing_extensions import override  # pragma: no cover
+
+logger: logging.Logger = logging.getLogger(__name__)
+
+# Perplexity attribution header — sent on every outgoing request so the API can
+# identify integration traffic. Slug is fixed; version follows the package.
+PERPLEXITY_ATTRIBUTION_HEADER = "X-Pplx-Integration"
+PERPLEXITY_ATTRIBUTION_SLUG = "semantic-kernel"
+
+
+def _build_attribution_value() -> str:
+    return f"{PERPLEXITY_ATTRIBUTION_SLUG}/{semantic_kernel_version}"
+
+
+@experimental
+class PerplexityChatCompletion(ChatCompletionClientBase):
+    """Perplexity chat completion service.
+
+    Perplexity exposes an OpenAI-compatible chat completions endpoint at
+    https://api.perplexity.ai/chat/completions, so this connector reuses the
+    ``openai`` Python SDK with a custom ``base_url`` and an attribution header.
+    """
+
+    client: AsyncOpenAI
+
+    def __init__(
+        self,
+        ai_model_id: str | None = None,
+        api_key: str | None = None,
+        base_url: str | None = None,
+        service_id: str | None = None,
+        default_headers: Mapping[str, str] | None = None,
+        async_client: AsyncOpenAI | None = None,
+        env_file_path: str | None = None,
+        env_file_encoding: str | None = None,
+    ) -> None:
+        """Initialize a PerplexityChatCompletion service.
+
+        Args:
+            ai_model_id: Perplexity model name. Defaults to ``sonar-pro``. See
+                https://docs.perplexity.ai/api-reference/chat-completions-post for available models.
+            api_key: Perplexity API key. If not provided the value from the ``PERPLEXITY_API_KEY``
+                environment variable (or ``env_file_path``) is used.
+            base_url: Override the API base URL. Defaults to ``https://api.perplexity.ai``.
+            service_id: Service ID tied to the execution settings.
+            default_headers: Additional default headers to send with every request. The Perplexity
+                attribution header is always added.
+            async_client: An existing ``AsyncOpenAI`` client to use. If provided, ``api_key`` and
+                ``base_url`` are ignored, but the caller is responsible for configuring the
+                attribution header on the client.
+            env_file_path: Optional path to a ``.env`` file to load settings from.
+            env_file_encoding: Encoding of the ``.env`` file.
+        """
+        try:
+            perplexity_settings = PerplexitySettings(
+                api_key=api_key,
+                chat_model_id=ai_model_id,
+                base_url=base_url,
+                env_file_path=env_file_path,
+                env_file_encoding=env_file_encoding,
+            )
+        except ValidationError as ex:
+            raise ServiceInitializationError("Failed to create Perplexity settings.", ex) from ex
+
+        if not async_client and not perplexity_settings.api_key:
+            raise ServiceInitializationError("The Perplexity API key is required.")
+
+        if not async_client:
+            merged_headers: dict[str, str] = dict(copy(default_headers)) if default_headers else {}
+            # Attribution header — must be present on every outgoing request.
+            merged_headers[PERPLEXITY_ATTRIBUTION_HEADER] = _build_attribution_value()
+            if APP_INFO:
+                merged_headers.update(APP_INFO)
+                merged_headers = prepend_semantic_kernel_to_user_agent(merged_headers)
+
+            async_client = AsyncOpenAI(
+                api_key=perplexity_settings.api_key.get_secret_value() if perplexity_settings.api_key else None,
+                base_url=perplexity_settings.base_url,
+                default_headers=merged_headers,
+            )
+
+        super().__init__(
+            ai_model_id=perplexity_settings.chat_model_id,
+            service_id=service_id or "",
+            client=async_client,
+        )
+
+    @classmethod
+    def from_dict(cls, settings: dict[str, Any]) -> "PerplexityChatCompletion":
+        """Initialize a Perplexity service from a dictionary of settings."""
+        return cls(
+            ai_model_id=settings.get("ai_model_id"),
+            api_key=settings.get("api_key"),
+            base_url=settings.get("base_url"),
+            service_id=settings.get("service_id"),
+            default_headers=settings.get("default_headers"),
+            env_file_path=settings.get("env_file_path"),
+        )
+
+    @override
+    def get_prompt_execution_settings_class(self) -> type["PromptExecutionSettings"]:
+        return PerplexityChatPromptExecutionSettings
+
+    @override
+    def service_url(self) -> str | None:
+        return str(self.client.base_url)
+
+    @override
+    @trace_chat_completion("perplexity")
+    async def _inner_get_chat_message_contents(
+        self,
+        chat_history: "ChatHistory",
+        settings: "PromptExecutionSettings",
+    ) -> list["ChatMessageContent"]:
+        if not isinstance(settings, PerplexityChatPromptExecutionSettings):
+            settings = self.get_prompt_execution_settings_from_settings(settings)
+        assert isinstance(settings, PerplexityChatPromptExecutionSettings)  # nosec
+
+        settings.stream = False
+        settings.messages = self._prepare_chat_history_for_request(chat_history)
+        settings.ai_model_id = settings.ai_model_id or self.ai_model_id
+
+        response = await self._send_request(settings)
+        assert isinstance(response, ChatCompletion)  # nosec
+        response_metadata = self._get_metadata_from_chat_response(response)
+        return [self._create_chat_message_content(response, choice, response_metadata) for choice in response.choices]
+
+    @override
+    @trace_streaming_chat_completion("perplexity")
+    async def _inner_get_streaming_chat_message_contents(
+        self,
+        chat_history: "ChatHistory",
+        settings: "PromptExecutionSettings",
+        function_invoke_attempt: int = 0,
+    ) -> AsyncGenerator[list["StreamingChatMessageContent"], Any]:
+        if not isinstance(settings, PerplexityChatPromptExecutionSettings):
+            settings = self.get_prompt_execution_settings_from_settings(settings)
+        assert isinstance(settings, PerplexityChatPromptExecutionSettings)  # nosec
+
+        settings.stream = True
+        settings.messages = self._prepare_chat_history_for_request(chat_history)
+        settings.ai_model_id = settings.ai_model_id or self.ai_model_id
+
+        response = await self._send_request(settings)
+        assert isinstance(response, AsyncStream)  # nosec
+
+        async for chunk in response:
+            if len(chunk.choices) == 0:
+                continue
+            chunk_metadata = self._get_metadata_from_chat_response(chunk)
+            yield [
+                self._create_streaming_chat_message_content(chunk, choice, chunk_metadata, function_invoke_attempt)
+                for choice in chunk.choices
+            ]
+
+    async def _send_request(
+        self, settings: PerplexityChatPromptExecutionSettings
+    ) -> ChatCompletion | AsyncStream[ChatCompletionChunk]:
+        """Send a chat completion request to the Perplexity API."""
+        try:
+            return await self.client.chat.completions.create(**settings.prepare_settings_dict())
+        except Exception as ex:
+            raise ServiceResponseException(
+                f"{type(self)} service failed to complete the chat",
+                ex,
+            ) from ex
+
+    def _create_chat_message_content(
+        self, response: ChatCompletion, choice: Choice, response_metadata: dict[str, Any]
+    ) -> "ChatMessageContent":
+        metadata = self._get_metadata_from_chat_choice(choice)
+        metadata.update(response_metadata)
+
+        items: list[Any] = []
+        if choice.message.content:
+            items.append(TextContent(text=choice.message.content))
+
+        return ChatMessageContent(
+            inner_content=response,
+            ai_model_id=self.ai_model_id,
+            metadata=metadata,
+            role=AuthorRole(choice.message.role),
+            items=items,
+            finish_reason=(FinishReason(choice.finish_reason) if choice.finish_reason else None),
+        )
+
+    def _create_streaming_chat_message_content(
+        self,
+        chunk: ChatCompletionChunk,
+        choice: ChunkChoice,
+        chunk_metadata: dict[str, Any],
+        function_invoke_attempt: int,
+    ) -> StreamingChatMessageContent:
+        metadata = self._get_metadata_from_chat_choice(choice)
+        metadata.update(chunk_metadata)
+
+        items: list[Any] = []
+        if choice.delta and choice.delta.content is not None:
+            items.append(StreamingTextContent(choice_index=choice.index, text=choice.delta.content))
+        return StreamingChatMessageContent(
+            choice_index=choice.index,
+            inner_content=chunk,
+            ai_model_id=self.ai_model_id,
+            metadata=metadata,
+            role=(AuthorRole(choice.delta.role) if choice.delta and choice.delta.role else AuthorRole.ASSISTANT),
+            finish_reason=(FinishReason(choice.finish_reason) if choice.finish_reason else None),
+            items=items,
+            function_invoke_attempt=function_invoke_attempt,
+        )
+
+    def _get_metadata_from_chat_response(self, response: ChatCompletion | ChatCompletionChunk) -> dict[str, Any]:
+        metadata: dict[str, Any] = {
+            "id": response.id,
+            "created": response.created,
+            "system_fingerprint": getattr(response, "system_fingerprint", None),
+            "usage": CompletionUsage.from_openai(response.usage) if response.usage is not None else None,
+        }
+        # Perplexity returns a top-level ``citations`` list alongside the OpenAI-shaped payload;
+        # surface it on the metadata so callers can render source attribution.
+        citations = getattr(response, "citations", None)
+        if citations is not None:
+            metadata["citations"] = citations
+        return metadata
+
+    def _get_metadata_from_chat_choice(self, choice: Choice | ChunkChoice) -> dict[str, Any]:
+        return {
+            "logprobs": getattr(choice, "logprobs", None),
+        }
+
+    def _prepare_chat_history_for_request(
+        self,
+        chat_history: ChatHistory,
+        role_key: str = "role",
+        content_key: str = "content",
+    ) -> list[dict[str, Any]]:
+        messages: list[dict[str, Any]] = []
+        for message in chat_history.messages:
+            messages.append({role_key: message.role.value, content_key: message.content})
+        return messages
+
+    def to_dict(self) -> dict[str, str]:
+        """Create a dict of the service settings."""
+        client_settings = {
+            "api_key": self.client.api_key,
+            "default_headers": {k: v for k, v in self.client.default_headers.items() if k != USER_AGENT},
+        }
+        base = self.model_dump(
+            exclude={
+                "service_id",
+                "client",
+            },
+            by_alias=True,
+            exclude_none=True,
+        )
+        base.update(client_settings)
+        return base

--- a/python/semantic_kernel/connectors/ai/perplexity/services/perplexity_chat_completion.py
+++ b/python/semantic_kernel/connectors/ai/perplexity/services/perplexity_chat_completion.py
@@ -8,18 +8,26 @@ from typing import Any
 
 from openai import AsyncOpenAI, AsyncStream
 from openai.types.chat.chat_completion import ChatCompletion, Choice
-from openai.types.chat.chat_completion_chunk import ChatCompletionChunk
-from openai.types.chat.chat_completion_chunk import Choice as ChunkChoice
+from openai.types.chat.chat_completion_chunk import (
+    ChatCompletionChunk,
+    Choice as ChunkChoice,
+)
 from pydantic import ValidationError
 
 from semantic_kernel import __version__ as semantic_kernel_version
-from semantic_kernel.connectors.ai.chat_completion_client_base import ChatCompletionClientBase
+from semantic_kernel.connectors.ai.chat_completion_client_base import (
+    ChatCompletionClientBase,
+)
 from semantic_kernel.connectors.ai.completion_usage import CompletionUsage
 from semantic_kernel.connectors.ai.perplexity.prompt_execution_settings.perplexity_prompt_execution_settings import (
     PerplexityChatPromptExecutionSettings,
 )
-from semantic_kernel.connectors.ai.perplexity.settings.perplexity_settings import PerplexitySettings
-from semantic_kernel.connectors.ai.prompt_execution_settings import PromptExecutionSettings
+from semantic_kernel.connectors.ai.perplexity.settings.perplexity_settings import (
+    PerplexitySettings,
+)
+from semantic_kernel.connectors.ai.prompt_execution_settings import (
+    PromptExecutionSettings,
+)
 from semantic_kernel.const import USER_AGENT
 from semantic_kernel.contents import (
     AuthorRole,
@@ -30,13 +38,19 @@ from semantic_kernel.contents import (
     TextContent,
 )
 from semantic_kernel.contents.chat_history import ChatHistory
-from semantic_kernel.exceptions.service_exceptions import ServiceInitializationError, ServiceResponseException
+from semantic_kernel.exceptions.service_exceptions import (
+    ServiceInitializationError,
+    ServiceResponseException,
+)
 from semantic_kernel.utils.feature_stage_decorator import experimental
 from semantic_kernel.utils.telemetry.model_diagnostics.decorators import (
     trace_chat_completion,
     trace_streaming_chat_completion,
 )
-from semantic_kernel.utils.telemetry.user_agent import APP_INFO, prepend_semantic_kernel_to_user_agent
+from semantic_kernel.utils.telemetry.user_agent import (
+    APP_INFO,
+    prepend_semantic_kernel_to_user_agent,
+)
 
 if sys.version_info >= (3, 12):
     from typing import override  # pragma: no cover
@@ -138,6 +152,7 @@ class PerplexityChatCompletion(ChatCompletionClientBase):
             service_id=settings.get("service_id"),
             default_headers=settings.get("default_headers"),
             env_file_path=settings.get("env_file_path"),
+            env_file_encoding=settings.get("env_file_encoding"),
         )
 
     @override
@@ -276,15 +291,13 @@ class PerplexityChatCompletion(ChatCompletionClientBase):
         role_key: str = "role",
         content_key: str = "content",
     ) -> list[dict[str, Any]]:
-        messages: list[dict[str, Any]] = []
-        for message in chat_history.messages:
-            messages.append({role_key: message.role.value, content_key: message.content})
-        return messages
+        return [{role_key: message.role.value, content_key: message.content} for message in chat_history.messages]
 
     def to_dict(self) -> dict[str, str]:
         """Create a dict of the service settings."""
         client_settings = {
             "api_key": self.client.api_key,
+            "base_url": str(self.client.base_url),
             "default_headers": {k: v for k, v in self.client.default_headers.items() if k != USER_AGENT},
         }
         base = self.model_dump(

--- a/python/semantic_kernel/connectors/ai/perplexity/settings/__init__.py
+++ b/python/semantic_kernel/connectors/ai/perplexity/settings/__init__.py
@@ -1,0 +1,1 @@
+# Copyright (c) Microsoft. All rights reserved.

--- a/python/semantic_kernel/connectors/ai/perplexity/settings/perplexity_settings.py
+++ b/python/semantic_kernel/connectors/ai/perplexity/settings/perplexity_settings.py
@@ -1,0 +1,33 @@
+# Copyright (c) Microsoft. All rights reserved.
+
+from typing import ClassVar
+
+from pydantic import SecretStr
+
+from semantic_kernel.kernel_pydantic import KernelBaseSettings
+
+
+class PerplexitySettings(KernelBaseSettings):
+    """Perplexity model settings.
+
+    The settings are first loaded from environment variables with the prefix 'PERPLEXITY_'. If the
+    environment variables are not found, the settings can be loaded from a .env file with the
+    encoding 'utf-8'. If the settings are not found in the .env file, the settings are ignored;
+    however, validation will fail alerting that the settings are missing.
+
+    Optional settings for prefix 'PERPLEXITY_' are:
+    - api_key: SecretStr - Perplexity API key, see https://docs.perplexity.ai/guides/getting-started
+        (Env var PERPLEXITY_API_KEY)
+    - chat_model_id: str - The Perplexity chat model ID to use. Defaults to 'sonar-pro'.
+        See https://docs.perplexity.ai/api-reference/chat-completions-post.
+        (Env var PERPLEXITY_CHAT_MODEL_ID)
+    - base_url: str - The base URL for the Perplexity API. Defaults to 'https://api.perplexity.ai'.
+        (Env var PERPLEXITY_BASE_URL)
+    - env_file_path: str | None - if provided, the .env settings are read from this file path location
+    """
+
+    env_prefix: ClassVar[str] = "PERPLEXITY_"
+
+    api_key: SecretStr | None = None
+    chat_model_id: str = "sonar-pro"
+    base_url: str = "https://api.perplexity.ai"

--- a/python/tests/unit/connectors/ai/perplexity/__init__.py
+++ b/python/tests/unit/connectors/ai/perplexity/__init__.py
@@ -1,0 +1,1 @@
+# Copyright (c) Microsoft. All rights reserved.

--- a/python/tests/unit/connectors/ai/perplexity/conftest.py
+++ b/python/tests/unit/connectors/ai/perplexity/conftest.py
@@ -1,0 +1,28 @@
+# Copyright (c) Microsoft. All rights reserved.
+
+from pytest import fixture
+
+
+@fixture()
+def perplexity_unit_test_env(monkeypatch, exclude_list, override_env_param_dict):
+    """Fixture to set environment variables for PerplexitySettings."""
+    if exclude_list is None:
+        exclude_list = []
+
+    if override_env_param_dict is None:
+        override_env_param_dict = {}
+
+    env_vars = {
+        "PERPLEXITY_API_KEY": "test_api_key",
+        "PERPLEXITY_CHAT_MODEL_ID": "sonar-pro",
+    }
+
+    env_vars.update(override_env_param_dict)
+
+    for key, value in env_vars.items():
+        if key not in exclude_list:
+            monkeypatch.setenv(key, value)
+        else:
+            monkeypatch.delenv(key, raising=False)
+
+    return env_vars

--- a/python/tests/unit/connectors/ai/perplexity/services/__init__.py
+++ b/python/tests/unit/connectors/ai/perplexity/services/__init__.py
@@ -1,0 +1,1 @@
+# Copyright (c) Microsoft. All rights reserved.

--- a/python/tests/unit/connectors/ai/perplexity/services/test_perplexity_chat_completion.py
+++ b/python/tests/unit/connectors/ai/perplexity/services/test_perplexity_chat_completion.py
@@ -1,0 +1,146 @@
+# Copyright (c) Microsoft. All rights reserved.
+
+from unittest.mock import AsyncMock, patch
+
+import pytest
+from openai import AsyncOpenAI
+from openai.resources.chat.completions import AsyncCompletions
+from openai.types.chat import ChatCompletion, ChatCompletionMessage
+from openai.types.chat.chat_completion import Choice
+from openai.types.completion_usage import CompletionUsage
+
+from semantic_kernel import __version__ as semantic_kernel_version
+from semantic_kernel.connectors.ai.perplexity import (
+    PerplexityChatCompletion,
+    PerplexityChatPromptExecutionSettings,
+)
+from semantic_kernel.connectors.ai.perplexity.services.perplexity_chat_completion import (
+    PERPLEXITY_ATTRIBUTION_HEADER,
+    PERPLEXITY_ATTRIBUTION_SLUG,
+)
+from semantic_kernel.contents import ChatHistory
+from semantic_kernel.exceptions import ServiceInitializationError, ServiceResponseException
+
+
+def _create_mock_chat_completion(content: str = "Hello!") -> ChatCompletion:
+    message = ChatCompletionMessage(role="assistant", content=content)
+    choice = Choice(finish_reason="stop", index=0, message=message)
+    usage = CompletionUsage(completion_tokens=20, prompt_tokens=10, total_tokens=30)
+    return ChatCompletion(
+        id="test-id",
+        choices=[choice],
+        created=1234567890,
+        model="sonar-pro",
+        object="chat.completion",
+        usage=usage,
+    )
+
+
+class TestPerplexityChatCompletion:
+    """Test cases for PerplexityChatCompletion."""
+
+    def test_init_with_defaults(self, perplexity_unit_test_env):
+        """Service uses the env-supplied API key and default model."""
+        service = PerplexityChatCompletion()
+        assert service.ai_model_id == perplexity_unit_test_env["PERPLEXITY_CHAT_MODEL_ID"]
+        assert str(service.client.base_url).rstrip("/") == "https://api.perplexity.ai"
+
+    def test_default_model_is_sonar_pro(self, monkeypatch):
+        """When no model env var is set, the connector defaults to 'sonar-pro'."""
+        monkeypatch.setenv("PERPLEXITY_API_KEY", "k")
+        monkeypatch.delenv("PERPLEXITY_CHAT_MODEL_ID", raising=False)
+        service = PerplexityChatCompletion()
+        assert service.ai_model_id == "sonar-pro"
+
+    def test_init_with_custom_model(self, perplexity_unit_test_env):
+        service = PerplexityChatCompletion(ai_model_id="sonar-pro")
+        assert service.ai_model_id == "sonar-pro"
+
+    def test_init_with_custom_base_url(self, perplexity_unit_test_env):
+        service = PerplexityChatCompletion(base_url="https://example.test/api")
+        assert str(service.client.base_url).rstrip("/") == "https://example.test/api"
+
+    @pytest.mark.parametrize("exclude_list", [["PERPLEXITY_API_KEY"]], indirect=True)
+    def test_init_with_missing_api_key(self, perplexity_unit_test_env):
+        """A missing API key (and no provided client) raises a clear error."""
+        with pytest.raises(ServiceInitializationError):
+            PerplexityChatCompletion()
+
+    def test_init_with_existing_client(self, perplexity_unit_test_env):
+        """Passing an existing AsyncOpenAI client bypasses settings validation of api_key."""
+        client = AsyncOpenAI(api_key="ignored", base_url="https://api.perplexity.ai")
+        service = PerplexityChatCompletion(async_client=client)
+        assert service.client is client
+
+    def test_attribution_header_present_on_default_client(self, perplexity_unit_test_env):
+        """Every outgoing request must carry the X-Pplx-Integration header."""
+        service = PerplexityChatCompletion()
+        headers = service.client.default_headers
+        assert PERPLEXITY_ATTRIBUTION_HEADER in headers
+        expected = f"{PERPLEXITY_ATTRIBUTION_SLUG}/{semantic_kernel_version}"
+        assert headers[PERPLEXITY_ATTRIBUTION_HEADER] == expected
+
+    def test_user_supplied_default_headers_are_merged(self, perplexity_unit_test_env):
+        """Caller-provided headers are kept alongside the attribution header."""
+        service = PerplexityChatCompletion(default_headers={"X-Custom": "yes"})
+        headers = service.client.default_headers
+        assert headers["X-Custom"] == "yes"
+        assert PERPLEXITY_ATTRIBUTION_HEADER in headers
+
+    def test_get_prompt_execution_settings_class(self, perplexity_unit_test_env):
+        service = PerplexityChatCompletion()
+        assert service.get_prompt_execution_settings_class() == PerplexityChatPromptExecutionSettings
+
+    def test_service_url(self, perplexity_unit_test_env):
+        service = PerplexityChatCompletion()
+        assert "perplexity.ai" in service.service_url()
+
+    @pytest.mark.asyncio
+    @patch.object(AsyncCompletions, "create", new_callable=AsyncMock)
+    async def test_get_chat_message_contents(self, mock_create, perplexity_unit_test_env):
+        mock_create.return_value = _create_mock_chat_completion("Hello!")
+
+        service = PerplexityChatCompletion()
+        chat_history = ChatHistory()
+        chat_history.add_user_message("Hello")
+        settings = PerplexityChatPromptExecutionSettings()
+
+        result = await service.get_chat_message_contents(chat_history, settings)
+
+        assert len(result) == 1
+        assert result[0].content == "Hello!"
+        # The model parameter should default to the configured one (sonar-pro).
+        call_kwargs = mock_create.call_args[1]
+        assert call_kwargs.get("model") == "sonar-pro"
+
+    @pytest.mark.asyncio
+    @patch.object(AsyncCompletions, "create", new_callable=AsyncMock)
+    async def test_search_filters_passed_through(self, mock_create, perplexity_unit_test_env):
+        """Perplexity-specific filter fields are forwarded on the request."""
+        mock_create.return_value = _create_mock_chat_completion("ok")
+
+        service = PerplexityChatCompletion()
+        chat_history = ChatHistory()
+        chat_history.add_user_message("news")
+        settings = PerplexityChatPromptExecutionSettings(
+            search_recency_filter="day",
+            search_domain_filter=["wikipedia.org"],
+        )
+
+        await service.get_chat_message_contents(chat_history, settings)
+
+        call_kwargs = mock_create.call_args[1]
+        assert call_kwargs["search_recency_filter"] == "day"
+        assert call_kwargs["search_domain_filter"] == ["wikipedia.org"]
+
+    @pytest.mark.asyncio
+    @patch.object(AsyncCompletions, "create", new_callable=AsyncMock)
+    async def test_error_handling(self, mock_create, perplexity_unit_test_env):
+        mock_create.side_effect = Exception("API Error")
+
+        service = PerplexityChatCompletion()
+        chat_history = ChatHistory()
+        chat_history.add_user_message("Hello")
+
+        with pytest.raises(ServiceResponseException):
+            await service.get_chat_message_contents(chat_history, PerplexityChatPromptExecutionSettings())

--- a/python/tests/unit/connectors/ai/perplexity/services/test_perplexity_chat_completion.py
+++ b/python/tests/unit/connectors/ai/perplexity/services/test_perplexity_chat_completion.py
@@ -60,6 +60,13 @@ class TestPerplexityChatCompletion:
         service = PerplexityChatCompletion(base_url="https://example.test/api")
         assert str(service.client.base_url).rstrip("/") == "https://example.test/api"
 
+    def test_to_dict_from_dict_preserves_base_url(self, perplexity_unit_test_env):
+        service = PerplexityChatCompletion(base_url="https://example.test/api")
+        serialized_settings = service.to_dict()
+        round_tripped_service = PerplexityChatCompletion.from_dict(serialized_settings)
+
+        assert str(round_tripped_service.client.base_url) == str(service.client.base_url)
+
     @pytest.mark.parametrize("exclude_list", [["PERPLEXITY_API_KEY"]], indirect=True)
     def test_init_with_missing_api_key(self, perplexity_unit_test_env):
         """A missing API key (and no provided client) raises a clear error."""

--- a/python/tests/unit/connectors/ai/perplexity/settings/__init__.py
+++ b/python/tests/unit/connectors/ai/perplexity/settings/__init__.py
@@ -1,0 +1,1 @@
+# Copyright (c) Microsoft. All rights reserved.

--- a/python/tests/unit/connectors/ai/perplexity/settings/test_perplexity_settings.py
+++ b/python/tests/unit/connectors/ai/perplexity/settings/test_perplexity_settings.py
@@ -1,0 +1,36 @@
+# Copyright (c) Microsoft. All rights reserved.
+
+from semantic_kernel.connectors.ai.perplexity.settings.perplexity_settings import PerplexitySettings
+
+
+class TestPerplexitySettings:
+    """Test cases for PerplexitySettings."""
+
+    def test_init_with_defaults(self):
+        """Test initialization uses documented defaults."""
+        settings = PerplexitySettings()
+        assert settings.api_key is None
+        assert settings.chat_model_id == "sonar-pro"
+        assert settings.base_url == "https://api.perplexity.ai"
+
+    def test_init_with_values(self):
+        """Test initialization with explicit values."""
+        settings = PerplexitySettings(
+            api_key="test-api-key",
+            chat_model_id="sonar-pro",
+            base_url="https://example.test/api",
+        )
+
+        assert settings.api_key.get_secret_value() == "test-api-key"
+        assert settings.chat_model_id == "sonar-pro"
+        assert settings.base_url == "https://example.test/api"
+
+    def test_loads_from_env(self, monkeypatch):
+        """Settings should pick up values from PERPLEXITY_* env vars."""
+        monkeypatch.setenv("PERPLEXITY_API_KEY", "env-api-key")
+        monkeypatch.setenv("PERPLEXITY_CHAT_MODEL_ID", "sonar-pro")
+
+        settings = PerplexitySettings()
+
+        assert settings.api_key.get_secret_value() == "env-api-key"
+        assert settings.chat_model_id == "sonar-pro"

--- a/python/tests/unit/connectors/ai/perplexity/test_perplexity_prompt_execution_settings.py
+++ b/python/tests/unit/connectors/ai/perplexity/test_perplexity_prompt_execution_settings.py
@@ -1,0 +1,33 @@
+# Copyright (c) Microsoft. All rights reserved.
+
+import pytest
+from pydantic import ValidationError
+
+from semantic_kernel.connectors.ai.perplexity import (
+    PerplexityChatPromptExecutionSettings,
+)
+
+
+class TestPerplexityChatPromptExecutionSettings:
+    def test_defaults(self):
+        s = PerplexityChatPromptExecutionSettings()
+        assert s.stream is False
+        assert s.temperature is None
+        assert s.search_recency_filter is None
+
+    def test_serialization_aliases_model_field(self):
+        """ai_model_id is serialized as 'model' so it maps to OpenAI-shaped requests."""
+        s = PerplexityChatPromptExecutionSettings(ai_model_id="sonar-pro")
+        dumped = s.prepare_settings_dict()
+        assert dumped.get("model") == "sonar-pro"
+        assert "ai_model_id" not in dumped
+
+    def test_temperature_bounds(self):
+        with pytest.raises(ValidationError):
+            PerplexityChatPromptExecutionSettings(temperature=3.0)
+
+    def test_search_recency_filter_enum(self):
+        s = PerplexityChatPromptExecutionSettings(search_recency_filter="week")
+        assert s.search_recency_filter == "week"
+        with pytest.raises(ValidationError):
+            PerplexityChatPromptExecutionSettings(search_recency_filter="century")

--- a/python/tests/unit/connectors/ai/perplexity/test_perplexity_prompt_execution_settings.py
+++ b/python/tests/unit/connectors/ai/perplexity/test_perplexity_prompt_execution_settings.py
@@ -6,6 +6,7 @@ from pydantic import ValidationError
 from semantic_kernel.connectors.ai.perplexity import (
     PerplexityChatPromptExecutionSettings,
 )
+from semantic_kernel.connectors.ai.prompt_execution_settings import PromptExecutionSettings
 
 
 class TestPerplexityChatPromptExecutionSettings:
@@ -21,6 +22,24 @@ class TestPerplexityChatPromptExecutionSettings:
         dumped = s.prepare_settings_dict()
         assert dumped.get("model") == "sonar-pro"
         assert "ai_model_id" not in dumped
+
+    def test_serialization_aliases_number_of_responses_field(self):
+        """number_of_responses is serialized as 'n' so it maps to OpenAI-shaped requests."""
+        s = PerplexityChatPromptExecutionSettings(number_of_responses=2)
+        dumped = s.prepare_settings_dict()
+        assert dumped.get("n") == 2
+        assert "number_of_responses" not in dumped
+
+    def test_number_of_responses_from_generic_prompt_execution_settings(self):
+        settings = PromptExecutionSettings(
+            extension_data={
+                "number_of_responses": 2,
+            },
+        )
+        chat_settings = PerplexityChatPromptExecutionSettings.from_prompt_execution_settings(settings)
+        dumped = chat_settings.prepare_settings_dict()
+        assert chat_settings.number_of_responses == 2
+        assert dumped.get("n") == 2
 
     def test_temperature_bounds(self):
         with pytest.raises(ValidationError):


### PR DESCRIPTION
## Summary

Adds a Perplexity chat completion connector to the Python SDK, mirroring the existing third-party connector patterns. The Perplexity Agent API is OpenAI-compatible, so this connector reuses the `openai` Python SDK with a custom `base_url` (`https://api.perplexity.ai`) and an attribution header sent on every request.

- Docs: https://docs.perplexity.ai/api-reference/chat-completions-post
- OpenAI-compatible: yes (same request shape, same SDK, different host)
- Default model: `sonar-pro`

### What's included

- `semantic_kernel/connectors/ai/perplexity/`
  - `settings/perplexity_settings.py` — `PERPLEXITY_*` env-var-driven Pydantic settings.
  - `prompt_execution_settings/perplexity_prompt_execution_settings.py` — OpenAI-shaped chat parameters plus Perplexity-specific search filters (`search_recency_filter`, `search_domain_filter`, `return_images`, `return_related_questions`).
  - `services/perplexity_chat_completion.py` — `PerplexityChatCompletion` service supporting streaming and non-streaming, decorated `@experimental`.
- `tests/unit/connectors/ai/perplexity/` — unit tests covering settings, prompt execution settings, chat completion behavior, response serialization round-trips, and canonical `number_of_responses` aliasing.
- `samples/concepts/setup/chat_completion_services.py` — new `Services.PERPLEXITY` registry entry.
- `samples/concepts/setup/ALL_SETTINGS.md` — documents the new `PERPLEXITY_*` env vars.

### Attribution header

Every outgoing request carries `X-Pplx-Integration: semantic-kernel/<package-version>`, set as a default header on the `AsyncOpenAI` client. A unit test asserts this is present.

### Notes

- This is a **chat completion connector only**. A search-API connector can be added in a follow-up if useful.
- Mirrors the OpenAI-compatible third-party provider pattern, with the addition of the attribution header and Perplexity-specific search controls.
- Does **not** add any new third-party dependencies — uses `openai` (already a core dep) with `base_url` overridden.
- `sonar-pro` is the only user-facing model in docs/samples.

## Test plan

- [x] `cd python && uv run pytest tests/unit/connectors/ai/perplexity/` — 23 passed
- [x] `uv run ruff check python/semantic_kernel/connectors/ai/perplexity/` — passes
- [x] `cd python && uv run mypy semantic_kernel/connectors/ai/perplexity/` — Success: no issues found in 7 source files
- [ ] Live smoke test against `https://api.perplexity.ai/chat/completions` (not run here — requires a real `PERPLEXITY_API_KEY`)