### PR TITLE
.Net: fix(Redis): RedisJsonMapper excludes unannotated POCO properties from JSON payload

### DIFF
--- a/dotnet/src/VectorData/Redis/RedisJsonMapper.cs
+++ b/dotnet/src/VectorData/Redis/RedisJsonMapper.cs
@@ -1,9 +1,8 @@
-﻿// Copyright (c) Microsoft. All rights reserved.
+// Copyright (c) Microsoft. All rights reserved.
 
 using System;
 using System.Collections.Generic;
 using System.Diagnostics;
-using System.Linq;
 using System.Text.Json;
 using System.Text.Json.Nodes;
 using Microsoft.Extensions.AI;
@@ -27,22 +26,28 @@ internal sealed class RedisJsonMapper<TConsumerDataModel>(
     /// <inheritdoc />
     public (string Key, JsonNode Node) MapFromDataToStorageModel(TConsumerDataModel dataModel, int recordIndex, IReadOnlyList<Embedding>?[]? generatedEmbeddings)
     {
-        // Convert the provided record into a JsonNode object and try to get the key field for it.
-        // Since we already checked that the key field is a string in the constructor, and that it exists on the model,
-        // the only edge case we have to be concerned about is if the key field is null.
-        var jsonNode = JsonSerializer.SerializeToNode(dataModel, jsonSerializerOptions)!.AsObject();
-
-        if (!(jsonNode.TryGetPropertyValue(this._keyPropertyStorageName, out var keyField) && keyField is JsonValue jsonValue))
+        // Get the key value from the key property.
+        var keyValue = model.KeyProperty.GetValueAsObject(dataModel) switch
         {
-            throw new InvalidOperationException($"Missing key field '{this._keyPropertyStorageName}' on provided record of type {typeof(TConsumerDataModel).FullName}.");
+            string s => s,
+            Guid g => g.ToString(),
+            null => throw new InvalidOperationException($"Missing key field '{this._keyPropertyStorageName}' on provided record of type {typeof(TConsumerDataModel).FullName}."),
+            _ => throw new UnreachableException()
+        };
+
+        // Build the JSON object selectively from annotated data and vector properties only,
+        // so that unannotated public properties are not persisted into Redis.
+        var jsonObject = new JsonObject();
+
+        foreach (var dataProperty in model.DataProperties)
+        {
+            var value = dataProperty.GetValueAsObject(dataModel);
+            jsonObject[dataProperty.StorageName] = value is null
+                ? null
+                : JsonSerializer.SerializeToNode(value, dataProperty.Type, jsonSerializerOptions);
         }
 
-        // Remove the key field from the JSON object since we don't want to store it in the redis payload.
-        var keyValue = jsonValue.ToString();
-        jsonNode.Remove(this._keyPropertyStorageName);
-
-        // Go over the vector properties; inject any generated embeddings to overwrite the JSON serialized above.
-        // Also, for Embedding<T> properties we also need to overwrite with a simple array (since Embedding<T> gets serialized as a complex object).
+        // Serialize vector properties; generated embeddings (if any) override the property value.
         for (var i = 0; i < model.VectorProperties.Count; i++)
         {
             var property = model.VectorProperties[i];
@@ -57,20 +62,32 @@ internal sealed class RedisJsonMapper<TConsumerDataModel>(
                     case var t2 when t2 == typeof(float[]):
                     case var t3 when t3 == typeof(ReadOnlyMemory<double>):
                     case var t4 when t4 == typeof(double[]):
-                        // The .NET vector property is a ReadOnlyMemory<T> or T[] (not an Embedding), which means that JsonSerializer
-                        // already serialized it correctly above.
-                        // In addition, there's no generated embedding (which would be an Embedding which we'd need to handle manually).
-                        // So there's nothing for us to do.
+                        // Serialize directly - JsonSerializer handles these types correctly.
+                        var rawValue = property.GetValueAsObject(dataModel);
+                        if (rawValue is null)
+                        {
+                            jsonObject[property.StorageName] = null;
+                        }
+                        else
+                        {
+                            jsonObject[property.StorageName] = JsonSerializer.SerializeToNode(rawValue, property.Type, jsonSerializerOptions);
+                        }
                         continue;
 
                     case var t when t == typeof(Embedding<float>):
                     case var t1 when t1 == typeof(Embedding<double>):
-                        embedding = (Embedding)property.GetValueAsObject(dataModel)!;
+                        embedding = (Embedding?)property.GetValueAsObject(dataModel);
                         break;
 
                     default:
                         throw new UnreachableException();
                 }
+            }
+
+            if (embedding is null)
+            {
+                jsonObject[property.StorageName] = null;
+                continue;
             }
 
             var jsonArray = new JsonArray();
@@ -95,10 +112,10 @@ internal sealed class RedisJsonMapper<TConsumerDataModel>(
                     throw new UnreachableException();
             }
 
-            jsonNode[property.StorageName] = jsonArray;
+            jsonObject[property.StorageName] = jsonArray;
         }
 
-        return (keyValue, jsonNode);
+        return (keyValue, jsonObject);
     }
 
     /// <inheritdoc />

