### PR TITLE
.Net: Version bump 1.76.0

### DIFF
--- a/dotnet/nuget/nuget-package.props
+++ b/dotnet/nuget/nuget-package.props
@@ -1,7 +1,7 @@
 <Project>
   <PropertyGroup>
     <!-- Central version prefix - applies to all nuget packages. -->
-    <VersionPrefix>1.75.0</VersionPrefix>
+    <VersionPrefix>1.76.0</VersionPrefix>
     <PackageVersion Condition="'$(VersionSuffix)' != ''">$(VersionPrefix)-$(VersionSuffix)</PackageVersion>
     <PackageVersion Condition="'$(VersionSuffix)' == ''">$(VersionPrefix)</PackageVersion>
 
@@ -9,7 +9,7 @@
     <IsPackable>true</IsPackable>
 
     <!-- Package validation. Baseline Version should be the latest version available on NuGet. -->
-    <PackageValidationBaselineVersion>1.74.0</PackageValidationBaselineVersion>
+    <PackageValidationBaselineVersion>1.75.0</PackageValidationBaselineVersion>
     <!-- Validate assembly attributes only for Publish builds -->
     <NoWarn Condition="'$(Configuration)' != 'Publish'">$(NoWarn);CP0003</NoWarn>
     <!-- Do not validate reference assemblies -->


### PR DESCRIPTION
### Motivation and Context

Bump SK .NET version for the next release.

### Description

- VersionPrefix: 1.75.0  1.76.0
- PackageValidationBaselineVersion: 1.74.0  1.75.0