### PR TITLE
Python: fix(vertex-ai): filter out thought parts from chat message content

### DIFF
--- a/python/semantic_kernel/connectors/ai/google/vertex_ai/services/vertex_ai_chat_completion.py
+++ b/python/semantic_kernel/connectors/ai/google/vertex_ai/services/vertex_ai_chat_completion.py
@@ -249,7 +249,7 @@ class VertexAIChatCompletion(VertexAIBase, ChatCompletionClientBase):
         items: list[CMC_ITEM_TYPES] = []
         for idx, part in enumerate(candidate.content.parts):
             part_dict = part.to_dict()
-            if "text" in part_dict:
+            if "text" in part_dict and not part_dict.get("thought"):
                 items.append(TextContent(text=part.text, inner_content=response, metadata=response_metadata))
             elif "function_call" in part_dict:
                 fc_metadata: dict[str, Any] = {}
@@ -304,7 +304,7 @@ class VertexAIChatCompletion(VertexAIBase, ChatCompletionClientBase):
         items: list[STREAMING_ITEM_TYPES] = []
         for idx, part in enumerate(candidate.content.parts):
             part_dict = part.to_dict()
-            if "text" in part_dict:
+            if "text" in part_dict and not part_dict.get("thought"):
                 items.append(
                     StreamingTextContent(
                         choice_index=candidate.index,


### PR DESCRIPTION
## Summary

When Gemini is used via Vertex AI with `include_thoughts=True`, the model returns reasoning/thought parts alongside regular text parts. Thought parts have `{"text": "...", "thought": True}` in their `to_dict()` representation.

`_create_chat_message_content` and `_create_streaming_chat_message_content` in `VertexAIChatCompletion` checked only `if "text" in part_dict`, so thought text leaked into `TextContent` / `StreamingTextContent` items — exposing internal chain-of-thought reasoning as regular assistant output.

## Fix

Add `and not part_dict.get("thought")` to the text-part guard at both call sites (non-streaming line 252, streaming line 307):

```python
# BEFORE
if "text" in part_dict:

# AFTER
if "text" in part_dict and not part_dict.get("thought"):
```

This matches the fix already applied to `GoogleAIChatCompletion` for the same issue (#13710), and mirrors the `thought_signature` handling already present in the same loops.

## Related

- #13710 — same bug in `GoogleAIChatCompletion` (fixed by #13711 / #13890, which do not touch `VertexAIChatCompletion`)