### PR TITLE
.Net: Enable default-on server URL validation for OpenAPI plugins

### DIFF
--- a/dotnet/Directory.Packages.props
+++ b/dotnet/Directory.Packages.props
@@ -106,7 +106,7 @@
     <PackageVersion Include="PdfPig" Version="0.1.13" />
     <PackageVersion Include="Pinecone.Client" Version="3.1.0" />
     <PackageVersion Include="Prompty.Core" Version="0.2.3-beta" />
-    <PackageVersion Include="Scriban" Version="7.1.0" />
+    <PackageVersion Include="Scriban" Version="7.2.0" />
     <PackageVersion Include="PuppeteerSharp" Version="20.2.5" />
     <PackageVersion Include="System.Diagnostics.DiagnosticSource" Version="10.0.2" />
     <PackageVersion Include="System.IdentityModel.Tokens.Jwt" Version="8.16.0" />

--- a/dotnet/src/Functions/Functions.OpenApi/CompatibilitySuppressions.xml
+++ b/dotnet/src/Functions/Functions.OpenApi/CompatibilitySuppressions.xml
@@ -3,8 +3,50 @@
 <Suppressions xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:xsd="http://www.w3.org/2001/XMLSchema">
   <Suppression>
     <DiagnosticId>CP0002</DiagnosticId>
+    <Target>M:Microsoft.SemanticKernel.Plugins.OpenApi.RestApiOperationServerUrlValidationOptions.get_AllowedSchemes</Target>
+    <Left>lib/net10.0/Microsoft.SemanticKernel.Plugins.OpenApi.dll</Left>
+    <Right>lib/net10.0/Microsoft.SemanticKernel.Plugins.OpenApi.dll</Right>
+    <IsBaselineSuppression>true</IsBaselineSuppression>
+  </Suppression>
+  <Suppression>
+    <DiagnosticId>CP0002</DiagnosticId>
+    <Target>M:Microsoft.SemanticKernel.Plugins.OpenApi.RestApiOperationServerUrlValidationOptions.set_AllowedSchemes(System.Collections.Generic.IReadOnlyList{System.String})</Target>
+    <Left>lib/net10.0/Microsoft.SemanticKernel.Plugins.OpenApi.dll</Left>
+    <Right>lib/net10.0/Microsoft.SemanticKernel.Plugins.OpenApi.dll</Right>
+    <IsBaselineSuppression>true</IsBaselineSuppression>
+  </Suppression>
+  <Suppression>
+    <DiagnosticId>CP0002</DiagnosticId>
+    <Target>M:Microsoft.SemanticKernel.Plugins.OpenApi.RestApiOperationServerUrlValidationOptions.get_AllowedSchemes</Target>
+    <Left>lib/net8.0/Microsoft.SemanticKernel.Plugins.OpenApi.dll</Left>
+    <Right>lib/net8.0/Microsoft.SemanticKernel.Plugins.OpenApi.dll</Right>
+    <IsBaselineSuppression>true</IsBaselineSuppression>
+  </Suppression>
+  <Suppression>
+    <DiagnosticId>CP0002</DiagnosticId>
+    <Target>M:Microsoft.SemanticKernel.Plugins.OpenApi.RestApiOperationServerUrlValidationOptions.set_AllowedSchemes(System.Collections.Generic.IReadOnlyList{System.String})</Target>
+    <Left>lib/net8.0/Microsoft.SemanticKernel.Plugins.OpenApi.dll</Left>
+    <Right>lib/net8.0/Microsoft.SemanticKernel.Plugins.OpenApi.dll</Right>
+    <IsBaselineSuppression>true</IsBaselineSuppression>
+  </Suppression>
+  <Suppression>
+    <DiagnosticId>CP0002</DiagnosticId>
     <Target>F:Microsoft.SemanticKernel.Plugins.OpenApi.OpenApiKernelFunctionContext.KernelFunctionContextKey</Target>
     <Left>lib/netstandard2.0/Microsoft.SemanticKernel.Plugins.OpenApi.dll</Left>
     <Right>lib/net8.0/Microsoft.SemanticKernel.Plugins.OpenApi.dll</Right>
+  </Suppression>
+  <Suppression>
+    <DiagnosticId>CP0002</DiagnosticId>
+    <Target>M:Microsoft.SemanticKernel.Plugins.OpenApi.RestApiOperationServerUrlValidationOptions.get_AllowedSchemes</Target>
+    <Left>lib/netstandard2.0/Microsoft.SemanticKernel.Plugins.OpenApi.dll</Left>
+    <Right>lib/netstandard2.0/Microsoft.SemanticKernel.Plugins.OpenApi.dll</Right>
+    <IsBaselineSuppression>true</IsBaselineSuppression>
+  </Suppression>
+  <Suppression>
+    <DiagnosticId>CP0002</DiagnosticId>
+    <Target>M:Microsoft.SemanticKernel.Plugins.OpenApi.RestApiOperationServerUrlValidationOptions.set_AllowedSchemes(System.Collections.Generic.IReadOnlyList{System.String})</Target>
+    <Left>lib/netstandard2.0/Microsoft.SemanticKernel.Plugins.OpenApi.dll</Left>
+    <Right>lib/netstandard2.0/Microsoft.SemanticKernel.Plugins.OpenApi.dll</Right>
+    <IsBaselineSuppression>true</IsBaselineSuppression>
   </Suppression>
 </Suppressions>

--- a/dotnet/src/Functions/Functions.OpenApi/Extensions/OpenApiFunctionExecutionParameters.cs
+++ b/dotnet/src/Functions/Functions.OpenApi/Extensions/OpenApiFunctionExecutionParameters.cs
@@ -99,11 +99,26 @@ public class OpenApiFunctionExecutionParameters
     public RestApiParameterFilter? ParameterFilter { get; set; }
 
     /// <summary>
-    /// Options for validating server URLs before making HTTP requests.
-    /// When set, the plugin will validate each resolved URL against the configured allowed base URLs and schemes
-    /// before sending the HTTP request. This helps prevent Server-Side Request Forgery (SSRF) attacks.
-    /// If null (default), no URL validation is performed.
+    /// Options for validating server URLs before making HTTP requests, to help prevent
+    /// Server-Side Request Forgery (SSRF) attacks against private/internal infrastructure.
     /// </summary>
+    /// <remarks>
+    /// <para>
+    /// Validation is <b>on by default</b>: when this property is <c>null</c>, the plugin behaves
+    /// as if a default-constructed <see cref="RestApiOperationServerUrlValidationOptions"/> was
+    /// supplied. The implicit policy permits only HTTPS URLs that resolve to public IP
+    /// addresses, blocking loopback, link-local, RFC1918, IPv6 ULA, CGNAT and other
+    /// non-public ranges (including the cloud-metadata address <c>169.254.169.254</c>).
+    /// </para>
+    /// <para>
+    /// To allow plaintext HTTP or private/loopback hosts (for example for localhost
+    /// development or on-prem APIs), set
+    /// <see cref="RestApiOperationServerUrlValidationOptions.AllowedBaseUrls"/> with the
+    /// specific allowed origins, or set
+    /// <see cref="RestApiOperationServerUrlValidationOptions.AllowPrivateNetworkAccess"/>
+    /// to <c>true</c>.
+    /// </para>
+    /// </remarks>
     [Experimental("SKEXP0040")]
     public RestApiOperationServerUrlValidationOptions? ServerUrlValidationOptions { get; set; }
 

--- a/dotnet/src/Functions/Functions.OpenApi/RestApiOperationRunner.cs
+++ b/dotnet/src/Functions/Functions.OpenApi/RestApiOperationRunner.cs
@@ -121,11 +121,6 @@ internal sealed class RestApiOperationRunner
     private readonly RestApiOperationServerUrlValidationOptions? _serverUrlValidationOptions;
 
     /// <summary>
-    /// Default allowed schemes when none are explicitly configured.
-    /// </summary>
-    private static readonly IReadOnlyList<string> s_defaultAllowedSchemes = ["https"];
-
-    /// <summary>
     /// Creates an instance of the <see cref="RestApiOperationRunner"/> class.
     /// </summary>
     /// <param name="httpClient">An instance of the HttpClient class.</param>
@@ -191,7 +186,7 @@ internal sealed class RestApiOperationRunner
     /// <param name="options">Options for REST API operation run.</param>
     /// <param name="cancellationToken">The cancellation token.</param>
     /// <returns>The task execution result.</returns>
