### PR TITLE
.Net: Harden CloudDrivePlugin defaults and add path validation

### DIFF
--- a/dotnet/src/Plugins/Plugins.MsGraph/CloudDrivePlugin.cs
+++ b/dotnet/src/Plugins/Plugins.MsGraph/CloudDrivePlugin.cs
@@ -123,7 +123,7 @@ public sealed class CloudDrivePlugin
 
         Ensure.NotNullOrWhitespace(filePath, nameof(filePath));
 
-        var canonicalPath = Path.GetFullPath(Environment.ExpandEnvironmentVariables(filePath));
+        var canonicalPath = CanonicalizePath(filePath);
 
         if (!this.IsUploadPathAllowed(canonicalPath))
         {
@@ -211,11 +211,10 @@ public sealed class CloudDrivePlugin
     }
 
     /// <summary>
-    /// If a list of allowed upload directories has been provided, the directory of the provided filePath is checked
-    /// to verify it is in the allowed directory list. Paths are canonicalized before comparison.
-    /// Subdirectories of allowed directories are also permitted.
+    /// Expands environment variables and resolves the path to its canonical form.
+    /// This must be called before validation to prevent validate/use mismatches.
     /// </summary>
-    private bool IsUploadPathAllowed(string path)
+    private static string CanonicalizePath(string path)
     {
         Ensure.NotNullOrWhitespace(path, nameof(path));
 
@@ -224,19 +223,39 @@ public sealed class CloudDrivePlugin
             throw new ArgumentException("Invalid file path, UNC paths are not supported.", nameof(path));
         }
 
-        string? directoryPath = Path.GetDirectoryName(path);
+        // Expand environment variables first, then canonicalize — so that
+        // validation and I/O operate on the same resolved path.
+        var expanded = Environment.ExpandEnvironmentVariables(path);
+
+        // Re-check after expansion: an env var could have expanded to a UNC
+        // or extended-path prefix (e.g., %NETSHARE% → \\server\share).
+        if (expanded.StartsWith("\\\\", StringComparison.OrdinalIgnoreCase))
+        {
+            throw new ArgumentException("Invalid file path, UNC paths are not supported.", nameof(path));
+        }
+
+        return Path.GetFullPath(expanded);
+    }
+
+    /// <summary>
+    /// Checks whether a canonicalized file path falls within one of the allowed upload directories.
+    /// Subdirectories of allowed directories are also permitted.
+    /// </summary>
+    private bool IsUploadPathAllowed(string canonicalPath)
+    {
+        Ensure.NotNullOrWhitespace(canonicalPath, nameof(canonicalPath));
+
+        string? directoryPath = Path.GetDirectoryName(canonicalPath);
 
         if (string.IsNullOrEmpty(directoryPath))
         {
-            throw new ArgumentException("Invalid file path, a fully qualified file location must be specified.", nameof(path));
+            throw new ArgumentException("Invalid file path, a fully qualified file location must be specified.", nameof(canonicalPath));
         }
 
         if (this._allowedUploadDirectories.Count == 0)
         {
             return false;
         }
-
-        var canonicalDir = Path.GetFullPath(directoryPath);
 
         foreach (var allowedDirectory in this._allowedUploadDirectories)
         {
@@ -247,8 +266,8 @@ public sealed class CloudDrivePlugin
                 canonicalAllowed += separator;
             }
 
-            if (canonicalDir.StartsWith(canonicalAllowed, s_pathComparison)
-                || (canonicalDir + separator).Equals(canonicalAllowed, s_pathComparison))
+            if (directoryPath.StartsWith(canonicalAllowed, s_pathComparison)
+                || (directoryPath + separator).Equals(canonicalAllowed, s_pathComparison))
             {
                 return true;
             }

--- a/dotnet/src/Plugins/Plugins.MsGraph/CloudDrivePlugin.cs
+++ b/dotnet/src/Plugins/Plugins.MsGraph/CloudDrivePlugin.cs
@@ -222,7 +222,7 @@ public sealed class CloudDrivePlugin
         var normalizedPath = path.Replace('\\', '/');
 
         // Collapse ".." and "." segments to prevent traversal bypass.
-        var segments = normalizedPath.Split('/', StringSplitOptions.RemoveEmptyEntries);
+        var segments = normalizedPath.Split(new[] { '/' }, StringSplitOptions.RemoveEmptyEntries);
         var stack = new List<string>();
         foreach (var segment in segments)
         {

--- a/dotnet/src/Plugins/Plugins.MsGraph/CloudDrivePlugin.cs
+++ b/dotnet/src/Plugins/Plugins.MsGraph/CloudDrivePlugin.cs
@@ -18,12 +18,13 @@ namespace Microsoft.SemanticKernel.Plugins.MsGraph;
 /// </summary>
 /// <remarks>
 /// <para>
-/// This plugin is secure by default. <see cref="AllowedUploadDirectories"/> must be explicitly configured
-/// before any file upload operations are permitted. By default, all local file paths are denied.
+/// This plugin is secure by default. <see cref="AllowedUploadDirectories"/> and <see cref="AllowedSharePaths"/>
+/// must be explicitly configured before file upload or share-link operations are permitted.
+/// By default, all paths are denied.
 /// </para>
 /// <para>
 /// When exposing this plugin to an LLM via auto function calling, ensure that
-/// <see cref="AllowedUploadDirectories"/> is restricted to trusted values only.
+/// <see cref="AllowedUploadDirectories"/> and <see cref="AllowedSharePaths"/> are restricted to trusted values only.
 /// </para>
 /// </remarks>
 public sealed class CloudDrivePlugin
@@ -31,6 +32,7 @@ public sealed class CloudDrivePlugin
     private readonly ICloudDriveConnector _connector;
     private readonly ILogger _logger;
     private HashSet<string> _allowedUploadDirectories = [];
+    private HashSet<string> _allowedSharePaths = [];
 
     /// <summary>
     /// Initializes a new instance of the <see cref="CloudDrivePlugin"/> class.
@@ -57,6 +59,21 @@ public sealed class CloudDrivePlugin
     {
         get => this._allowedUploadDirectories;
         set => this._allowedUploadDirectories = value is null ? [] : new HashSet<string>(value, StringComparer.OrdinalIgnoreCase);
+    }
+
+    /// <summary>
+    /// List of allowed remote paths for which sharing links may be created. Subdirectories of allowed paths are also permitted.
+    /// </summary>
+    /// <remarks>
+    /// Defaults to an empty collection (no paths allowed). Must be explicitly populated
+    /// with trusted remote paths before any share-link operations will succeed.
+    /// Paths are normalized with forward slashes before comparison and matched case-insensitively
+    /// (OneDrive paths are case-insensitive).
+    /// </remarks>
+    public IEnumerable<string> AllowedSharePaths
+    {
+        get => this._allowedSharePaths;
+        set => this._allowedSharePaths = value is null ? [] : new HashSet<string>(value, StringComparer.OrdinalIgnoreCase);
     }
 
     /// <summary>
@@ -131,8 +148,15 @@ public sealed class CloudDrivePlugin
         CancellationToken cancellationToken = default)
     {
         this._logger.LogDebug("Creating link for '{0}'", filePath);
-        const string Type = "view"; // TODO expose this as an SK variable
-        const string Scope = "anonymous"; // TODO expose this as an SK variable
+        const string Type = "view";
+        const string Scope = "organization";
+
+        Ensure.NotNullOrWhitespace(filePath, nameof(filePath));
+
+        if (!this.IsSharePathAllowed(filePath))
+        {
+            throw new InvalidOperationException("Creating a share link for the provided path is not allowed. Configure 'AllowedSharePaths' with trusted remote paths to enable sharing.");
+        }
 
         return await this._connector.CreateShareLinkAsync(filePath, Type, Scope, cancellationToken).ConfigureAwait(false);
     }
@@ -143,6 +167,48 @@ public sealed class CloudDrivePlugin
         RuntimeInformation.IsOSPlatform(OSPlatform.Windows)
             ? StringComparison.OrdinalIgnoreCase
             : StringComparison.Ordinal;
+
+    /// <summary>
+    /// Checks whether the provided remote path is allowed for sharing.
+    /// Paths are normalized with forward slashes and compared case-insensitively
+    /// (OneDrive paths are case-insensitive). Subdirectories of allowed paths are permitted.
+    /// </summary>
+    private bool IsSharePathAllowed(string path)
+    {
+        Ensure.NotNullOrWhitespace(path, nameof(path));
+
+        if (this._allowedSharePaths.Count == 0)
+        {
+            return false;
+        }
+
+        // Normalize to forward slashes for consistent comparison of remote paths.
+        var normalizedPath = path.Replace('\\', '/');
+
+        foreach (var allowedPath in this._allowedSharePaths)
+        {
+            var normalizedAllowed = allowedPath.Replace('\\', '/');
+            if (!normalizedAllowed.EndsWith("/", StringComparison.Ordinal))
+            {
+                normalizedAllowed += "/";
+            }
+
+            var normalizedDir = normalizedPath;
+            int lastSlash = normalizedDir.LastIndexOf('/');
+            if (lastSlash >= 0)
+            {
+                normalizedDir = normalizedDir.Substring(0, lastSlash);
+            }
+
+            if ((normalizedDir + "/").StartsWith(normalizedAllowed, StringComparison.OrdinalIgnoreCase)
+                || (normalizedDir + "/").Equals(normalizedAllowed, StringComparison.OrdinalIgnoreCase))
+            {
+                return true;
+            }
+        }
+
+        return false;
+    }
 
     /// <summary>
     /// If a list of allowed upload directories has been provided, the directory of the provided filePath is checked

--- a/dotnet/src/Plugins/Plugins.MsGraph/CloudDrivePlugin.cs
+++ b/dotnet/src/Plugins/Plugins.MsGraph/CloudDrivePlugin.cs
@@ -62,13 +62,15 @@ public sealed class CloudDrivePlugin
     }
 
     /// <summary>
