### PR TITLE
.Net: OpenAI: throw clear error when tool result call ID is missing

### DIFF
--- a/dotnet/src/Connectors/Connectors.OpenAI.UnitTests/Services/OpenAIChatCompletionServiceTests.cs
+++ b/dotnet/src/Connectors/Connectors.OpenAI.UnitTests/Services/OpenAIChatCompletionServiceTests.cs
@@ -917,6 +917,34 @@ public sealed class OpenAIChatCompletionServiceTests : IDisposable
     }
 
     [Fact]
+    public async Task FunctionResultsWithoutCallIdThrowClearExceptionAsync()
+    {
+        // Arrange
+        this._messageHandlerStub.ResponseToReturn = new HttpResponseMessage(System.Net.HttpStatusCode.OK)
+        {
+            Content = new StringContent(ChatCompletionResponse)
+        };
+
+        var sut = new OpenAIChatCompletionService(modelId: "gpt-3.5-turbo", apiKey: "NOKEY", httpClient: this._httpClient);
+
+        var chatHistory = new ChatHistory
+        {
+            new ChatMessageContent(AuthorRole.Tool,
+            [
+                new FunctionResultContent(functionName: "GetCurrentWeather", pluginName: "MyPlugin", callId: null, result: "rainy")
+            ])
+        };
+
+        var settings = new OpenAIPromptExecutionSettings() { ToolCallBehavior = ToolCallBehavior.EnableKernelFunctions };
+
+        // Act
+        var exception = await Assert.ThrowsAsync<ArgumentException>(() => sut.GetChatMessageContentAsync(chatHistory, settings));
+
+        // Assert
+        Assert.Contains("missing a tool call id", exception.Message, StringComparison.OrdinalIgnoreCase);
+    }
+
+    [Fact]
     public async Task FunctionResultsCanBeProvidedToLLMAsManyResultsInOneChatMessageAsync()
     {
         // Arrange

--- a/dotnet/src/Connectors/Connectors.OpenAI.UnitTests/Services/OpenAIChatCompletionServiceTests.cs
+++ b/dotnet/src/Connectors/Connectors.OpenAI.UnitTests/Services/OpenAIChatCompletionServiceTests.cs
@@ -917,7 +917,7 @@ public sealed class OpenAIChatCompletionServiceTests : IDisposable
     }
 
     [Fact]
-    public async Task FunctionResultsWithoutCallIdThrowClearExceptionAsync()
+    public async Task FunctionResultsWithoutCallIdThrowsClearExceptionAsync()
     {
         // Arrange
         this._messageHandlerStub.ResponseToReturn = new HttpResponseMessage(System.Net.HttpStatusCode.OK)

--- a/dotnet/src/Connectors/Connectors.OpenAI/Core/ClientCore.ChatCompletion.cs
+++ b/dotnet/src/Connectors/Connectors.OpenAI/Core/ClientCore.ChatCompletion.cs
@@ -759,6 +759,11 @@ internal partial class ClientCore
                     continue;
                 }
 
+                if (string.IsNullOrWhiteSpace(resultContent.CallId))
+                {
+                    throw new ArgumentException("Function result message is missing a tool call id. Provide FunctionResultContent.CallId when sending tool results to OpenAI.");
+                }
+
                 toolMessages ??= [];
 
                 if (resultContent.Result is Exception ex)

--- a/dotnet/src/Connectors/Connectors.OpenAI/Core/ClientCore.ChatCompletion.cs
+++ b/dotnet/src/Connectors/Connectors.OpenAI/Core/ClientCore.ChatCompletion.cs
@@ -762,8 +762,8 @@ internal partial class ClientCore
                 if (string.IsNullOrWhiteSpace(resultContent.CallId))
                 {
                     throw new ArgumentException(
-                        $"Function result message is missing a tool call id. Provide {nameof(FunctionResultContent.CallId)} when sending tool results to OpenAI.",
-                        nameof(FunctionResultContent.CallId));
+                        $"Function result message is missing a tool call ID. Provide {nameof(FunctionResultContent.CallId)} when sending tool results to OpenAI.",
+                        nameof(message));
                 }
 
                 toolMessages ??= [];

--- a/dotnet/src/Connectors/Connectors.OpenAI/Core/ClientCore.ChatCompletion.cs
+++ b/dotnet/src/Connectors/Connectors.OpenAI/Core/ClientCore.ChatCompletion.cs
@@ -761,7 +761,9 @@ internal partial class ClientCore
 
                 if (string.IsNullOrWhiteSpace(resultContent.CallId))
                 {
-                    throw new ArgumentException("Function result message is missing a tool call id. Provide FunctionResultContent.CallId when sending tool results to OpenAI.");
+                    throw new ArgumentException(
+                        $"Function result message is missing a tool call id. Provide {nameof(FunctionResultContent.CallId)} when sending tool results to OpenAI.",
+                        nameof(FunctionResultContent.CallId));
                 }
 
                 toolMessages ??= [];


### PR DESCRIPTION
## Motivation and Context
This pull request addresses issue #10125.

When a tool result is sent to the OpenAI connector without a tool call ID, the failure mode is not clear to contributors and users. In practice, this can happen when function calls are constructed synthetically (for example, without a provider-generated call ID). Instead of failing later in a less obvious way, this change makes the behavior explicit and easier to diagnose.

## Problem Summary
The OpenAI request conversion path accepts tool result messages (AuthorRole.Tool) and transforms FunctionResultContent items into OpenAI tool messages.

Before this change:
- A missing FunctionResultContent.CallId could flow into message conversion.
- The resulting error was indirect and not actionable.

Expected behavior:
- Fail fast with a clear error message that explains what is missing and how to fix it.

## What Changed
### 1) Added explicit validation in OpenAI tool-result conversion
File changed:
- dotnet/src/Connectors/Connectors.OpenAI/Core/ClientCore.ChatCompletion.cs

Change:
- Added a guard for string.IsNullOrWhiteSpace(resultContent.CallId) in the tool-result handling path.
- If the call ID is missing, the code now throws ArgumentException with a clear, actionable message.

Why:
- 	ool_call_id is required when constructing OpenAI tool messages.
- This makes the contract explicit and prevents hidden downstream failures.

### 2) Added a regression unit test
File changed:
- dotnet/src/Connectors/Connectors.OpenAI.UnitTests/Services/OpenAIChatCompletionServiceTests.cs

New test:
- FunctionResultsWithoutCallIdThrowClearExceptionAsync

What it validates:
- Given a tool message containing FunctionResultContent with callId: null,
- The OpenAI chat completion flow throws ArgumentException,
- And the message clearly indicates the missing tool call ID.

Why:
- Prevents regressions and documents expected behavior for future contributors.

## Validation
I ran targeted connector tests for this area:

- dotnet test Connectors.OpenAI.UnitTests.csproj --filter FullyQualifiedName~OpenAIChatCompletionServiceTests.FunctionResults

Result:
- 3 passed, 0 failed.

## Impact and Compatibility
- Scope is limited to OpenAI connector tool-result message conversion.
- No public API shape changes.
- Behavior change is intentional: invalid input now fails early with a clearer exception.

## Notes for Reviewers
As a newer contributor, I focused on making the fix minimal and explicit:
- one small runtime guard where the invalid state appears,
- one regression test to lock the behavior.

If maintainers prefer a different exception type or wording, I can update quickly.