### PR TITLE
.Net: Pin SharpCompress 0.48.0 to fix GHSA-6c8g-7p36-r338

### DIFF
--- a/dotnet/Directory.Packages.props
+++ b/dotnet/Directory.Packages.props
@@ -172,6 +172,7 @@
     <PackageVersion Include="DuckDB.NET.Data.Full" Version="1.2.0" />
     <PackageVersion Include="DuckDB.NET.Data" Version="1.1.3" />
     <PackageVersion Include="MongoDB.Driver" Version="3.5.2" />
+    <PackageVersion Include="SharpCompress" Version="0.48.0" /><!-- Vulnerability fix: GHSA-6c8g-7p36-r338; transitively pinned via MongoDB.Driver -->
     <PackageVersion Include="Snappier" Version="1.3.1" /><!-- Vulnerability fix: GHSA-pggp-6c3x-2xmx; transitively pinned via MongoDB.Driver -->
     <PackageVersion Include="Microsoft.Graph" Version="5.105.0" />
     <PackageVersion Include="Microsoft.Graph.Core" Version="3.2.6" />

--- a/dotnet/src/VectorData/CosmosMongoDB/CosmosMongoDB.csproj
+++ b/dotnet/src/VectorData/CosmosMongoDB/CosmosMongoDB.csproj
@@ -30,6 +30,7 @@
 
   <ItemGroup>
     <PackageReference Include="MongoDB.Driver" />
+    <PackageReference Include="SharpCompress" /><!-- Pin to patched version; overrides transitive 0.30.1 from MongoDB.Driver (GHSA-6c8g-7p36-r338) -->
     <PackageReference Include="Snappier" /><!-- Pin to patched version; overrides transitive 1.0.0 from MongoDB.Driver (GHSA-pggp-6c3x-2xmx) -->
   </ItemGroup>
 

--- a/dotnet/src/VectorData/MongoDB/MongoDB.csproj
+++ b/dotnet/src/VectorData/MongoDB/MongoDB.csproj
@@ -30,6 +30,7 @@
 
   <ItemGroup>
     <PackageReference Include="MongoDB.Driver" />
+    <PackageReference Include="SharpCompress" /><!-- Pin to patched version; overrides transitive 0.30.1 from MongoDB.Driver (GHSA-6c8g-7p36-r338) -->
     <PackageReference Include="Snappier" /><!-- Pin to patched version; overrides transitive 1.0.0 from MongoDB.Driver (GHSA-pggp-6c3x-2xmx) -->
   </ItemGroup>
 


### PR DESCRIPTION
## Summary

Fixes a moderate-severity transitive vulnerability flagged by `dotnet list package --vulnerable --include-transitive` across 10 projects in the solution.

| Package | Current (resolved) | Pinned | Severity | Advisory |
|---|---|---|---|---|
| SharpCompress | 0.30.1 | 0.48.0 | Moderate | [GHSA-6c8g-7p36-r338](https://github.com/advisories/GHSA-6c8g-7p36-r338) |

## Why a transitive pin

`SharpCompress` is pulled in transitively via `MongoDB.Driver 3.5.2`:

`MongoDB.Driver (v3.5.2) -> SharpCompress (v0.30.1)`

The latest `MongoDB.Driver` (3.8.0) still declares `SharpCompress (>= 0.30.1)` as a floor, so a minor bump of `MongoDB.Driver` does not lift the resolved `SharpCompress` version. There is no transitive update path through the direct dependency.

The advisory's vulnerable range is `<= 0.47.4`, so `0.48.0` is the smallest non-vulnerable release. `1.0.0` was rejected as it is a major-version jump.

## Changes

This mirrors the existing `Snappier` vulnerability pin pattern already in the repo (same file locations, same comment style):

1. `dotnet/Directory.Packages.props` -- add `PackageVersion` for `SharpCompress 0.48.0` next to the `MongoDB.Driver` / `Snappier` entries with a vulnerability comment.
2. `dotnet/src/VectorData/MongoDB/MongoDB.csproj` -- add direct `PackageReference Include="SharpCompress"` to override the transitive resolution.
3. `dotnet/src/VectorData/CosmosMongoDB/CosmosMongoDB.csproj` -- same.

The pin in the two `Connectors.*` source projects propagates the override to all downstream consumers (samples, integration tests, conformance tests, unit tests).

## Verification

| Check | Scope | Result |
|---|---|---|
| `dotnet list SK-dotnet.slnx package --vulnerable --include-transitive` | Full solution (155 projects) | All clean (was 10 projects flagging) |
| `dotnet build --warnaserror` | `MongoDB.csproj` | Pass |
| `dotnet build --warnaserror` | `CosmosMongoDB.csproj` | Pass |
| `dotnet format --verify-no-changes` (CI-parity Docker `mcr.microsoft.com/dotnet/sdk:10.0`) | Both csproj | Pass (Formatted 0 of N files) |
| `dotnet test` | `MongoDB.UnitTests` | 37/37 passed |
| `dotnet test` | `CosmosMongoDB.UnitTests` | 28/28 passed |

Conformance test projects skipped (require live emulators, pre-existing env-dependent suites, not impacted by a transitive pin).