-    public Task<RestApiOperationResponse> RunAsync(
+    public async Task<RestApiOperationResponse> RunAsync(
         RestApiOperation operation,
         KernelArguments arguments,
         RestApiOperationRunOptions? options = null,
@@ -199,80 +194,16 @@ internal sealed class RestApiOperationRunner
     {
         var url = this._urlFactory?.Invoke(operation, arguments, options) ?? this.BuildsOperationUrl(operation, arguments, options?.ServerUrlOverride, options?.ApiHostUrl);
 
-        this.ValidateUrl(url);
+        await ServerUrlValidator.ValidateAsync(url, this._serverUrlValidationOptions, cancellationToken).ConfigureAwait(false);
 
         var headers = this._headersFactory?.Invoke(operation, arguments, options) ?? operation.BuildHeaders(arguments);
 
         var (Payload, Content) = this._payloadFactory?.Invoke(operation, arguments, this._enableDynamicPayload, this._enablePayloadNamespacing, options) ?? this.BuildOperationPayload(operation, arguments);
 
-        return this.SendAsync(operation, url, headers, Payload, Content, options, cancellationToken);
+        return await this.SendAsync(operation, url, headers, Payload, Content, options, cancellationToken).ConfigureAwait(false);
     }
 
     #region private
-
-    /// <summary>
-    /// Validates the resolved URL against the configured server URL validation options.
-    /// </summary>
-    /// <param name="url">The resolved URL to validate.</param>
-    /// <exception cref="InvalidOperationException">Thrown when the URL violates the validation rules.</exception>
-    private void ValidateUrl(Uri url)
-    {
-        if (this._serverUrlValidationOptions is null)
-        {
-            return;
-        }
-
-        // Validate the URI scheme.
-        var allowedSchemes = this._serverUrlValidationOptions.AllowedSchemes ?? s_defaultAllowedSchemes;
-        if (allowedSchemes.Count > 0)
-        {
-            bool schemeAllowed = false;
-            foreach (var scheme in allowedSchemes)
-            {
-                if (string.Equals(url.Scheme, scheme, StringComparison.OrdinalIgnoreCase))
-                {
-                    schemeAllowed = true;
-                    break;
-                }
-            }
-
-            if (!schemeAllowed)
-            {
-                throw new InvalidOperationException(
-                    $"The request URI scheme '{url.Scheme}' is not allowed. Allowed schemes: {string.Join(", ", allowedSchemes)}.");
-            }
-        }
-
-        // Validate the URL against the allowed base URLs.
-        if (this._serverUrlValidationOptions.AllowedBaseUrls is { Count: > 0 } allowedBaseUrls)
-        {
-            bool baseUrlAllowed = false;
-
-            foreach (var baseUrl in allowedBaseUrls)
-            {
-                // Use only scheme + authority + path for comparison, ignoring any query or fragment.
-                var baseUrlPath = baseUrl.GetLeftPart(UriPartial.Path);
-                var urlPath = url.GetLeftPart(UriPartial.Path);
-                var baseUrlWithSlash = baseUrlPath;
-                if (!baseUrlWithSlash.EndsWith("/", StringComparison.Ordinal))
-                {
-                    baseUrlWithSlash += "/";
-                }
-                if (string.Equals(urlPath, baseUrlPath, StringComparison.OrdinalIgnoreCase) ||
-                    urlPath.StartsWith(baseUrlWithSlash, StringComparison.OrdinalIgnoreCase))
-                {
-                    baseUrlAllowed = true;
-                    break;
-                }
-            }
-
-            if (!baseUrlAllowed)
-            {
-                throw new InvalidOperationException(
-                    $"The request URI '{url}' is not allowed. It does not match any of the allowed base URLs.");
-            }
-        }
-    }
 
     /// <summary>
     /// Sends an HTTP request.

--- a/dotnet/src/Functions/Functions.OpenApi/RestApiOperationServerUrlValidationOptions.cs
+++ b/dotnet/src/Functions/Functions.OpenApi/RestApiOperationServerUrlValidationOptions.cs
@@ -8,25 +8,64 @@ namespace Microsoft.SemanticKernel.Plugins.OpenApi;
 
 /// <summary>
 /// Options for validating server URLs before making HTTP requests in the OpenAPI plugin.
-/// When configured, these options help prevent Server-Side Request Forgery (SSRF) attacks
-/// by restricting which URLs the plugin is allowed to call.
+/// These options control the secure-by-default protection against Server-Side Request Forgery
+/// (SSRF) attacks that the OpenAPI plugin applies to URLs derived from the OpenAPI document
+/// (the <c>servers[].url</c> field and any server-variable substitutions).
 /// </summary>
+/// <remarks>
+/// <para>
+/// When <see cref="OpenApiFunctionExecutionParameters.ServerUrlValidationOptions"/> is left
+/// <see langword="null"/>, a default-constructed instance of this class is applied. The default
+/// policy is:
+/// </para>
+/// <list type="bullet">
+///   <item><description>Only the <c>https</c> scheme is permitted for URLs that are not on the
+///         <see cref="AllowedBaseUrls"/> allowlist.</description></item>
+///   <item><description>Requests whose host resolves to a loopback, link-local (including the
+///         cloud metadata endpoint <c>169.254.169.254</c>), private (RFC1918), IPv6 unique local
+///         (<c>fc00::/7</c>), carrier-grade NAT, multicast, or reserved IP range are rejected.</description></item>
+/// </list>
+/// <para>
+/// A URL that matches an entry in <see cref="AllowedBaseUrls"/> is an explicit allow and
+/// bypasses both the implicit https-only gate and the private-IP gate, so an allowlist can be
+/// used to opt specific intranet hosts back in.
+/// </para>
+/// <para>
+/// <b>Known limitation:</b> URL validation is performed before the HTTP request is sent. If the
+/// <see cref="System.Net.Http.HttpClient"/> used to invoke the plugin has automatic redirect
+/// following enabled (the default), an attacker that controls a public host may redirect the
+/// request to a private address. Configure your <see cref="System.Net.Http.HttpClient"/> with
+/// <c>AllowAutoRedirect = false</c> when consuming OpenAPI documents from untrusted sources.
+/// </para>
+/// </remarks>
 [Experimental("SKEXP0040")]
 public class RestApiOperationServerUrlValidationOptions
 {
     /// <summary>
-    /// Gets or sets the allowed base URLs.
-    /// If set, only requests to URLs that start with one of these base URLs will be permitted.
-    /// For example, if <c>AllowedBaseUrls</c> contains <c>https://api.example.com</c>,
-    /// then requests to <c>https://api.example.com/v1/users</c> will be allowed,
-    /// but requests to <c>https://evil.com/data</c> will be blocked.
-    /// If null, no base URL restriction is applied (scheme validation still applies).
+    /// Gets or sets the explicit allowlist of base URLs. A request whose final URL matches one
+    /// of these entries (same scheme, host, port, and path prefix) is permitted regardless of
+    /// the implicit scheme and private-IP gates.
     /// </summary>
+    /// <remarks>
+    /// For example, with <c>AllowedBaseUrls = [new Uri("https://api.example.com/v1")]</c>:
+    /// <c>https://api.example.com/v1/users</c> is allowed, <c>https://api.example.com/v2/...</c>
+    /// is rejected, and <c>https://evil.com/...</c> is rejected. Query strings and fragments in
+    /// the entries are ignored for comparison. Adding an <c>http://</c> entry (for example,
+    /// <c>http://localhost:5000</c> or <c>http://intranet.corp</c>) is the recommended way to
+    /// opt-in specific plaintext or intranet endpoints without weakening the global defaults.
+    /// </remarks>
     public IReadOnlyList<Uri>? AllowedBaseUrls { get; set; }
 
     /// <summary>
-    /// Gets or sets the allowed URI schemes.
-    /// If null or empty, only <c>https</c> is permitted.
+    /// Gets or sets a value indicating whether requests to private, loopback, link-local, and
+    /// other non-public IP ranges are permitted for URLs that are not covered by
+    /// <see cref="AllowedBaseUrls"/>. The default is <see langword="false"/> (secure).
     /// </summary>
-    public IReadOnlyList<string>? AllowedSchemes { get; set; }
+    /// <remarks>
+    /// Setting this to <see langword="true"/> disables the SSRF protections that block requests
+    /// to cloud metadata services (e.g. <c>169.254.169.254</c>), <c>localhost</c>, RFC1918
+    /// networks, and similar ranges. Only enable this in trusted environments (such as local
+    /// development). Prefer adding specific hosts to <see cref="AllowedBaseUrls"/> instead.
+    /// </remarks>
+    public bool AllowPrivateNetworkAccess { get; set; }
 }

--- a/dotnet/src/Functions/Functions.OpenApi/ServerUrlValidator.cs
+++ b/dotnet/src/Functions/Functions.OpenApi/ServerUrlValidator.cs
@@ -25,10 +25,13 @@ internal static class ServerUrlValidator
     /// <param name="options">The validation policy. If <see langword="null"/>, the secure
     /// default policy (https-only and private/loopback/link-local IPs blocked) is applied.</param>
     /// <param name="cancellationToken">Cancellation token for the asynchronous DNS resolution.</param>
+    /// <param name="dnsResolver">Optional DNS resolver for testing. When <see langword="null"/>,
+    /// <see cref="Dns.GetHostAddressesAsync(string)"/> is used.</param>
     public static async Task ValidateAsync(
         Uri url,
         RestApiOperationServerUrlValidationOptions? options,
-        CancellationToken cancellationToken = default)
+        CancellationToken cancellationToken = default,
+        Func<string, CancellationToken, Task<IPAddress[]>>? dnsResolver = null)
     {
         if (url is null)
         {
@@ -58,7 +61,7 @@ internal static class ServerUrlValidator
             throw new InvalidOperationException(
                 $"The request URI scheme '{url.Scheme}' is not allowed. " +
                 $"Only '{ImplicitAllowedScheme}' is permitted by default. " +
-                $"To allow this URL, add it to " +
+                "To allow this URL, add it to " +
                 $"{nameof(RestApiOperationServerUrlValidationOptions)}.{nameof(RestApiOperationServerUrlValidationOptions.AllowedBaseUrls)}.");
         }
 
@@ -68,7 +71,7 @@ internal static class ServerUrlValidator
             return;
         }
 
-        await EnsurePublicHostAsync(url, cancellationToken).ConfigureAwait(false);
+        await EnsurePublicHostAsync(url, cancellationToken, dnsResolver).ConfigureAwait(false);
     }
 
     private static bool TryMatchAllowedBaseUrl(Uri url, IReadOnlyList<Uri>? allowedBaseUrls)
@@ -110,7 +113,10 @@ internal static class ServerUrlValidator
         return false;
     }
 
