### PR TITLE
Update Kiota packages to fix NU1903 vulnerability

### DIFF
--- a/dotnet/Directory.Packages.props
+++ b/dotnet/Directory.Packages.props
@@ -73,7 +73,8 @@
     <PackageVersion Include="Microsoft.CodeAnalysis.CSharp" Version="4.13.0" />
     <PackageVersion Include="Microsoft.Identity.Client" Version="4.81.0" />
     <PackageVersion Include="Microsoft.Identity.Client.Extensions.Msal" Version="4.81.0" />
-    <PackageVersion Include="Microsoft.IdentityModel.JsonWebTokens" Version="8.15.0" />
+    <PackageVersion Include="Microsoft.IdentityModel.JsonWebTokens" Version="8.16.0" />
+    <PackageVersion Include="Microsoft.Kiota.Abstractions" Version="1.22.2" />
     <PackageVersion Include="Microsoft.Kiota.Authentication.Azure" Version="1.22.2" />
     <PackageVersion Include="Microsoft.Kiota.Http.HttpClientLibrary" Version="1.22.2" />
     <PackageVersion Include="Microsoft.Kiota.Serialization.Json" Version="1.22.2" />
@@ -108,7 +109,7 @@
     <PackageVersion Include="Scriban" Version="7.1.0" />
     <PackageVersion Include="PuppeteerSharp" Version="20.2.5" />
     <PackageVersion Include="System.Diagnostics.DiagnosticSource" Version="10.0.2" />
-    <PackageVersion Include="System.IdentityModel.Tokens.Jwt" Version="8.15.0" />
+    <PackageVersion Include="System.IdentityModel.Tokens.Jwt" Version="8.16.0" />
     <PackageVersion Include="System.IO.Packaging" Version="10.0.2" />
     <PackageVersion Include="System.Linq.AsyncEnumerable" Version="10.0.4" />
     <PackageVersion Include="System.Memory.Data" Version="10.0.2" />
@@ -172,7 +173,8 @@
     <PackageVersion Include="DuckDB.NET.Data" Version="1.1.3" />
     <PackageVersion Include="MongoDB.Driver" Version="3.5.2" />
     <PackageVersion Include="Snappier" Version="1.3.1" /><!-- Vulnerability fix: GHSA-pggp-6c3x-2xmx; transitively pinned via MongoDB.Driver -->
-    <PackageVersion Include="Microsoft.Graph" Version="5.94.0" />
+    <PackageVersion Include="Microsoft.Graph" Version="5.105.0" />
+    <PackageVersion Include="Microsoft.Graph.Core" Version="3.2.6" />
     <PackageVersion Include="Microsoft.OpenApi" Version="1.6.24" />
     <PackageVersion Include="Microsoft.OpenApi.Readers" Version="1.6.24" />
     <PackageVersion Include="Microsoft.OpenApi.ApiManifest" Version="0.5.6-preview" />

--- a/dotnet/Directory.Packages.props
+++ b/dotnet/Directory.Packages.props
@@ -74,9 +74,9 @@
     <PackageVersion Include="Microsoft.Identity.Client" Version="4.81.0" />
     <PackageVersion Include="Microsoft.Identity.Client.Extensions.Msal" Version="4.81.0" />
     <PackageVersion Include="Microsoft.IdentityModel.JsonWebTokens" Version="8.15.0" />
-    <PackageVersion Include="Microsoft.Kiota.Authentication.Azure" Version="1.21.1" />
-    <PackageVersion Include="Microsoft.Kiota.Http.HttpClientLibrary" Version="1.21.1" />
-    <PackageVersion Include="Microsoft.Kiota.Serialization.Json" Version="1.21.1" />
+    <PackageVersion Include="Microsoft.Kiota.Authentication.Azure" Version="1.22.2" />
+    <PackageVersion Include="Microsoft.Kiota.Http.HttpClientLibrary" Version="1.22.2" />
+    <PackageVersion Include="Microsoft.Kiota.Serialization.Json" Version="1.22.2" />
     <PackageVersion Include="Microsoft.ML.OnnxRuntime" Version="1.23.2" />
     <PackageVersion Include="Microsoft.ML.OnnxRuntime.Gpu" Version="1.23.2" />
     <PackageVersion Include="Microsoft.ML.Tokenizers.Data.Cl100kBase" Version="2.0.0" />

