### PR TITLE
.Net: Fix TextChunker orphan chunk token counting

### DIFF
--- a/dotnet/src/SemanticKernel.Core/Text/TextChunker.cs
+++ b/dotnet/src/SemanticKernel.Core/Text/TextChunker.cs
@@ -51,7 +51,6 @@ public static class TextChunker
     /// <returns>The number of tokens in the input string.</returns>
     public delegate int TokenCounter(string input);
 
-    private static readonly char[] s_spaceChar = [' '];
     private static readonly string?[] s_plaintextSplitOptions = ["\n", ".。．", "?!", ";", ":", ",，、", ")]}", " ", "-", null];
     private static readonly string?[] s_markdownSplitOptions = [".\u3002\uFF0E", "?!", ";", ":", ",\uFF0C\u3001", ")]}", " ", "-", "\n\r", null];
 
@@ -192,18 +191,11 @@ public static class TextChunker
 
             if (GetTokenCount(lastParagraph, tokenCounter) < adjustedMaxTokensPerParagraph / 4)
             {
-                var lastParagraphTokens = lastParagraph.Split(s_spaceChar, StringSplitOptions.RemoveEmptyEntries);
-                var secondLastParagraphTokens = secondLastParagraph.Split(s_spaceChar, StringSplitOptions.RemoveEmptyEntries);
+                var mergedParagraph = $"{secondLastParagraph} {lastParagraph}";
 
-                var lastParagraphTokensCount = lastParagraphTokens.Length;
-                var secondLastParagraphTokensCount = secondLastParagraphTokens.Length;
-
-                if (lastParagraphTokensCount + secondLastParagraphTokensCount <= adjustedMaxTokensPerParagraph)
+                if (GetTokenCount(mergedParagraph, tokenCounter) <= adjustedMaxTokensPerParagraph)
                 {
-                    var newSecondLastParagraph = string.Join(" ", secondLastParagraphTokens);
-                    var newLastParagraph = string.Join(" ", lastParagraphTokens);
-
-                    paragraphs[paragraphs.Count - 2] = $"{newSecondLastParagraph} {newLastParagraph}";
+                    paragraphs[paragraphs.Count - 2] = mergedParagraph;
                     paragraphs.RemoveAt(paragraphs.Count - 1);
                 }
             }

--- a/dotnet/src/SemanticKernel.UnitTests/Text/TextChunkerTests.cs
+++ b/dotnet/src/SemanticKernel.UnitTests/Text/TextChunkerTests.cs
@@ -819,4 +819,19 @@ public sealed class TextChunkerTests
         Assert.Contains("Second line", combined);
         Assert.Contains("Third line", combined);
     }
+
+    [Fact]
+    public void SplitPlainTextParagraphsDoesNotMergeOrphanChunkBeyondTokenLimit()
+    {
+        var lines = new[]
+        {
+            new string('a', 45),
+            new string('b', 10),
+        };
+
+        var result = TextChunker.SplitPlainTextParagraphs(lines, 52, tokenCounter: input => input.Length);
+
+        Assert.Equal(2, result.Count);
+        Assert.All(result, paragraph => Assert.True(paragraph.Length <= 52));
+    }
 }


### PR DESCRIPTION
### Motivation and Context

Fixes #13713.

`TextChunker.ProcessParagraphs` used word counts when deciding whether to glue a small final/orphan paragraph back into the previous paragraph. With a custom token counter, that could merge two paragraphs whose actual token count exceeds `maxTokensPerParagraph`, producing an oversized final chunk.

### Description

This changes the orphan merge check to build the candidate merged paragraph and evaluate it with `GetTokenCount(...)`, so the same token-counting logic controls both splitting and final orphan gluing. It also adds a regression test using a custom length-based token counter where the previous word-count check would have produced an oversized merged chunk.

### Contribution Checklist

- [ ] The code builds clean without any errors or warnings
- [ ] The PR follows the [SK Contribution Guidelines](https://github.com/microsoft/semantic-kernel/blob/main/CONTRIBUTING.md) and the [pre-submission formatting script](https://github.com/microsoft/semantic-kernel/blob/main/CONTRIBUTING.md#development-scripts) raises no violations
- [ ] All unit tests pass, and I have added new tests where possible
- [x] I didn't break anyone :)

Local verification: `git diff --check` passes. I could not run `dotnet test dotnet/src/SemanticKernel.UnitTests/SemanticKernel.UnitTests.csproj --filter FullyQualifiedName~TextChunkerTests --no-restore` because this environment does not have the `dotnet` CLI installed.