-    private static async Task EnsurePublicHostAsync(Uri url, CancellationToken cancellationToken)
+    private static async Task EnsurePublicHostAsync(
+        Uri url,
+        CancellationToken cancellationToken,
+        Func<string, CancellationToken, Task<IPAddress[]>>? dnsResolver)
     {
         var host = url.DnsSafeHost;
 
@@ -133,25 +139,41 @@ internal static class ServerUrlValidator
         IPAddress[] addresses;
         try
         {
+            if (dnsResolver is not null)
+            {
+                addresses = await dnsResolver(host, cancellationToken).ConfigureAwait(false);
+            }
+            else
+            {
 #if NET
-            addresses = await Dns.GetHostAddressesAsync(host, cancellationToken).ConfigureAwait(false);
+                addresses = await Dns.GetHostAddressesAsync(host, cancellationToken).ConfigureAwait(false);
 #else
-            addresses = await Dns.GetHostAddressesAsync(host).ConfigureAwait(false);
-            cancellationToken.ThrowIfCancellationRequested();
+                addresses = await Dns.GetHostAddressesAsync(host).ConfigureAwait(false);
+                cancellationToken.ThrowIfCancellationRequested();
 #endif
+            }
         }
         catch (SocketException)
         {
-            // DNS resolution failed. Fall through and let the HTTP layer surface the error.
-            // This does not create an SSRF risk: an unresolvable host cannot reach a private
-            // address either. Throwing here would also break legitimate scenarios where the
-            // host is temporarily unreachable from the validating machine but resolvable later.
-            return;
+            // DNS resolution failed. Fail closed: block the request rather than allowing
+            // it to proceed unvalidated. A TOCTOU race could otherwise allow a private
+            // target to be reached if DNS fails here but succeeds when HttpClient resolves.
+            throw new InvalidOperationException(
+                $"The request URI '{url}' is not allowed: DNS resolution for host '{host}' failed. " +
+                "The request is blocked as a precaution to prevent potential access to private network addresses. " +
+                "To allow this URL, add it to " +
+                $"{nameof(RestApiOperationServerUrlValidationOptions)}.{nameof(RestApiOperationServerUrlValidationOptions.AllowedBaseUrls)} " +
+                $"or set {nameof(RestApiOperationServerUrlValidationOptions)}.{nameof(RestApiOperationServerUrlValidationOptions.AllowPrivateNetworkAccess)} = true.");
         }
 
         if (addresses is null || addresses.Length == 0)
         {
-            return;
+            // No addresses returned. Fail closed for the same TOCTOU reason.
+            throw new InvalidOperationException(
+                $"The request URI '{url}' is not allowed: DNS resolution for host '{host}' returned no addresses. " +
+                "The request is blocked as a precaution. To allow this URL, add it to " +
+                $"{nameof(RestApiOperationServerUrlValidationOptions)}.{nameof(RestApiOperationServerUrlValidationOptions.AllowedBaseUrls)} " +
+                $"or set {nameof(RestApiOperationServerUrlValidationOptions)}.{nameof(RestApiOperationServerUrlValidationOptions.AllowPrivateNetworkAccess)} = true.");
         }
 
         foreach (var address in addresses)
@@ -166,8 +188,8 @@ internal static class ServerUrlValidator
         {
             throw new InvalidOperationException(
                 $"The request URI '{url}' is not allowed: host resolves to a {category} address ({address}), " +
-                $"which is blocked by default to prevent Server-Side Request Forgery (SSRF). " +
-                $"To allow this URL, add it to " +
+                "which is blocked by default to prevent Server-Side Request Forgery (SSRF). " +
+                "To allow this URL, add it to " +
                 $"{nameof(RestApiOperationServerUrlValidationOptions)}.{nameof(RestApiOperationServerUrlValidationOptions.AllowedBaseUrls)} " +
                 $"or set {nameof(RestApiOperationServerUrlValidationOptions)}.{nameof(RestApiOperationServerUrlValidationOptions.AllowPrivateNetworkAccess)} = true.");
         }

--- a/dotnet/src/Functions/Functions.OpenApi/ServerUrlValidator.cs
+++ b/dotnet/src/Functions/Functions.OpenApi/ServerUrlValidator.cs
@@ -184,7 +184,7 @@ internal static class ServerUrlValidator
 
     private static void EnsurePublicAddress(Uri url, IPAddress address)
     {
-        if (TryClassifyNonPublic(address, out var category))
+        if (TryCategorizeNonPublicAddress(address, out var category))
         {
             throw new InvalidOperationException(
                 $"The request URI '{url}' is not allowed: host resolves to a {category} address ({address}), " +
@@ -199,7 +199,7 @@ internal static class ServerUrlValidator
     /// Returns true and sets <paramref name="category"/> to a human-readable label when the
     /// supplied address is in a non-public IP range that should be blocked by default.
     /// </summary>
-    internal static bool TryClassifyNonPublic(IPAddress address, out string category)
+    internal static bool TryCategorizeNonPublicAddress(IPAddress address, out string category)
     {
         // Normalize IPv4-mapped IPv6 (::ffff:a.b.c.d) to its IPv4 form so the v4 checks apply.
         if (address.AddressFamily == AddressFamily.InterNetworkV6 && IsIPv4MappedToIPv6(address))

--- a/dotnet/src/Functions/Functions.OpenApi/ServerUrlValidator.cs
+++ b/dotnet/src/Functions/Functions.OpenApi/ServerUrlValidator.cs
@@ -1,0 +1,385 @@
+﻿// Copyright (c) Microsoft. All rights reserved.
+
+using System;
+using System.Collections.Generic;
+using System.Net;
+using System.Net.Sockets;
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace Microsoft.SemanticKernel.Plugins.OpenApi;
+
+/// <summary>
+/// Classifies URLs against a <see cref="RestApiOperationServerUrlValidationOptions"/> policy
+/// to prevent Server-Side Request Forgery (SSRF) via untrusted OpenAPI server URLs.
+/// </summary>
+internal static class ServerUrlValidator
+{
+    private const string ImplicitAllowedScheme = "https";
+
+    /// <summary>
+    /// Validates the given URL against the supplied policy and throws
+    /// <see cref="InvalidOperationException"/> if the URL is not permitted.
+    /// </summary>
+    /// <param name="url">The fully resolved request URL to validate.</param>
+    /// <param name="options">The validation policy. If <see langword="null"/>, the secure
+    /// default policy (https-only and private/loopback/link-local IPs blocked) is applied.</param>
+    /// <param name="cancellationToken">Cancellation token for the asynchronous DNS resolution.</param>
+    public static async Task ValidateAsync(
+        Uri url,
+        RestApiOperationServerUrlValidationOptions? options,
+        CancellationToken cancellationToken = default)
+    {
+        if (url is null)
+        {
+            throw new ArgumentNullException(nameof(url));
+        }
+
+        // Treat null as a default-constructed instance so protection is on by default.
+        options ??= new RestApiOperationServerUrlValidationOptions();
+
+        // 1. Explicit allow: a matching AllowedBaseUrls entry bypasses the implicit gates.
+        if (TryMatchAllowedBaseUrl(url, options.AllowedBaseUrls))
+        {
+            return;
+        }
+
+        // If the caller set AllowedBaseUrls and the URL didn't match, reject before further
+        // checks so the failure message points the developer at the right knob.
+        if (options.AllowedBaseUrls is { Count: > 0 })
+        {
+            throw new InvalidOperationException(
+                $"The request URI '{url}' is not allowed. It does not match any of the allowed base URLs.");
+        }
+
+        // 2. Implicit scheme gate: only https is allowed by default.
+        if (!string.Equals(url.Scheme, ImplicitAllowedScheme, StringComparison.OrdinalIgnoreCase))
+        {
+            throw new InvalidOperationException(
+                $"The request URI scheme '{url.Scheme}' is not allowed. " +
+                $"Only '{ImplicitAllowedScheme}' is permitted by default. " +
+                $"To allow this URL, add it to " +
+                $"{nameof(RestApiOperationServerUrlValidationOptions)}.{nameof(RestApiOperationServerUrlValidationOptions.AllowedBaseUrls)}.");
+        }
+
+        // 3. Implicit private-IP gate.
+        if (options.AllowPrivateNetworkAccess)
+        {
+            return;
+        }
+
+        await EnsurePublicHostAsync(url, cancellationToken).ConfigureAwait(false);
+    }
+
+    private static bool TryMatchAllowedBaseUrl(Uri url, IReadOnlyList<Uri>? allowedBaseUrls)
+    {
+        if (allowedBaseUrls is not { Count: > 0 })
+        {
+            return false;
+        }
+
+        var urlPath = url.GetLeftPart(UriPartial.Path);
+
+        foreach (var baseUrl in allowedBaseUrls)
+        {
+            if (baseUrl is null)
+            {
+                continue;
+            }
+
+            // Scheme, host, and port must all match for the explicit allow to apply.
+            if (!string.Equals(url.Scheme, baseUrl.Scheme, StringComparison.OrdinalIgnoreCase) ||
+                !string.Equals(url.Host, baseUrl.Host, StringComparison.OrdinalIgnoreCase) ||
+                url.Port != baseUrl.Port)
+            {
+                continue;
+            }
+
+            var baseUrlPath = baseUrl.GetLeftPart(UriPartial.Path);
+            var baseUrlWithSlash = baseUrlPath.EndsWith("/", StringComparison.Ordinal)
+                ? baseUrlPath
+                : baseUrlPath + "/";
+
+            if (string.Equals(urlPath, baseUrlPath, StringComparison.OrdinalIgnoreCase) ||
+                urlPath.StartsWith(baseUrlWithSlash, StringComparison.OrdinalIgnoreCase))
+            {
+                return true;
+            }
+        }
+
+        return false;
+    }
+
+    private static async Task EnsurePublicHostAsync(Uri url, CancellationToken cancellationToken)
+    {
+        var host = url.DnsSafeHost;
+
+        // Case 1: literal IP in the URL.
+        if (url.HostNameType == UriHostNameType.IPv4 || url.HostNameType == UriHostNameType.IPv6)
+        {
+            if (!IPAddress.TryParse(host, out var ip))
+            {
+                // Should be unreachable — .NET's Uri already classified this as an IP address.
+                // Fail closed: block the request rather than silently skipping validation.
+                throw new InvalidOperationException(
+                    $"The server URL '{url}' has a host identified as an IP address but could not be parsed. The request is blocked as a precaution.");
+            }
+
+            EnsurePublicAddress(url, ip);
+            return;
+        }
+
+        // Case 2: hostname - resolve and validate every returned address (defeats DNS rebinding).
+        IPAddress[] addresses;
+        try
+        {
+#if NET
+            addresses = await Dns.GetHostAddressesAsync(host, cancellationToken).ConfigureAwait(false);
+#else
+            addresses = await Dns.GetHostAddressesAsync(host).ConfigureAwait(false);
+            cancellationToken.ThrowIfCancellationRequested();
+#endif
+        }
+        catch (SocketException)
+        {
+            // DNS resolution failed. Fall through and let the HTTP layer surface the error.
+            // This does not create an SSRF risk: an unresolvable host cannot reach a private
+            // address either. Throwing here would also break legitimate scenarios where the
+            // host is temporarily unreachable from the validating machine but resolvable later.
+            return;
+        }
+
+        if (addresses is null || addresses.Length == 0)
+        {
+            return;
+        }
+
+        foreach (var address in addresses)
+        {
+            EnsurePublicAddress(url, address);
+        }
+    }
+
+    private static void EnsurePublicAddress(Uri url, IPAddress address)
+    {
+        if (TryClassifyNonPublic(address, out var category))
+        {
+            throw new InvalidOperationException(
+                $"The request URI '{url}' is not allowed: host resolves to a {category} address ({address}), " +
+                $"which is blocked by default to prevent Server-Side Request Forgery (SSRF). " +
+                $"To allow this URL, add it to " +
+                $"{nameof(RestApiOperationServerUrlValidationOptions)}.{nameof(RestApiOperationServerUrlValidationOptions.AllowedBaseUrls)} " +
+                $"or set {nameof(RestApiOperationServerUrlValidationOptions)}.{nameof(RestApiOperationServerUrlValidationOptions.AllowPrivateNetworkAccess)} = true.");
+        }
+    }
+
+    /// <summary>
+    /// Returns true and sets <paramref name="category"/> to a human-readable label when the
+    /// supplied address is in a non-public IP range that should be blocked by default.
+    /// </summary>
+    internal static bool TryClassifyNonPublic(IPAddress address, out string category)
+    {
+        // Normalize IPv4-mapped IPv6 (::ffff:a.b.c.d) to its IPv4 form so the v4 checks apply.
+        if (address.AddressFamily == AddressFamily.InterNetworkV6 && IsIPv4MappedToIPv6(address))
+        {
+            address = MapToIPv4(address);
+        }
+
+        if (address.AddressFamily == AddressFamily.InterNetwork)
+        {
+            return TryClassifyIPv4(address, out category);
+        }
+
+        if (address.AddressFamily == AddressFamily.InterNetworkV6)
+        {
+            return TryClassifyIPv6(address, out category);
+        }
+
+        // Not IPv4 or IPv6 - reject conservatively.
+        category = "non-IP";
+        return true;
+    }
+
+    private static bool TryClassifyIPv4(IPAddress address, out string category)
+    {
+        var bytes = address.GetAddressBytes();
+        var b0 = bytes[0];
+        var b1 = bytes[1];
+        var b2 = bytes[2];
+
+        // 0.0.0.0/8 - "this network", unspecified.
+        if (b0 == 0)
+        {
+            category = "unspecified";
+            return true;
+        }
+
+        // 10.0.0.0/8
+        if (b0 == 10)
+        {
+            category = "private (RFC1918)";
+            return true;
+        }
+
+        // 127.0.0.0/8 - loopback.
+        if (b0 == 127)
+        {
+            category = "loopback";
+            return true;
+        }
+
+        // 169.254.0.0/16 - link-local (includes cloud metadata 169.254.169.254).
+        if (b0 == 169 && b1 == 254)
+        {
+            category = "link-local";
+            return true;
+        }
+
+        // 172.16.0.0/12
+        if (b0 == 172 && b1 >= 16 && b1 <= 31)
+        {
+            category = "private (RFC1918)";
+            return true;
+        }
+
+        // 192.168.0.0/16
+        if (b0 == 192 && b1 == 168)
+        {
+            category = "private (RFC1918)";
+            return true;
+        }
+
+        // 100.64.0.0/10 - carrier-grade NAT.
+        if (b0 == 100 && b1 >= 64 && b1 <= 127)
+        {
+            category = "carrier-grade NAT";
+            return true;
+        }
+
+        // 198.18.0.0/15 - benchmarking.
+        if (b0 == 198 && (b1 == 18 || b1 == 19))
+        {
+            category = "benchmarking";
+            return true;
+        }
+
+        // 192.0.0.0/24 (IETF protocol assignments) and 192.0.2.0/24 (TEST-NET-1).
+        if (b0 == 192 && b1 == 0 && (b2 == 0 || b2 == 2))
+        {
+            category = "reserved";
+            return true;
+        }
+
+        // 198.51.100.0/24 (TEST-NET-2).
+        if (b0 == 198 && b1 == 51 && b2 == 100)
+        {
+            category = "reserved";
+            return true;
+        }
+
+        // 203.0.113.0/24 (TEST-NET-3).
+        if (b0 == 203 && b1 == 0 && b2 == 113)
+        {
+            category = "reserved";
+            return true;
+        }
+
+        // 224.0.0.0/4 - multicast.
+        if (b0 >= 224 && b0 <= 239)
+        {
+            category = "multicast";
+            return true;
+        }
+
+        // 240.0.0.0/4 - reserved (includes 255.255.255.255 broadcast).
+        if (b0 >= 240)
+        {
+            category = "reserved";
+            return true;
+        }
+
+        category = string.Empty;
+        return false;
+    }
+
+    private static bool TryClassifyIPv6(IPAddress address, out string category)
+    {
+        if (IPAddress.IsLoopback(address))
+        {
+            category = "loopback";
+            return true;
+        }
+
+        var bytes = address.GetAddressBytes();
+
+        // :: (unspecified)
+        if (address.Equals(IPAddress.IPv6None))
+        {
+            category = "unspecified";
+            return true;
+        }
+
+        // fe80::/10 - link-local.
+        if (bytes[0] == 0xfe && (bytes[1] & 0xC0) == 0x80)
+        {
+            category = "link-local";
+            return true;
+        }
+
+        // fc00::/7 - unique local (private).
+        if ((bytes[0] & 0xfe) == 0xfc)
+        {
+            category = "private (IPv6 ULA)";
+            return true;
+        }
+
+        // ff00::/8 - multicast.
+        if (bytes[0] == 0xff)
+        {
+            category = "multicast";
+            return true;
+        }
+
+        // 2001:db8::/32 - documentation.
+        if (bytes[0] == 0x20 && bytes[1] == 0x01 && bytes[2] == 0x0d && bytes[3] == 0xb8)
+        {
+            category = "reserved";
+            return true;
+        }
+
+        category = string.Empty;
+        return false;
+    }
+
+    private static bool IsIPv4MappedToIPv6(IPAddress address)
+    {
+#if NET
+        return address.IsIPv4MappedToIPv6;
+#else
+        var bytes = address.GetAddressBytes();
+        if (bytes.Length != 16)
+        {
+            return false;
+        }
+        for (int i = 0; i < 10; i++)
+        {
+            if (bytes[i] != 0)
+            {
+                return false;
+            }
+        }
+        return bytes[10] == 0xff && bytes[11] == 0xff;
+#endif
+    }
+
+    private static IPAddress MapToIPv4(IPAddress address)
+    {
+#if NET
+        return address.MapToIPv4();
+#else
+        var bytes = address.GetAddressBytes();
+        var v4 = new byte[4] { bytes[12], bytes[13], bytes[14], bytes[15] };
+        return new IPAddress(v4);
+#endif
+    }
+}

--- a/dotnet/src/Functions/Functions.UnitTests/OpenApi/Extensions/OpenApiKernelExtensionsTests.cs
+++ b/dotnet/src/Functions/Functions.UnitTests/OpenApi/Extensions/OpenApiKernelExtensionsTests.cs
@@ -170,6 +170,12 @@ public sealed class OpenApiKernelExtensionsTests : IDisposable
         using var httpClient = new HttpClient(messageHandlerStub, false);
 
         this._executionParameters.HttpClient = httpClient;
+        // Permit the test scenario URLs (including http://localhost:3001/) under the
+        // secure-by-default SSRF policy by explicitly allowlisting the expected base.
+        this._executionParameters.ServerUrlValidationOptions = new RestApiOperationServerUrlValidationOptions
+        {
+            AllowedBaseUrls = [new Uri(expectedServerUrl)]
+        };
 
         var arguments = this.GetFakeFunctionArguments();
 

--- a/dotnet/src/Functions/Functions.UnitTests/OpenApi/Extensions/OpenApiKernelExtensionsTests.cs
+++ b/dotnet/src/Functions/Functions.UnitTests/OpenApi/Extensions/OpenApiKernelExtensionsTests.cs
@@ -45,7 +45,18 @@ public sealed class OpenApiKernelExtensionsTests : IDisposable
     {
         this._kernel = new Kernel();
 
-        this._executionParameters = new OpenApiFunctionExecutionParameters() { EnableDynamicPayload = false };
+        this._executionParameters = new OpenApiFunctionExecutionParameters()
+        {
+            EnableDynamicPayload = false,
+            ServerUrlValidationOptions = new RestApiOperationServerUrlValidationOptions
+            {
+                AllowedBaseUrls =
+                [
+                    new Uri("https://my-key-vault.vault.azure.net"),
+                    new Uri("https://server-override.com")
+                ]
+            }
+        };
 
         this._openApiDocument = ResourcePluginsProvider.LoadFromResource("documentV2_0.json");
 

--- a/dotnet/src/Functions/Functions.UnitTests/OpenApi/OpenApiKernelPluginFactoryTests.cs
+++ b/dotnet/src/Functions/Functions.UnitTests/OpenApi/OpenApiKernelPluginFactoryTests.cs
@@ -174,6 +174,12 @@ public sealed class OpenApiKernelPluginFactoryTests
         using var httpClient = new HttpClient(messageHandlerStub, false);
 
         this._executionParameters.HttpClient = httpClient;
+        // Permit the test scenario URLs (including http://localhost:3001/) under the
+        // secure-by-default SSRF policy by explicitly allowlisting the expected base.
+        this._executionParameters.ServerUrlValidationOptions = new RestApiOperationServerUrlValidationOptions
+        {
+            AllowedBaseUrls = [new Uri(expectedServerUrl)]
+        };
 
         var arguments = new KernelArguments
         {

--- a/dotnet/src/Functions/Functions.UnitTests/OpenApi/OpenApiKernelPluginFactoryTests.cs
+++ b/dotnet/src/Functions/Functions.UnitTests/OpenApi/OpenApiKernelPluginFactoryTests.cs
@@ -35,7 +35,18 @@ public sealed class OpenApiKernelPluginFactoryTests
     /// </summary>
     public OpenApiKernelPluginFactoryTests()
     {
-        this._executionParameters = new OpenApiFunctionExecutionParameters() { EnableDynamicPayload = false };
+        this._executionParameters = new OpenApiFunctionExecutionParameters()
+        {
+            EnableDynamicPayload = false,
+            ServerUrlValidationOptions = new RestApiOperationServerUrlValidationOptions
+            {
+                AllowedBaseUrls =
+                [
+                    new Uri("https://my-key-vault.vault.azure.net"),
+                    new Uri("https://server-override.com")
+                ]
+            }
+        };
 
         this._openApiDocument = ResourcePluginsProvider.LoadFromResource("documentV2_0.json");
     }

--- a/dotnet/src/Functions/Functions.UnitTests/OpenApi/RestApiOperationRunnerTests.cs
+++ b/dotnet/src/Functions/Functions.UnitTests/OpenApi/RestApiOperationRunnerTests.cs
@@ -2466,4 +2466,3 @@ public sealed class RestApiOperationRunnerTests : IDisposable
         }
     }
 }
-

--- a/dotnet/src/Functions/Functions.UnitTests/OpenApi/RestApiOperationRunnerTests.cs
+++ b/dotnet/src/Functions/Functions.UnitTests/OpenApi/RestApiOperationRunnerTests.cs
@@ -41,6 +41,14 @@ public sealed class RestApiOperationRunnerTests : IDisposable
     private readonly HttpClient _httpClient;
 
     /// <summary>
+    /// Default validation options that allowlist the fake test host used by most tests.
+    /// </summary>
+    private readonly RestApiOperationServerUrlValidationOptions _defaultValidationOptions = new()
+    {
+        AllowedBaseUrls = [new Uri("https://fake-random-test-host")]
+    };
+
+    /// <summary>
     /// Creates an instance of a <see cref="RestApiOperationRunnerTests"/> class.
     /// </summary>
     public RestApiOperationRunnerTests()
@@ -91,7 +99,7 @@ public sealed class RestApiOperationRunnerTests : IDisposable
             { "content-type", "application/json" }
         };
 
-        var sut = new RestApiOperationRunner(this._httpClient, this._authenticationHandlerMock.Object);
+        var sut = new RestApiOperationRunner(this._httpClient, this._authenticationHandlerMock.Object, serverUrlValidationOptions: this._defaultValidationOptions);
 
         // Act
         var result = await sut.RunAsync(operation, arguments);
@@ -161,7 +169,7 @@ public sealed class RestApiOperationRunnerTests : IDisposable
             { "content-type", "text/plain"}
         };
 
-        var sut = new RestApiOperationRunner(this._httpClient, this._authenticationHandlerMock.Object);
+        var sut = new RestApiOperationRunner(this._httpClient, this._authenticationHandlerMock.Object, serverUrlValidationOptions: this._defaultValidationOptions);
 
         // Act
         var result = await sut.RunAsync(operation, arguments);
@@ -238,7 +246,7 @@ public sealed class RestApiOperationRunnerTests : IDisposable
             ["X-HD-3"] = new DateTimeOffset(2023, 12, 06, 11, 53, 36, TimeSpan.FromHours(-2)),
         };
 
-        var sut = new RestApiOperationRunner(this._httpClient, this._authenticationHandlerMock.Object, userAgent: "fake-agent");
+        var sut = new RestApiOperationRunner(this._httpClient, this._authenticationHandlerMock.Object, userAgent: "fake-agent", serverUrlValidationOptions: this._defaultValidationOptions);
 
         // Act
         await sut.RunAsync(operation, arguments);
@@ -294,7 +302,7 @@ public sealed class RestApiOperationRunnerTests : IDisposable
             { "fake-header", "fake-header-value" }
         };
 
