### PR TITLE
Python: fix: apply collection-name prefix to keys in RedisJsonCollection._inner_delete

### DIFF
--- a/python/semantic_kernel/connectors/redis.py
+++ b/python/semantic_kernel/connectors/redis.py
@@ -706,7 +706,7 @@ class RedisJsonCollection(RedisCollection[TKey, TModel], Generic[TKey, TModel]):
 
     @override
     async def _inner_delete(self, keys: Sequence[str], **kwargs: Any) -> None:
-        await asyncio.gather(*[self.redis_database.json().delete(key, **kwargs) for key in keys])
+        await asyncio.gather(*[self.redis_database.json().delete(self._get_redis_key(key), **kwargs) for key in keys])
 
     @override
     def _serialize_dicts_to_store_models(

--- a/python/tests/unit/connectors/memory/test_redis_store.py
+++ b/python/tests/unit/connectors/memory/test_redis_store.py
@@ -276,24 +276,15 @@ async def test_delete(collection_hash, collection_json, type_):
     await collection._inner_delete(["id1"])
 
 
-@mark.parametrize("type_", ["hashset", "json"])
-async def test_delete_with_prefix(
-    collection_with_prefix_hash, collection_with_prefix_json, mock_delete_hash, mock_delete_json, type_
-):
-    if type_ == "hashset":
-        collection = collection_with_prefix_hash
-        mock_delete = mock_delete_hash
-    else:
-        collection = collection_with_prefix_json
-        mock_delete = mock_delete_json
+@mark.parametrize("type_", ["hash", "json"])
+async def test_delete_with_prefix(request, type_):
+    collection = request.getfixturevalue(f"collection_with_prefix_{type_}")
+    mock_delete = request.getfixturevalue(f"mock_delete_{type_}")
 
     await collection._inner_delete(["id1"])
 
     # Verify the collection-name prefix was applied to the key
-    if type_ == "hashset":
-        mock_delete.assert_called_once_with("test:id1")
-    else:
-        mock_delete.assert_called_once_with("test:id1")
+    mock_delete.assert_called_once_with("test:id1")
 
 
 async def test_collection_exists(collection_hash, mock_collection_exists):

--- a/python/tests/unit/connectors/memory/test_redis_store.py
+++ b/python/tests/unit/connectors/memory/test_redis_store.py
@@ -276,6 +276,26 @@ async def test_delete(collection_hash, collection_json, type_):
     await collection._inner_delete(["id1"])
 
 
+@mark.parametrize("type_", ["hashset", "json"])
+async def test_delete_with_prefix(
+    collection_with_prefix_hash, collection_with_prefix_json, mock_delete_hash, mock_delete_json, type_
+):
+    if type_ == "hashset":
+        collection = collection_with_prefix_hash
+        mock_delete = mock_delete_hash
+    else:
+        collection = collection_with_prefix_json
+        mock_delete = mock_delete_json
+
+    await collection._inner_delete(["id1"])
+
+    # Verify the collection-name prefix was applied to the key
+    if type_ == "hashset":
+        mock_delete.assert_called_once_with("test:id1")
+    else:
+        mock_delete.assert_called_once_with("test:id1")
+
+
 async def test_collection_exists(collection_hash, mock_collection_exists):
     await collection_hash.collection_exists()
 


### PR DESCRIPTION
## Motivation and Context

Fixes #13904

The  method passes raw keys to  without applying the collection-name prefix via . This causes deletes to fail when , because the prefixed keys used in upsert/get don't match the unprefixed keys passed to delete.

The sibling  already correctly uses  (line 581 of ).

## Description

**One-line fix** in :

```python
# Before (bug):
await asyncio.gather(*[self.redis_database.json().delete(key, **kwargs) for key in keys])

# After (fix):
await asyncio.gather(*[self.redis_database.json().delete(self._get_redis_key(key), **kwargs) for key in keys])
```

**Test added** in :

Added  that verifies the collection-name prefix is applied to keys during delete for both hashset and JSON collection types.

## Contribution Checklist

- [x] I have built and tested the code locally
- [x] Tests pass (28/28)