### PR TITLE
.Net: Fix TextChunker orphan merge token count

### DIFF
--- a/dotnet/src/SemanticKernel.Core/Text/TextChunker.cs
+++ b/dotnet/src/SemanticKernel.Core/Text/TextChunker.cs
@@ -51,7 +51,6 @@ public static class TextChunker
     /// <returns>The number of tokens in the input string.</returns>
     public delegate int TokenCounter(string input);
 
-    private static readonly char[] s_spaceChar = [' '];
     private static readonly string?[] s_plaintextSplitOptions = ["\n", ".。．", "?!", ";", ":", ",，、", ")]}", " ", "-", null];
     private static readonly string?[] s_markdownSplitOptions = [".\u3002\uFF0E", "?!", ";", ":", ",\uFF0C\u3001", ")]}", " ", "-", "\n\r", null];
 
@@ -192,18 +191,11 @@ public static class TextChunker
 
             if (GetTokenCount(lastParagraph, tokenCounter) < adjustedMaxTokensPerParagraph / 4)
             {
-                var lastParagraphTokens = lastParagraph.Split(s_spaceChar, StringSplitOptions.RemoveEmptyEntries);
-                var secondLastParagraphTokens = secondLastParagraph.Split(s_spaceChar, StringSplitOptions.RemoveEmptyEntries);
+                var mergedParagraph = $"{secondLastParagraph} {lastParagraph}";
 
-                var lastParagraphTokensCount = lastParagraphTokens.Length;
-                var secondLastParagraphTokensCount = secondLastParagraphTokens.Length;
-
-                if (lastParagraphTokensCount + secondLastParagraphTokensCount <= adjustedMaxTokensPerParagraph)
+                if (GetTokenCount(mergedParagraph, tokenCounter) <= adjustedMaxTokensPerParagraph)
                 {
-                    var newSecondLastParagraph = string.Join(" ", secondLastParagraphTokens);
-                    var newLastParagraph = string.Join(" ", lastParagraphTokens);
-
-                    paragraphs[paragraphs.Count - 2] = $"{newSecondLastParagraph} {newLastParagraph}";
+                    paragraphs[paragraphs.Count - 2] = mergedParagraph;
                     paragraphs.RemoveAt(paragraphs.Count - 1);
                 }
             }

--- a/dotnet/src/SemanticKernel.UnitTests/Text/TextChunkerTests.cs
+++ b/dotnet/src/SemanticKernel.UnitTests/Text/TextChunkerTests.cs
@@ -819,4 +819,17 @@ public sealed class TextChunkerTests
         Assert.Contains("Second line", combined);
         Assert.Contains("Third line", combined);
     }
+
+    [Fact]
+    public void SplitPlainTextParagraphsDoesNotMergeOrphanParagraphBeyondTokenLimit()
+    {
+        var lines = new[] { $"{new string('a', 19)}\nb" };
+
+        var result = TextChunker.SplitPlainTextParagraphs(lines, 20, tokenCounter: input => input.Length);
+
+        Assert.Collection(
+            result,
+            paragraph => Assert.Equal(new string('a', 19), paragraph),
+            paragraph => Assert.Equal("b", paragraph));
+    }
 }

--- a/dotnet/src/SemanticKernel.UnitTests/Text/TextChunkerTests.cs
+++ b/dotnet/src/SemanticKernel.UnitTests/Text/TextChunkerTests.cs
@@ -832,4 +832,16 @@ public sealed class TextChunkerTests
             paragraph => Assert.Equal(new string('a', 19), paragraph),
             paragraph => Assert.Equal("b", paragraph));
     }
+
+    [Fact]
+    public void SplitPlainTextParagraphsMergesOrphanParagraphWithinTokenLimit()
+    {
+        var lines = new[] { new string('a', 16), "abc" };
+
+        var result = TextChunker.SplitPlainTextParagraphs(lines, 20, tokenCounter: input => input.Length);
+
+        Assert.Collection(
+            result,
+            paragraph => Assert.Equal($"{new string('a', 16)} abc", paragraph));
+    }
 }


### PR DESCRIPTION
## Summary

Fixes #13713. `TextChunker.SplitPlainTextParagraphs` now checks the configured token counter before merging a short final paragraph into the previous paragraph. This prevents the orphan-paragraph balancing step from creating a chunk that exceeds the requested token limit when a custom token counter is used.

## Root Cause

The orphan merge logic compared the number of whitespace-delimited words in the last two paragraphs against `adjustedMaxTokensPerParagraph`. That word count can be lower than the actual token count reported by the provided `TokenCounter`, so the merge could produce an oversized chunk.

## Change

- Build the candidate merged paragraph using the existing paragraph strings.
- Call `GetTokenCount(mergedParagraph, tokenCounter)` before merging.
- Add regression tests using a length-based token counter for both the oversized merge case and the still-fits merge case.

## Validation

Using local .NET SDK `10.0.100` installed under `/tmp/dotnet`:

- `PATH=/tmp/dotnet:$PATH DOTNET_ROOT=/tmp/dotnet DOTNET_CLI_TELEMETRY_OPTOUT=1 dotnet test dotnet/src/SemanticKernel.UnitTests/SemanticKernel.UnitTests.csproj --filter TextChunkerTests` -> 41 passed
- `PATH=/tmp/dotnet:$PATH DOTNET_ROOT=/tmp/dotnet DOTNET_CLI_TELEMETRY_OPTOUT=1 dotnet format dotnet/src/SemanticKernel.UnitTests/SemanticKernel.UnitTests.csproj --include dotnet/src/SemanticKernel.Core/Text/TextChunker.cs dotnet/src/SemanticKernel.UnitTests/Text/TextChunkerTests.cs --verify-no-changes --no-restore`
- `git diff --check`

Full repository test suite was not run because the focused TextChunker unit tests cover the changed behavior.