-        var sut = new RestApiOperationRunner(this._httpClient, this._authenticationHandlerMock.Object, "fake-user-agent");
+        var sut = new RestApiOperationRunner(this._httpClient, this._authenticationHandlerMock.Object, "fake-user-agent", serverUrlValidationOptions: this._defaultValidationOptions);
 
         // Act
         await sut.RunAsync(operation, arguments);
@@ -343,7 +351,7 @@ public sealed class RestApiOperationRunnerTests : IDisposable
             { "enabled", true }
         };
 
-        var sut = new RestApiOperationRunner(this._httpClient, this._authenticationHandlerMock.Object, enableDynamicPayload: true);
+        var sut = new RestApiOperationRunner(this._httpClient, this._authenticationHandlerMock.Object, enableDynamicPayload: true, serverUrlValidationOptions: this._defaultValidationOptions);
 
         // Act
         var result = await sut.RunAsync(operation, arguments);
@@ -413,7 +421,7 @@ public sealed class RestApiOperationRunnerTests : IDisposable
             { "params", "[1,2,3]" }
         };
 
-        var sut = new RestApiOperationRunner(this._httpClient, this._authenticationHandlerMock.Object, enableDynamicPayload: true);
+        var sut = new RestApiOperationRunner(this._httpClient, this._authenticationHandlerMock.Object, enableDynamicPayload: true, serverUrlValidationOptions: this._defaultValidationOptions);
 
         // Act
         var result = await sut.RunAsync(operation, arguments);
@@ -506,7 +514,8 @@ public sealed class RestApiOperationRunnerTests : IDisposable
             this._httpClient,
             this._authenticationHandlerMock.Object,
             enableDynamicPayload: true,
-            enablePayloadNamespacing: true);
+            enablePayloadNamespacing: true,
+            serverUrlValidationOptions: this._defaultValidationOptions);
 
         // Act
         var result = await sut.RunAsync(operation, arguments);
@@ -571,7 +580,8 @@ public sealed class RestApiOperationRunnerTests : IDisposable
         var sut = new RestApiOperationRunner(
             this._httpClient,
             this._authenticationHandlerMock.Object,
-            enableDynamicPayload: true);
+            enableDynamicPayload: true,
+            serverUrlValidationOptions: this._defaultValidationOptions);
 
         // Act
         var exception = await Assert.ThrowsAsync<KernelException>(async () => await sut.RunAsync(operation, arguments));
@@ -600,7 +610,8 @@ public sealed class RestApiOperationRunnerTests : IDisposable
         var sut = new RestApiOperationRunner(
             this._httpClient,
             this._authenticationHandlerMock.Object,
-            enableDynamicPayload: false);
+            enableDynamicPayload: false,
+            serverUrlValidationOptions: this._defaultValidationOptions);
 
         // Act
         var exception = await Assert.ThrowsAsync<KernelException>(async () => await sut.RunAsync(operation, arguments));
