### PR TITLE
Python: honor reducer auto-reduce in chat completion threads

### DIFF
--- a/python/semantic_kernel/agents/chat_completion/chat_completion_agent.py
+++ b/python/semantic_kernel/agents/chat_completion/chat_completion_agent.py
@@ -89,7 +89,10 @@ class ChatHistoryAgentThread(AgentThread):
             or "thread_id" not in new_message.metadata
             or new_message.metadata["thread_id"] != self._id
         ):
-            self._chat_history.add_message(new_message)
+            if isinstance(self._chat_history, ChatHistoryReducer):
+                await self._chat_history.add_message_async(new_message)
+            else:
+                self._chat_history.add_message(new_message)
 
     async def get_messages(self) -> AsyncIterable[ChatMessageContent]:
         """Retrieve the current chat history.

--- a/python/tests/unit/agents/chat_completion/test_chat_completion_agent.py
+++ b/python/tests/unit/agents/chat_completion/test_chat_completion_agent.py
@@ -164,6 +164,19 @@ def test_initialize_with_reducer_chat_history():
     assert isinstance(thread._chat_history, ChatHistoryTruncationReducer)
 
 
+async def test_thread_with_reducer_auto_reduces_new_messages():
+    reducer = ChatHistoryTruncationReducer(target_count=1, auto_reduce=True)
+    thread = ChatHistoryAgentThread(chat_history=reducer, thread_id="reducer_test_thread")
+
+    await thread.on_new_message(ChatMessageContent(role=AuthorRole.USER, content="first"))
+    await thread.on_new_message(ChatMessageContent(role=AuthorRole.ASSISTANT, content="second"))
+
+    messages = [message async for message in thread.get_messages()]
+
+    assert len(messages) == 1
+    assert messages[0].content == "second"
+
+
 async def test_get_response(kernel_with_ai_service: tuple[Kernel, ChatCompletionClientBase]):
     kernel, _ = kernel_with_ai_service
     agent = ChatCompletionAgent(


### PR DESCRIPTION
### Motivation and Context

Fixes #12303.

`ChatHistoryAgentThread` can be initialized with a `ChatHistoryReducer`, but new thread messages were appended with `add_message()`. That bypasses reducer `add_message_async()` behavior, so reducers configured with `auto_reduce=True` do not reduce history as messages are added through the agent thread.

### Description

- call `add_message_async()` when the thread history is a `ChatHistoryReducer`
- keep the existing synchronous append path for plain `ChatHistory`
- add a regression test proving a truncation reducer with `auto_reduce=True` reduces newly added thread messages

### Contribution Checklist

- [x] The code builds clean without any errors or warnings
- [x] The PR follows the SK Contribution Guidelines
- [x] The code follows the .NET coding conventions and Python coding conventions
- [x] All unit tests pass, and I have added new tests where possible
- [ ] I didn't break anyone :smile:

### Validation

From `python/`:

- `uv run --python 3.12 pytest tests/unit/agents/chat_completion/test_chat_completion_agent.py -q` -> 24 passed
- `uv run --python 3.12 pytest tests/unit/contents/test_chat_history_truncation_reducer.py tests/unit/agents/chat_completion/test_chat_completion_agent.py -q` -> 42 passed
- `uv run ruff check semantic_kernel/agents/chat_completion/chat_completion_agent.py tests/unit/agents/chat_completion/test_chat_completion_agent.py` -> passed
- `git diff --check` -> passed
