### PR TITLE
Python: preserve image/nested content in FunctionResultContent.from_function_call_content_and_result

### DIFF
--- a/python/semantic_kernel/contents/function_result_content.py
+++ b/python/semantic_kernel/contents/function_result_content.py
@@ -144,7 +144,8 @@ class FunctionResultContent(KernelContent):
                 res = result.items[0].data_uri
             elif isinstance(result.items[0], FunctionResultContent):
                 res = result.items[0].result
-            res = str(result)
+            else:
+                res = str(result)
         else:
             res = result
         return cls(

--- a/python/tests/unit/contents/test_function_result_content.py
+++ b/python/tests/unit/contents/test_function_result_content.py
@@ -116,6 +116,25 @@ def test_from_fcc_and_result(result: any):
     assert frc.metadata == {"test": "test", "test2": "test2"}
 
 
+def test_from_fcc_and_result_preserves_image_and_nested_content():
+    # When the result is a ChatMessageContent whose first item is an
+    # ImageContent or a nested FunctionResultContent, that item's data must be
+    # surfaced - not overwritten by str(result).
+    fcc = FunctionCallContent(id="test", name="test-function", arguments="{}")
+
+    img = ImageContent(data=b"\x89PNG\r\n", mime_type="image/png", data_format="base64")
+    frc_img = FunctionResultContent.from_function_call_content_and_result(
+        fcc, ChatMessageContent(role="tool", items=[img])
+    )
+    assert frc_img.result == img.data_uri
+
+    nested = FunctionResultContent(id="n", name="p-f", result={"k": "v"})
+    frc_nested = FunctionResultContent.from_function_call_content_and_result(
+        fcc, ChatMessageContent(role="tool", items=[nested])
+    )
+    assert frc_nested.result == {"k": "v"}
+
+
 def test_to_cmc():
     frc = FunctionResultContent(id="test", name="test-function", result="test-result")
     cmc = frc.to_chat_message_content()


### PR DESCRIPTION
### Motivation and Context

In `FunctionResultContent.from_function_call_content_and_result`, the `ChatMessageContent` branch selects `res` from the first item, then **unconditionally overwrites it**:

```python
elif isinstance(result, ChatMessageContent):
    if isinstance(result.items[0], TextContent):
        res = result.items[0].text
    elif isinstance(result.items[0], ImageContent):
        res = result.items[0].data_uri      # computed...
    elif isinstance(result.items[0], FunctionResultContent):
        res = result.items[0].result        # ...then discarded
    res = str(result)                        # clobbers all three branches
```

`res = str(result)` is mis-indented — it runs for every item type, so the `ImageContent` and nested-`FunctionResultContent` branches are dead code. Image `data_uri` and nested results are silently lost (become an empty string, since `str(cmc)` of an image-only/result-only message is empty). The `TextContent` case is masked only because `str(cmc)` coincidentally equals the text.

### Description

Move `res = str(result)` into an `else` of the inner `if/elif`, so it is only the fallback for unrecognized item types.

### Verification

Added a regression test (image + nested cases). It fails on the previous code (`frc.result == ""`) and passes with the fix.

```
pytest tests/unit/contents/test_function_result_content.py   # 25 passed
ruff check                                                   # clean
```