@@ -633,7 +644,7 @@ public sealed class RestApiOperationRunnerTests : IDisposable
             { "payload", "fake-input-value" },
         };
 
-        var sut = new RestApiOperationRunner(this._httpClient, this._authenticationHandlerMock.Object, enableDynamicPayload: true);
+        var sut = new RestApiOperationRunner(this._httpClient, this._authenticationHandlerMock.Object, enableDynamicPayload: true, serverUrlValidationOptions: this._defaultValidationOptions);
 
         // Act
         var result = await sut.RunAsync(operation, arguments);
@@ -676,7 +687,7 @@ public sealed class RestApiOperationRunnerTests : IDisposable
             { "content-type", $"{contentType}" },
         };
 
-        var sut = new RestApiOperationRunner(this._httpClient, this._authenticationHandlerMock.Object, enableDynamicPayload: false);
+        var sut = new RestApiOperationRunner(this._httpClient, this._authenticationHandlerMock.Object, enableDynamicPayload: false, serverUrlValidationOptions: this._defaultValidationOptions);
 
         // Act
         var result = await sut.RunAsync(operation, arguments);
@@ -724,7 +735,8 @@ public sealed class RestApiOperationRunnerTests : IDisposable
             this._httpClient,
             this._authenticationHandlerMock.Object,
             enableDynamicPayload: true,
-            enablePayloadNamespacing: true);
+            enablePayloadNamespacing: true,
+            serverUrlValidationOptions: this._defaultValidationOptions);
 
         // Act
         var result = await sut.RunAsync(operation, arguments);
@@ -772,7 +784,8 @@ public sealed class RestApiOperationRunnerTests : IDisposable
             this._httpClient,
             this._authenticationHandlerMock.Object,
             enableDynamicPayload: true,
-            enablePayloadNamespacing: true);
+            enablePayloadNamespacing: true,
+            serverUrlValidationOptions: this._defaultValidationOptions);
 
         // Act
         var result = await sut.RunAsync(operation, arguments);
@@ -828,7 +841,7 @@ public sealed class RestApiOperationRunnerTests : IDisposable
             { "p2", 28 },
         };
 
-        var sut = new RestApiOperationRunner(this._httpClient, this._authenticationHandlerMock.Object);
+        var sut = new RestApiOperationRunner(this._httpClient, this._authenticationHandlerMock.Object, serverUrlValidationOptions: this._defaultValidationOptions);
 
         // Act
         var result = await sut.RunAsync(operation, arguments);
@@ -877,7 +890,7 @@ public sealed class RestApiOperationRunnerTests : IDisposable
             { "p2", "v2" },
         };
 
-        var sut = new RestApiOperationRunner(this._httpClient, this._authenticationHandlerMock.Object);
+        var sut = new RestApiOperationRunner(this._httpClient, this._authenticationHandlerMock.Object, serverUrlValidationOptions: this._defaultValidationOptions);
 
         // Act
         var result = await sut.RunAsync(operation, arguments);
@@ -925,7 +938,7 @@ public sealed class RestApiOperationRunnerTests : IDisposable
             { "p2", "v2" }, //Providing argument for the required parameter only
         };
 
-        var sut = new RestApiOperationRunner(this._httpClient, this._authenticationHandlerMock.Object);
+        var sut = new RestApiOperationRunner(this._httpClient, this._authenticationHandlerMock.Object, serverUrlValidationOptions: this._defaultValidationOptions);
 
         // Act
         var result = await sut.RunAsync(operation, arguments);
@@ -962,7 +975,7 @@ public sealed class RestApiOperationRunnerTests : IDisposable
 
         var arguments = new KernelArguments(); //Providing no arguments
 
-        var sut = new RestApiOperationRunner(this._httpClient, this._authenticationHandlerMock.Object);
+        var sut = new RestApiOperationRunner(this._httpClient, this._authenticationHandlerMock.Object, serverUrlValidationOptions: this._defaultValidationOptions);
 
         // Act and Assert
         await Assert.ThrowsAsync<KernelException>(() => sut.RunAsync(operation, arguments));
@@ -998,7 +1011,7 @@ public sealed class RestApiOperationRunnerTests : IDisposable
             { "content-type", "application/json" }
         };
 
-        var sut = new RestApiOperationRunner(this._httpClient, this._authenticationHandlerMock.Object);
+        var sut = new RestApiOperationRunner(this._httpClient, this._authenticationHandlerMock.Object, serverUrlValidationOptions: this._defaultValidationOptions);
 
         // Act
         var result = await sut.RunAsync(operation, arguments);
@@ -1041,7 +1054,7 @@ public sealed class RestApiOperationRunnerTests : IDisposable
             { "content-type", "application/json" }
         };
 
-        var sut = new RestApiOperationRunner(this._httpClient, this._authenticationHandlerMock.Object);
+        var sut = new RestApiOperationRunner(this._httpClient, this._authenticationHandlerMock.Object, serverUrlValidationOptions: this._defaultValidationOptions);
 
         // Act
         var result = await sut.RunAsync(operation, arguments);
@@ -1077,7 +1090,7 @@ public sealed class RestApiOperationRunnerTests : IDisposable
             { "content-type", "application/json" }
         };
 
-        var sut = new RestApiOperationRunner(this._httpClient, this._authenticationHandlerMock.Object);
+        var sut = new RestApiOperationRunner(this._httpClient, this._authenticationHandlerMock.Object, serverUrlValidationOptions: this._defaultValidationOptions);
 
         // Act & Assert
         var kernelException = await Assert.ThrowsAsync<KernelException>(() => sut.RunAsync(operation, arguments));
@@ -1122,7 +1135,7 @@ public sealed class RestApiOperationRunnerTests : IDisposable
             { "enabled", true }
         };
 
-        var sut = new RestApiOperationRunner(this._httpClient, this._authenticationHandlerMock.Object, enableDynamicPayload: true);
+        var sut = new RestApiOperationRunner(this._httpClient, this._authenticationHandlerMock.Object, enableDynamicPayload: true, serverUrlValidationOptions: this._defaultValidationOptions);
 
         // Act
         var result = await sut.RunAsync(operation, arguments);
@@ -1175,7 +1188,7 @@ public sealed class RestApiOperationRunnerTests : IDisposable
             { "enabled", true }
         };
 
-        var sut = new RestApiOperationRunner(this._httpClient, this._authenticationHandlerMock.Object, enableDynamicPayload: true);
+        var sut = new RestApiOperationRunner(this._httpClient, this._authenticationHandlerMock.Object, enableDynamicPayload: true, serverUrlValidationOptions: this._defaultValidationOptions);
 
         // Act
         var result = await sut.RunAsync(operation, arguments);
@@ -1232,7 +1245,7 @@ public sealed class RestApiOperationRunnerTests : IDisposable
             KernelArguments = arguments,
         };
 
-        var sut = new RestApiOperationRunner(this._httpClient, this._authenticationHandlerMock.Object, enableDynamicPayload: true);
+        var sut = new RestApiOperationRunner(this._httpClient, this._authenticationHandlerMock.Object, enableDynamicPayload: true, serverUrlValidationOptions: this._defaultValidationOptions);
 
         // Act
         var result = await sut.RunAsync(operation, arguments, options);
@@ -1271,7 +1284,7 @@ public sealed class RestApiOperationRunnerTests : IDisposable
             { "content-type", "application/json" }
         };
 
-        var sut = new RestApiOperationRunner(this._httpClient, this._authenticationHandlerMock.Object);
+        var sut = new RestApiOperationRunner(this._httpClient, this._authenticationHandlerMock.Object, serverUrlValidationOptions: this._defaultValidationOptions);
 
         // Act & Assert
         var actualException = await Assert.ThrowsAsync(expectedExceptionType, () => sut.RunAsync(operation, arguments));
@@ -1316,7 +1329,7 @@ public sealed class RestApiOperationRunnerTests : IDisposable
             return await context.Response.Content.ReadAsStreamAsync(cancellationToken);
         }
 
-        var sut = new RestApiOperationRunner(this._httpClient, this._authenticationHandlerMock.Object, httpResponseContentReader: ReadHttpResponseContentAsync);
+        var sut = new RestApiOperationRunner(this._httpClient, this._authenticationHandlerMock.Object, httpResponseContentReader: ReadHttpResponseContentAsync, serverUrlValidationOptions: this._defaultValidationOptions);
 
         // Act
         var response = await sut.RunAsync(operation, [], cancellationToken: expectedCancellationToken);
@@ -1350,7 +1363,7 @@ public sealed class RestApiOperationRunnerTests : IDisposable
             return Task.FromResult<object?>(null); // Return null to indicate that no content is returned
         }
 
-        var sut = new RestApiOperationRunner(this._httpClient, this._authenticationHandlerMock.Object, httpResponseContentReader: ReadHttpResponseContentAsync);
+        var sut = new RestApiOperationRunner(this._httpClient, this._authenticationHandlerMock.Object, httpResponseContentReader: ReadHttpResponseContentAsync, serverUrlValidationOptions: this._defaultValidationOptions);
 
         // Act
         var response = await sut.RunAsync(operation, []);
@@ -1385,7 +1398,7 @@ public sealed class RestApiOperationRunnerTests : IDisposable
             return contentStream;
         }
 
-        var sut = new RestApiOperationRunner(this._httpClient, this._authenticationHandlerMock.Object, httpResponseContentReader: ReadHttpResponseContentAsync);
+        var sut = new RestApiOperationRunner(this._httpClient, this._authenticationHandlerMock.Object, httpResponseContentReader: ReadHttpResponseContentAsync, serverUrlValidationOptions: this._defaultValidationOptions);
 
         // Act
         var response = await sut.RunAsync(operation, []);
@@ -1445,7 +1458,7 @@ public sealed class RestApiOperationRunnerTests : IDisposable
             KernelArguments = arguments,
         };
 
-        var sut = new RestApiOperationRunner(this._httpClient, this._authenticationHandlerMock.Object, enableDynamicPayload: true);
+        var sut = new RestApiOperationRunner(this._httpClient, this._authenticationHandlerMock.Object, enableDynamicPayload: true, serverUrlValidationOptions: this._defaultValidationOptions);
 
         // Act
         var result = await sut.RunAsync(operation, arguments, options);
@@ -1510,7 +1523,7 @@ public sealed class RestApiOperationRunnerTests : IDisposable
             KernelArguments = arguments,
         };
 
-        var sut = new RestApiOperationRunner(this._httpClient, this._authenticationHandlerMock.Object, enableDynamicPayload: true);
+        var sut = new RestApiOperationRunner(this._httpClient, this._authenticationHandlerMock.Object, enableDynamicPayload: true, serverUrlValidationOptions: this._defaultValidationOptions);
 
         // Act
         var result = await sut.RunAsync(operation, arguments, options);
@@ -1605,13 +1618,23 @@ public sealed class RestApiOperationRunnerTests : IDisposable
             return ((JsonObject)JsonObject.Parse(json)!, new StringContent(json, Encoding.UTF8, MediaTypeNames.Application.Json));
         }
 
+        var validationOptions = new RestApiOperationServerUrlValidationOptions
+        {
+            AllowedBaseUrls =
+            [
+                new Uri("https://fake-random-test-host"),
+                new Uri("https://fake-random-test-host-from-factory")
+            ]
+        };
+
         var sut = new RestApiOperationRunner(
             this._httpClient,
             enableDynamicPayload: true,
             enablePayloadNamespacing: true,
             urlFactory: CreateUrl,
             headersFactory: CreateHeaders,
-            payloadFactory: CreatePayload);
+            payloadFactory: CreatePayload,
+            serverUrlValidationOptions: validationOptions);
 
         // Act
         var result = await sut.RunAsync(expectedOperation, expectedArguments, expectedOptions);
