### PR TITLE
.Net: fix function enum argument deserialization

### DIFF
--- a/dotnet/src/InternalUtilities/src/Schema/KernelJsonSchemaBuilder.cs
+++ b/dotnet/src/InternalUtilities/src/Schema/KernelJsonSchemaBuilder.cs
@@ -28,7 +28,7 @@ internal static class KernelJsonSchemaBuilder
 
     [RequiresUnreferencedCode("Uses JsonStringEnumConverter and DefaultJsonTypeInfoResolver classes, making it incompatible with AOT scenarios.")]
     [RequiresDynamicCode("Uses JsonStringEnumConverter and DefaultJsonTypeInfoResolver classes, making it incompatible with AOT scenarios.")]
-    internal static JsonSerializerOptions GetDefaultOptionsForSerialization() => GetDefaultOptions();
+    internal static JsonSerializerOptions GetDefaultJsonSerializerOptions() => GetDefaultOptions();
 
     private static readonly JsonElement s_trueSchemaAsObject = JsonElement.Parse("{}");
     private static readonly JsonElement s_falseSchemaAsObject = JsonElement.Parse("""{"not":true}""");

--- a/dotnet/src/InternalUtilities/src/Schema/KernelJsonSchemaBuilder.cs
+++ b/dotnet/src/InternalUtilities/src/Schema/KernelJsonSchemaBuilder.cs
@@ -26,6 +26,10 @@ internal static class KernelJsonSchemaBuilder
     private static JsonSerializerOptions? s_options;
     internal static readonly AIJsonSchemaCreateOptions s_schemaOptions = new();
 
+    [RequiresUnreferencedCode("Uses JsonStringEnumConverter and DefaultJsonTypeInfoResolver classes, making it incompatible with AOT scenarios.")]
+    [RequiresDynamicCode("Uses JsonStringEnumConverter and DefaultJsonTypeInfoResolver classes, making it incompatible with AOT scenarios.")]
+    internal static JsonSerializerOptions GetDefaultOptionsForSerialization() => GetDefaultOptions();
+
     private static readonly JsonElement s_trueSchemaAsObject = JsonElement.Parse("{}");
     private static readonly JsonElement s_falseSchemaAsObject = JsonElement.Parse("""{"not":true}""");
 

--- a/dotnet/src/SemanticKernel.Core/Functions/KernelFunctionFromMethod.cs
+++ b/dotnet/src/SemanticKernel.Core/Functions/KernelFunctionFromMethod.cs
@@ -789,7 +789,7 @@ internal sealed partial class KernelFunctionFromMethod : KernelFunction
     {
         try
         {
-            JsonSerializerOptions effectiveOptions = jsonSerializerOptions ?? KernelJsonSchemaBuilder.GetDefaultOptionsForSerialization();
+            JsonSerializerOptions effectiveOptions = jsonSerializerOptions ?? KernelJsonSchemaBuilder.GetDefaultJsonSerializerOptions();
 
             deserializedValue = value switch
             {

--- a/dotnet/src/SemanticKernel.Core/Functions/KernelFunctionFromMethod.cs
+++ b/dotnet/src/SemanticKernel.Core/Functions/KernelFunctionFromMethod.cs
@@ -789,18 +789,20 @@ internal sealed partial class KernelFunctionFromMethod : KernelFunction
     {
         try
         {
+            JsonSerializerOptions effectiveOptions = jsonSerializerOptions ?? KernelJsonSchemaBuilder.GetDefaultOptionsForSerialization();
+
             deserializedValue = value switch
             {
-                JsonDocument document => document.Deserialize(targetType, jsonSerializerOptions),
-                JsonNode node => node.Deserialize(targetType, jsonSerializerOptions),
-                JsonElement element => element.Deserialize(targetType, jsonSerializerOptions),
+                JsonDocument document => document.Deserialize(targetType, effectiveOptions),
+                JsonNode node => node.Deserialize(targetType, effectiveOptions),
+                JsonElement element => element.Deserialize(targetType, effectiveOptions),
                 // The JSON can be represented by other data types from various libraries. For example, JObject, JToken, and JValue from the Newtonsoft.Json library.
                 // Since we don't take dependencies on these libraries and don't have access to the types here,
                 // the only way to deserialize those types is to convert them to a string first by calling the 'ToString' method.
                 // Attempting to use the 'JsonSerializer.Serialize' method, instead of calling the 'ToString' directly on those types, can lead to unpredictable outcomes.
                 // For instance, the JObject for { "id": 28 } JSON is serialized into the string  "{ "Id": [] }", and the deserialization fails with the
                 // following exception - "The JSON value could not be converted to System.Int32. Path: $.Id | LineNumber: 0 | BytePositionInLine: 7."
-                _ => JsonSerializer.Deserialize(value.ToString()!, targetType, jsonSerializerOptions)
+                _ => JsonSerializer.Deserialize(value.ToString()!, targetType, effectiveOptions)
             };
 
             return true;

--- a/dotnet/src/SemanticKernel.UnitTests/Functions/KernelFunctionFromMethodTests1.cs
+++ b/dotnet/src/SemanticKernel.UnitTests/Functions/KernelFunctionFromMethodTests1.cs
@@ -1413,11 +1413,29 @@ public sealed class KernelFunctionFromMethodTests1
         var func = KernelFunctionFactory.CreateFromMethod((CustomTypeForJsonTests param) => { actualArgValue = param; });
 
         // Act
-        var res = await func.InvokeAsync(this._kernel, new() { ["param"] = jsonString });
+        _ = await func.InvokeAsync(this._kernel, new() { ["param"] = jsonString });
 
         // Assert
         Assert.NotNull(actualArgValue);
         Assert.Equal(28, actualArgValue.Id);
+    }
+
+    [Fact]
+    public async Task ItCanDeserializeStringEnumsWithDefaultJsonOptionsAsync()
+    {
+        // Arrange
+        var jsonString = @"[{""unit"":""hours""}]";
+        Reminder[]? actualArgValue = null;
+
+        var func = KernelFunctionFactory.CreateFromMethod((Reminder[] param) => { actualArgValue = param; });
+
+        // Act
+        var res = await func.InvokeAsync(this._kernel, new() { ["param"] = jsonString });
+
+        // Assert
+        Assert.NotNull(actualArgValue);
+        Assert.Single(actualArgValue);
+        Assert.Equal(ReminderUnit.Hours, actualArgValue[0].Unit);
     }
 
     [Fact]
@@ -1584,6 +1602,19 @@ public sealed class KernelFunctionFromMethodTests1
     {
         [JsonPropertyName("id")]
         public int Id { get; set; }
+    }
+
+    private sealed class Reminder
+    {
+        [JsonPropertyName("unit")]
+        public ReminderUnit Unit { get; set; }
+    }
+
+    private enum ReminderUnit
+    {
+        Minutes,
+        Hours,
+        Days
     }
 
     private sealed class ThirdPartyJsonPrimitive(string jsonToReturn)

--- a/dotnet/src/SemanticKernel.UnitTests/Functions/KernelFunctionFromMethodTests1.cs
+++ b/dotnet/src/SemanticKernel.UnitTests/Functions/KernelFunctionFromMethodTests1.cs
@@ -1430,7 +1430,7 @@ public sealed class KernelFunctionFromMethodTests1
         var func = KernelFunctionFactory.CreateFromMethod((Reminder[] param) => { actualArgValue = param; });
 
         // Act
-        var res = await func.InvokeAsync(this._kernel, new() { ["param"] = jsonString });
+        _ = await func.InvokeAsync(this._kernel, new() { ["param"] = jsonString });
 
         // Assert
         Assert.NotNull(actualArgValue);


### PR DESCRIPTION
﻿## Summary

Fixes #13589.

`KernelJsonSchemaBuilder` builds function parameter schemas with the default schema options, including string enum handling. When a tool call comes back as JSON and no custom `JsonSerializerOptions` are supplied, `KernelFunctionFromMethod.TryToDeserializeValue` was using plain `System.Text.Json` defaults instead, so nested enum values like `"hours"` failed to bind.

This patch reuses the schema builder's default options as the fallback for argument deserialization, while preserving caller-provided serializer options when they exist.

I also checked the previous PR for this issue (#13623). It was closed by the author due inactivity rather than rejected, so this is a fresh patch with a smaller test surface.

## Validation

```text
dotnet test dotnet\src\SemanticKernel.UnitTests\SemanticKernel.UnitTests.csproj --framework net10.0 --filter "FullyQualifiedName~KernelFunctionFromMethodTests1" --no-restore --logger "console;verbosity=minimal"
# passed: 75

dotnet format dotnet\src\SemanticKernel.UnitTests\SemanticKernel.UnitTests.csproj --include dotnet/src/InternalUtilities/src/Schema/KernelJsonSchemaBuilder.cs dotnet/src/SemanticKernel.Core/Functions/KernelFunctionFromMethod.cs dotnet/src/SemanticKernel.UnitTests/Functions/KernelFunctionFromMethodTests1.cs --verify-no-changes --no-restore

git diff --check
```
