### PR TITLE
.Net: docs: rebrand Azure Cosmos DB for MongoDB vCore -> Azure DocumentDB

### DIFF
--- a/dotnet/src/VectorData/CosmosMongoDB/CosmosMongoCollection.cs
+++ b/dotnet/src/VectorData/CosmosMongoDB/CosmosMongoCollection.cs
@@ -22,7 +22,7 @@ using MEVD = Microsoft.Extensions.VectorData;
 namespace Microsoft.SemanticKernel.Connectors.CosmosMongoDB;
 
 /// <summary>
-/// Service for storing and retrieving vector records, that uses Azure CosmosDB MongoDB as the underlying storage.
+/// Service for storing and retrieving vector records, that uses Azure DocumentDB (with MongoDB compatibility) as the underlying storage.
 /// </summary>
 /// <typeparam name="TKey">The data type of the record key. Must be either <see cref="string"/>.</typeparam>
 /// <typeparam name="TRecord">The data model to use for adding, updating and retrieving data from storage.</typeparam>
@@ -44,10 +44,10 @@ public class CosmosMongoCollection<TKey, TRecord> : VectorStoreCollection<TKey, 
     /// <summary>The default options for vector search.</summary>
     private static readonly MEVD.VectorSearchOptions<TRecord> s_defaultVectorSearchOptions = new();
 
-    /// <summary><see cref="IMongoDatabase"/> that can be used to manage the collections in Azure CosmosDB MongoDB.</summary>
+    /// <summary><see cref="IMongoDatabase"/> that can be used to manage the collections in Azure DocumentDB.</summary>
     private readonly IMongoDatabase _mongoDatabase;
 
-    /// <summary>Azure CosmosDB MongoDB collection to perform record operations.</summary>
+    /// <summary>Azure DocumentDB collection to perform record operations.</summary>
     private readonly IMongoCollection<BsonDocument> _mongoCollection;
 
     /// <summary>Interface for mapping between a storage model, and the consumer record data model.</summary>
@@ -76,7 +76,7 @@ public class CosmosMongoCollection<TKey, TRecord> : VectorStoreCollection<TKey, 
     /// <summary>
     /// Initializes a new instance of the <see cref="CosmosMongoCollection{TKey, TRecord}"/> class.
     /// </summary>
-    /// <param name="mongoDatabase"><see cref="IMongoDatabase"/> that can be used to manage the collections in Azure CosmosDB MongoDB.</param>
+    /// <param name="mongoDatabase"><see cref="IMongoDatabase"/> that can be used to manage the collections in Azure DocumentDB.</param>
     /// <param name="name">The name of the collection that this <see cref="CosmosMongoCollection{TKey, TRecord}"/> will access.</param>
     /// <param name="options">Optional configuration options for this class.</param>
     [RequiresDynamicCode("This constructor is incompatible with NativeAOT. For dynamic mapping via Dictionary<string, object?>, instantiate CosmosMongoDynamicCollection instead.")]
@@ -397,7 +397,7 @@ public class CosmosMongoCollection<TKey, TRecord> : VectorStoreCollection<TKey, 
                 itemsAmount,
                 filter),
             _ => throw new InvalidOperationException(
-                $"Index kind '{vectorProperty.IndexKind}' on {nameof(VectorStoreVectorProperty)} '{vectorProperty.StorageName}' is not supported by the Azure CosmosDB for MongoDB VectorStore. " +
+                $"Index kind '{vectorProperty.IndexKind}' on {nameof(VectorStoreVectorProperty)} '{vectorProperty.StorageName}' is not supported by the Azure DocumentDB VectorStore. " +
                 $"Supported index kinds are: {string.Join(", ", [IndexKind.Hnsw, IndexKind.IvfFlat])}")
         };
 