@@ -1708,7 +1731,7 @@ public sealed class RestApiOperationRunnerTests : IDisposable
             securityRequirements: []
         );
 
-        var sut = new RestApiOperationRunner(this._httpClient, this._authenticationHandlerMock.Object);
+        var sut = new RestApiOperationRunner(this._httpClient, this._authenticationHandlerMock.Object, serverUrlValidationOptions: this._defaultValidationOptions);
 
         // Act
         var result = await sut.RunAsync(operation, []);
@@ -1746,7 +1769,7 @@ public sealed class RestApiOperationRunnerTests : IDisposable
             { "content-type", actualContentType },
         };
 
-        var sut = new RestApiOperationRunner(this._httpClient, this._authenticationHandlerMock.Object, enableDynamicPayload: false);
+        var sut = new RestApiOperationRunner(this._httpClient, this._authenticationHandlerMock.Object, enableDynamicPayload: false, serverUrlValidationOptions: this._defaultValidationOptions);
 
         // Act
         var result = await sut.RunAsync(operation, arguments);
@@ -1793,7 +1816,7 @@ public sealed class RestApiOperationRunnerTests : IDisposable
             { "content-type", "text/plain" },
         };
 
-        var sut = new RestApiOperationRunner(this._httpClient, responseFactory: RestApiOperationResponseFactory);
+        var sut = new RestApiOperationRunner(this._httpClient, responseFactory: RestApiOperationResponseFactory, serverUrlValidationOptions: this._defaultValidationOptions);
 
         using var cancellationTokenSource = new CancellationTokenSource();
 
@@ -1844,7 +1867,7 @@ public sealed class RestApiOperationRunnerTests : IDisposable
             { "content-type", "text/plain" },
         };
 
-        var sut = new RestApiOperationRunner(this._httpClient, responseFactory: RestApiOperationResponseFactory);
+        var sut = new RestApiOperationRunner(this._httpClient, responseFactory: RestApiOperationResponseFactory, serverUrlValidationOptions: this._defaultValidationOptions);
 
         // Act
         var response = await sut.RunAsync(operation, arguments);
@@ -1899,7 +1922,7 @@ public sealed class RestApiOperationRunnerTests : IDisposable
             { "content-type", "text/plain" },
         };
 
-        var sut = new RestApiOperationRunner(this._httpClient, responseFactory: RestApiOperationResponseFactory);
+        var sut = new RestApiOperationRunner(this._httpClient, responseFactory: RestApiOperationResponseFactory, serverUrlValidationOptions: this._defaultValidationOptions);
 
         // Act
         var response = await sut.RunAsync(operation, arguments);
@@ -1923,7 +1946,7 @@ public sealed class RestApiOperationRunnerTests : IDisposable
             securityRequirements: []
         );
 
-        var sut = new RestApiOperationRunner(this._httpClient, this._authenticationHandlerMock.Object);
+        var sut = new RestApiOperationRunner(this._httpClient, this._authenticationHandlerMock.Object, serverUrlValidationOptions: this._defaultValidationOptions);
 
         // Act & Assert - secure-by-default policy blocks plaintext http.
         var exception = await Assert.ThrowsAsync<InvalidOperationException>(() => sut.RunAsync(operation, []));
@@ -1962,7 +1985,7 @@ public sealed class RestApiOperationRunnerTests : IDisposable
         // Arrange
         var operation = new RestApiOperation(
             id: "test",
-            servers: [new RestApiServer("https://api.example.com")],
+            servers: [new RestApiServer("https://1.1.1.1")],
             path: "/api/data",
             method: HttpMethod.Get,
             description: "test operation",
@@ -2256,7 +2279,9 @@ public sealed class RestApiOperationRunnerTests : IDisposable
             securityRequirements: []
         );
 
-        var sut = new RestApiOperationRunner(this._httpClient, this._authenticationHandlerMock.Object);
+        var validationOptions = new RestApiOperationServerUrlValidationOptions();
+
+        var sut = new RestApiOperationRunner(this._httpClient, this._authenticationHandlerMock.Object, serverUrlValidationOptions: validationOptions);
 
         // Act & Assert
         var exception = await Assert.ThrowsAsync<InvalidOperationException>(() => sut.RunAsync(operation, []));
@@ -2290,7 +2315,9 @@ public sealed class RestApiOperationRunnerTests : IDisposable
             securityRequirements: []
         );
 
-        var sut = new RestApiOperationRunner(this._httpClient, this._authenticationHandlerMock.Object);
+        var validationOptions = new RestApiOperationServerUrlValidationOptions();
+
+        var sut = new RestApiOperationRunner(this._httpClient, this._authenticationHandlerMock.Object, serverUrlValidationOptions: validationOptions);
 
         // LLM-supplied host steers the request at the cloud metadata service.
         var arguments = new KernelArguments { { "host", "169.254.169.254" } };
@@ -2374,7 +2401,9 @@ public sealed class RestApiOperationRunnerTests : IDisposable
             securityRequirements: []
         );
 
-        var sut = new RestApiOperationRunner(this._httpClient, this._authenticationHandlerMock.Object);
+        var validationOptions = new RestApiOperationServerUrlValidationOptions();
+
+        var sut = new RestApiOperationRunner(this._httpClient, this._authenticationHandlerMock.Object, serverUrlValidationOptions: validationOptions);
 
         var runOptions = new RestApiOperationRunOptions
         {
@@ -2437,3 +2466,4 @@ public sealed class RestApiOperationRunnerTests : IDisposable
         }
     }
 }
+

--- a/dotnet/src/Functions/Functions.UnitTests/OpenApi/RestApiOperationRunnerTests.cs
+++ b/dotnet/src/Functions/Functions.UnitTests/OpenApi/RestApiOperationRunnerTests.cs
@@ -1909,9 +1909,9 @@ public sealed class RestApiOperationRunnerTests : IDisposable
     }
 
     [Fact]
-    public async Task ItShouldAllowRequestWhenNoValidationOptionsConfiguredAsync()
+    public async Task ItShouldBlockHttpRequestByDefaultWhenNoValidationOptionsConfiguredAsync()
     {
-        // Arrange - no validation options (default behavior)
+        // Arrange - no validation options (default-on protection applies).
         var operation = new RestApiOperation(
             id: "test",
             servers: [new RestApiServer("http://internal-service:8080")],
@@ -1925,8 +1925,9 @@ public sealed class RestApiOperationRunnerTests : IDisposable
 
         var sut = new RestApiOperationRunner(this._httpClient, this._authenticationHandlerMock.Object);
 
-        // Act & Assert - should not throw
-        await sut.RunAsync(operation, []);
+        // Act & Assert - secure-by-default policy blocks plaintext http.
+        var exception = await Assert.ThrowsAsync<InvalidOperationException>(() => sut.RunAsync(operation, []));
+        Assert.Contains("http", exception.Message, StringComparison.OrdinalIgnoreCase);
     }
 
     [Fact]
@@ -1945,7 +1946,7 @@ public sealed class RestApiOperationRunnerTests : IDisposable
         );
 
         var validationOptions = new RestApiOperationServerUrlValidationOptions();
-        // Default AllowedSchemes is ["https"], so "http" should be blocked.
+        // Default policy permits only "https" implicitly, so "http" should be blocked.
 
         var sut = new RestApiOperationRunner(this._httpClient, this._authenticationHandlerMock.Object, serverUrlValidationOptions: validationOptions);
 
@@ -2075,7 +2076,6 @@ public sealed class RestApiOperationRunnerTests : IDisposable
 
         var validationOptions = new RestApiOperationServerUrlValidationOptions
         {
-            AllowedSchemes = ["http", "https"],
             AllowedBaseUrls = [new Uri("http://api.example.com")]
         };
 
@@ -2229,6 +2229,162 @@ public sealed class RestApiOperationRunnerTests : IDisposable
 
         // Act & Assert - should not throw; the path portion matches the allowed base URL
         await sut.RunAsync(operation, arguments);
+    }
+
+    [Theory]
+    [InlineData("http://169.254.169.254/latest/meta-data/iam/")]   // AWS / Azure / GCP metadata
+    [InlineData("https://169.254.169.254/latest/meta-data/iam/")]
+    [InlineData("http://127.0.0.1:8888")]
+    [InlineData("https://127.0.0.1/")]
+    [InlineData("http://10.0.0.5/internal")]
+    [InlineData("https://192.168.1.1/admin")]
+    [InlineData("https://[::1]/")]
+    [InlineData("http://[fe80::1]/")]
+    public async Task ItShouldBlockSsrfTargetsByDefaultAsync(string maliciousServerUrl)
+    {
+        // Arrange - reproduces the MSRC 108836 PoC: a malicious OpenAPI document whose
+        // servers[].url points at a private/loopback/link-local address. With the secure
+        // default policy, the call must throw before any HTTP traffic leaves the host.
+        var operation = new RestApiOperation(
+            id: "exploit",
+            servers: [new RestApiServer(maliciousServerUrl)],
+            path: "/",
+            method: HttpMethod.Get,
+            description: "ssrf attempt",
+            parameters: [],
+            responses: new Dictionary<string, RestApiExpectedResponse>(),
+            securityRequirements: []
+        );
+
+        var sut = new RestApiOperationRunner(this._httpClient, this._authenticationHandlerMock.Object);
+
+        // Act & Assert
+        var exception = await Assert.ThrowsAsync<InvalidOperationException>(() => sut.RunAsync(operation, []));
+        Assert.Contains("not allowed", exception.Message, StringComparison.OrdinalIgnoreCase);
+
+        // Verify no HTTP traffic was sent before the validator threw.
+        Assert.Null(this._httpMessageHandlerStub.RequestUri);
+    }
+
+    [Fact]
+    public async Task ItShouldBlockSsrfTargetSuppliedViaServerVariableFromKernelArgumentsAsync()
+    {
+        // Arrange - second SSRF vector covered by the same chokepoint: an LLM (or other
+        // untrusted source of KernelArguments) supplies the value for a server variable.
+        var operation = new RestApiOperation(
+            id: "weather",
+            servers:
+            [
+                new RestApiServer(
+                    "https://{host}/api",
+                    new Dictionary<string, RestApiServerVariable>
+                    {
+                        { "host", new RestApiServerVariable("api.weather.example.com") }
+                    })
+            ],
+            path: "/forecast",
+            method: HttpMethod.Get,
+            description: "weather",
+            parameters: [],
+            responses: new Dictionary<string, RestApiExpectedResponse>(),
+            securityRequirements: []
+        );
+
+        var sut = new RestApiOperationRunner(this._httpClient, this._authenticationHandlerMock.Object);
+
+        // LLM-supplied host steers the request at the cloud metadata service.
+        var arguments = new KernelArguments { { "host", "169.254.169.254" } };
+
+        // Act & Assert
+        var exception = await Assert.ThrowsAsync<InvalidOperationException>(() => sut.RunAsync(operation, arguments));
+        Assert.Contains("link-local", exception.Message, StringComparison.OrdinalIgnoreCase);
+        Assert.Null(this._httpMessageHandlerStub.RequestUri);
+    }
+
+    [Fact]
+    public async Task ItShouldAllowPrivateAddressWhenAllowPrivateNetworkAccessIsTrueAsync()
+    {
+        // Arrange - localhost dev opt-out.
+        var operation = new RestApiOperation(
+            id: "test",
+            servers: [new RestApiServer("http://127.0.0.1:5000")],
+            path: "/api",
+            method: HttpMethod.Get,
+            description: "dev loop",
+            parameters: [],
+            responses: new Dictionary<string, RestApiExpectedResponse>(),
+            securityRequirements: []
+        );
+
+        var validationOptions = new RestApiOperationServerUrlValidationOptions
+        {
+            AllowPrivateNetworkAccess = true,
+            // http requires explicit allow because https is the implicit default.
+            AllowedBaseUrls = [new Uri("http://127.0.0.1:5000")]
+        };
+
+        var sut = new RestApiOperationRunner(this._httpClient, this._authenticationHandlerMock.Object, serverUrlValidationOptions: validationOptions);
+
+        // Act & Assert - should not throw.
+        await sut.RunAsync(operation, []);
+    }
+
+    [Fact]
+    public async Task ItShouldAllowExplicitAllowedBaseUrlForPlaintextIntranetAsync()
+    {
+        // Arrange - explicit allow bypasses both the implicit https gate and the private-IP
+        // gate so a mixed-scheme intranet allowlist works without enabling
+        // AllowPrivateNetworkAccess globally.
+        var operation = new RestApiOperation(
+            id: "test",
+            servers: [new RestApiServer("http://192.168.1.100/v1")],
+            path: "/orders",
+            method: HttpMethod.Get,
+            description: "intranet",
+            parameters: [],
+            responses: new Dictionary<string, RestApiExpectedResponse>(),
+            securityRequirements: []
+        );
+
+        var validationOptions = new RestApiOperationServerUrlValidationOptions
+        {
+            AllowedBaseUrls = [new Uri("http://192.168.1.100/v1")]
+            // AllowPrivateNetworkAccess stays false.
+        };
+
+        var sut = new RestApiOperationRunner(this._httpClient, this._authenticationHandlerMock.Object, serverUrlValidationOptions: validationOptions);
+
+        // Act & Assert - should not throw.
+        await sut.RunAsync(operation, []);
+    }
+
+    [Fact]
+    public async Task ItShouldValidateServerUrlOverrideAsync()
+    {
+        // Arrange - the ServerUrlOverride must be validated too, since it can be sourced from
+        // attacker-influenced configuration.
+        var operation = new RestApiOperation(
+            id: "test",
+            servers: [new RestApiServer("https://api.example.com")],
+            path: "/users",
+            method: HttpMethod.Get,
+            description: "test",
+            parameters: [],
+            responses: new Dictionary<string, RestApiExpectedResponse>(),
+            securityRequirements: []
+        );
+
+        var sut = new RestApiOperationRunner(this._httpClient, this._authenticationHandlerMock.Object);
+
+        var runOptions = new RestApiOperationRunOptions
+        {
+            ServerUrlOverride = new Uri("http://169.254.169.254/")
+        };
+
+        // Act & Assert
+        var exception = await Assert.ThrowsAsync<InvalidOperationException>(() => sut.RunAsync(operation, [], runOptions));
+        Assert.Contains("not allowed", exception.Message, StringComparison.OrdinalIgnoreCase);
+        Assert.Null(this._httpMessageHandlerStub.RequestUri);
     }
 
     /// <summary>

