### PR TITLE
.Net: Fix TextChunker token-counted paragraph merge

### DIFF
--- a/dotnet/src/SemanticKernel.Core/Text/TextChunker.cs
+++ b/dotnet/src/SemanticKernel.Core/Text/TextChunker.cs
@@ -202,9 +202,13 @@ public static class TextChunker
                 {
                     var newSecondLastParagraph = string.Join(" ", secondLastParagraphTokens);
                     var newLastParagraph = string.Join(" ", lastParagraphTokens);
+                    var mergedParagraph = $"{newSecondLastParagraph} {newLastParagraph}";
 
-                    paragraphs[paragraphs.Count - 2] = $"{newSecondLastParagraph} {newLastParagraph}";
-                    paragraphs.RemoveAt(paragraphs.Count - 1);
+                    if (GetTokenCount(mergedParagraph, tokenCounter) <= adjustedMaxTokensPerParagraph)
+                    {
+                        paragraphs[paragraphs.Count - 2] = mergedParagraph;
+                        paragraphs.RemoveAt(paragraphs.Count - 1);
+                    }
                 }
             }
         }

--- a/dotnet/src/SemanticKernel.UnitTests/Text/TextChunkerTests.cs
+++ b/dotnet/src/SemanticKernel.UnitTests/Text/TextChunkerTests.cs
@@ -559,6 +559,45 @@ public sealed class TextChunkerTests
     }
 
     [Fact]
+    public void SplitPlainTextParagraphsWithCustomTokenCounterDoesNotMergePastTokenLimit()
+    {
+        List<string> input =
+        [
+            "abcdefghijklmnopqr",
+            "abc"
+        ];
+
+        var expected = new[]
+        {
+            "abcdefghijklmnopqr",
+            "abc"
+        };
+
+        var result = TextChunker.SplitPlainTextParagraphs(input, 20, tokenCounter: static (input) => input.Length);
+
+        Assert.Equal(expected, result);
+    }
+
+    [Fact]
+    public void SplitPlainTextParagraphsWithCustomTokenCounterStillMergesWhenCandidateFits()
+    {
+        List<string> input =
+        [
+            "abcdefghijklmnop",
+            "abc"
+        ];
+
+        var expected = new[]
+        {
+            "abcdefghijklmnop abc"
+        };
+
+        var result = TextChunker.SplitPlainTextParagraphs(input, 20, tokenCounter: static (input) => input.Length);
+
+        Assert.Equal(expected, result);
+    }
+
+    [Fact]
     public void CanSplitTextParagraphsWithOverlapAndCustomTokenCounter()
     {
         List<string> input =


### PR DESCRIPTION
Fixes #13713.

## Summary

- Validate the final short-paragraph merge candidate with the configured `TokenCounter`
- Preserve the existing merge behavior when the candidate fits under the paragraph token budget
- Add custom-token-counter regressions for the over-limit and still-fits cases

## Verification

Using local .NET SDK `10.0.100` installed under `/tmp/dotnet`:

- `PATH=/tmp/dotnet:$PATH DOTNET_ROOT=/tmp/dotnet DOTNET_CLI_TELEMETRY_OPTOUT=1 dotnet test dotnet/src/SemanticKernel.UnitTests/SemanticKernel.UnitTests.csproj --filter TextChunkerTests` -> 41 passed
- reviewer pass: same focused TextChunker test command -> 41 passed
- `PATH=/tmp/dotnet:$PATH DOTNET_ROOT=/tmp/dotnet DOTNET_CLI_TELEMETRY_OPTOUT=1 dotnet format dotnet/src/SemanticKernel.UnitTests/SemanticKernel.UnitTests.csproj --include dotnet/src/SemanticKernel.Core/Text/TextChunker.cs dotnet/src/SemanticKernel.UnitTests/Text/TextChunkerTests.cs --verify-no-changes --no-restore`
- `git diff --check`