--- a/dotnet/src/VectorData/CosmosMongoDB/CosmosMongoCollectionCreateMapping.cs
+++ b/dotnet/src/VectorData/CosmosMongoDB/CosmosMongoCollectionCreateMapping.cs
@@ -105,7 +105,7 @@ internal static class CosmosMongoCollectionCreateMapping
     }
 
     /// <summary>
-    /// More information about Azure DocumentDB index kinds here: <see href="https://learn.microsoft.com/azure/documentdb/" />.
+    /// More information about Azure DocumentDB index kinds here: <see href="https://learn.microsoft.com/en-us/azure/documentdb/vector-search" />.
     /// </summary>
     private static string GetIndexKind(string? indexKind, string vectorPropertyName)
         => CosmosMongoCollectionSearchMapping.GetVectorPropertyIndexKind(indexKind) switch

--- a/dotnet/src/VectorData/CosmosMongoDB/CosmosMongoCollectionCreateMapping.cs
+++ b/dotnet/src/VectorData/CosmosMongoDB/CosmosMongoCollectionCreateMapping.cs
@@ -9,7 +9,7 @@ using MongoDB.Bson;
 namespace Microsoft.SemanticKernel.Connectors.CosmosMongoDB;
 
 /// <summary>
-/// Contains mapping helpers to use when creating a collection in Azure CosmosDB MongoDB.
+/// Contains mapping helpers to use when creating a collection in Azure DocumentDB (with MongoDB compatibility).
 /// </summary>
 internal static class CosmosMongoCollectionCreateMapping
 {
@@ -105,18 +105,18 @@ internal static class CosmosMongoCollectionCreateMapping
     }
 
     /// <summary>
-    /// More information about Azure CosmosDB for MongoDB index kinds here: <see href="https://learn.microsoft.com/en-us/azure/cosmos-db/mongodb/vcore/vector-search" />.
+    /// More information about Azure DocumentDB index kinds here: <see href="https://learn.microsoft.com/azure/documentdb/" />.
     /// </summary>
     private static string GetIndexKind(string? indexKind, string vectorPropertyName)
         => CosmosMongoCollectionSearchMapping.GetVectorPropertyIndexKind(indexKind) switch
         {
             IndexKind.Hnsw => "vector-hnsw",
             IndexKind.IvfFlat => "vector-ivf",
-            _ => throw new NotSupportedException($"Index kind '{indexKind}' on {nameof(VectorStoreVectorProperty)} '{vectorPropertyName}' is not supported by the Azure CosmosDB for MongoDB VectorStore.")
+            _ => throw new NotSupportedException($"Index kind '{indexKind}' on {nameof(VectorStoreVectorProperty)} '{vectorPropertyName}' is not supported by the Azure DocumentDB VectorStore.")
         };
 
     /// <summary>
-    /// More information about Azure CosmosDB for MongoDB distance functions here: <see href="https://learn.microsoft.com/en-us/azure/cosmos-db/mongodb/vcore/vector-search" />.
+    /// More information about Azure DocumentDB distance functions here: <see href="https://learn.microsoft.com/azure/documentdb/" />.
     /// </summary>
     private static string GetDistanceFunction(string? distanceFunction, string vectorPropertyName)
         => CosmosMongoCollectionSearchMapping.GetVectorPropertyDistanceFunction(distanceFunction) switch
@@ -124,6 +124,6 @@ internal static class CosmosMongoCollectionCreateMapping
             DistanceFunction.CosineDistance => "COS",
             DistanceFunction.DotProductSimilarity => "IP",
             DistanceFunction.EuclideanDistance => "L2",
-            _ => throw new NotSupportedException($"Distance function '{distanceFunction}' for {nameof(VectorStoreVectorProperty)} '{vectorPropertyName}' is not supported by the Azure CosmosDB for MongoDB VectorStore.")
+            _ => throw new NotSupportedException($"Distance function '{distanceFunction}' for {nameof(VectorStoreVectorProperty)} '{vectorPropertyName}' is not supported by the Azure DocumentDB VectorStore.")
         };
 }

