### PR TITLE
.Net: fix: respect token limit when merging text chunks

### DIFF
--- a/dotnet/src/SemanticKernel.Core/Text/TextChunker.cs
+++ b/dotnet/src/SemanticKernel.Core/Text/TextChunker.cs
@@ -195,15 +195,11 @@ public static class TextChunker
                 var lastParagraphTokens = lastParagraph.Split(s_spaceChar, StringSplitOptions.RemoveEmptyEntries);
                 var secondLastParagraphTokens = secondLastParagraph.Split(s_spaceChar, StringSplitOptions.RemoveEmptyEntries);
 
-                var lastParagraphTokensCount = lastParagraphTokens.Length;
-                var secondLastParagraphTokensCount = secondLastParagraphTokens.Length;
+                var mergedParagraph = $"{string.Join(" ", secondLastParagraphTokens)} {string.Join(" ", lastParagraphTokens)}";
 
-                if (lastParagraphTokensCount + secondLastParagraphTokensCount <= adjustedMaxTokensPerParagraph)
+                if (GetTokenCount(mergedParagraph, tokenCounter) <= adjustedMaxTokensPerParagraph)
                 {
-                    var newSecondLastParagraph = string.Join(" ", secondLastParagraphTokens);
-                    var newLastParagraph = string.Join(" ", lastParagraphTokens);
-
-                    paragraphs[paragraphs.Count - 2] = $"{newSecondLastParagraph} {newLastParagraph}";
+                    paragraphs[paragraphs.Count - 2] = mergedParagraph;
                     paragraphs.RemoveAt(paragraphs.Count - 1);
                 }
             }

--- a/dotnet/src/SemanticKernel.UnitTests/Text/TextChunkerTests.cs
+++ b/dotnet/src/SemanticKernel.UnitTests/Text/TextChunkerTests.cs
@@ -559,6 +559,17 @@ public sealed class TextChunkerTests
     }
 
     [Fact]
+    public void SplitTextParagraphsDoesNotMergeShortLastParagraphPastTokenLimit()
+    {
+        var input = new[] { "123456789", "x" };
+
+        var result = TextChunker.SplitPlainTextParagraphs(input, 10, tokenCounter: input => input.Length);
+
+        Assert.Equal(["123456789", "x"], result);
+        Assert.All(result, paragraph => Assert.True(paragraph.Length <= 10, $"Paragraph exceeded token limit: {paragraph}"));
+    }
+
+    [Fact]
     public void CanSplitTextParagraphsWithOverlapAndCustomTokenCounter()
     {
         List<string> input =

--- a/dotnet/src/SemanticKernel.UnitTests/Text/TextChunkerTests.cs
+++ b/dotnet/src/SemanticKernel.UnitTests/Text/TextChunkerTests.cs
@@ -563,7 +563,7 @@ public sealed class TextChunkerTests
     {
         var input = new[] { "123456789", "x" };
 
-        var result = TextChunker.SplitPlainTextParagraphs(input, 10, tokenCounter: input => input.Length);
+        var result = TextChunker.SplitPlainTextParagraphs(input, 10, tokenCounter: text => text.Length);
 
         Assert.Equal(["123456789", "x"], result);
         Assert.All(result, paragraph => Assert.True(paragraph.Length <= 10, $"Paragraph exceeded token limit: {paragraph}"));


### PR DESCRIPTION
## Summary
- Fix TextChunker short-tail paragraph merging to validate the merged paragraph with the configured token counter instead of word count.
- Add a regression test for a short final paragraph that would previously be merged past maxTokensPerParagraph.

Fixes #13713

## Validation
- DOTNET_ROOT=/tmp/dotnet10 PATH=/tmp/dotnet10:$PATH DOTNET_CLI_TELEMETRY_OPTOUT=1 dotnet test dotnet/src/SemanticKernel.UnitTests/SemanticKernel.UnitTests.csproj --filter "FullyQualifiedName~TextChunkerTests" --no-restore