### PR TITLE
Python: Fix Postgres filter SQL composition

### DIFF
--- a/python/semantic_kernel/connectors/postgres.py
+++ b/python/semantic_kernel/connectors/postgres.py
@@ -795,9 +795,9 @@ class PostgresCollection(
 
         if where_clauses := self._build_filter(options.filter):  # type: ignore
             query += (
-                sql.SQL("WHERE {clause}").format(clause=sql.SQL(" AND ").join(where_clauses))
+                sql.SQL(" WHERE {clause}").format(clause=sql.SQL(" AND ").join(where_clauses))
                 if isinstance(where_clauses, list)
-                else sql.SQL("WHERE {clause}").format(clause=where_clauses)
+                else sql.SQL(" WHERE {clause}").format(clause=where_clauses)
             )
 
         query += sql.SQL(" ORDER BY {dist_col} LIMIT {limit}").format(
@@ -849,7 +849,7 @@ class PostgresCollection(
         )
 
     @override
-    def _lambda_parser(self, node: ast.AST) -> Any:
+    def _lambda_parser(self, node: ast.AST) -> sql.Composable:
         # Comparison operations
         match node:
             case ast.Compare():
@@ -861,41 +861,41 @@ class PostgresCollection(
                         right = node.comparators[idx]
                         op = node.ops[idx]
                         values.append(self._lambda_parser(ast.Compare(left=left, ops=[op], comparators=[right])))
-                    return f"({' AND '.join(values)})"
+                    return sql.SQL("({})").format(sql.SQL(" AND ").join(values))
                 left = self._lambda_parser(node.left)
                 right = self._lambda_parser(node.comparators[0])
                 op = node.ops[0]
                 match op:
                     case ast.In():
-                        return f"{left} IN {right}"
+                        return sql.SQL("{} IN {}").format(left, right)
                     case ast.NotIn():
-                        return f"{left} NOT IN {right}"
+                        return sql.SQL("{} NOT IN {}").format(left, right)
                     case ast.Eq():
-                        return f"{left} = {right}"
+                        return sql.SQL("{} = {}").format(left, right)
                     case ast.NotEq():
-                        return f"{left} <> {right}"
+                        return sql.SQL("{} <> {}").format(left, right)
                     case ast.Gt():
-                        return f"{left} > {right}"
+                        return sql.SQL("{} > {}").format(left, right)
                     case ast.GtE():
-                        return f"{left} >= {right}"
+                        return sql.SQL("{} >= {}").format(left, right)
                     case ast.Lt():
-                        return f"{left} < {right}"
+                        return sql.SQL("{} < {}").format(left, right)
                     case ast.LtE():
-                        return f"{left} <= {right}"
+                        return sql.SQL("{} <= {}").format(left, right)
                 raise NotImplementedError(f"Unsupported operator: {type(op)}")
             case ast.BoolOp():
                 op = node.op  # type: ignore
                 values = [self._lambda_parser(v) for v in node.values]
                 if isinstance(op, ast.And):
-                    return f"({' AND '.join(values)})"
+                    return sql.SQL("({})").format(sql.SQL(" AND ").join(values))
                 if isinstance(op, ast.Or):
-                    return f"({' OR '.join(values)})"
+                    return sql.SQL("({})").format(sql.SQL(" OR ").join(values))
                 raise NotImplementedError(f"Unsupported BoolOp: {type(op)}")
             case ast.UnaryOp():
                 match node.op:
                     case ast.Not():
                         operand = self._lambda_parser(node.operand)
-                        return f"NOT ({operand})"
+                        return sql.SQL("NOT ({})").format(operand)
                     case ast.UAdd() | ast.USub() | ast.Invert():
                         raise NotImplementedError("Unary +, -, ~ are not supported in PostgreSQL filters.")
             case ast.Attribute():
@@ -904,25 +904,19 @@ class PostgresCollection(
                     raise VectorStoreOperationException(
                         f"Field '{node.attr}' not in data model (storage property names are used)."
                     )
-                return f'"{node.attr}"'
+                return sql.Identifier(node.attr)
             case ast.Name():
                 # Only allow names that are in the data model
                 if node.id not in self.definition.storage_names:
                     raise VectorStoreOperationException(
                         f"Field '{node.id}' not in data model (storage property names are used)."
                     )
-                return f'"{node.id}"'
+                return sql.Identifier(node.id)
             case ast.Constant():
-                if isinstance(node.value, str):
-                    return "'" + node.value.replace("'", "''") + "'"
-                if node.value is None:
-                    return "NULL"
-                if isinstance(node.value, bool):
-                    return "TRUE" if node.value else "FALSE"
-                return str(node.value)
-            case ast.List():
+                return sql.Literal(node.value)
+            case ast.List() | ast.Tuple():
                 # For IN/NOT IN lists
-                return "(" + ", ".join(self._lambda_parser(elt) for elt in node.elts) + ")"
+                return sql.SQL("({})").format(sql.SQL(", ").join(self._lambda_parser(elt) for elt in node.elts))
         raise NotImplementedError(f"Unsupported AST node: {type(node)}")
 
     @override

--- a/python/semantic_kernel/connectors/postgres.py
+++ b/python/semantic_kernel/connectors/postgres.py
@@ -871,8 +871,16 @@ class PostgresCollection(
                     case ast.NotIn():
                         return sql.SQL("{} NOT IN {}").format(left, right)
                     case ast.Eq():
+                        if isinstance(node.comparators[0], ast.Constant) and node.comparators[0].value is None:
+                            return sql.SQL("{} IS NULL").format(left)
+                        if isinstance(node.left, ast.Constant) and node.left.value is None:
+                            return sql.SQL("{} IS NULL").format(right)
                         return sql.SQL("{} = {}").format(left, right)
                     case ast.NotEq():
+                        if isinstance(node.comparators[0], ast.Constant) and node.comparators[0].value is None:
+                            return sql.SQL("{} IS NOT NULL").format(left)
+                        if isinstance(node.left, ast.Constant) and node.left.value is None:
+                            return sql.SQL("{} IS NOT NULL").format(right)
                         return sql.SQL("{} <> {}").format(left, right)
                     case ast.Gt():
                         return sql.SQL("{} > {}").format(left, right)

--- a/python/tests/unit/connectors/memory/test_postgres_store.py
+++ b/python/tests/unit/connectors/memory/test_postgres_store.py
@@ -390,6 +390,40 @@ async def test_vector_search_multiple_filters_are_combined_with_and(
     )
 
 
+@pytest.mark.parametrize(
+    ("filter", "expected_filter"),
+    [
+        ("lambda record: record.content_type == None", '"content_type" IS NULL'),
+        ("lambda record: record.content_type != None", '"content_type" IS NOT NULL'),
+        ("lambda record: None == record.content_type", '"content_type" IS NULL'),
+        ("lambda record: None != record.content_type", '"content_type" IS NOT NULL'),
+    ],
+)
+async def test_vector_search_filter_renders_null_comparisons(
+    vector_store: PostgresStore,
+    mock_cursor: Mock,
+    filter: str,
+    expected_filter: str,
+) -> None:
+    collection = vector_store.get_collection(collection_name="test_collection", record_type=FilterableDataModel)
+
+    await collection.search(
+        vector=[1.0, 2.0, 3.0],
+        top=5,
+        filter=filter,
+        include_total_count=True,
+    )
+
+    execute_args, _ = mock_cursor.execute.call_args
+    statement_str = execute_args[0].as_string()
+
+    assert statement_str == (
+        'SELECT "id", "content_type", "version", "embedding" <=> %s as "sk_pg_distance" '
+        'FROM "public"."test_collection" '
+        f"WHERE {expected_filter} ORDER BY \"sk_pg_distance\" LIMIT 5"
+    )
+
+
 async def test_model_post_init_conflicting_distance_column_name(vector_store: PostgresStore) -> None:
     @vectorstoremodel
     @dataclass

--- a/python/tests/unit/connectors/memory/test_postgres_store.py
+++ b/python/tests/unit/connectors/memory/test_postgres_store.py
@@ -68,6 +68,24 @@ class SimpleDataModel:
     ] = None
 
 
+@vectorstoremodel
+@dataclass
+class FilterableDataModel:
+    id: Annotated[int, VectorStoreField("key")]
+    embedding: Annotated[
+        list[float] | str | None,
+        VectorStoreField(
+            "vector",
+            index_kind=IndexKind.HNSW,
+            dimensions=1536,
+            distance_function=DistanceFunction.COSINE_DISTANCE,
+            type="float",
+        ),
+    ]
+    content_type: Annotated[str, VectorStoreField("data")]
+    version: Annotated[int, VectorStoreField("data")]
+
+
 # region VectorStore Tests
 
 
@@ -320,6 +338,56 @@ async def test_vector_search(
         )
 
     assert statement_str == expected_statement
+
+
+async def test_vector_search_filter_embeds_where_clause_as_sql_expression(
+    vector_store: PostgresStore,
+    mock_cursor: Mock,
+) -> None:
+    collection = vector_store.get_collection(collection_name="test_collection", record_type=FilterableDataModel)
+
+    await collection.search(
+        vector=[1.0, 2.0, 3.0],
+        top=5,
+        filter="lambda record: record.content_type == 'course'",
+        include_total_count=True,
+    )
+
+    execute_args, _ = mock_cursor.execute.call_args
+    statement_str = execute_args[0].as_string()
+
+    assert statement_str == (
+        'SELECT "id", "content_type", "version", "embedding" <=> %s as "sk_pg_distance" '
+        'FROM "public"."test_collection" '
+        'WHERE "content_type" = \'course\' ORDER BY "sk_pg_distance" LIMIT 5'
+    )
+
+
+async def test_vector_search_multiple_filters_are_combined_with_and(
+    vector_store: PostgresStore,
+    mock_cursor: Mock,
+) -> None:
+    collection = vector_store.get_collection(collection_name="test_collection", record_type=FilterableDataModel)
+
+    await collection.search(
+        vector=[1.0, 2.0, 3.0],
+        top=5,
+        filter=[
+            "lambda record: record.content_type in ['course', 'lesson']",
+            "lambda record: not (record.version < 2)",
+        ],
+        include_total_count=True,
+    )
+
+    execute_args, _ = mock_cursor.execute.call_args
+    statement_str = execute_args[0].as_string()
+
+    assert statement_str == (
+        'SELECT "id", "content_type", "version", "embedding" <=> %s as "sk_pg_distance" '
+        'FROM "public"."test_collection" '
+        "WHERE \"content_type\" IN ('course', 'lesson') AND NOT (\"version\" < 2) "
+        'ORDER BY "sk_pg_distance" LIMIT 5'
+    )
 
 
 async def test_model_post_init_conflicting_distance_column_name(vector_store: PostgresStore) -> None:


### PR DESCRIPTION
### Motivation and Context

Fixes #13595.

Postgres vector-search lambda filters were parsed into plain strings and then passed through `psycopg.sql.SQL.format()`. psycopg treats non-composable values as SQL literals, so filter predicates could be embedded as quoted strings instead of SQL expressions. The filtered query also missed a leading space before `WHERE`.

### Description

- Build Postgres filter clauses with `psycopg.sql` composables instead of plain strings
- Use `sql.Identifier` for field names and `sql.Literal` for constants
- Preserve existing boolean/comparison/list filter behavior while composing `AND`, `OR`, `NOT`, `IN`, and chained comparisons as SQL fragments
- Add regression tests for single and multiple filtered vector-search queries

### Contribution Checklist

- [x] The code builds clean without any errors or warnings
- [x] The PR follows the SK Contribution Guidelines
- [x] The code follows the Python coding conventions
- [x] All unit tests pass, and I have added new tests where possible
- [ ] I didn't break anyone :smile:

### Validation

From `python/`:

- `.venv/bin/python -m pytest tests/unit/connectors/memory/test_postgres_store.py -q` -> 22 passed
- `.venv/bin/ruff check semantic_kernel/connectors/postgres.py tests/unit/connectors/memory/test_postgres_store.py` -> passed
- `.venv/bin/ruff format --check semantic_kernel/connectors/postgres.py tests/unit/connectors/memory/test_postgres_store.py` -> passed
- `git diff --check` -> passed
