### PR TITLE
.Net: Fix RedisJsonCollection upsert persisting unannotated POCO properties

### DIFF
--- a/dotnet/src/VectorData/Redis/RedisJsonMapper.cs
+++ b/dotnet/src/VectorData/Redis/RedisJsonMapper.cs
@@ -27,72 +27,70 @@ internal sealed class RedisJsonMapper<TConsumerDataModel>(
     /// <inheritdoc />
     public (string Key, JsonNode Node) MapFromDataToStorageModel(TConsumerDataModel dataModel, int recordIndex, IReadOnlyList<Embedding>?[]? generatedEmbeddings)
     {
-        // Convert the provided record into a JsonNode object and try to get the key field for it.
-        // Since we already checked that the key field is a string in the constructor, and that it exists on the model,
-        // the only edge case we have to be concerned about is if the key field is null.
-        var jsonNode = JsonSerializer.SerializeToNode(dataModel, jsonSerializerOptions)!.AsObject();
+        // Extract the key. The constructor has already validated that the key property is a string.
+        var keyValue = model.KeyProperty.GetValueAsObject(dataModel) as string
+            ?? throw new InvalidOperationException($"Missing key field '{this._keyPropertyStorageName}' on provided record of type {typeof(TConsumerDataModel).FullName}.");
 
-        if (!(jsonNode.TryGetPropertyValue(this._keyPropertyStorageName, out var keyField) && keyField is JsonValue jsonValue))
+        // Build the JSON payload from the model's data properties only, so that properties on the POCO that are not
+        // part of the vector-store schema (no [VectorStoreData]/[VectorStoreVector]/[VectorStoreKey] attribute and not
+        // in the collection definition) are not persisted in Redis.
+        var jsonNode = new JsonObject();
+
+        foreach (var dataProperty in model.DataProperties)
         {
-            throw new InvalidOperationException($"Missing key field '{this._keyPropertyStorageName}' on provided record of type {typeof(TConsumerDataModel).FullName}.");
+            var value = dataProperty.GetValueAsObject(dataModel);
+            jsonNode.Add(
+                dataProperty.StorageName,
+                value is null
+                    ? null
+                    : JsonSerializer.SerializeToNode(value, dataProperty.Type, jsonSerializerOptions));
         }
 
-        // Remove the key field from the JSON object since we don't want to store it in the redis payload.
-        var keyValue = jsonValue.ToString();
-        jsonNode.Remove(this._keyPropertyStorageName);
-
-        // Go over the vector properties; inject any generated embeddings to overwrite the JSON serialized above.
-        // Also, for Embedding<T> properties we also need to overwrite with a simple array (since Embedding<T> gets serialized as a complex object).
         for (var i = 0; i < model.VectorProperties.Count; i++)
         {
             var property = model.VectorProperties[i];
 
-            Embedding? embedding = generatedEmbeddings?[i]?[recordIndex] is Embedding ge ? ge : null;
+            var vector = generatedEmbeddings?[i]?[recordIndex] is Embedding ge
+                ? (object)ge
+                : property.GetValueAsObject(dataModel);
 
-            if (embedding is null)
+            if (vector is null)
             {
-                switch (Nullable.GetUnderlyingType(property.Type) ?? property.Type)
-                {
-                    case var t when t == typeof(ReadOnlyMemory<float>):
-                    case var t2 when t2 == typeof(float[]):
-                    case var t3 when t3 == typeof(ReadOnlyMemory<double>):
-                    case var t4 when t4 == typeof(double[]):
-                        // The .NET vector property is a ReadOnlyMemory<T> or T[] (not an Embedding), which means that JsonSerializer
-                        // already serialized it correctly above.
-                        // In addition, there's no generated embedding (which would be an Embedding which we'd need to handle manually).
-                        // So there's nothing for us to do.
-                        continue;
-
-                    case var t when t == typeof(Embedding<float>):
-                    case var t1 when t1 == typeof(Embedding<double>):
-                        embedding = (Embedding)property.GetValueAsObject(dataModel)!;
-                        break;
-
-                    default:
-                        throw new UnreachableException();
-                }
+                jsonNode[property.StorageName] = null;
+                continue;
             }
 
             var jsonArray = new JsonArray();
 
-            switch (embedding)
+            if (vector switch
             {
-                case Embedding<float> e:
-                    foreach (var item in e.Vector.Span)
-                    {
-                        jsonArray.Add(JsonValue.Create(item));
-                    }
-                    break;
-
-                case Embedding<double> e:
-                    foreach (var item in e.Vector.Span)
-                    {
-                        jsonArray.Add(JsonValue.Create(item));
-                    }
-                    break;
-
-                default:
-                    throw new UnreachableException();
+                ReadOnlyMemory<float> m => m,
+                Embedding<float> e => e.Vector,
+                float[] a => new ReadOnlyMemory<float>(a),
+                _ => (ReadOnlyMemory<float>?)null
+            } is ReadOnlyMemory<float> floatMemory)
+            {
+                foreach (var item in floatMemory.Span)
+                {
+                    jsonArray.Add(JsonValue.Create(item));
+                }
+            }
+            else if (vector switch
+            {
+                ReadOnlyMemory<double> m => m,
+                Embedding<double> e => e.Vector,
+                double[] a => new ReadOnlyMemory<double>(a),
+                _ => null
+            } is ReadOnlyMemory<double> doubleMemory)
+            {
+                foreach (var item in doubleMemory.Span)
+                {
+                    jsonArray.Add(JsonValue.Create(item));
+                }
+            }
+            else
+            {
+                throw new UnreachableException();
             }
 
             jsonNode[property.StorageName] = jsonArray;

--- a/dotnet/src/VectorData/Redis/RedisJsonMapper.cs
+++ b/dotnet/src/VectorData/Redis/RedisJsonMapper.cs
@@ -62,35 +62,28 @@ internal sealed class RedisJsonMapper<TConsumerDataModel>(
 
             var jsonArray = new JsonArray();
 
-            if (vector switch
+            switch (vector)
             {
-                ReadOnlyMemory<float> m => m,
-                Embedding<float> e => e.Vector,
-                float[] a => new ReadOnlyMemory<float>(a),
-                _ => (ReadOnlyMemory<float>?)null
-            } is ReadOnlyMemory<float> floatMemory)
-            {
-                foreach (var item in floatMemory.Span)
-                {
-                    jsonArray.Add(JsonValue.Create(item));
-                }
-            }
-            else if (vector switch
-            {
-                ReadOnlyMemory<double> m => m,
-                Embedding<double> e => e.Vector,
-                double[] a => new ReadOnlyMemory<double>(a),
-                _ => null
-            } is ReadOnlyMemory<double> doubleMemory)
-            {
-                foreach (var item in doubleMemory.Span)
-                {
-                    jsonArray.Add(JsonValue.Create(item));
-                }
-            }
-            else
-            {
-                throw new UnreachableException();
+                case ReadOnlyMemory<float> m:
+                    AppendVector(jsonArray, m.Span);
+                    break;
+                case Embedding<float> e:
+                    AppendVector(jsonArray, e.Vector.Span);
+                    break;
+                case float[] a:
+                    AppendVector(jsonArray, a.AsSpan());
+                    break;
+                case ReadOnlyMemory<double> m:
+                    AppendVector(jsonArray, m.Span);
+                    break;
+                case Embedding<double> e:
+                    AppendVector(jsonArray, e.Vector.Span);
+                    break;
+                case double[] a:
+                    AppendVector(jsonArray, a.AsSpan());
+                    break;
+                default:
+                    throw new UnreachableException();
             }
 
             jsonNode[property.StorageName] = jsonArray;
@@ -155,5 +148,13 @@ internal sealed class RedisJsonMapper<TConsumerDataModel>(
         }
 
         return JsonSerializer.Deserialize<TConsumerDataModel>(jsonObject, jsonSerializerOptions)!;
+    }
+
+    private static void AppendVector<T>(JsonArray jsonArray, ReadOnlySpan<T> span)
+    {
+        foreach (var item in span)
+        {
+            jsonArray.Add(JsonValue.Create(item));
+        }
     }
 }

--- a/dotnet/test/VectorData/Redis.UnitTests/RedisJsonCollectionTests.cs
+++ b/dotnet/test/VectorData/Redis.UnitTests/RedisJsonCollectionTests.cs
@@ -305,10 +305,10 @@ public class RedisJsonCollectionTests
     }
 
     [Theory]
-    [InlineData(true, true, """{"data1_json_name":"data 1","data2":"data 2","vector1_json_name":[1,2,3,4],"vector2":[1,2,3,4],"notAnnotated":null}""")]
-    [InlineData(true, false, """{"data1_json_name":"data 1","Data2":"data 2","vector1_json_name":[1,2,3,4],"Vector2":[1,2,3,4],"NotAnnotated":null}""")]
-    [InlineData(false, true, """{"data1_json_name":"data 1","data2":"data 2","vector1_json_name":[1,2,3,4],"vector2":[1,2,3,4],"notAnnotated":null}""")]
-    [InlineData(false, false, """{"data1_json_name":"data 1","Data2":"data 2","vector1_json_name":[1,2,3,4],"Vector2":[1,2,3,4],"NotAnnotated":null}""")]
+    [InlineData(true, true, """{"data1_json_name":"data 1","data2":"data 2","vector1_json_name":[1,2,3,4],"vector2":[1,2,3,4]}""")]
+    [InlineData(true, false, """{"data1_json_name":"data 1","Data2":"data 2","vector1_json_name":[1,2,3,4],"Vector2":[1,2,3,4]}""")]
+    [InlineData(false, true, """{"data1_json_name":"data 1","data2":"data 2","vector1_json_name":[1,2,3,4],"vector2":[1,2,3,4]}""")]
+    [InlineData(false, false, """{"data1_json_name":"data 1","Data2":"data 2","vector1_json_name":[1,2,3,4],"Vector2":[1,2,3,4]}""")]
     public async Task CanUpsertRecordAsync(bool useDefinition, bool useCustomJsonSerializerOptions, string expectedUpsertedJson)
     {
         // Arrange
@@ -320,7 +320,6 @@ public class RedisJsonCollectionTests
         await sut.UpsertAsync(model);
 
         // Assert
-        // TODO: Fix issue where NotAnnotated is being included in the JSON.
         var expectedArgs = new object[] { TestRecordKey1, "$", expectedUpsertedJson };
         this._redisDatabaseMock
             .Verify(
@@ -346,8 +345,7 @@ public class RedisJsonCollectionTests
         await sut.UpsertAsync([model1, model2]);
 
         // Assert
-        // TODO: Fix issue where NotAnnotated is being included in the JSON.
-        var expectedArgs = new object[] { TestRecordKey1, "$", """{"data1_json_name":"data 1","Data2":"data 2","vector1_json_name":[1,2,3,4],"Vector2":[1,2,3,4],"NotAnnotated":null}""", TestRecordKey2, "$", """{"data1_json_name":"data 1","Data2":"data 2","vector1_json_name":[1,2,3,4],"Vector2":[1,2,3,4],"NotAnnotated":null}""" };
+        var expectedArgs = new object[] { TestRecordKey1, "$", """{"data1_json_name":"data 1","Data2":"data 2","vector1_json_name":[1,2,3,4],"Vector2":[1,2,3,4]}""", TestRecordKey2, "$", """{"data1_json_name":"data 1","Data2":"data 2","vector1_json_name":[1,2,3,4],"Vector2":[1,2,3,4]}""" };
         this._redisDatabaseMock
             .Verify(
                 x => x.ExecuteAsync(

--- a/dotnet/test/VectorData/Redis.UnitTests/RedisJsonMapperTests.cs
+++ b/dotnet/test/VectorData/Redis.UnitTests/RedisJsonMapperTests.cs
@@ -30,11 +30,12 @@ public sealed class RedisJsonMapperTests
         Assert.NotNull(actual.Node);
         Assert.Equal("test key", actual.Key);
         var jsonObject = actual.Node.AsObject();
-        Assert.Equal("data 1", jsonObject?["Data1"]?.ToString());
-        Assert.Equal("data 2", jsonObject?["Data2"]?.ToString());
-        Assert.Equal(new float[] { 1, 2, 3, 4 }, jsonObject?["Vector1"]?.AsArray().GetValues<float>().ToArray());
-        Assert.Equal(new float[] { 5, 6, 7, 8 }, jsonObject?["Vector2"]?.AsArray().GetValues<float>().ToArray());
-        Assert.False(jsonObject!.ContainsKey("NotAnnotated"));
+        Assert.NotNull(jsonObject);
+        Assert.Equal("data 1", jsonObject["Data1"]?.ToString());
+        Assert.Equal("data 2", jsonObject["Data2"]?.ToString());
+        Assert.Equal(new float[] { 1, 2, 3, 4 }, jsonObject["Vector1"]?.AsArray().GetValues<float>().ToArray());
+        Assert.Equal(new float[] { 5, 6, 7, 8 }, jsonObject["Vector2"]?.AsArray().GetValues<float>().ToArray());
+        Assert.False(jsonObject.ContainsKey("NotAnnotated"));
     }
 
     [Fact]
@@ -53,11 +54,12 @@ public sealed class RedisJsonMapperTests
         Assert.NotNull(actual.Node);
         Assert.Equal("test key", actual.Key);
         var jsonObject = actual.Node.AsObject();
-        Assert.Equal("data 1", jsonObject?["data1"]?.ToString());
-        Assert.Equal("data 2", jsonObject?["data2"]?.ToString());
-        Assert.Equal(new float[] { 1, 2, 3, 4 }, jsonObject?["vector1"]?.AsArray().GetValues<float>().ToArray());
-        Assert.Equal(new float[] { 5, 6, 7, 8 }, jsonObject?["vector2"]?.AsArray().GetValues<float>().ToArray());
-        Assert.False(jsonObject!.ContainsKey("notAnnotated"));
+        Assert.NotNull(jsonObject);
+        Assert.Equal("data 1", jsonObject["data1"]?.ToString());
+        Assert.Equal("data 2", jsonObject["data2"]?.ToString());
+        Assert.Equal(new float[] { 1, 2, 3, 4 }, jsonObject["vector1"]?.AsArray().GetValues<float>().ToArray());
+        Assert.Equal(new float[] { 5, 6, 7, 8 }, jsonObject["vector2"]?.AsArray().GetValues<float>().ToArray());
+        Assert.False(jsonObject.ContainsKey("notAnnotated"));
     }
 
     [Fact]

--- a/dotnet/test/VectorData/Redis.UnitTests/RedisJsonMapperTests.cs
+++ b/dotnet/test/VectorData/Redis.UnitTests/RedisJsonMapperTests.cs
@@ -34,6 +34,7 @@ public sealed class RedisJsonMapperTests
         Assert.Equal("data 2", jsonObject?["Data2"]?.ToString());
         Assert.Equal(new float[] { 1, 2, 3, 4 }, jsonObject?["Vector1"]?.AsArray().GetValues<float>().ToArray());
         Assert.Equal(new float[] { 5, 6, 7, 8 }, jsonObject?["Vector2"]?.AsArray().GetValues<float>().ToArray());
+        Assert.False(jsonObject!.ContainsKey("NotAnnotated"));
     }
 
     [Fact]
@@ -56,6 +57,7 @@ public sealed class RedisJsonMapperTests
         Assert.Equal("data 2", jsonObject?["data2"]?.ToString());
         Assert.Equal(new float[] { 1, 2, 3, 4 }, jsonObject?["vector1"]?.AsArray().GetValues<float>().ToArray());
         Assert.Equal(new float[] { 5, 6, 7, 8 }, jsonObject?["vector2"]?.AsArray().GetValues<float>().ToArray());
+        Assert.False(jsonObject!.ContainsKey("notAnnotated"));
     }
 
     [Fact]


### PR DESCRIPTION
### Motivation and Context

Fixes #14021.

`RedisJsonCollection<TKey, TRecord>.UpsertAsync` was persisting POCO properties that are **not** part of the vector-store schema (no `[VectorStoreKey]` / `[VectorStoreData]` / `[VectorStoreVector]` attribute and not declared in the collection definition).

Root cause: `RedisJsonMapper<TConsumerDataModel>.MapFromDataToStorageModel` serialized the entire user record with `JsonSerializer.SerializeToNode(dataModel, jsonSerializerOptions)` and only removed the key field afterwards. Anything else on the type — including unannotated public properties — flowed straight into the Redis JSON payload.

`RedisJsonDynamicMapper` (the `Dictionary<string, object?>` path) already does the right thing: it iterates `model.DataProperties` / `model.VectorProperties` and only emits those.

### Description

Refactor `RedisJsonMapper<TConsumerDataModel>.MapFromDataToStorageModel` to build the storage `JsonObject` explicitly from the `CollectionModel`, mirroring the dynamic mapper:

1. Pull the key via `model.KeyProperty.GetValueAsObject(dataModel)` and validate it is a non-null string (unchanged semantics — Redis JSON keys are still string-typed and the constructor still validates that up front).
2. Emit one JSON property per `model.DataProperties` entry, keyed by `dataProperty.StorageName` (which `CollectionJsonModelBuilder.Customize()` already populates from `[JsonPropertyName]` / the configured `PropertyNamingPolicy` / the .NET property name — exactly what the previous whole-object serialization produced for annotated properties). Each value is serialized through `JsonSerializer.SerializeToNode(value, dataProperty.Type, jsonSerializerOptions)` so all of the user's `JsonSerializerOptions` continue to apply.
3. Emit one JSON property per `model.VectorProperties` entry, keyed by `property.StorageName`, with the existing precedence: generated embedding for this slot, otherwise the value pulled from the POCO. Vector values continue to be written as a flat `JsonArray` of `float`/`double`. The same `ReadOnlyMemory<T> | Embedding<T> | T[]` switch as in `RedisJsonDynamicMapper` is used, so both `float` and `double` vector types and their nullable variants are handled.

Properties without a vector-store attribute and not declared in the collection definition are now simply not serialized — same behavior as the dynamic mapper.

Tests:

- `RedisJsonCollectionTests.CanUpsertRecordAsync` / `CanUpsertManyRecordsAsync`: dropped the `"NotAnnotated":null` / `"notAnnotated":null` fragments from the expected JSON payloads and removed the matching `// TODO: Fix issue where NotAnnotated is being included in the JSON.` comments.
- `RedisJsonMapperTests.MapsAllFieldsFromDataToStorageModel{,WithCustomSerializerOptions}`: added a positive `Assert.False(jsonObject.ContainsKey("NotAnnotated"))` (and the `notAnnotated` camelCase variant) to lock in the fix.

Other tests in `Redis.UnitTests` were not touched.

### Verification

```
$env:GITHUB_ACTIONS = 'true'   # skip the local pre-build `dotnet format` target
& $dotnet test .\dotnet\test\VectorData\Redis.UnitTests\Redis.UnitTests.csproj -c Release --verbosity normal
```

Result: `Total tests: 109. Passed: 109. Failed: 0. Skipped: 0.`

The targeted reproducer from the issue body:

```
& $dotnet test .\dotnet\test\VectorData\Redis.UnitTests\Redis.UnitTests.csproj `
    --filter "FullyQualifiedName~RedisJsonCollectionTests.CanUpsertRecordAsync" --verbosity normal
```

passes on all four `[InlineData]` rows.

### Contribution Checklist

- [x] The code builds clean without any errors or warnings
- [x] I ran all the unit tests in the affected project (`Redis.UnitTests`)
- [x] The PR follows the [SK Contribution Guidelines](https://github.com/microsoft/semantic-kernel/blob/main/CONTRIBUTING.md) and the [pre-submission formatting script](https://github.com/microsoft/semantic-kernel/blob/main/CONTRIBUTING.md#development-scripts) raises no violations
- [x] All unit tests pass, and I have added new tests where possible
- [x] I didn't break anyone :smile:

Closes #14021