--- a/dotnet/samples/Demos/BookingRestaurant/BookingRestaurant.csproj
+++ b/dotnet/samples/Demos/BookingRestaurant/BookingRestaurant.csproj
@@ -20,9 +20,9 @@
     
     <!-- Microsoft.Graph.Core is referencing really old versions of these libraries that pin old System dependencies.
          These package references can be removed once Microsoft.Graph updates. -->
-    <PackageReference Include="Microsoft.Kiota.Authentication.Azure" VersionOverride="1.22.2" />
-    <PackageReference Include="Microsoft.Kiota.Http.HttpClientLibrary" VersionOverride="1.22.2" />
-    <PackageReference Include="Microsoft.Kiota.Serialization.Json" VersionOverride="1.22.2" />
+    <PackageReference Include="Microsoft.Kiota.Authentication.Azure" />
+    <PackageReference Include="Microsoft.Kiota.Http.HttpClientLibrary" />
+    <PackageReference Include="Microsoft.Kiota.Serialization.Json" />
   </ItemGroup>
 
   <ItemGroup>

--- a/dotnet/samples/Demos/BookingRestaurant/BookingRestaurant.csproj
+++ b/dotnet/samples/Demos/BookingRestaurant/BookingRestaurant.csproj
@@ -20,9 +20,9 @@
     
     <!-- Microsoft.Graph.Core is referencing really old versions of these libraries that pin old System dependencies.
          These package references can be removed once Microsoft.Graph updates. -->
-    <PackageReference Include="Microsoft.Kiota.Authentication.Azure" VersionOverride="1.21.0" />
-    <PackageReference Include="Microsoft.Kiota.Http.HttpClientLibrary" VersionOverride="1.21.0" />
-    <PackageReference Include="Microsoft.Kiota.Serialization.Json" VersionOverride="1.21.0" />
+    <PackageReference Include="Microsoft.Kiota.Authentication.Azure" VersionOverride="1.22.2" />
+    <PackageReference Include="Microsoft.Kiota.Http.HttpClientLibrary" VersionOverride="1.22.2" />
+    <PackageReference Include="Microsoft.Kiota.Serialization.Json" VersionOverride="1.22.2" />
   </ItemGroup>
 
   <ItemGroup>

--- a/dotnet/src/Plugins/Plugins.MsGraph/Plugins.MsGraph.csproj
+++ b/dotnet/src/Plugins/Plugins.MsGraph/Plugins.MsGraph.csproj
@@ -19,6 +19,7 @@
 
   <ItemGroup>
     <PackageReference Include="Microsoft.Graph" />
+    <PackageReference Include="Microsoft.Graph.Core" />
     <PackageReference Include="Microsoft.Identity.Client.Extensions.Msal" />
     <PackageReference Include="Microsoft.Identity.Client" />
     <PackageReference Include="Microsoft.IdentityModel.JsonWebTokens" />


### PR DESCRIPTION
## Problem

NuGet audit reports NU1903 for `Microsoft.Kiota.Abstractions` < 1.22.0 ([GHSA-7j59-v9qr-6fq9](https://github.com/advisories/GHSA-7j59-v9qr-6fq9)) — the Kiota `RedirectHandler` leaks `Cookie` and `Proxy-Authorization` headers on cross-host redirects.

The vulnerability is pulled in transitively via `Microsoft.Graph` → `Microsoft.Graph.Core` 3.2.5 → `Microsoft.Kiota.Abstractions` 1.17.1.

## Fix

- **`Microsoft.Graph`**: 5.94.0 → 5.105.0
- **`Microsoft.Graph.Core`**: added at 3.2.6 (requires `Kiota.Abstractions` ≥ 1.22.1)
- **`Microsoft.Kiota.Abstractions`**: added at 1.22.2
- **`Microsoft.IdentityModel.JsonWebTokens`**: 8.15.0 → 8.16.0 (required by Graph.Core 3.2.6)
- **`System.IdentityModel.Tokens.Jwt`**: 8.15.0 → 8.16.0 (required by Graph.Core 3.2.6)
- Added direct `Microsoft.Graph.Core` `PackageReference` in `Plugins.MsGraph.csproj` to pin the transitive version

## Verification

All three affected projects report no vulnerable packages after the change:
- `Plugins.MsGraph`
- `Concepts`
- `Plugins.UnitTests`