### PR TITLE
Python: fix(redis): wrap IndexDefinition prefix in list; use _get_redis_key in JSON delete

### DIFF
--- a/python/semantic_kernel/connectors/redis.py
+++ b/python/semantic_kernel/connectors/redis.py
@@ -278,7 +278,7 @@ class RedisCollection(
             raise VectorStoreOperationException("Invalid index type supplied.")
         fields = _definition_to_redis_fields(self.definition, self.collection_type)
         index_definition = IndexDefinition(
-            prefix=f"{self.collection_name}:", index_type=INDEX_TYPE_MAP[self.collection_type]
+            prefix=[f"{self.collection_name}:"], index_type=INDEX_TYPE_MAP[self.collection_type]
         )
         await self.redis_database.ft(self.collection_name).create_index(fields, definition=index_definition, **kwargs)
 
@@ -706,7 +706,7 @@ class RedisJsonCollection(RedisCollection[TKey, TModel], Generic[TKey, TModel]):
 
     @override
     async def _inner_delete(self, keys: Sequence[str], **kwargs: Any) -> None:
-        await asyncio.gather(*[self.redis_database.json().delete(key, **kwargs) for key in keys])
+        await asyncio.gather(*[self.redis_database.json().delete(self._get_redis_key(key), **kwargs) for key in keys])
 
     @override
     def _serialize_dicts_to_store_models(

--- a/python/semantic_kernel/connectors/redis.py
+++ b/python/semantic_kernel/connectors/redis.py
@@ -277,9 +277,12 @@ class RedisCollection(
                 return
             raise VectorStoreOperationException("Invalid index type supplied.")
         fields = _definition_to_redis_fields(self.definition, self.collection_type)
-        index_definition = IndexDefinition(
-            prefix=[f"{self.collection_name}:"], index_type=INDEX_TYPE_MAP[self.collection_type]
-        )
+        if self.prefix_collection_name_to_key_names:
+            index_definition = IndexDefinition(
+                prefix=[f"{self.collection_name}:"], index_type=INDEX_TYPE_MAP[self.collection_type]
+            )
+        else:
+            index_definition = IndexDefinition(index_type=INDEX_TYPE_MAP[self.collection_type])
         await self.redis_database.ft(self.collection_name).create_index(fields, definition=index_definition, **kwargs)
 
     @override

--- a/python/tests/unit/connectors/memory/test_redis_store.py
+++ b/python/tests/unit/connectors/memory/test_redis_store.py
@@ -306,3 +306,28 @@ async def test_create_index_manual(collection_hash, mock_ensure_collection_exist
 async def test_create_index_fail(collection_hash, mock_ensure_collection_exists):
     with raises(VectorStoreOperationException, match="Invalid index type supplied."):
         await collection_hash.ensure_collection_exists(index_definition="index_definition", fields="fields")
+
+
+async def test_create_index_respects_prefix_flag(
+    collection_hash, collection_with_prefix_hash, mock_ensure_collection_exists
+):
+    from redis.commands.search.index_definition import IndexDefinition
+
+    # Without prefix flag: IndexDefinition should NOT contain the collection prefix
+    await collection_hash.ensure_collection_exists()
+    index_def = mock_ensure_collection_exists.call_args.kwargs["definition"]
+    assert isinstance(index_def, IndexDefinition)
+    assert "test:" not in index_def.args
+
+    mock_ensure_collection_exists.reset_mock()
+
+    # With prefix flag: IndexDefinition should include ["test:"] as prefix
+    await collection_with_prefix_hash.ensure_collection_exists()
+    index_def = mock_ensure_collection_exists.call_args.kwargs["definition"]
+    assert isinstance(index_def, IndexDefinition)
+    assert "test:" in index_def.args
+
+
+async def test_delete_json_with_prefix(collection_with_prefix_json, mock_delete_json):
+    await collection_with_prefix_json._inner_delete(["id1"])
+    mock_delete_json.assert_called_once_with("test:id1")


### PR DESCRIPTION
## Summary

Two bugs in `python/semantic_kernel/connectors/redis.py`:

### Bug 1 — `IndexDefinition` prefix iterates character-by-character (fixes #13894)

`ensure_collection_exists` passed a bare `str` as the `prefix` argument:

```python
# before
index_definition = IndexDefinition(
    prefix=f"{self.collection_name}:", index_type=...
)
```

`redis-py`'s `IndexDefinition` accepts an iterable of prefixes. When passed a plain string it iterates character by character, generating a `PREFIX N c o l l e c t i o n ...` clause instead of `PREFIX 1 collection_name:`. This causes the index to match nothing (or incorrectly).

```python
# after
index_definition = IndexDefinition(
    prefix=[f"{self.collection_name}:"], index_type=...
)
```

### Bug 2 — `RedisJsonCollection._inner_delete` silently no-ops (fixes #13904)

`_inner_delete` passed the raw caller key to `json().delete()`:

```python
# before
async def _inner_delete(self, keys: Sequence[str], **kwargs: Any) -> None:
    await asyncio.gather(*[self.redis_database.json().delete(key, **kwargs) for key in keys])
```

But `_single_upsert` stores keys as `{collection_name}:{key}` (via `_get_redis_key`). The delete always targeted a non-existent key and returned 0 without raising. `RedisHashsetCollection._inner_delete` already uses `_get_redis_key` correctly.

```python
# after
async def _inner_delete(self, keys: Sequence[str], **kwargs: Any) -> None:
    await asyncio.gather(*[self.redis_database.json().delete(self._get_redis_key(key), **kwargs) for key in keys])
```

## Testing

Both fixes are straightforward and can be verified with a live Redis instance by:
1. Creating a `RedisJsonCollection`, upserting a record, then deleting it and confirming it's gone.
2. Checking `FT.INFO <collection_name>` to confirm the `PREFIX` clause is `1 <collection_name>:` after `ensure_collection_exists`.