--- a/dotnet/src/Functions/Functions.UnitTests/OpenApi/ServerUrlValidatorTests.cs
+++ b/dotnet/src/Functions/Functions.UnitTests/OpenApi/ServerUrlValidatorTests.cs
@@ -158,11 +158,11 @@ public class ServerUrlValidatorTests
         // Simulates an attacker-controlled hostname (e.g., evil.com) resolving to the
         // cloud metadata address — the most realistic SSRF vector.
         var url = new Uri("https://evil.example.com/latest/meta-data/");
-        Func<string, CancellationToken, Task<IPAddress[]>> fakeResolver =
-            (_, _) => Task.FromResult(new[] { IPAddress.Parse("169.254.169.254") });
+        Task<IPAddress[]> FakeResolver(string _, CancellationToken _1) =>
+            Task.FromResult(new[] { IPAddress.Parse("169.254.169.254") });
 
         var ex = await Assert.ThrowsAsync<InvalidOperationException>(() =>
-            ServerUrlValidator.ValidateAsync(url, options: null, dnsResolver: fakeResolver));
+            ServerUrlValidator.ValidateAsync(url, options: null, dnsResolver: FakeResolver));
         Assert.Contains("link-local", ex.Message, StringComparison.OrdinalIgnoreCase);
     }
 
@@ -170,11 +170,11 @@ public class ServerUrlValidatorTests
     public async Task ItShouldBlockHostnameResolvingToLoopbackAsync()
     {
         var url = new Uri("https://attacker.example.com/api");
-        Func<string, CancellationToken, Task<IPAddress[]>> fakeResolver =
-            (_, _) => Task.FromResult(new[] { IPAddress.Parse("127.0.0.1") });
+        Task<IPAddress[]> FakeResolver(string _, CancellationToken _1) =>
+            Task.FromResult(new[] { IPAddress.Parse("127.0.0.1") });
 
         var ex = await Assert.ThrowsAsync<InvalidOperationException>(() =>
-            ServerUrlValidator.ValidateAsync(url, options: null, dnsResolver: fakeResolver));
+            ServerUrlValidator.ValidateAsync(url, options: null, dnsResolver: FakeResolver));
         Assert.Contains("loopback", ex.Message, StringComparison.OrdinalIgnoreCase);
     }
 
@@ -183,15 +183,15 @@ public class ServerUrlValidatorTests
     {
         // DNS rebinding defense: even if one address is public, a private one must block.
         var url = new Uri("https://rebind.example.com/");
-        Func<string, CancellationToken, Task<IPAddress[]>> fakeResolver =
-            (_, _) => Task.FromResult(new[]
+        Task<IPAddress[]> FakeResolver(string _, CancellationToken _1) =>
+            Task.FromResult(new[]
             {
                 IPAddress.Parse("93.184.216.34"),  // public
                 IPAddress.Parse("10.0.0.1")        // private
             });
 
         var ex = await Assert.ThrowsAsync<InvalidOperationException>(() =>
-            ServerUrlValidator.ValidateAsync(url, options: null, dnsResolver: fakeResolver));
+            ServerUrlValidator.ValidateAsync(url, options: null, dnsResolver: FakeResolver));
         Assert.Contains("private", ex.Message, StringComparison.OrdinalIgnoreCase);
     }
 
@@ -199,22 +199,22 @@ public class ServerUrlValidatorTests
     public async Task ItShouldAllowHostnameResolvingToPublicIpAsync()
     {
         var url = new Uri("https://api.example.com/");
-        Func<string, CancellationToken, Task<IPAddress[]>> fakeResolver =
-            (_, _) => Task.FromResult(new[] { IPAddress.Parse("93.184.216.34") });
+        Task<IPAddress[]> FakeResolver(string _, CancellationToken _1) =>
+            Task.FromResult(new[] { IPAddress.Parse("93.184.216.34") });
 
         // Should not throw.
-        await ServerUrlValidator.ValidateAsync(url, options: null, dnsResolver: fakeResolver);
+        await ServerUrlValidator.ValidateAsync(url, options: null, dnsResolver: FakeResolver);
     }
 
     [Fact]
     public async Task ItShouldBlockWhenDnsResolutionFailsAsync()
     {
         var url = new Uri("https://unreachable.example.com/");
-        Func<string, CancellationToken, Task<IPAddress[]>> fakeResolver =
-            (_, _) => throw new SocketException();
+        Task<IPAddress[]> FakeResolver(string _, CancellationToken _1) =>
+            throw new SocketException();
 
         var ex = await Assert.ThrowsAsync<InvalidOperationException>(() =>
-            ServerUrlValidator.ValidateAsync(url, options: null, dnsResolver: fakeResolver));
+            ServerUrlValidator.ValidateAsync(url, options: null, dnsResolver: FakeResolver));
         Assert.Contains("DNS resolution", ex.Message, StringComparison.OrdinalIgnoreCase);
     }
 
@@ -222,11 +222,11 @@ public class ServerUrlValidatorTests
     public async Task ItShouldBlockWhenDnsReturnsEmptyAsync()
     {
         var url = new Uri("https://empty-dns.example.com/");
-        Func<string, CancellationToken, Task<IPAddress[]>> fakeResolver =
-            (_, _) => Task.FromResult(Array.Empty<IPAddress>());
+        Task<IPAddress[]> FakeResolver(string _, CancellationToken _1) =>
+            Task.FromResult(Array.Empty<IPAddress>());
 
         var ex = await Assert.ThrowsAsync<InvalidOperationException>(() =>
-            ServerUrlValidator.ValidateAsync(url, options: null, dnsResolver: fakeResolver));
+            ServerUrlValidator.ValidateAsync(url, options: null, dnsResolver: FakeResolver));
         Assert.Contains("no addresses", ex.Message, StringComparison.OrdinalIgnoreCase);
     }
 }

--- a/dotnet/src/Functions/Functions.UnitTests/OpenApi/ServerUrlValidatorTests.cs
+++ b/dotnet/src/Functions/Functions.UnitTests/OpenApi/ServerUrlValidatorTests.cs
@@ -1,4 +1,4 @@
-// Copyright (c) Microsoft. All rights reserved.
+﻿// Copyright (c) Microsoft. All rights reserved.
 
 using System;
 using System.Net;

--- a/dotnet/src/Functions/Functions.UnitTests/OpenApi/ServerUrlValidatorTests.cs
+++ b/dotnet/src/Functions/Functions.UnitTests/OpenApi/ServerUrlValidatorTests.cs
@@ -2,6 +2,8 @@
 
 using System;
 using System.Net;
+using System.Net.Sockets;
+using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.SemanticKernel.Plugins.OpenApi;
 using Xunit;
@@ -148,5 +150,83 @@ public class ServerUrlValidatorTests
         var options = new RestApiOperationServerUrlValidationOptions { AllowPrivateNetworkAccess = true };
 
         await ServerUrlValidator.ValidateAsync(url, options);
+    }
+
+    [Fact]
+    public async Task ItShouldBlockHostnameResolvingToPrivateIpAsync()
+    {
+        // Simulates an attacker-controlled hostname (e.g., evil.com) resolving to the
+        // cloud metadata address — the most realistic SSRF vector.
+        var url = new Uri("https://evil.example.com/latest/meta-data/");
+        Func<string, CancellationToken, Task<IPAddress[]>> fakeResolver =
+            (_, _) => Task.FromResult(new[] { IPAddress.Parse("169.254.169.254") });
+
+        var ex = await Assert.ThrowsAsync<InvalidOperationException>(() =>
+            ServerUrlValidator.ValidateAsync(url, options: null, dnsResolver: fakeResolver));
+        Assert.Contains("link-local", ex.Message, StringComparison.OrdinalIgnoreCase);
+    }
+
+    [Fact]
+    public async Task ItShouldBlockHostnameResolvingToLoopbackAsync()
+    {
+        var url = new Uri("https://attacker.example.com/api");
+        Func<string, CancellationToken, Task<IPAddress[]>> fakeResolver =
+            (_, _) => Task.FromResult(new[] { IPAddress.Parse("127.0.0.1") });
+
+        var ex = await Assert.ThrowsAsync<InvalidOperationException>(() =>
+            ServerUrlValidator.ValidateAsync(url, options: null, dnsResolver: fakeResolver));
+        Assert.Contains("loopback", ex.Message, StringComparison.OrdinalIgnoreCase);
+    }
+
+    [Fact]
+    public async Task ItShouldBlockWhenAnyResolvedAddressIsPrivateAsync()
+    {
+        // DNS rebinding defense: even if one address is public, a private one must block.
+        var url = new Uri("https://rebind.example.com/");
+        Func<string, CancellationToken, Task<IPAddress[]>> fakeResolver =
+            (_, _) => Task.FromResult(new[]
+            {
+                IPAddress.Parse("93.184.216.34"),  // public
+                IPAddress.Parse("10.0.0.1")        // private
+            });
+
+        var ex = await Assert.ThrowsAsync<InvalidOperationException>(() =>
+            ServerUrlValidator.ValidateAsync(url, options: null, dnsResolver: fakeResolver));
+        Assert.Contains("private", ex.Message, StringComparison.OrdinalIgnoreCase);
+    }
+
+    [Fact]
+    public async Task ItShouldAllowHostnameResolvingToPublicIpAsync()
+    {
+        var url = new Uri("https://api.example.com/");
+        Func<string, CancellationToken, Task<IPAddress[]>> fakeResolver =
+            (_, _) => Task.FromResult(new[] { IPAddress.Parse("93.184.216.34") });
+
+        // Should not throw.
+        await ServerUrlValidator.ValidateAsync(url, options: null, dnsResolver: fakeResolver);
+    }
+
+    [Fact]
+    public async Task ItShouldBlockWhenDnsResolutionFailsAsync()
+    {
+        var url = new Uri("https://unreachable.example.com/");
+        Func<string, CancellationToken, Task<IPAddress[]>> fakeResolver =
+            (_, _) => throw new SocketException();
+
+        var ex = await Assert.ThrowsAsync<InvalidOperationException>(() =>
+            ServerUrlValidator.ValidateAsync(url, options: null, dnsResolver: fakeResolver));
+        Assert.Contains("DNS resolution", ex.Message, StringComparison.OrdinalIgnoreCase);
+    }
+
+    [Fact]
+    public async Task ItShouldBlockWhenDnsReturnsEmptyAsync()
+    {
+        var url = new Uri("https://empty-dns.example.com/");
+        Func<string, CancellationToken, Task<IPAddress[]>> fakeResolver =
+            (_, _) => Task.FromResult(Array.Empty<IPAddress>());
+
+        var ex = await Assert.ThrowsAsync<InvalidOperationException>(() =>
+            ServerUrlValidator.ValidateAsync(url, options: null, dnsResolver: fakeResolver));
+        Assert.Contains("no addresses", ex.Message, StringComparison.OrdinalIgnoreCase);
     }
 }