-    /// List of allowed remote paths for which sharing links may be created. Subdirectories of allowed paths are also permitted.
+    /// List of allowed remote directory prefixes for which sharing links may be created.
+    /// A file is permitted if its parent directory starts with (or equals) any entry in this list.
+    /// Subdirectories of allowed paths are also permitted.
     /// </summary>
     /// <remarks>
     /// Defaults to an empty collection (no paths allowed). Must be explicitly populated
-    /// with trusted remote paths before any share-link operations will succeed.
-    /// Paths are normalized with forward slashes before comparison and matched case-insensitively
-    /// (OneDrive paths are case-insensitive).
+    /// with trusted remote directory paths before any share-link operations will succeed.
+    /// Paths are normalized with forward slashes and dot-segments are collapsed before comparison.
+    /// Matching is case-insensitive (OneDrive paths are case-insensitive).
     /// </remarks>
     public IEnumerable<string> AllowedSharePaths
     {
@@ -170,8 +172,9 @@ public sealed class CloudDrivePlugin
 
     /// <summary>
     /// Checks whether the provided remote path is allowed for sharing.
-    /// Paths are normalized with forward slashes and compared case-insensitively
-    /// (OneDrive paths are case-insensitive). Subdirectories of allowed paths are permitted.
+    /// Paths are normalized with forward slashes, dot-segments are collapsed,
+    /// and compared case-insensitively (OneDrive paths are case-insensitive).
+    /// Subdirectories of allowed paths are permitted.
     /// </summary>
     private bool IsSharePathAllowed(string path)
     {
@@ -182,12 +185,12 @@ public sealed class CloudDrivePlugin
             return false;
         }
 
-        // Normalize to forward slashes for consistent comparison of remote paths.
-        var normalizedPath = path.Replace('\\', '/');
+        // Normalize to forward slashes and collapse dot-segments to prevent traversal bypass.
+        var normalizedPath = NormalizeRemotePath(path);
 
         foreach (var allowedPath in this._allowedSharePaths)
         {
-            var normalizedAllowed = allowedPath.Replace('\\', '/');
+            var normalizedAllowed = NormalizeRemotePath(allowedPath);
             if (!normalizedAllowed.EndsWith("/", StringComparison.Ordinal))
             {
                 normalizedAllowed += "/";
@@ -211,6 +214,32 @@ public sealed class CloudDrivePlugin
     }
 
     /// <summary>
+    /// Normalizes a remote path by replacing backslashes with forward slashes
+    /// and collapsing "." and ".." segments to prevent traversal bypass.
+    /// </summary>
+    private static string NormalizeRemotePath(string path)
+    {
+        var normalizedPath = path.Replace('\\', '/');
+
+        // Collapse ".." and "." segments to prevent traversal bypass.
+        var segments = normalizedPath.Split('/', StringSplitOptions.RemoveEmptyEntries);
+        var stack = new List<string>();
+        foreach (var segment in segments)
+        {
+            if (segment == ".." && stack.Count > 0)
+            {
+                stack.RemoveAt(stack.Count - 1);
+            }
+            else if (segment != "." && segment != "..")
+            {
+                stack.Add(segment);
+            }
+        }
+
+        return "/" + string.Join("/", stack);
+    }
+
+    /// <summary>
     /// Expands environment variables and resolves the path to its canonical form.
     /// This must be called before validation to prevent validate/use mismatches.
     /// </summary>
@@ -218,7 +247,8 @@ public sealed class CloudDrivePlugin
     {
         Ensure.NotNullOrWhitespace(path, nameof(path));
 
-        if (path.StartsWith("\\\\", StringComparison.OrdinalIgnoreCase))
+        if (path.StartsWith("\\\\", StringComparison.OrdinalIgnoreCase) ||
+            path.StartsWith("//", StringComparison.OrdinalIgnoreCase))
         {
             throw new ArgumentException("Invalid file path, UNC paths are not supported.", nameof(path));
         }
@@ -229,7 +259,8 @@ public sealed class CloudDrivePlugin
 
         // Re-check after expansion: an env var could have expanded to a UNC
         // or extended-path prefix (e.g., %NETSHARE% → \\server\share).
-        if (expanded.StartsWith("\\\\", StringComparison.OrdinalIgnoreCase))
+        if (expanded.StartsWith("\\\\", StringComparison.OrdinalIgnoreCase) ||
+            expanded.StartsWith("//", StringComparison.OrdinalIgnoreCase))
         {
             throw new ArgumentException("Invalid file path, UNC paths are not supported.", nameof(path));
         }

--- a/dotnet/src/Plugins/Plugins.MsGraph/CloudDrivePlugin.cs
+++ b/dotnet/src/Plugins/Plugins.MsGraph/CloudDrivePlugin.cs
@@ -18,13 +18,15 @@ namespace Microsoft.SemanticKernel.Plugins.MsGraph;
 /// </summary>
 /// <remarks>
 /// <para>
-/// This plugin is secure by default. <see cref="AllowedUploadDirectories"/> and <see cref="AllowedSharePaths"/>
-/// must be explicitly configured before file upload or share-link operations are permitted.
+/// This plugin is secure by default. <see cref="AllowedUploadDirectories"/>, <see cref="AllowedUploadDestinationPaths"/>,
+/// <see cref="AllowedReadPaths"/>, and <see cref="AllowedSharePaths"/> must be explicitly configured
+/// before file upload, read, or share-link operations are permitted.
 /// By default, all paths are denied.
 /// </para>
 /// <para>
 /// When exposing this plugin to an LLM via auto function calling, ensure that
-/// <see cref="AllowedUploadDirectories"/> and <see cref="AllowedSharePaths"/> are restricted to trusted values only.
+/// <see cref="AllowedUploadDirectories"/>, <see cref="AllowedUploadDestinationPaths"/>, <see cref="AllowedReadPaths"/>,
+/// and <see cref="AllowedSharePaths"/> are restricted to trusted values only.
 /// </para>
 /// </remarks>
 public sealed class CloudDrivePlugin
@@ -33,6 +35,8 @@ public sealed class CloudDrivePlugin
     private readonly ILogger _logger;
     private HashSet<string> _allowedUploadDirectories = [];
     private HashSet<string> _allowedSharePaths = [];
+    private HashSet<string> _allowedReadPaths = [];
+    private HashSet<string> _allowedUploadDestinationPaths = [];
 
     /// <summary>
     /// Initializes a new instance of the <see cref="CloudDrivePlugin"/> class.
@@ -79,6 +83,40 @@ public sealed class CloudDrivePlugin
     }
 
     /// <summary>
+    /// List of allowed remote directory prefixes from which file contents may be read.
+    /// A file is permitted if its parent directory starts with (or equals) any entry in this list.
+    /// Subdirectories of allowed paths are also permitted.
+    /// </summary>
+    /// <remarks>
+    /// Defaults to an empty collection (no paths allowed). Must be explicitly populated
+    /// with trusted remote directory paths before any read operations will succeed.
+    /// Paths are normalized with forward slashes and dot-segments are collapsed before comparison.
+    /// Matching is case-insensitive (OneDrive paths are case-insensitive).
+    /// </remarks>
+    public IEnumerable<string> AllowedReadPaths
+    {
+        get => this._allowedReadPaths;
+        set => this._allowedReadPaths = value is null ? [] : new HashSet<string>(value, StringComparer.OrdinalIgnoreCase);
+    }
+
+    /// <summary>
+    /// List of allowed remote directory prefixes to which files may be uploaded.
+    /// A destination is permitted if its parent directory starts with (or equals) any entry in this list.
+    /// Subdirectories of allowed paths are also permitted.
+    /// </summary>
+    /// <remarks>
+    /// Defaults to an empty collection (no paths allowed). Must be explicitly populated
+    /// with trusted remote directory paths before any upload-destination operations will succeed.
+    /// Paths are normalized with forward slashes and dot-segments are collapsed before comparison.
+    /// Matching is case-insensitive (OneDrive paths are case-insensitive).
+    /// </remarks>
+    public IEnumerable<string> AllowedUploadDestinationPaths
+    {
+        get => this._allowedUploadDestinationPaths;
+        set => this._allowedUploadDestinationPaths = value is null ? [] : new HashSet<string>(value, StringComparer.OrdinalIgnoreCase);
+    }
+
+    /// <summary>
     /// Get the contents of a file stored in a cloud drive.
     /// </summary>
     /// <param name="filePath">The path to the file.</param>
@@ -90,6 +128,14 @@ public sealed class CloudDrivePlugin
         CancellationToken cancellationToken = default)
     {
         this._logger.LogDebug("Getting file content for '{0}'", filePath);
+
+        Ensure.NotNullOrWhitespace(filePath, nameof(filePath));
+
+        if (!this.IsAllowedRemotePath(filePath, this._allowedReadPaths))
+        {
+            throw new InvalidOperationException("Reading from the provided path is not allowed. Configure 'AllowedReadPaths' with trusted remote paths to enable reading.");
+        }
+
         Stream? fileContentStream = await this._connector.GetFileContentStreamAsync(filePath, cancellationToken).ConfigureAwait(false);
 
         if (fileContentStream is null)
@@ -121,6 +167,11 @@ public sealed class CloudDrivePlugin
         if (string.IsNullOrWhiteSpace(destinationPath))
         {
             throw new ArgumentException("Variable was null or whitespace", nameof(destinationPath));
+        }
+
+        if (!this.IsAllowedRemotePath(destinationPath, this._allowedUploadDestinationPaths))
+        {
+            throw new InvalidOperationException("Uploading to the provided remote destination is not allowed. Configure 'AllowedUploadDestinationPaths' with trusted remote paths to enable uploads.");
         }
 
         Ensure.NotNullOrWhitespace(filePath, nameof(filePath));
@@ -155,7 +206,7 @@ public sealed class CloudDrivePlugin
 
         Ensure.NotNullOrWhitespace(filePath, nameof(filePath));
 
-        if (!this.IsSharePathAllowed(filePath))
+        if (!this.IsAllowedRemotePath(filePath, this._allowedSharePaths))
         {
             throw new InvalidOperationException("Creating a share link for the provided path is not allowed. Configure 'AllowedSharePaths' with trusted remote paths to enable sharing.");
         }
@@ -171,16 +222,16 @@ public sealed class CloudDrivePlugin
             : StringComparison.Ordinal;
 
     /// <summary>
-    /// Checks whether the provided remote path is allowed for sharing.
+    /// Checks whether the provided remote path falls within one of the allowed remote directory prefixes.
     /// Paths are normalized with forward slashes, dot-segments are collapsed,
     /// and compared case-insensitively (OneDrive paths are case-insensitive).
     /// Subdirectories of allowed paths are permitted.
     /// </summary>
-    private bool IsSharePathAllowed(string path)
+    private bool IsAllowedRemotePath(string path, HashSet<string> allowedPaths)
     {
         Ensure.NotNullOrWhitespace(path, nameof(path));
 
-        if (this._allowedSharePaths.Count == 0)
+        if (allowedPaths.Count == 0)
         {
             return false;
         }
@@ -188,7 +239,7 @@ public sealed class CloudDrivePlugin
         // Normalize to forward slashes and collapse dot-segments to prevent traversal bypass.
         var normalizedPath = NormalizeRemotePath(path);
 
-        foreach (var allowedPath in this._allowedSharePaths)
+        foreach (var allowedPath in allowedPaths)
         {
             var normalizedAllowed = NormalizeRemotePath(allowedPath);
             if (!normalizedAllowed.EndsWith("/", StringComparison.Ordinal))

--- a/dotnet/src/Plugins/Plugins.MsGraph/Connectors/OneDriveConnector.cs
+++ b/dotnet/src/Plugins/Plugins.MsGraph/Connectors/OneDriveConnector.cs
@@ -114,7 +114,7 @@ public class OneDriveConnector : ICloudDriveConnector
     }
 
     /// <inheritdoc/>
-    public async Task<string> CreateShareLinkAsync(string filePath, string type = "view", string scope = "anonymous",
+    public async Task<string> CreateShareLinkAsync(string filePath, string type = "view", string scope = "organization",
         CancellationToken cancellationToken = default)
     {
         Ensure.NotNullOrWhitespace(filePath, nameof(filePath));

--- a/dotnet/src/Plugins/Plugins.MsGraph/ICloudDriveConnector.cs
+++ b/dotnet/src/Plugins/Plugins.MsGraph/ICloudDriveConnector.cs
@@ -19,7 +19,7 @@ public interface ICloudDriveConnector
     /// <param name="scope">Scope of the link.</param>
     /// <param name="cancellationToken">The <see cref="CancellationToken"/> to monitor for cancellation requests. The default is <see cref="CancellationToken.None"/>.</param>
     /// <returns>Shareable link.</returns>
-    Task<string> CreateShareLinkAsync(string filePath, string type = "view", string scope = "anonymous", CancellationToken cancellationToken = default);
+    Task<string> CreateShareLinkAsync(string filePath, string type = "view", string scope = "organization", CancellationToken cancellationToken = default);
 
     /// <summary>
     /// Get the content of a file.

--- a/dotnet/src/Plugins/Plugins.UnitTests/MsGraph/CloudDrivePluginTests.cs
+++ b/dotnet/src/Plugins/Plugins.UnitTests/MsGraph/CloudDrivePluginTests.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) Microsoft. All rights reserved.
+// Copyright (c) Microsoft. All rights reserved.
 
 using System;
 using System.IO;
@@ -25,10 +25,10 @@ public class CloudDrivePluginTests
         connectorMock.Setup(c => c.UploadSmallFileAsync(It.IsAny<string>(), It.IsAny<string>(), It.IsAny<CancellationToken>()))
             .Returns(Task.CompletedTask);
 
-        CloudDrivePlugin target = new(connectorMock.Object) { AllowedUploadDirectories = [allowedDir] };
+        CloudDrivePlugin target = new(connectorMock.Object) { AllowedUploadDirectories = [allowedDir], AllowedUploadDestinationPaths = ["/"] };
 
         // Act
-        await target.UploadFileAsync(anyFilePath, Guid.NewGuid().ToString());
+        await target.UploadFileAsync(anyFilePath, "/remote.txt");
 
         // Assert
         connectorMock.VerifyAll();
@@ -123,16 +123,16 @@ public class CloudDrivePluginTests
     [Fact]
     public async Task GetFileContentAsyncSucceedsAsync()
     {
-        string anyFilePath = Guid.NewGuid().ToString();
+        string anyFilePath = "/Documents/report.txt";
         string expectedContent = Guid.NewGuid().ToString();
         using MemoryStream expectedStream = new(Encoding.UTF8.GetBytes(expectedContent));
 
         // Arrange
         Mock<ICloudDriveConnector> connectorMock = new();
-        connectorMock.Setup(c => c.GetFileContentStreamAsync(It.IsAny<string>(), It.IsAny<CancellationToken>()))
+        connectorMock.Setup(c => c.GetFileContentStreamAsync(anyFilePath, It.IsAny<CancellationToken>()))
             .ReturnsAsync(expectedStream);
 
-        CloudDrivePlugin target = new(connectorMock.Object);
+        CloudDrivePlugin target = new(connectorMock.Object) { AllowedReadPaths = ["/Documents"] };
 
         // Act
         string? actual = await target.GetFileContentAsync(anyFilePath);
@@ -164,9 +164,7 @@ public class CloudDrivePluginTests
         var traversalPath = Path.Combine(allowedDir, "..", "outside-folder", "secret.txt");
 
         Mock<ICloudDriveConnector> connectorMock = new();
-        CloudDrivePlugin target = new(connectorMock.Object) { AllowedUploadDirectories = [allowedDir] };
-
-        // Act & Assert — traversal path is canonicalized and rejected
+        CloudDrivePlugin target = new(connectorMock.Object) { AllowedUploadDirectories = [allowedDir], AllowedUploadDestinationPaths = ["/"] };
         await Assert.ThrowsAsync<InvalidOperationException>(async () =>
             await target.UploadFileAsync(traversalPath, "/remote.txt"));
     }
@@ -176,7 +174,7 @@ public class CloudDrivePluginTests
     {
         // Arrange
         Mock<ICloudDriveConnector> connectorMock = new();
-        CloudDrivePlugin target = new(connectorMock.Object) { AllowedUploadDirectories = [Path.GetTempPath()] };
+        CloudDrivePlugin target = new(connectorMock.Object) { AllowedUploadDirectories = [Path.GetTempPath()], AllowedUploadDestinationPaths = ["/"] };
 
         // Act & Assert — UNC paths are rejected (ArgumentException on Windows, InvalidOperationException on Linux
         // where the path is canonicalized differently and fails the allowlist check instead)
@@ -192,7 +190,7 @@ public class CloudDrivePluginTests
         var disallowedPath = Path.Combine(Path.GetTempPath(), "disallowed", "file.txt");
 
         Mock<ICloudDriveConnector> connectorMock = new();
-        CloudDrivePlugin target = new(connectorMock.Object) { AllowedUploadDirectories = [allowedDir] };
+        CloudDrivePlugin target = new(connectorMock.Object) { AllowedUploadDirectories = [allowedDir], AllowedUploadDestinationPaths = ["/"] };
 
         // Act & Assert
         await Assert.ThrowsAsync<InvalidOperationException>(async () =>
@@ -210,7 +208,7 @@ public class CloudDrivePluginTests
         connectorMock.Setup(c => c.UploadSmallFileAsync(It.IsAny<string>(), It.IsAny<string>(), It.IsAny<CancellationToken>()))
             .Returns(Task.CompletedTask);
 
-        CloudDrivePlugin target = new(connectorMock.Object) { AllowedUploadDirectories = [allowedDir] };
+        CloudDrivePlugin target = new(connectorMock.Object) { AllowedUploadDirectories = [allowedDir], AllowedUploadDestinationPaths = ["/"] };
 
         // Act — subdirectory of allowed folder should succeed
         await target.UploadFileAsync(subDirPath, "/remote.txt");
@@ -235,7 +233,7 @@ public class CloudDrivePluginTests
             connectorMock.Setup(c => c.UploadSmallFileAsync(It.IsAny<string>(), It.IsAny<string>(), It.IsAny<CancellationToken>()))
                 .Returns(Task.CompletedTask);
 
-            CloudDrivePlugin target = new(connectorMock.Object) { AllowedUploadDirectories = [tempDir] };
+            CloudDrivePlugin target = new(connectorMock.Object) { AllowedUploadDirectories = [tempDir], AllowedUploadDestinationPaths = ["/"] };
 
             // Act — env var should be expanded and path should be allowed
             await target.UploadFileAsync(envVarPath, "/remote.txt");
@@ -263,7 +261,7 @@ public class CloudDrivePluginTests
             var envVarPath = Path.Combine($"%{envVarName}%", "outside-file.txt");
 
             Mock<ICloudDriveConnector> connectorMock = new();
-            CloudDrivePlugin target = new(connectorMock.Object) { AllowedUploadDirectories = [allowedDir] };
+            CloudDrivePlugin target = new(connectorMock.Object) { AllowedUploadDirectories = [allowedDir], AllowedUploadDestinationPaths = ["/"] };
 
             // Act & Assert — expanded path is outside allowed directory
             await Assert.ThrowsAsync<InvalidOperationException>(async () =>
@@ -286,7 +284,7 @@ public class CloudDrivePluginTests
         connectorMock.Setup(c => c.UploadSmallFileAsync(It.IsAny<string>(), It.IsAny<string>(), It.IsAny<CancellationToken>()))
             .Returns(Task.CompletedTask);
 
-        CloudDrivePlugin target = new(connectorMock.Object) { AllowedUploadDirectories = [allowedDir] };
+        CloudDrivePlugin target = new(connectorMock.Object) { AllowedUploadDirectories = [allowedDir], AllowedUploadDestinationPaths = ["/"] };
 
         if (RuntimeInformation.IsOSPlatform(OSPlatform.Windows))
         {
@@ -315,7 +313,7 @@ public class CloudDrivePluginTests
             var maliciousPath = Path.Combine($"%{envVarName}%", "secret.txt");
 
             Mock<ICloudDriveConnector> connectorMock = new();
-            CloudDrivePlugin target = new(connectorMock.Object) { AllowedUploadDirectories = [Path.GetTempPath()] };
+            CloudDrivePlugin target = new(connectorMock.Object) { AllowedUploadDirectories = [Path.GetTempPath()], AllowedUploadDestinationPaths = ["/"] };
 
             // Act & Assert — UNC path after env-var expansion should be rejected
             await Assert.ThrowsAsync<ArgumentException>(async () =>
@@ -356,7 +354,7 @@ public class CloudDrivePluginTests
     {
         // Arrange — forward-slash UNC paths should also be rejected
         Mock<ICloudDriveConnector> connectorMock = new();
-        CloudDrivePlugin target = new(connectorMock.Object) { AllowedUploadDirectories = [Path.GetTempPath()] };
+        CloudDrivePlugin target = new(connectorMock.Object) { AllowedUploadDirectories = [Path.GetTempPath()], AllowedUploadDestinationPaths = ["/"] };
 
         // Act & Assert — forward-slash UNC path is rejected
         await Assert.ThrowsAsync<ArgumentException>(async () =>
@@ -376,7 +374,7 @@ public class CloudDrivePluginTests
             var maliciousPath = $"%{envVarName}%/secret.txt";
 
             Mock<ICloudDriveConnector> connectorMock = new();
-            CloudDrivePlugin target = new(connectorMock.Object) { AllowedUploadDirectories = [Path.GetTempPath()] };
+            CloudDrivePlugin target = new(connectorMock.Object) { AllowedUploadDirectories = [Path.GetTempPath()], AllowedUploadDestinationPaths = ["/"] };
 
             // Act & Assert — forward-slash UNC path after env-var expansion should be rejected
             await Assert.ThrowsAsync<ArgumentException>(async () =>
@@ -403,7 +401,7 @@ public class CloudDrivePluginTests
             var maliciousPath = Path.Combine(allowedDir, $"%{envVarName}%", "secret.txt");
 
             Mock<ICloudDriveConnector> connectorMock = new();
-            CloudDrivePlugin target = new(connectorMock.Object) { AllowedUploadDirectories = [allowedDir] };
+            CloudDrivePlugin target = new(connectorMock.Object) { AllowedUploadDirectories = [allowedDir], AllowedUploadDestinationPaths = ["/"] };
 
             // Act & Assert — after env-var expansion, the canonical path lands outside the allowed directory
             await Assert.ThrowsAsync<InvalidOperationException>(async () =>
@@ -413,5 +411,170 @@ public class CloudDrivePluginTests
         {
             Environment.SetEnvironmentVariable(envVarName, originalValue);
         }
+    }
+
+    [Fact]
+    public async Task GetFileContentAsyncDeniesAllPathsByDefaultAsync()
+    {
+        // Arrange
+        Mock<ICloudDriveConnector> connectorMock = new();
+        CloudDrivePlugin target = new(connectorMock.Object);
+
+        // Act & Assert — default config denies all read paths
+        await Assert.ThrowsAsync<InvalidOperationException>(async () =>
+            await target.GetFileContentAsync("/Documents/secret.docx"));
+    }
+
+    [Fact]
+    public async Task GetFileContentAsyncDeniesPathsOutsideAllowedAsync()
+    {
+        // Arrange
+        Mock<ICloudDriveConnector> connectorMock = new();
+        CloudDrivePlugin target = new(connectorMock.Object) { AllowedReadPaths = ["/Documents/Public"] };
+
+        // Act & Assert — path outside allowed read paths is denied
+        await Assert.ThrowsAsync<InvalidOperationException>(async () =>
+            await target.GetFileContentAsync("/Confidential/secret.docx"));
+    }
+
+    [Fact]
+    public async Task GetFileContentAsyncDeniesPathTraversalAsync()
+    {
+        // Arrange
+        Mock<ICloudDriveConnector> connectorMock = new();
+        CloudDrivePlugin target = new(connectorMock.Object) { AllowedReadPaths = ["/Documents"] };
+
+        // Act & Assert — traversal path should be denied
+        await Assert.ThrowsAsync<InvalidOperationException>(async () =>
+            await target.GetFileContentAsync("/Documents/../Confidential/secret.docx"));
+    }
+
+    [Fact]
+    public async Task GetFileContentAsyncAllowsSubdirectoriesOfAllowedReadPathsAsync()
+    {
+        // Arrange
+        string filePath = "/Documents/Public/Reports/Q1/summary.docx";
+        string expectedContent = "file content";
+        using MemoryStream expectedStream = new(Encoding.UTF8.GetBytes(expectedContent));
+
+        Mock<ICloudDriveConnector> connectorMock = new();
+        connectorMock.Setup(c => c.GetFileContentStreamAsync(filePath, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(expectedStream);
+
+        CloudDrivePlugin target = new(connectorMock.Object) { AllowedReadPaths = ["/Documents/Public"] };
+
+        // Act
+        string? actual = await target.GetFileContentAsync(filePath);
+
+        // Assert
+        Assert.Equal(expectedContent, actual);
+        connectorMock.VerifyAll();
+    }
+
+    [Fact]
+    public async Task GetFileContentAsyncDoesNotCallConnectorWhenDeniedAsync()
+    {
+        // Arrange
+        Mock<ICloudDriveConnector> connectorMock = new(MockBehavior.Strict);
+        CloudDrivePlugin target = new(connectorMock.Object) { AllowedReadPaths = ["/Documents"] };
+
+        // Act & Assert — connector should never be called for denied paths
+        await Assert.ThrowsAsync<InvalidOperationException>(async () =>
+            await target.GetFileContentAsync("/Confidential/secret.docx"));
+        connectorMock.VerifyNoOtherCalls();
+    }
+
+    [Fact]
+    public async Task UploadFileAsyncDeniesDisallowedDestinationPathAsync()
+    {
+        // Arrange
+        string allowedDir = Path.GetTempPath();
+        string anyFilePath = Path.Combine(allowedDir, Guid.NewGuid().ToString());
+
+        Mock<ICloudDriveConnector> connectorMock = new();
+        CloudDrivePlugin target = new(connectorMock.Object)
+        {
+            AllowedUploadDirectories = [allowedDir],
+            AllowedUploadDestinationPaths = ["/Documents/Uploads"]
+        };
+
+        // Act & Assert — destination outside allowed paths is denied
+        await Assert.ThrowsAsync<InvalidOperationException>(async () =>
+            await target.UploadFileAsync(anyFilePath, "/Confidential/secret.docx"));
+    }
+
+    [Fact]
+    public async Task UploadFileAsyncDeniesAllDestinationPathsByDefaultAsync()
+    {
+        // Arrange
+        string allowedDir = Path.GetTempPath();
+        string anyFilePath = Path.Combine(allowedDir, Guid.NewGuid().ToString());
+
+        Mock<ICloudDriveConnector> connectorMock = new();
+        CloudDrivePlugin target = new(connectorMock.Object) { AllowedUploadDirectories = [allowedDir] };
+
+        // Act & Assert — default config denies all destination paths
+        await Assert.ThrowsAsync<InvalidOperationException>(async () =>
+            await target.UploadFileAsync(anyFilePath, "/remote.txt"));
+    }
+
+    [Fact]
+    public async Task UploadFileAsyncAllowsDestinationInAllowedPathAsync()
+    {
+        // Arrange
+        string allowedDir = Path.GetTempPath();
+        string anyFilePath = Path.Combine(allowedDir, Guid.NewGuid().ToString());
+
+        Mock<ICloudDriveConnector> connectorMock = new();
+        connectorMock.Setup(c => c.UploadSmallFileAsync(It.IsAny<string>(), It.IsAny<string>(), It.IsAny<CancellationToken>()))
+            .Returns(Task.CompletedTask);
+
+        CloudDrivePlugin target = new(connectorMock.Object)
+        {
+            AllowedUploadDirectories = [allowedDir],
+            AllowedUploadDestinationPaths = ["/Documents"]
+        };
+
+        // Act
+        await target.UploadFileAsync(anyFilePath, "/Documents/Uploads/report.txt");
+
+        // Assert
+        connectorMock.VerifyAll();
+    }
+
+    [Fact]
+    public async Task UploadFileAsyncDeniesDestinationPathTraversalAsync()
+    {
+        // Arrange
+        string allowedDir = Path.GetTempPath();
+        string anyFilePath = Path.Combine(allowedDir, Guid.NewGuid().ToString());
+
+        Mock<ICloudDriveConnector> connectorMock = new();
+        CloudDrivePlugin target = new(connectorMock.Object)
+        {
+            AllowedUploadDirectories = [allowedDir],
+            AllowedUploadDestinationPaths = ["/Documents"]
+        };
+
+        // Act & Assert — traversal in destination path should be denied
+        await Assert.ThrowsAsync<InvalidOperationException>(async () =>
+            await target.UploadFileAsync(anyFilePath, "/Documents/../Confidential/secret.docx"));
+    }
+
+    [Fact]
+    public async Task UploadFileAsyncDoesNotCallConnectorWhenDestinationDeniedAsync()
+    {
+        // Arrange
+        Mock<ICloudDriveConnector> connectorMock = new(MockBehavior.Strict);
+        CloudDrivePlugin target = new(connectorMock.Object)
+        {
+            AllowedUploadDirectories = [Path.GetTempPath()],
+            AllowedUploadDestinationPaths = ["/Documents"]
+        };
+
+        // Act & Assert — connector should never be called when destination is denied
+        await Assert.ThrowsAsync<InvalidOperationException>(async () =>
+            await target.UploadFileAsync(Path.Combine(Path.GetTempPath(), "file.txt"), "/Confidential/secret.docx"));
+        connectorMock.VerifyNoOtherCalls();
     }
 }

--- a/dotnet/src/Plugins/Plugins.UnitTests/MsGraph/CloudDrivePluginTests.cs
+++ b/dotnet/src/Plugins/Plugins.UnitTests/MsGraph/CloudDrivePluginTests.cs
@@ -38,17 +38,82 @@ public class CloudDrivePluginTests
     public async Task CreateLinkAsyncSucceedsAsync()
     {
         // Arrange
-        string anyFilePath = Guid.NewGuid().ToString();
+        string anyFilePath = "/Documents/report.docx";
         string anyLink = Guid.NewGuid().ToString();
 
         Mock<ICloudDriveConnector> connectorMock = new();
-        connectorMock.Setup(c => c.CreateShareLinkAsync(It.IsAny<string>(), It.IsAny<string>(), It.IsAny<string>(), It.IsAny<CancellationToken>()))
+        connectorMock.Setup(c => c.CreateShareLinkAsync(anyFilePath, "view", "organization", It.IsAny<CancellationToken>()))
             .ReturnsAsync(anyLink);
 
-        CloudDrivePlugin target = new(connectorMock.Object);
+        CloudDrivePlugin target = new(connectorMock.Object) { AllowedSharePaths = ["/Documents"] };
 
         // Act
         string actual = await target.CreateLinkAsync(anyFilePath);
+
+        // Assert
+        Assert.Equal(anyLink, actual);
+        connectorMock.VerifyAll();
+    }
+
+    [Fact]
+    public async Task CreateLinkAsyncUsesOrganizationScopeAsync()
+    {
+        // Arrange
+        string anyFilePath = "/Documents/report.docx";
+        string anyLink = Guid.NewGuid().ToString();
+
+        Mock<ICloudDriveConnector> connectorMock = new();
+        connectorMock.Setup(c => c.CreateShareLinkAsync(anyFilePath, "view", "organization", It.IsAny<CancellationToken>()))
+            .ReturnsAsync(anyLink);
+
+        CloudDrivePlugin target = new(connectorMock.Object) { AllowedSharePaths = ["/Documents"] };
+
+        // Act
+        await target.CreateLinkAsync(anyFilePath);
+
+        // Assert — verify "organization" scope was passed, not "anonymous"
+        connectorMock.Verify(c => c.CreateShareLinkAsync(anyFilePath, "view", "organization", It.IsAny<CancellationToken>()), Times.Once);
+    }
+
+    [Fact]
+    public async Task CreateLinkAsyncDeniesAllPathsByDefaultAsync()
+    {
+        // Arrange
+        Mock<ICloudDriveConnector> connectorMock = new();
+        CloudDrivePlugin target = new(connectorMock.Object);
+
+        // Act & Assert — default config denies all share paths
+        await Assert.ThrowsAsync<InvalidOperationException>(async () =>
+            await target.CreateLinkAsync("/Documents/secret.docx"));
+    }
+
+    [Fact]
+    public async Task CreateLinkAsyncDeniesPathsOutsideAllowedAsync()
+    {
+        // Arrange
+        Mock<ICloudDriveConnector> connectorMock = new();
+        CloudDrivePlugin target = new(connectorMock.Object) { AllowedSharePaths = ["/Documents/Public"] };
+
+        // Act & Assert — path outside allowed share paths is denied
+        await Assert.ThrowsAsync<InvalidOperationException>(async () =>
+            await target.CreateLinkAsync("/Confidential/secret.docx"));
+    }
+
+    [Fact]
+    public async Task CreateLinkAsyncAllowsSubdirectoriesOfAllowedSharePathsAsync()
+    {
+        // Arrange
+        string filePath = "/Documents/Public/Reports/Q1/summary.docx";
+        string anyLink = Guid.NewGuid().ToString();
+
+        Mock<ICloudDriveConnector> connectorMock = new();
+        connectorMock.Setup(c => c.CreateShareLinkAsync(filePath, "view", "organization", It.IsAny<CancellationToken>()))
+            .ReturnsAsync(anyLink);
+
+        CloudDrivePlugin target = new(connectorMock.Object) { AllowedSharePaths = ["/Documents/Public"] };
+
+        // Act — subdirectory of allowed share path should succeed
+        string actual = await target.CreateLinkAsync(filePath);
 
         // Assert
         Assert.Equal(anyLink, actual);

--- a/dotnet/src/Plugins/Plugins.UnitTests/MsGraph/CloudDrivePluginTests.cs
+++ b/dotnet/src/Plugins/Plugins.UnitTests/MsGraph/CloudDrivePluginTests.cs
@@ -25,10 +25,10 @@ public class CloudDrivePluginTests
         connectorMock.Setup(c => c.UploadSmallFileAsync(It.IsAny<string>(), It.IsAny<string>(), It.IsAny<CancellationToken>()))
             .Returns(Task.CompletedTask);
 
-        CloudDrivePlugin target = new(connectorMock.Object) { AllowedUploadDirectories = [allowedDir] };
+        CloudDrivePlugin target = new(connectorMock.Object) { AllowedUploadDirectories = [allowedDir], AllowedUploadDestinationPaths = ["/"] };
 
         // Act
-        await target.UploadFileAsync(anyFilePath, Guid.NewGuid().ToString());
+        await target.UploadFileAsync(anyFilePath, "/remote.txt");
 
         // Assert
         connectorMock.VerifyAll();
@@ -123,16 +123,16 @@ public class CloudDrivePluginTests
     [Fact]
     public async Task GetFileContentAsyncSucceedsAsync()
     {
-        string anyFilePath = Guid.NewGuid().ToString();
+        string anyFilePath = "/Documents/report.txt";
         string expectedContent = Guid.NewGuid().ToString();
         using MemoryStream expectedStream = new(Encoding.UTF8.GetBytes(expectedContent));
 
         // Arrange
         Mock<ICloudDriveConnector> connectorMock = new();
-        connectorMock.Setup(c => c.GetFileContentStreamAsync(It.IsAny<string>(), It.IsAny<CancellationToken>()))
+        connectorMock.Setup(c => c.GetFileContentStreamAsync(anyFilePath, It.IsAny<CancellationToken>()))
             .ReturnsAsync(expectedStream);
 
-        CloudDrivePlugin target = new(connectorMock.Object);
+        CloudDrivePlugin target = new(connectorMock.Object) { AllowedReadPaths = ["/Documents"] };
 
         // Act
         string? actual = await target.GetFileContentAsync(anyFilePath);
@@ -164,9 +164,7 @@ public class CloudDrivePluginTests
         var traversalPath = Path.Combine(allowedDir, "..", "outside-folder", "secret.txt");
 
         Mock<ICloudDriveConnector> connectorMock = new();
-        CloudDrivePlugin target = new(connectorMock.Object) { AllowedUploadDirectories = [allowedDir] };
-
-        // Act & Assert — traversal path is canonicalized and rejected
+        CloudDrivePlugin target = new(connectorMock.Object) { AllowedUploadDirectories = [allowedDir], AllowedUploadDestinationPaths = ["/"] };
         await Assert.ThrowsAsync<InvalidOperationException>(async () =>
             await target.UploadFileAsync(traversalPath, "/remote.txt"));
     }
@@ -176,7 +174,7 @@ public class CloudDrivePluginTests
     {
         // Arrange
         Mock<ICloudDriveConnector> connectorMock = new();
-        CloudDrivePlugin target = new(connectorMock.Object) { AllowedUploadDirectories = [Path.GetTempPath()] };
+        CloudDrivePlugin target = new(connectorMock.Object) { AllowedUploadDirectories = [Path.GetTempPath()], AllowedUploadDestinationPaths = ["/"] };
 
         // Act & Assert — UNC paths are rejected (ArgumentException on Windows, InvalidOperationException on Linux
         // where the path is canonicalized differently and fails the allowlist check instead)
@@ -192,7 +190,7 @@ public class CloudDrivePluginTests
         var disallowedPath = Path.Combine(Path.GetTempPath(), "disallowed", "file.txt");
 
         Mock<ICloudDriveConnector> connectorMock = new();
-        CloudDrivePlugin target = new(connectorMock.Object) { AllowedUploadDirectories = [allowedDir] };
+        CloudDrivePlugin target = new(connectorMock.Object) { AllowedUploadDirectories = [allowedDir], AllowedUploadDestinationPaths = ["/"] };
 
         // Act & Assert
         await Assert.ThrowsAsync<InvalidOperationException>(async () =>
@@ -210,7 +208,7 @@ public class CloudDrivePluginTests
         connectorMock.Setup(c => c.UploadSmallFileAsync(It.IsAny<string>(), It.IsAny<string>(), It.IsAny<CancellationToken>()))
             .Returns(Task.CompletedTask);
 
-        CloudDrivePlugin target = new(connectorMock.Object) { AllowedUploadDirectories = [allowedDir] };
+        CloudDrivePlugin target = new(connectorMock.Object) { AllowedUploadDirectories = [allowedDir], AllowedUploadDestinationPaths = ["/"] };
 
         // Act — subdirectory of allowed folder should succeed
         await target.UploadFileAsync(subDirPath, "/remote.txt");
@@ -235,7 +233,7 @@ public class CloudDrivePluginTests
             connectorMock.Setup(c => c.UploadSmallFileAsync(It.IsAny<string>(), It.IsAny<string>(), It.IsAny<CancellationToken>()))
                 .Returns(Task.CompletedTask);
 
-            CloudDrivePlugin target = new(connectorMock.Object) { AllowedUploadDirectories = [tempDir] };
+            CloudDrivePlugin target = new(connectorMock.Object) { AllowedUploadDirectories = [tempDir], AllowedUploadDestinationPaths = ["/"] };
 
             // Act — env var should be expanded and path should be allowed
             await target.UploadFileAsync(envVarPath, "/remote.txt");
@@ -263,7 +261,7 @@ public class CloudDrivePluginTests
             var envVarPath = Path.Combine($"%{envVarName}%", "outside-file.txt");
 
             Mock<ICloudDriveConnector> connectorMock = new();
-            CloudDrivePlugin target = new(connectorMock.Object) { AllowedUploadDirectories = [allowedDir] };
+            CloudDrivePlugin target = new(connectorMock.Object) { AllowedUploadDirectories = [allowedDir], AllowedUploadDestinationPaths = ["/"] };
 
             // Act & Assert — expanded path is outside allowed directory
             await Assert.ThrowsAsync<InvalidOperationException>(async () =>
@@ -286,7 +284,7 @@ public class CloudDrivePluginTests
         connectorMock.Setup(c => c.UploadSmallFileAsync(It.IsAny<string>(), It.IsAny<string>(), It.IsAny<CancellationToken>()))
             .Returns(Task.CompletedTask);
 
-        CloudDrivePlugin target = new(connectorMock.Object) { AllowedUploadDirectories = [allowedDir] };
+        CloudDrivePlugin target = new(connectorMock.Object) { AllowedUploadDirectories = [allowedDir], AllowedUploadDestinationPaths = ["/"] };
 
         if (RuntimeInformation.IsOSPlatform(OSPlatform.Windows))
         {
@@ -315,7 +313,7 @@ public class CloudDrivePluginTests
             var maliciousPath = Path.Combine($"%{envVarName}%", "secret.txt");
 
             Mock<ICloudDriveConnector> connectorMock = new();
-            CloudDrivePlugin target = new(connectorMock.Object) { AllowedUploadDirectories = [Path.GetTempPath()] };
+            CloudDrivePlugin target = new(connectorMock.Object) { AllowedUploadDirectories = [Path.GetTempPath()], AllowedUploadDestinationPaths = ["/"] };
 
             // Act & Assert — UNC path after env-var expansion should be rejected
             await Assert.ThrowsAsync<ArgumentException>(async () =>
@@ -356,7 +354,7 @@ public class CloudDrivePluginTests
     {
         // Arrange — forward-slash UNC paths should also be rejected
         Mock<ICloudDriveConnector> connectorMock = new();
-        CloudDrivePlugin target = new(connectorMock.Object) { AllowedUploadDirectories = [Path.GetTempPath()] };
+        CloudDrivePlugin target = new(connectorMock.Object) { AllowedUploadDirectories = [Path.GetTempPath()], AllowedUploadDestinationPaths = ["/"] };
 
         // Act & Assert — forward-slash UNC path is rejected
         await Assert.ThrowsAsync<ArgumentException>(async () =>
@@ -376,7 +374,7 @@ public class CloudDrivePluginTests
             var maliciousPath = $"%{envVarName}%/secret.txt";
 
             Mock<ICloudDriveConnector> connectorMock = new();
-            CloudDrivePlugin target = new(connectorMock.Object) { AllowedUploadDirectories = [Path.GetTempPath()] };
+            CloudDrivePlugin target = new(connectorMock.Object) { AllowedUploadDirectories = [Path.GetTempPath()], AllowedUploadDestinationPaths = ["/"] };
 
             // Act & Assert — forward-slash UNC path after env-var expansion should be rejected
             await Assert.ThrowsAsync<ArgumentException>(async () =>
@@ -403,7 +401,7 @@ public class CloudDrivePluginTests
             var maliciousPath = Path.Combine(allowedDir, $"%{envVarName}%", "secret.txt");
 
             Mock<ICloudDriveConnector> connectorMock = new();
-            CloudDrivePlugin target = new(connectorMock.Object) { AllowedUploadDirectories = [allowedDir] };
+            CloudDrivePlugin target = new(connectorMock.Object) { AllowedUploadDirectories = [allowedDir], AllowedUploadDestinationPaths = ["/"] };
 
             // Act & Assert — after env-var expansion, the canonical path lands outside the allowed directory
             await Assert.ThrowsAsync<InvalidOperationException>(async () =>
@@ -413,5 +411,170 @@ public class CloudDrivePluginTests
         {
             Environment.SetEnvironmentVariable(envVarName, originalValue);
         }
+    }
+
+    [Fact]
+    public async Task GetFileContentAsyncDeniesAllPathsByDefaultAsync()
+    {
+        // Arrange
+        Mock<ICloudDriveConnector> connectorMock = new();
+        CloudDrivePlugin target = new(connectorMock.Object);
+
+        // Act & Assert — default config denies all read paths
+        await Assert.ThrowsAsync<InvalidOperationException>(async () =>
+            await target.GetFileContentAsync("/Documents/secret.docx"));
+    }
+
+    [Fact]
+    public async Task GetFileContentAsyncDeniesPathsOutsideAllowedAsync()
+    {
+        // Arrange
+        Mock<ICloudDriveConnector> connectorMock = new();
+        CloudDrivePlugin target = new(connectorMock.Object) { AllowedReadPaths = ["/Documents/Public"] };
+
+        // Act & Assert — path outside allowed read paths is denied
+        await Assert.ThrowsAsync<InvalidOperationException>(async () =>
+            await target.GetFileContentAsync("/Confidential/secret.docx"));
+    }
+
+    [Fact]
+    public async Task GetFileContentAsyncDeniesPathTraversalAsync()
+    {
+        // Arrange
+        Mock<ICloudDriveConnector> connectorMock = new();
+        CloudDrivePlugin target = new(connectorMock.Object) { AllowedReadPaths = ["/Documents"] };
+
+        // Act & Assert — traversal path should be denied
+        await Assert.ThrowsAsync<InvalidOperationException>(async () =>
+            await target.GetFileContentAsync("/Documents/../Confidential/secret.docx"));
+    }
+
+    [Fact]
+    public async Task GetFileContentAsyncAllowsSubdirectoriesOfAllowedReadPathsAsync()
+    {
+        // Arrange
+        string filePath = "/Documents/Public/Reports/Q1/summary.docx";
+        string expectedContent = "file content";
+        using MemoryStream expectedStream = new(Encoding.UTF8.GetBytes(expectedContent));
+
+        Mock<ICloudDriveConnector> connectorMock = new();
+        connectorMock.Setup(c => c.GetFileContentStreamAsync(filePath, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(expectedStream);
+
+        CloudDrivePlugin target = new(connectorMock.Object) { AllowedReadPaths = ["/Documents/Public"] };
+
+        // Act
+        string? actual = await target.GetFileContentAsync(filePath);
+
+        // Assert
+        Assert.Equal(expectedContent, actual);
+        connectorMock.VerifyAll();
+    }
+
+    [Fact]
+    public async Task GetFileContentAsyncDoesNotCallConnectorWhenDeniedAsync()
+    {
+        // Arrange
+        Mock<ICloudDriveConnector> connectorMock = new(MockBehavior.Strict);
+        CloudDrivePlugin target = new(connectorMock.Object) { AllowedReadPaths = ["/Documents"] };
+
+        // Act & Assert — connector should never be called for denied paths
+        await Assert.ThrowsAsync<InvalidOperationException>(async () =>
+            await target.GetFileContentAsync("/Confidential/secret.docx"));
+        connectorMock.VerifyNoOtherCalls();
+    }
+
+    [Fact]
+    public async Task UploadFileAsyncDeniesDisallowedDestinationPathAsync()
+    {
+        // Arrange
+        string allowedDir = Path.GetTempPath();
+        string anyFilePath = Path.Combine(allowedDir, Guid.NewGuid().ToString());
+
+        Mock<ICloudDriveConnector> connectorMock = new();
+        CloudDrivePlugin target = new(connectorMock.Object)
+        {
+            AllowedUploadDirectories = [allowedDir],
+            AllowedUploadDestinationPaths = ["/Documents/Uploads"]
+        };
+
+        // Act & Assert — destination outside allowed paths is denied
+        await Assert.ThrowsAsync<InvalidOperationException>(async () =>
+            await target.UploadFileAsync(anyFilePath, "/Confidential/secret.docx"));
+    }
+
+    [Fact]
+    public async Task UploadFileAsyncDeniesAllDestinationPathsByDefaultAsync()
+    {
+        // Arrange
+        string allowedDir = Path.GetTempPath();
+        string anyFilePath = Path.Combine(allowedDir, Guid.NewGuid().ToString());
+
+        Mock<ICloudDriveConnector> connectorMock = new();
+        CloudDrivePlugin target = new(connectorMock.Object) { AllowedUploadDirectories = [allowedDir] };
+
+        // Act & Assert — default config denies all destination paths
+        await Assert.ThrowsAsync<InvalidOperationException>(async () =>
+            await target.UploadFileAsync(anyFilePath, "/remote.txt"));
+    }
+
+    [Fact]
+    public async Task UploadFileAsyncAllowsDestinationInAllowedPathAsync()
+    {
+        // Arrange
+        string allowedDir = Path.GetTempPath();
+        string anyFilePath = Path.Combine(allowedDir, Guid.NewGuid().ToString());
+
+        Mock<ICloudDriveConnector> connectorMock = new();
+        connectorMock.Setup(c => c.UploadSmallFileAsync(It.IsAny<string>(), It.IsAny<string>(), It.IsAny<CancellationToken>()))
+            .Returns(Task.CompletedTask);
+
+        CloudDrivePlugin target = new(connectorMock.Object)
+        {
+            AllowedUploadDirectories = [allowedDir],
+            AllowedUploadDestinationPaths = ["/Documents"]
+        };
+
+        // Act
+        await target.UploadFileAsync(anyFilePath, "/Documents/Uploads/report.txt");
+
+        // Assert
+        connectorMock.VerifyAll();
+    }
+
+    [Fact]
+    public async Task UploadFileAsyncDeniesDestinationPathTraversalAsync()
+    {
+        // Arrange
+        string allowedDir = Path.GetTempPath();
+        string anyFilePath = Path.Combine(allowedDir, Guid.NewGuid().ToString());
+
+        Mock<ICloudDriveConnector> connectorMock = new();
+        CloudDrivePlugin target = new(connectorMock.Object)
+        {
+            AllowedUploadDirectories = [allowedDir],
+            AllowedUploadDestinationPaths = ["/Documents"]
+        };
+
+        // Act & Assert — traversal in destination path should be denied
+        await Assert.ThrowsAsync<InvalidOperationException>(async () =>
+            await target.UploadFileAsync(anyFilePath, "/Documents/../Confidential/secret.docx"));
+    }
+
+    [Fact]
+    public async Task UploadFileAsyncDoesNotCallConnectorWhenDestinationDeniedAsync()
+    {
+        // Arrange
+        Mock<ICloudDriveConnector> connectorMock = new(MockBehavior.Strict);
+        CloudDrivePlugin target = new(connectorMock.Object)
+        {
+            AllowedUploadDirectories = [Path.GetTempPath()],
+            AllowedUploadDestinationPaths = ["/Documents"]
+        };
+
+        // Act & Assert — connector should never be called when destination is denied
+        await Assert.ThrowsAsync<InvalidOperationException>(async () =>
+            await target.UploadFileAsync(Path.Combine(Path.GetTempPath(), "file.txt"), "/Confidential/secret.docx"));
+        connectorMock.VerifyNoOtherCalls();
     }
 }

--- a/dotnet/src/Plugins/Plugins.UnitTests/MsGraph/CloudDrivePluginTests.cs
+++ b/dotnet/src/Plugins/Plugins.UnitTests/MsGraph/CloudDrivePluginTests.cs
@@ -301,4 +301,56 @@ public class CloudDrivePluginTests
                 await target.UploadFileAsync(filePath, "/remote.txt"));
         }
     }
+
+    [Fact]
+    public async Task ItDeniesEnvVarExpansionToUncPathAsync()
+    {
+        // Arrange — env var that expands to a UNC path should be rejected
+        var envVarName = "SK_TEST_UNC_" + Guid.NewGuid().ToString("N")[..8];
+        var originalValue = Environment.GetEnvironmentVariable(envVarName);
+
+        try
+        {
+            Environment.SetEnvironmentVariable(envVarName, "\\\\server\\share");
+            var maliciousPath = Path.Combine($"%{envVarName}%", "secret.txt");
+
+            Mock<ICloudDriveConnector> connectorMock = new();
+            CloudDrivePlugin target = new(connectorMock.Object) { AllowedUploadDirectories = [Path.GetTempPath()] };
+
+            // Act & Assert — UNC path after env-var expansion should be rejected
+            await Assert.ThrowsAsync<ArgumentException>(async () =>
+                await target.UploadFileAsync(maliciousPath, "/remote.txt"));
+        }
+        finally
+        {
+            Environment.SetEnvironmentVariable(envVarName, originalValue);
+        }
+    }
+
+    [Fact]
+    public async Task ItDeniesEnvVarTraversalBypassAsync()
+    {
+        // Arrange — env var that expands to a traversal path
+        var allowedDir = Path.Combine(Path.GetTempPath(), "allowed-sandbox");
+        var envVarName = "SK_TEST_TRAV_" + Guid.NewGuid().ToString("N")[..8];
+        var originalValue = Environment.GetEnvironmentVariable(envVarName);
+
+        try
+        {
+            Environment.SetEnvironmentVariable(envVarName,
+                $"{Path.DirectorySeparatorChar}..{Path.DirectorySeparatorChar}elsewhere");
+            var maliciousPath = Path.Combine(allowedDir, $"%{envVarName}%", "secret.txt");
+
+            Mock<ICloudDriveConnector> connectorMock = new();
+            CloudDrivePlugin target = new(connectorMock.Object) { AllowedUploadDirectories = [allowedDir] };
+
+            // Act & Assert — after env-var expansion, the canonical path lands outside the allowed directory
+            await Assert.ThrowsAsync<InvalidOperationException>(async () =>
+                await target.UploadFileAsync(maliciousPath, "/remote.txt"));
+        }
+        finally
+        {
+            Environment.SetEnvironmentVariable(envVarName, originalValue);
+        }
+    }
 }

--- a/dotnet/src/Plugins/Plugins.UnitTests/MsGraph/CloudDrivePluginTests.cs
+++ b/dotnet/src/Plugins/Plugins.UnitTests/MsGraph/CloudDrivePluginTests.cs
@@ -328,6 +328,67 @@ public class CloudDrivePluginTests
     }
 
     [Fact]
+    public async Task CreateLinkAsyncDeniesPathTraversalAsync()
+    {
+        // Arrange — path with ".." segments that would bypass the allowed path prefix
+        Mock<ICloudDriveConnector> connectorMock = new();
+        CloudDrivePlugin target = new(connectorMock.Object) { AllowedSharePaths = ["/Documents"] };
+
+        // Act & Assert — traversal path should be denied even though it string-starts-with /Documents
+        await Assert.ThrowsAsync<InvalidOperationException>(async () =>
+            await target.CreateLinkAsync("/Documents/../Confidential/secret.docx"));
+    }
+
+    [Fact]
+    public async Task CreateLinkAsyncDeniesPathTraversalWithSubdirAsync()
+    {
+        // Arrange — traversal from an allowed subdirectory to an unauthorized location
+        Mock<ICloudDriveConnector> connectorMock = new();
+        CloudDrivePlugin target = new(connectorMock.Object) { AllowedSharePaths = ["/Documents/Public"] };
+
+        // Act & Assert — traversal should be denied
+        await Assert.ThrowsAsync<InvalidOperationException>(async () =>
+            await target.CreateLinkAsync("/Documents/Public/../Confidential/secret.docx"));
+    }
+
+    [Fact]
+    public async Task ItDeniesForwardSlashUncPathsAsync()
+    {
+        // Arrange — forward-slash UNC paths should also be rejected
+        Mock<ICloudDriveConnector> connectorMock = new();
+        CloudDrivePlugin target = new(connectorMock.Object) { AllowedUploadDirectories = [Path.GetTempPath()] };
+
+        // Act & Assert — forward-slash UNC path is rejected
+        await Assert.ThrowsAsync<ArgumentException>(async () =>
+            await target.UploadFileAsync("//server/share/file.txt", "/remote.txt"));
+    }
+
+    [Fact]
+    public async Task ItDeniesEnvVarExpansionToForwardSlashUncPathAsync()
+    {
+        // Arrange — env var that expands to a forward-slash UNC path should be rejected
+        var envVarName = "SK_TEST_FWDUNC_" + Guid.NewGuid().ToString("N")[..8];
+        var originalValue = Environment.GetEnvironmentVariable(envVarName);
+
+        try
+        {
+            Environment.SetEnvironmentVariable(envVarName, "//server/share");
+            var maliciousPath = $"%{envVarName}%/secret.txt";
+
+            Mock<ICloudDriveConnector> connectorMock = new();
+            CloudDrivePlugin target = new(connectorMock.Object) { AllowedUploadDirectories = [Path.GetTempPath()] };
+
+            // Act & Assert — forward-slash UNC path after env-var expansion should be rejected
+            await Assert.ThrowsAsync<ArgumentException>(async () =>
+                await target.UploadFileAsync(maliciousPath, "/remote.txt"));
+        }
+        finally
+        {
+            Environment.SetEnvironmentVariable(envVarName, originalValue);
+        }
+    }
+
+    [Fact]
     public async Task ItDeniesEnvVarTraversalBypassAsync()
     {
         // Arrange — env var that expands to a traversal path


### PR DESCRIPTION
### Description

- Improve default settings in CloudDrivePlugin
- Add path validation for share-link operations
- Improve path canonicalization
- Add regression tests

### Contribution Checklist

- [x] The code builds clean without any errors or warnings
- [x] The PR follows the [SK Contribution Guidelines](https://github.com/microsoft/semantic-kernel/blob/main/CONTRIBUTING.md)
- [x] The existing tests pass
- [x] New tests added