### PR TITLE
.Net: Fix #14021: Prune unannotated POCO properties from Redis JSON payloads

### DIFF
--- a/dotnet/src/VectorData/Redis/RedisJsonMapper.cs
+++ b/dotnet/src/VectorData/Redis/RedisJsonMapper.cs
@@ -47,10 +47,21 @@ internal sealed class RedisJsonMapper<TConsumerDataModel>(
         jsonNode.Remove(this._keyPropertyStorageName);
 
         // Remove any properties that are not part of the data model.
-        var propertiesToRemove = jsonNode.Select(x => x.Key).Where(key => !this._allowedStorageNames.Contains(key)).ToList();
-        foreach (var keyToRemove in propertiesToRemove)
+        List<string>? propertiesToRemove = null;
+        foreach (var kvp in jsonNode)
         {
-            jsonNode.Remove(keyToRemove);
+            if (!this._allowedStorageNames.Contains(kvp.Key))
+            {
+                (propertiesToRemove ??= new()).Add(kvp.Key);
+            }
+        }
+
+        if (propertiesToRemove is not null)
+        {
+            foreach (var keyToRemove in propertiesToRemove)
+            {
+                jsonNode.Remove(keyToRemove);
+            }
         }
 
         // Go over the vector properties; inject any generated embeddings to overwrite the JSON serialized above.

--- a/dotnet/src/VectorData/Redis/RedisJsonMapper.cs
+++ b/dotnet/src/VectorData/Redis/RedisJsonMapper.cs
@@ -24,6 +24,11 @@ internal sealed class RedisJsonMapper<TConsumerDataModel>(
     /// <summary>The key property.</summary>
     private readonly string _keyPropertyStorageName = model.KeyProperty.StorageName;
 
+    /// <summary>Storage names for the allowed properties that should be retained in the Redis payload.</summary>
+    private readonly HashSet<string> _allowedStorageNames = new(
+        model.DataProperties.Select(p => p.StorageName).Concat(model.VectorProperties.Select(p => p.StorageName)),
+        StringComparer.Ordinal);
+
     /// <inheritdoc />
     public (string Key, JsonNode Node) MapFromDataToStorageModel(TConsumerDataModel dataModel, int recordIndex, IReadOnlyList<Embedding>?[]? generatedEmbeddings)
     {
@@ -40,6 +45,13 @@ internal sealed class RedisJsonMapper<TConsumerDataModel>(
         // Remove the key field from the JSON object since we don't want to store it in the redis payload.
         var keyValue = jsonValue.ToString();
         jsonNode.Remove(this._keyPropertyStorageName);
+
+        // Remove any properties that are not part of the data model.
+        var propertiesToRemove = jsonNode.Select(x => x.Key).Where(key => !this._allowedStorageNames.Contains(key)).ToList();
+        foreach (var keyToRemove in propertiesToRemove)
+        {
+            jsonNode.Remove(keyToRemove);
+        }
 
         // Go over the vector properties; inject any generated embeddings to overwrite the JSON serialized above.
         // Also, for Embedding<T> properties we also need to overwrite with a simple array (since Embedding<T> gets serialized as a complex object).

--- a/dotnet/test/VectorData/Redis.UnitTests/RedisJsonCollectionTests.cs
+++ b/dotnet/test/VectorData/Redis.UnitTests/RedisJsonCollectionTests.cs
@@ -320,7 +320,6 @@ public class RedisJsonCollectionTests
         await sut.UpsertAsync(model);
 
         // Assert
-        // (Fixed) Removed TODO regarding NotAnnotated being included in the JSON.
         var expectedArgs = new object[] { TestRecordKey1, "$", expectedUpsertedJson };
         this._redisDatabaseMock
             .Verify(
@@ -346,7 +345,6 @@ public class RedisJsonCollectionTests
         await sut.UpsertAsync([model1, model2]);
 
         // Assert
-        // (Fixed) Removed TODO regarding NotAnnotated being included in the JSON.
         var expectedArgs = new object[] { TestRecordKey1, "$", """{"data1_json_name":"data 1","Data2":"data 2","vector1_json_name":[1,2,3,4],"Vector2":[1,2,3,4]}""", TestRecordKey2, "$", """{"data1_json_name":"data 1","Data2":"data 2","vector1_json_name":[1,2,3,4],"Vector2":[1,2,3,4]}""" };
         this._redisDatabaseMock
             .Verify(

--- a/dotnet/test/VectorData/Redis.UnitTests/RedisJsonCollectionTests.cs
+++ b/dotnet/test/VectorData/Redis.UnitTests/RedisJsonCollectionTests.cs
@@ -305,10 +305,10 @@ public class RedisJsonCollectionTests
     }
 
     [Theory]
-    [InlineData(true, true, """{"data1_json_name":"data 1","data2":"data 2","vector1_json_name":[1,2,3,4],"vector2":[1,2,3,4],"notAnnotated":null}""")]
-    [InlineData(true, false, """{"data1_json_name":"data 1","Data2":"data 2","vector1_json_name":[1,2,3,4],"Vector2":[1,2,3,4],"NotAnnotated":null}""")]
-    [InlineData(false, true, """{"data1_json_name":"data 1","data2":"data 2","vector1_json_name":[1,2,3,4],"vector2":[1,2,3,4],"notAnnotated":null}""")]
-    [InlineData(false, false, """{"data1_json_name":"data 1","Data2":"data 2","vector1_json_name":[1,2,3,4],"Vector2":[1,2,3,4],"NotAnnotated":null}""")]
+    [InlineData(true, true, """{"data1_json_name":"data 1","data2":"data 2","vector1_json_name":[1,2,3,4],"vector2":[1,2,3,4]}""")]
+    [InlineData(true, false, """{"data1_json_name":"data 1","Data2":"data 2","vector1_json_name":[1,2,3,4],"Vector2":[1,2,3,4]}""")]
+    [InlineData(false, true, """{"data1_json_name":"data 1","data2":"data 2","vector1_json_name":[1,2,3,4],"vector2":[1,2,3,4]}""")]
+    [InlineData(false, false, """{"data1_json_name":"data 1","Data2":"data 2","vector1_json_name":[1,2,3,4],"Vector2":[1,2,3,4]}""")]
     public async Task CanUpsertRecordAsync(bool useDefinition, bool useCustomJsonSerializerOptions, string expectedUpsertedJson)
     {
         // Arrange
@@ -320,7 +320,7 @@ public class RedisJsonCollectionTests
         await sut.UpsertAsync(model);
 
         // Assert
-        // TODO: Fix issue where NotAnnotated is being included in the JSON.
+        // (Fixed) Removed TODO regarding NotAnnotated being included in the JSON.
         var expectedArgs = new object[] { TestRecordKey1, "$", expectedUpsertedJson };
         this._redisDatabaseMock
             .Verify(
@@ -346,8 +346,8 @@ public class RedisJsonCollectionTests
         await sut.UpsertAsync([model1, model2]);
 
         // Assert
-        // TODO: Fix issue where NotAnnotated is being included in the JSON.
-        var expectedArgs = new object[] { TestRecordKey1, "$", """{"data1_json_name":"data 1","Data2":"data 2","vector1_json_name":[1,2,3,4],"Vector2":[1,2,3,4],"NotAnnotated":null}""", TestRecordKey2, "$", """{"data1_json_name":"data 1","Data2":"data 2","vector1_json_name":[1,2,3,4],"Vector2":[1,2,3,4],"NotAnnotated":null}""" };
+        // (Fixed) Removed TODO regarding NotAnnotated being included in the JSON.
+        var expectedArgs = new object[] { TestRecordKey1, "$", """{"data1_json_name":"data 1","Data2":"data 2","vector1_json_name":[1,2,3,4],"Vector2":[1,2,3,4]}""", TestRecordKey2, "$", """{"data1_json_name":"data 1","Data2":"data 2","vector1_json_name":[1,2,3,4],"Vector2":[1,2,3,4]}""" };
         this._redisDatabaseMock
             .Verify(
                 x => x.ExecuteAsync(

--- a/dotnet/test/VectorData/Redis.UnitTests/RedisJsonMapperTests.cs
+++ b/dotnet/test/VectorData/Redis.UnitTests/RedisJsonMapperTests.cs
@@ -34,6 +34,7 @@ public sealed class RedisJsonMapperTests
         Assert.Equal("data 2", jsonObject?["Data2"]?.ToString());
         Assert.Equal(new float[] { 1, 2, 3, 4 }, jsonObject?["Vector1"]?.AsArray().GetValues<float>().ToArray());
         Assert.Equal(new float[] { 5, 6, 7, 8 }, jsonObject?["Vector2"]?.AsArray().GetValues<float>().ToArray());
+        Assert.False(jsonObject!.ContainsKey("NotAnnotated"), "Unannotated properties should not be included in the storage model.");
     }
 
     [Fact]
@@ -56,6 +57,7 @@ public sealed class RedisJsonMapperTests
         Assert.Equal("data 2", jsonObject?["data2"]?.ToString());
         Assert.Equal(new float[] { 1, 2, 3, 4 }, jsonObject?["vector1"]?.AsArray().GetValues<float>().ToArray());
         Assert.Equal(new float[] { 5, 6, 7, 8 }, jsonObject?["vector2"]?.AsArray().GetValues<float>().ToArray());
+        Assert.False(jsonObject!.ContainsKey("notAnnotated"), "Unannotated properties should not be included in the storage model.");
     }
 
     [Fact]

--- a/dotnet/test/VectorData/Redis.UnitTests/RedisJsonMapperTests.cs
+++ b/dotnet/test/VectorData/Redis.UnitTests/RedisJsonMapperTests.cs
@@ -34,7 +34,8 @@ public sealed class RedisJsonMapperTests
         Assert.Equal("data 2", jsonObject?["Data2"]?.ToString());
         Assert.Equal(new float[] { 1, 2, 3, 4 }, jsonObject?["Vector1"]?.AsArray().GetValues<float>().ToArray());
         Assert.Equal(new float[] { 5, 6, 7, 8 }, jsonObject?["Vector2"]?.AsArray().GetValues<float>().ToArray());
-        Assert.False(jsonObject!.ContainsKey("NotAnnotated"), "Unannotated properties should not be included in the storage model.");
+        Assert.NotNull(jsonObject);
+        Assert.False(jsonObject.ContainsKey("NotAnnotated"), "Unannotated properties should not be included in the storage model.");
     }
 
     [Fact]
@@ -57,7 +58,8 @@ public sealed class RedisJsonMapperTests
         Assert.Equal("data 2", jsonObject?["data2"]?.ToString());
         Assert.Equal(new float[] { 1, 2, 3, 4 }, jsonObject?["vector1"]?.AsArray().GetValues<float>().ToArray());
         Assert.Equal(new float[] { 5, 6, 7, 8 }, jsonObject?["vector2"]?.AsArray().GetValues<float>().ToArray());
-        Assert.False(jsonObject!.ContainsKey("notAnnotated"), "Unannotated properties should not be included in the storage model.");
+        Assert.NotNull(jsonObject);
+        Assert.False(jsonObject.ContainsKey("notAnnotated"), "Unannotated properties should not be included in the storage model.");
     }
 
     [Fact]

--- a/dotnet/test/VectorData/Redis.UnitTests/RedisJsonMapperTests.cs
+++ b/dotnet/test/VectorData/Redis.UnitTests/RedisJsonMapperTests.cs
@@ -30,11 +30,11 @@ public sealed class RedisJsonMapperTests
         Assert.NotNull(actual.Node);
         Assert.Equal("test key", actual.Key);
         var jsonObject = actual.Node.AsObject();
-        Assert.Equal("data 1", jsonObject?["Data1"]?.ToString());
-        Assert.Equal("data 2", jsonObject?["Data2"]?.ToString());
-        Assert.Equal(new float[] { 1, 2, 3, 4 }, jsonObject?["Vector1"]?.AsArray().GetValues<float>().ToArray());
-        Assert.Equal(new float[] { 5, 6, 7, 8 }, jsonObject?["Vector2"]?.AsArray().GetValues<float>().ToArray());
         Assert.NotNull(jsonObject);
+        Assert.Equal("data 1", jsonObject["Data1"]?.ToString());
+        Assert.Equal("data 2", jsonObject["Data2"]?.ToString());
+        Assert.Equal(new float[] { 1, 2, 3, 4 }, jsonObject["Vector1"]?.AsArray().GetValues<float>().ToArray());
+        Assert.Equal(new float[] { 5, 6, 7, 8 }, jsonObject["Vector2"]?.AsArray().GetValues<float>().ToArray());
         Assert.False(jsonObject.ContainsKey("NotAnnotated"), "Unannotated properties should not be included in the storage model.");
     }
 
@@ -54,11 +54,11 @@ public sealed class RedisJsonMapperTests
         Assert.NotNull(actual.Node);
         Assert.Equal("test key", actual.Key);
         var jsonObject = actual.Node.AsObject();
-        Assert.Equal("data 1", jsonObject?["data1"]?.ToString());
-        Assert.Equal("data 2", jsonObject?["data2"]?.ToString());
-        Assert.Equal(new float[] { 1, 2, 3, 4 }, jsonObject?["vector1"]?.AsArray().GetValues<float>().ToArray());
-        Assert.Equal(new float[] { 5, 6, 7, 8 }, jsonObject?["vector2"]?.AsArray().GetValues<float>().ToArray());
         Assert.NotNull(jsonObject);
+        Assert.Equal("data 1", jsonObject["data1"]?.ToString());
+        Assert.Equal("data 2", jsonObject["data2"]?.ToString());
+        Assert.Equal(new float[] { 1, 2, 3, 4 }, jsonObject["vector1"]?.AsArray().GetValues<float>().ToArray());
+        Assert.Equal(new float[] { 5, 6, 7, 8 }, jsonObject["vector2"]?.AsArray().GetValues<float>().ToArray());
         Assert.False(jsonObject.ContainsKey("notAnnotated"), "Unannotated properties should not be included in the storage model.");
     }
 


### PR DESCRIPTION
### Motivation and Context
Resolves #14021

Currently, when the .NET [RedisJsonCollection](cci:1://file:///d:/code/semantic-kernel/dotnet/src/VectorData/Redis/RedisJsonCollection.cs:93:4-130:5) upserts data, the [RedisJsonMapper](cci:2://file:///d:/code/semantic-kernel/dotnet/src/VectorData/Redis/RedisJsonMapper.cs:17:0-172:1) serializes the provided POCO into a `JsonNode` using `JsonSerializerOptions`. Because `JsonSerializer` serializes all public properties by default, any POCO properties *not* uniquely annotated with `[VectorStoreData]` or `[VectorStoreVector]` inadvertently leak into the serialized JSON payload and are sent to Redis.

### Description
This PR addresses the serialization leak by implementing an explicit allow-list pruning phase within the mapper:
1. **Pre-computed Allow-List:** An `_allowedStorageNames` `HashSet` is populated inside [RedisJsonMapper](cci:2://file:///d:/code/semantic-kernel/dotnet/src/VectorData/Redis/RedisJsonMapper.cs:17:0-172:1) using the `StorageName` of all annotated `DataProperties` and `VectorProperties` from the active schema.
2. **Payload Pruning:** During [MapFromDataToStorageModel](cci:1://file:///d:/code/semantic-kernel/dotnet/src/VectorData/Redis/RedisJsonMapper.cs:31:4-113:5), after `JsonSerializer.SerializeToNode()` completes, we evaluate the top-level keys. Any unannotated keys absent from the allow-list are dynamically scrubbed via `jsonNode.Remove()`.

By serializing the full POCO first and conditionally dropping keys, we safely preserve all of the user's custom `System.Text.Json` settings (naming policies, custom converters, etc.) without mutating their global resolver caching or forcing them to pollute their POCOs with global `[JsonIgnore]` attributes.

### Testing of the Changes
* I updated [RedisJsonCollectionTests.cs](cci:7://file:///d:/code/semantic-kernel/dotnet/test/VectorData/Redis.UnitTests/RedisJsonCollectionTests.cs:0:0-0:0) to remove the hardcoded `notAnnotated` / `NotAnnotated` mock returns, as well as the original `// TODO` comments documenting the JSON leak.
* I added `Assert.False(jsonObject!.ContainsKey("NotAnnotated"))` to [RedisJsonMapperTests](cci:2://file:///d:/code/semantic-kernel/dotnet/test/VectorData/Redis.UnitTests/RedisJsonMapperTests.cs:15:0-149:1) to guarantee isolated test coverage against future regressions mapping [MultiPropsModel](cci:2://file:///d:/code/semantic-kernel/dotnet/test/VectorData/Redis.UnitTests/RedisJsonMapperTests.cs:130:4-148:5).
* Validated locally using .NET 10 SDK (`dotnet test` returned 109/109 success).