--- a/dotnet/test/VectorData/Redis.UnitTests/RedisJsonCollectionTests.cs
+++ b/dotnet/test/VectorData/Redis.UnitTests/RedisJsonCollectionTests.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) Microsoft. All rights reserved.
+// Copyright (c) Microsoft. All rights reserved.
 
 using System;
 using System.Collections.Generic;
@@ -305,10 +305,10 @@ public class RedisJsonCollectionTests
     }
 
     [Theory]
-    [InlineData(true, true, """{"data1_json_name":"data 1","data2":"data 2","vector1_json_name":[1,2,3,4],"vector2":[1,2,3,4],"notAnnotated":null}""")]
-    [InlineData(true, false, """{"data1_json_name":"data 1","Data2":"data 2","vector1_json_name":[1,2,3,4],"Vector2":[1,2,3,4],"NotAnnotated":null}""")]
-    [InlineData(false, true, """{"data1_json_name":"data 1","data2":"data 2","vector1_json_name":[1,2,3,4],"vector2":[1,2,3,4],"notAnnotated":null}""")]
-    [InlineData(false, false, """{"data1_json_name":"data 1","Data2":"data 2","vector1_json_name":[1,2,3,4],"Vector2":[1,2,3,4],"NotAnnotated":null}""")]
+    [InlineData(true, true, """{"data1_json_name":"data 1","data2":"data 2","vector1_json_name":[1,2,3,4],"vector2":[1,2,3,4]}""")]
+    [InlineData(true, false, """{"data1_json_name":"data 1","Data2":"data 2","vector1_json_name":[1,2,3,4],"Vector2":[1,2,3,4]}""")]
+    [InlineData(false, true, """{"data1_json_name":"data 1","data2":"data 2","vector1_json_name":[1,2,3,4],"vector2":[1,2,3,4]}""")]
+    [InlineData(false, false, """{"data1_json_name":"data 1","Data2":"data 2","vector1_json_name":[1,2,3,4],"Vector2":[1,2,3,4]}""")]
     public async Task CanUpsertRecordAsync(bool useDefinition, bool useCustomJsonSerializerOptions, string expectedUpsertedJson)
     {
         // Arrange
@@ -320,7 +320,6 @@ public class RedisJsonCollectionTests
         await sut.UpsertAsync(model);
 
         // Assert
-        // TODO: Fix issue where NotAnnotated is being included in the JSON.
         var expectedArgs = new object[] { TestRecordKey1, "$", expectedUpsertedJson };
         this._redisDatabaseMock
             .Verify(
@@ -346,8 +345,7 @@ public class RedisJsonCollectionTests
         await sut.UpsertAsync([model1, model2]);
 
         // Assert
-        // TODO: Fix issue where NotAnnotated is being included in the JSON.
-        var expectedArgs = new object[] { TestRecordKey1, "$", """{"data1_json_name":"data 1","Data2":"data 2","vector1_json_name":[1,2,3,4],"Vector2":[1,2,3,4],"NotAnnotated":null}""", TestRecordKey2, "$", """{"data1_json_name":"data 1","Data2":"data 2","vector1_json_name":[1,2,3,4],"Vector2":[1,2,3,4],"NotAnnotated":null}""" };
+        var expectedArgs = new object[] { TestRecordKey1, "$", """{"data1_json_name":"data 1","Data2":"data 2","vector1_json_name":[1,2,3,4],"Vector2":[1,2,3,4]}""", TestRecordKey2, "$", """{"data1_json_name":"data 1","Data2":"data 2","vector1_json_name":[1,2,3,4],"Vector2":[1,2,3,4]}""" };
         this._redisDatabaseMock
             .Verify(
                 x => x.ExecuteAsync(


### PR DESCRIPTION
Fixes #14021

`RedisJsonMapper.MapFromDataToStorageModel` was serializing the full POCO object via `JsonSerializer.SerializeToNode`, then removing only the key property. This caused unannotated public properties to be persisted into Redis JSON payloads.

The fix builds the JSON object selectively from `model.DataProperties` and `model.VectorProperties` only, matching the approach already used in `RedisJsonDynamicMapper`.

Updated unit tests to remove `NotAnnotated` from expected payloads and deleted the existing `// TODO: Fix issue where NotAnnotated is being included in the JSON.` comments.