--- a/dotnet/src/Functions/Functions.UnitTests/OpenApi/ServerUrlValidatorTests.cs
+++ b/dotnet/src/Functions/Functions.UnitTests/OpenApi/ServerUrlValidatorTests.cs
@@ -58,7 +58,7 @@ public class ServerUrlValidatorTests
         var ip = IPAddress.Parse(address);
 
         // Act
-        var blocked = ServerUrlValidator.TryClassifyNonPublic(ip, out var category);
+        var blocked = ServerUrlValidator.TryCategorizeNonPublicAddress(ip, out var category);
 
         // Assert
         Assert.True(blocked, $"Expected {address} to be classified as non-public.");
@@ -84,7 +84,7 @@ public class ServerUrlValidatorTests
         var ip = IPAddress.Parse(address);
 
         // Act
-        var blocked = ServerUrlValidator.TryClassifyNonPublic(ip, out _);
+        var blocked = ServerUrlValidator.TryCategorizeNonPublicAddress(ip, out _);
 
         // Assert
         Assert.False(blocked, $"Expected {address} to be treated as public.");

--- a/dotnet/src/Functions/Functions.UnitTests/OpenApi/ServerUrlValidatorTests.cs
+++ b/dotnet/src/Functions/Functions.UnitTests/OpenApi/ServerUrlValidatorTests.cs
@@ -1,0 +1,152 @@
+// Copyright (c) Microsoft. All rights reserved.
+
+using System;
+using System.Net;
+using System.Threading.Tasks;
+using Microsoft.SemanticKernel.Plugins.OpenApi;
+using Xunit;
+
+namespace SemanticKernel.Functions.UnitTests.OpenApi;
+
+/// <summary>
+/// Unit tests for the IP classification logic that backs the secure-by-default SSRF
+/// protection in <see cref="ServerUrlValidator"/>.
+/// </summary>
+public class ServerUrlValidatorTests
+{
+    [Theory]
+    // IPv4 - loopback
+    [InlineData("127.0.0.1", "loopback")]
+    [InlineData("127.255.255.254", "loopback")]
+    // IPv4 - link-local (cloud metadata)
+    [InlineData("169.254.169.254", "link-local")]
+    [InlineData("169.254.0.1", "link-local")]
+    // IPv4 - RFC1918
+    [InlineData("10.0.0.1", "private (RFC1918)")]
+    [InlineData("172.16.0.1", "private (RFC1918)")]
+    [InlineData("172.31.255.255", "private (RFC1918)")]
+    [InlineData("192.168.0.1", "private (RFC1918)")]
+    // IPv4 - CGNAT
+    [InlineData("100.64.0.1", "carrier-grade NAT")]
+    [InlineData("100.127.255.254", "carrier-grade NAT")]
+    // IPv4 - reserved / unspecified / multicast / benchmarking
+    [InlineData("0.0.0.0", "unspecified")]
+    [InlineData("224.0.0.1", "multicast")]
+    [InlineData("239.255.255.255", "multicast")]
+    [InlineData("240.0.0.1", "reserved")]
+    [InlineData("255.255.255.255", "reserved")]
+    [InlineData("198.18.0.1", "benchmarking")]
+    [InlineData("192.0.2.1", "reserved")]
+    [InlineData("198.51.100.1", "reserved")]
+    [InlineData("203.0.113.1", "reserved")]
+    // IPv6
+    [InlineData("::1", "loopback")]
+    [InlineData("::", "unspecified")]
+    [InlineData("fe80::1", "link-local")]
+    [InlineData("fc00::1", "private (IPv6 ULA)")]
+    [InlineData("fd00::1", "private (IPv6 ULA)")]
+    [InlineData("ff02::1", "multicast")]
+    [InlineData("2001:db8::1", "reserved")]
+    // IPv4-mapped IPv6 of a private address
+    [InlineData("::ffff:127.0.0.1", "loopback")]
+    [InlineData("::ffff:169.254.169.254", "link-local")]
+    public void ItShouldClassifyNonPublicAddresses(string address, string expectedCategory)
+    {
+        // Arrange
+        var ip = IPAddress.Parse(address);
+
+        // Act
+        var blocked = ServerUrlValidator.TryClassifyNonPublic(ip, out var category);
+
+        // Assert
+        Assert.True(blocked, $"Expected {address} to be classified as non-public.");
+        Assert.Equal(expectedCategory, category);
+    }
+
+    [Theory]
+    // Public IPv4
+    [InlineData("8.8.8.8")]
+    [InlineData("1.1.1.1")]
+    [InlineData("93.184.216.34")]
+    [InlineData("172.15.255.255")]   // just outside 172.16/12
+    [InlineData("172.32.0.1")]       // just outside 172.16/12
+    [InlineData("11.0.0.1")]         // just outside 10/8
+    [InlineData("192.169.0.1")]      // just outside 192.168/16
+    [InlineData("100.63.255.255")]   // just outside CGNAT
+    [InlineData("100.128.0.1")]      // just outside CGNAT
+    // Public IPv6
+    [InlineData("2606:4700:4700::1111")]   // Cloudflare DNS
+    public void ItShouldNotBlockPublicAddresses(string address)
+    {
+        // Arrange
+        var ip = IPAddress.Parse(address);
+
+        // Act
+        var blocked = ServerUrlValidator.TryClassifyNonPublic(ip, out _);
+
+        // Assert
+        Assert.False(blocked, $"Expected {address} to be treated as public.");
+    }
+
+    [Fact]
+    public async Task ItShouldRejectLiteralLinkLocalIPv4InUrlAsync()
+    {
+        // Arrange
+        var url = new Uri("https://169.254.169.254/latest/meta-data/");
+
+        // Act
+        var ex = await Assert.ThrowsAsync<InvalidOperationException>(() =>
+            ServerUrlValidator.ValidateAsync(url, options: null));
+
+        // Assert
+        Assert.Contains("link-local", ex.Message, StringComparison.OrdinalIgnoreCase);
+    }
+
+    [Fact]
+    public async Task ItShouldRejectLiteralLoopbackIPv6InUrlAsync()
+    {
+        var url = new Uri("https://[::1]/");
+        var ex = await Assert.ThrowsAsync<InvalidOperationException>(() =>
+            ServerUrlValidator.ValidateAsync(url, options: null));
+        Assert.Contains("loopback", ex.Message, StringComparison.OrdinalIgnoreCase);
+    }
+
+    [Fact]
+    public async Task ItShouldRejectHttpSchemeByDefaultForNonAllowlistedHostAsync()
+    {
+        var url = new Uri("http://api.example.com/");
+        var ex = await Assert.ThrowsAsync<InvalidOperationException>(() =>
+            ServerUrlValidator.ValidateAsync(url, options: null));
+        Assert.Contains("scheme", ex.Message, StringComparison.OrdinalIgnoreCase);
+    }
+
+    [Fact]
+    public async Task ItShouldAllowExplicitAllowedBaseUrlEvenForPrivateAddressAsync()
+    {
+        var url = new Uri("http://192.168.1.100/v1/orders");
+        var options = new RestApiOperationServerUrlValidationOptions
+        {
+            AllowedBaseUrls = [new Uri("http://192.168.1.100/v1")]
+        };
+
+        // Should not throw.
+        await ServerUrlValidator.ValidateAsync(url, options);
+    }
+
+    [Fact]
+    public async Task ItShouldAllowPublicHttpsHostByDefaultAsync()
+    {
+        // 1.1.1.1 is a literal public IP - exercises the validator without DNS.
+        var url = new Uri("https://1.1.1.1/");
+        await ServerUrlValidator.ValidateAsync(url, options: null);
+    }
+
+    [Fact]
+    public async Task ItShouldBypassPrivateGateWhenAllowPrivateNetworkAccessTrueAsync()
+    {
+        var url = new Uri("https://10.0.0.5/");
+        var options = new RestApiOperationServerUrlValidationOptions { AllowPrivateNetworkAccess = true };
+
+        await ServerUrlValidator.ValidateAsync(url, options);
+    }
+}

--- a/dotnet/src/IntegrationTests/CrossLanguage/OpenApiTest.cs
+++ b/dotnet/src/IntegrationTests/CrossLanguage/OpenApiTest.cs
@@ -105,7 +105,11 @@ public class OpenApiTest
         Kernel kernel = kernelProvider.GetNewKernel();
 
         using var httpMessageHandlerStub = new HttpMessageHandlerStub();
-        var execParams = new OpenApiFunctionExecutionParameters { HttpClient = new HttpClient(httpMessageHandlerStub) };
+        var execParams = new OpenApiFunctionExecutionParameters
+        {
+            HttpClient = new HttpClient(httpMessageHandlerStub),
+            ServerUrlValidationOptions = new() { AllowPrivateNetworkAccess = true }
+        };
         var plugin = await kernel.CreatePluginFromOpenApiAsync("LightBulb", "./CrossLanguage/Data/LightBulbApi.json", execParams);
 
         KernelFunction function = plugin[functionName];


### PR DESCRIPTION
### Motivation and Context

Strengthen the OpenAPI plugin's server URL handling by making validation active by default.

### Description

- Introduce `ServerUrlValidator` with host classification and DNS resolution
- Make `RestApiOperationServerUrlValidationOptions` enforce validation by default instead of opt-in
- Add `AllowPrivateNetworkAccess` opt-out for scenarios that require it
- Remove experimental `AllowedSchemes` property (SKEXP0040)
- Update `RestApiOperationRunner` to apply validation unconditionally
- Add unit tests

### Contribution Checklist

- [x] The code builds clean without any errors or warnings
- [x] The PR follows the [SK Contribution Guidelines](https://github.com/microsoft/semantic-kernel/blob/main/CONTRIBUTING.md)
- [x] The code follows the [.NET coding conventions](https://learn.microsoft.com/dotnet/csharp/fundamentals/coding-style/coding-conventions)
- [x] All unit tests pass
- [x] New unit tests added
