### PR TITLE
.Net: Preserve agent execution settings in handoff orchestration

### DIFF
--- a/dotnet/src/Agents/Orchestration/Handoff/HandoffActor.cs
+++ b/dotnet/src/Agents/Orchestration/Handoff/HandoffActor.cs
@@ -5,6 +5,7 @@ using System.Collections.Generic;
 using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.Extensions.Logging;
+using Microsoft.SemanticKernel;
 using Microsoft.SemanticKernel.Agents.Runtime;
 using Microsoft.SemanticKernel.Agents.Runtime.Core;
 using Microsoft.SemanticKernel.ChatCompletion;
@@ -66,18 +67,47 @@ internal sealed class HandoffActor :
         kernel.AutoFunctionInvocationFilters.Add(new HandoffInvocationFilter());
         kernel.Plugins.Add(this.CreateHandoffPlugin());
 
-        // Create invocation options that use auto-function invocation and our modified kernel.
+        // Preserve agent execution settings while enabling auto function choice for handoff plugins.
+        FunctionChoiceBehavior handoffFunctionChoice =
+            FunctionChoiceBehavior.Auto(options: new()
+            {
+                RetainArgumentTypes = true,
+            });
+
+        Dictionary<string, PromptExecutionSettings> executionSettings = [];
+        if (this.Agent.Arguments?.ExecutionSettings is { Count: > 0 } agentExecutionSettings)
+        {
+            foreach (KeyValuePair<string, PromptExecutionSettings> kv in agentExecutionSettings)
+            {
+                PromptExecutionSettings cloned = kv.Value.Clone();
+                cloned.FunctionChoiceBehavior = handoffFunctionChoice;
+                executionSettings[kv.Key] = cloned;
+            }
+        }
+        else
+        {
+            executionSettings[PromptExecutionSettings.DefaultServiceId] = new PromptExecutionSettings
+            {
+                FunctionChoiceBehavior = handoffFunctionChoice,
+            };
+        }
+
+        Dictionary<string, object?> parameters = [];
+        if (this.Agent.Arguments is { Count: > 0 } agentArguments)
+        {
+            foreach (KeyValuePair<string, object?> kv in agentArguments)
+            {
+                parameters[kv.Key] = kv.Value;
+            }
+        }
+
+        KernelArguments kernelArguments = new(parameters, executionSettings);
+
         AgentInvokeOptions options =
             new()
             {
                 Kernel = kernel,
-                KernelArguments = new(new PromptExecutionSettings
-                {
-                    FunctionChoiceBehavior = FunctionChoiceBehavior.Auto(options: new()
-                    {
-                        RetainArgumentTypes = true,
-                    })
-                }),
+                KernelArguments = kernelArguments,
                 OnIntermediateMessage = messageHandler,
             };
 

--- a/dotnet/src/Agents/UnitTests/Orchestration/HandoffOrchestrationTests.cs
+++ b/dotnet/src/Agents/UnitTests/Orchestration/HandoffOrchestrationTests.cs
@@ -3,12 +3,15 @@
 using System;
 using System.Collections.Generic;
 using System.Net.Http;
+using System.Text.Json;
 using System.Threading.Tasks;
 using Microsoft.SemanticKernel;
 using Microsoft.SemanticKernel.Agents;
 using Microsoft.SemanticKernel.Agents.Orchestration;
 using Microsoft.SemanticKernel.Agents.Orchestration.Handoff;
 using Microsoft.SemanticKernel.Agents.Runtime.InProcess;
+using Microsoft.SemanticKernel.Connectors.OpenAI;
+using ChatReasoningEffortLevel = global::OpenAI.Chat.ChatReasoningEffortLevel;
 using Xunit;
 
 namespace SemanticKernel.Agents.UnitTests.Orchestration;
@@ -88,6 +91,32 @@ public class HandoffOrchestrationTests : IDisposable
         Assert.Equal("Final response", response);
     }
 
+    [Fact]
+    public async Task HandoffOrchestrationPreservesAgentExecutionSettingsAsync()
+    {
+        // Arrange
+        HttpMessageHandlerStub messageHandlerStub = new();
+        ChatCompletionAgent mockAgent =
+            this.CreateMockAgent(
+                "Agent1",
+                "Test Agent",
+                Responses.Message("Final response"),
+                messageHandlerStub,
+                new KernelArguments(new OpenAIPromptExecutionSettings
+                {
+                    ReasoningEffort = ChatReasoningEffortLevel.High,
+                }));
+
+        // Act
+        string response = await ExecuteOrchestrationAsync(OrchestrationHandoffs.StartWith(mockAgent), mockAgent);
+
+        // Assert
+        Assert.Equal("Final response", response);
+
+        using JsonDocument requestBody = JsonDocument.Parse(messageHandlerStub.RequestContent!);
+        Assert.Equal("high", requestBody.RootElement.GetProperty("reasoning_effort").GetString());
+    }
+
     private static async Task<string> ExecuteOrchestrationAsync(OrchestrationHandoffs handoffs, params Agent[] mockAgents)
     {
         // Arrange
@@ -110,17 +139,15 @@ public class HandoffOrchestrationTests : IDisposable
         return response;
     }
 
-    private ChatCompletionAgent CreateMockAgent(string name, string description, string response)
+    private ChatCompletionAgent CreateMockAgent(string name, string description, string response, HttpMessageHandlerStub? messageHandlerStub = null, KernelArguments? arguments = null)
     {
-        HttpMessageHandlerStub messageHandlerStub =
-            new()
-            {
-                ResponseToReturn = new HttpResponseMessage
-                {
-                    StatusCode = System.Net.HttpStatusCode.OK,
-                    Content = new StringContent(response),
-                },
-            };
+        messageHandlerStub ??= new HttpMessageHandlerStub();
+
+        messageHandlerStub.ResponseToReturn = new HttpResponseMessage
+        {
+            StatusCode = System.Net.HttpStatusCode.OK,
+            Content = new StringContent(response),
+        };
         HttpClient httpClient = new(messageHandlerStub, disposeHandler: false);
 
         this._disposables.Add(messageHandlerStub);
@@ -136,6 +163,7 @@ public class HandoffOrchestrationTests : IDisposable
                 Name = name,
                 Description = description,
                 Kernel = kernel,
+                Arguments = arguments,
             };
 
         return mockAgent1;


### PR DESCRIPTION
### Motivation and Context

Fixes #13935.

Handoff orchestration created invocation options with a new base `PromptExecutionSettings`, which dropped agent-level provider-specific settings such as OpenAI `reasoning_effort`.

### Description

Preserves the agent's existing execution settings when creating handoff invocation options by cloning them before applying handoff function choice behavior.

Also preserves existing agent argument parameters and adds a regression test that verifies `reasoning_effort` is included in the outgoing request body.

### Contribution Checklist

- [x] The code builds clean without any errors or warnings
- [x] The PR follows the [SK Contribution Guidelines](https://github.com/microsoft/semantic-kernel/blob/main/CONTRIBUTING.md) and the [pre-submission formatting script](https://github.com/microsoft/semantic-kernel/blob/main/CONTRIBUTING.md#development-scripts) raises no violations
- [x] All unit tests pass, and I have added new tests where possible
- [x] I didn't break anyone :smile: