### PR TITLE
.Net: fix: count text chunker orphan glue by tokens

### DIFF
--- a/dotnet/src/SemanticKernel.Core/Text/TextChunker.cs
+++ b/dotnet/src/SemanticKernel.Core/Text/TextChunker.cs
@@ -195,15 +195,11 @@ public static class TextChunker
                 var lastParagraphTokens = lastParagraph.Split(s_spaceChar, StringSplitOptions.RemoveEmptyEntries);
                 var secondLastParagraphTokens = secondLastParagraph.Split(s_spaceChar, StringSplitOptions.RemoveEmptyEntries);
 
-                var lastParagraphTokensCount = lastParagraphTokens.Length;
-                var secondLastParagraphTokensCount = secondLastParagraphTokens.Length;
+                var combinedParagraph = string.Join(" ", secondLastParagraphTokens.Concat(lastParagraphTokens));
 
-                if (lastParagraphTokensCount + secondLastParagraphTokensCount <= adjustedMaxTokensPerParagraph)
+                if (GetTokenCount(combinedParagraph, tokenCounter) <= adjustedMaxTokensPerParagraph)
                 {
-                    var newSecondLastParagraph = string.Join(" ", secondLastParagraphTokens);
-                    var newLastParagraph = string.Join(" ", lastParagraphTokens);
-
-                    paragraphs[paragraphs.Count - 2] = $"{newSecondLastParagraph} {newLastParagraph}";
+                    paragraphs[paragraphs.Count - 2] = combinedParagraph;
                     paragraphs.RemoveAt(paragraphs.Count - 1);
                 }
             }

--- a/dotnet/src/SemanticKernel.UnitTests/Text/TextChunkerTests.cs
+++ b/dotnet/src/SemanticKernel.UnitTests/Text/TextChunkerTests.cs
@@ -819,4 +819,15 @@ public sealed class TextChunkerTests
         Assert.Contains("Second line", combined);
         Assert.Contains("Third line", combined);
     }
+
+    [Fact]
+    public void SplitPlainTextParagraphsDoesNotGlueLastParagraphPastTokenLimit()
+    {
+        var lines = new[] { new string('a', 14), "bbb" };
+
+        var result = TextChunker.SplitPlainTextParagraphs(lines, 16, tokenCounter: input => input.Length);
+
+        Assert.Equal(2, result.Count);
+        Assert.All(result, paragraph => Assert.True(paragraph.Length <= 16));
+    }
 }


### PR DESCRIPTION
﻿## Summary
- use the configured token counter when deciding whether to glue the final short paragraph into the previous one
- keep the existing whitespace normalization behavior for glued orphan paragraphs
- add a regression test where word-count based gluing would exceed the requested token limit

Fixes #13713.

## To verify
- `dotnet test .\src\SemanticKernel.UnitTests\SemanticKernel.UnitTests.csproj -f net10.0 --filter "FullyQualifiedName~SplitPlainTextParagraphsDoesNotGlueLastParagraphPastTokenLimit"`
- `dotnet test .\src\SemanticKernel.UnitTests\SemanticKernel.UnitTests.csproj -f net10.0 --filter "FullyQualifiedName~TextChunkerTests" --no-restore`
- `dotnet build .\src\SemanticKernel.Core\SemanticKernel.Core.csproj -f net10.0 --no-restore`
- `dotnet format .\src\SemanticKernel.Core\SemanticKernel.Core.csproj --verify-no-changes --no-restore`
- `dotnet format .\src\SemanticKernel.UnitTests\SemanticKernel.UnitTests.csproj --verify-no-changes --no-restore`