--- a/dotnet/src/VectorData/CosmosMongoDB/CosmosMongoCollectionSearchMapping.cs
+++ b/dotnet/src/VectorData/CosmosMongoDB/CosmosMongoCollectionSearchMapping.cs
@@ -7,7 +7,7 @@ using MongoDB.Bson;
 namespace Microsoft.SemanticKernel.Connectors.CosmosMongoDB;
 
 /// <summary>
-/// Contains mapping helpers to use when searching for documents using Azure CosmosDB MongoDB.
+/// Contains mapping helpers to use when searching for documents using Azure DocumentDB (with MongoDB compatibility).
 /// </summary>
 internal static class CosmosMongoCollectionSearchMapping
 {

--- a/dotnet/src/VectorData/CosmosMongoDB/CosmosMongoDB.csproj
+++ b/dotnet/src/VectorData/CosmosMongoDB/CosmosMongoDB.csproj
@@ -19,8 +19,8 @@
 
   <PropertyGroup>
     <!-- NuGet Package Settings -->
-    <Title>Azure CosmosDB MongoDB vCore provider for Microsoft.Extensions.VectorData</Title>
-    <Description>Azure CosmosDB MongoDB vCore provider for Microsoft.Extensions.VectorData by Semantic Kernel</Description>
+    <Title>Azure DocumentDB (with MongoDB compatibility) provider for Microsoft.Extensions.VectorData</Title>
+    <Description>Azure DocumentDB (with MongoDB compatibility) provider for Microsoft.Extensions.VectorData by Semantic Kernel</Description>
     <PackageReadmeFile>VECTORDATA-CONNECTORS-NUGET.md</PackageReadmeFile>
   </PropertyGroup>
 

--- a/dotnet/src/VectorData/CosmosMongoDB/CosmosMongoServiceCollectionExtensions.cs
+++ b/dotnet/src/VectorData/CosmosMongoDB/CosmosMongoServiceCollectionExtensions.cs
@@ -12,7 +12,7 @@ using MongoDB.Driver;
 namespace Microsoft.Extensions.DependencyInjection;
 
 /// <summary>
-/// Extension methods to register Azure CosmosDB MongoDB <see cref="VectorStore"/> instances on an <see cref="IServiceCollection"/>.
+/// Extension methods to register Azure DocumentDB (with MongoDB compatibility) <see cref="VectorStore"/> instances on an <see cref="IServiceCollection"/>.
 /// </summary>
 public static class CosmosMongoServiceCollectionExtensions
 {
@@ -86,8 +86,8 @@ public static class CosmosMongoServiceCollectionExtensions
     /// </summary>
     /// <param name="services">The <see cref="IServiceCollection"/> to register the <see cref="CosmosMongoVectorStore"/> on.</param>
     /// <param name="serviceKey">The key with which to associate the vector store.</param>
-    /// <param name="connectionString">Connection string required to connect to Azure CosmosDB MongoDB.</param>
-    /// <param name="databaseName">Database name for Azure CosmosDB MongoDB.</param>
+    /// <param name="connectionString">Connection string required to connect to Azure DocumentDB.</param>
+    /// <param name="databaseName">Database name for Azure DocumentDB.</param>
     /// <param name="options">Optional options to further configure the <see cref="CosmosMongoVectorStore"/>.</param>
     /// <param name="lifetime">The service lifetime for the store. Defaults to <see cref="ServiceLifetime.Singleton"/>.</param>
     /// <returns>Service collection.</returns>
@@ -197,8 +197,8 @@ public static class CosmosMongoServiceCollectionExtensions
     /// <param name="services">The <see cref="IServiceCollection"/> to register the <see cref="CosmosMongoCollection{TKey, TRecord}"/> on.</param>
     /// <param name="serviceKey">The key with which to associate the collection.</param>
     /// <param name="name">The name of the collection.</param>
-    /// <param name="connectionString">Connection string required to connect to Azure CosmosDB MongoDB.</param>
-    /// <param name="databaseName">Database name for Azure CosmosDB MongoDB.</param>
+    /// <param name="connectionString">Connection string required to connect to Azure DocumentDB.</param>
+    /// <param name="databaseName">Database name for Azure DocumentDB.</param>
     /// <param name="options">Optional options to further configure the <see cref="CosmosMongoCollection{TKey, TRecord}"/>.</param>
     /// <param name="lifetime">The service lifetime for the store. Defaults to <see cref="ServiceLifetime.Singleton"/>.</param>
     /// <returns>Service collection.</returns>

--- a/dotnet/src/VectorData/CosmosMongoDB/CosmosMongoVectorStore.cs
+++ b/dotnet/src/VectorData/CosmosMongoDB/CosmosMongoVectorStore.cs
@@ -15,7 +15,7 @@ using MongoDB.Driver;
 namespace Microsoft.SemanticKernel.Connectors.CosmosMongoDB;
 
 /// <summary>
-/// Class for accessing the list of collections in a Azure CosmosDB MongoDB vector store.
+/// Class for accessing the list of collections in an Azure DocumentDB (with MongoDB compatibility) vector store.
 /// </summary>
 /// <remarks>
 /// This class can be used with collections of any schema type, but requires you to provide schema information when getting a collection.
@@ -25,7 +25,7 @@ public sealed class CosmosMongoVectorStore : VectorStore
     /// <summary>Metadata about vector store.</summary>
     private readonly VectorStoreMetadata _metadata;
 
-    /// <summary><see cref="IMongoDatabase"/> that can be used to manage the collections in Azure CosmosDB MongoDB.</summary>
+    /// <summary><see cref="IMongoDatabase"/> that can be used to manage the collections in Azure DocumentDB.</summary>
     private readonly IMongoDatabase _mongoDatabase;
 
     /// <summary>A general purpose definition that can be used to construct a collection when needing to proxy schema agnostic operations.</summary>
@@ -36,7 +36,7 @@ public sealed class CosmosMongoVectorStore : VectorStore
     /// <summary>
     /// Initializes a new instance of the <see cref="CosmosMongoVectorStore"/> class.
     /// </summary>
-    /// <param name="mongoDatabase"><see cref="IMongoDatabase"/> that can be used to manage the collections in Azure CosmosDB MongoDB.</param>
+    /// <param name="mongoDatabase"><see cref="IMongoDatabase"/> that can be used to manage the collections in Azure DocumentDB.</param>
     /// <param name="options">Optional configuration options for this class.</param>
     public CosmosMongoVectorStore(IMongoDatabase mongoDatabase, CosmosMongoVectorStoreOptions? options = default)
     {

--- a/python/semantic_kernel/connectors/memory_stores/azure_cosmosdb/azure_cosmos_db_memory_store.py
+++ b/python/semantic_kernel/connectors/memory_stores/azure_cosmosdb/azure_cosmos_db_memory_store.py
@@ -28,7 +28,7 @@ logger: logging.Logger = logging.getLogger(__name__)
 
 @deprecated("This class will be removed in a future release, use AzureCosmosDBforMongoDBStore and Collection instead.")
 class AzureCosmosDBMemoryStore(MemoryStoreBase):
-    """A memory store that uses AzureCosmosDB for MongoDB vCore.
+    """A memory store that uses Azure DocumentDB (with MongoDB compatibility).
 
     To perform vector similarity search on a fully managed MongoDB compatible database service.
     https://learn.microsoft.com/en-us/azure/cosmos-db/mongodb/vcore/vector-search.

--- a/python/semantic_kernel/connectors/memory_stores/azure_cosmosdb/mongo_vcore_store_api.py
+++ b/python/semantic_kernel/connectors/memory_stores/azure_cosmosdb/mongo_vcore_store_api.py
@@ -25,7 +25,7 @@ else:
 
 @deprecated("This class will be removed in a future release.")
 class MongoStoreApi(AzureCosmosDBStoreApi):
-    """MongoStoreApi class for the Azure Cosmos DB Mongo store."""
+    """MongoStoreApi class for the Azure DocumentDB (with MongoDB compatibility) store."""
 
     database = None
     collection_name: str
@@ -41,7 +41,7 @@ class MongoStoreApi(AzureCosmosDBStoreApi):
 
     """
     Args:
-        collection_name: Name of the collection for the azure cosmos db mongo store
+        collection_name: Name of the collection for the Azure DocumentDB store
         index_name: Index for the collection
         vector_dimensions: Number of dimensions for vector similarity.
             The maximum number of supported dimensions is 2000
@@ -74,7 +74,7 @@ class MongoStoreApi(AzureCosmosDBStoreApi):
                         ef_construction has to be at least 2 * m
        ef_search: The size of the dynamic candidate list for search (40 by default).
                   A higher value provides better recall at  the cost of speed.
-       database: The Mongo Database object of the azure cosmos db mongo store
+       database: The Mongo Database object of the Azure DocumentDB store
     """
 
     def __init__(


### PR DESCRIPTION
## Summary

Microsoft has renamed the managed MongoDB-compatible service from **Azure Cosmos DB for MongoDB vCore** to **Azure DocumentDB (with MongoDB compatibility)**. The wire protocol, connection strings, drivers, and APIs are unchanged.

This PR updates user-visible references to the new product name in the `Microsoft.SemanticKernel.Connectors.CosmosMongoDB` package and the (deprecated) Python `azure_cosmosdb` memory store.

See: https://learn.microsoft.com/azure/documentdb/

## Scope (docs/strings only)

- `CosmosMongoDB.csproj` — NuGet `<Title>` and `<Description>`
- Public XML doc comments on `CosmosMongoVectorStore`, `CosmosMongoCollection`, `CosmosMongoServiceCollectionExtensions`, and the create/search mapping helpers
- User-visible `NotSupportedException` messages thrown for unsupported index kinds / distance functions
- Python docstrings on the deprecated `AzureCosmosDBMemoryStore` and `MongoStoreApi`

## Backward compatibility

All public type names, namespaces, assembly names, and package IDs are **intentionally unchanged**:

- Assembly: `Microsoft.SemanticKernel.Connectors.CosmosMongoDB`
- Namespace: `Microsoft.SemanticKernel.Connectors.CosmosMongoDB`
- Types: `CosmosMongoVectorStore`, `CosmosMongoCollection<TKey, TRecord>`, `CosmosMongoCollectionOptions`, etc.
- Python module path and class names

No source or binary breakage.

## Convention used

- First reference per file: **Azure DocumentDB (with MongoDB compatibility)**
- Subsequent references: **Azure DocumentDB**

## Files changed

- `dotnet/src/VectorData/CosmosMongoDB/CosmosMongoDB.csproj`
- `dotnet/src/VectorData/CosmosMongoDB/CosmosMongoVectorStore.cs`
- `dotnet/src/VectorData/CosmosMongoDB/CosmosMongoCollection.cs`
- `dotnet/src/VectorData/CosmosMongoDB/CosmosMongoCollectionCreateMapping.cs`
- `dotnet/src/VectorData/CosmosMongoDB/CosmosMongoCollectionSearchMapping.cs`
- `dotnet/src/VectorData/CosmosMongoDB/CosmosMongoServiceCollectionExtensions.cs`
- `python/semantic_kernel/connectors/memory_stores/azure_cosmosdb/azure_cosmos_db_memory_store.py`
- `python/semantic_kernel/connectors/memory_stores/azure_cosmosdb/mongo_vcore_store_api.py`
