### PR TITLE
Python: feat(python): support both  base64 and url  image uploads in Anthropi…

### DIFF
--- a/python/semantic_kernel/connectors/ai/anthropic/services/utils.py
+++ b/python/semantic_kernel/connectors/ai/anthropic/services/utils.py
@@ -10,6 +10,7 @@ from semantic_kernel.contents.chat_message_content import ChatMessageContent
 from semantic_kernel.contents.function_call_content import FunctionCallContent
 from semantic_kernel.contents.function_result_content import FunctionResultContent
 from semantic_kernel.contents.text_content import TextContent
+from semantic_kernel.contents.image_content import ImageContent
 from semantic_kernel.contents.utils.author_role import AuthorRole
 from semantic_kernel.functions.kernel_function_metadata import KernelFunctionMetadata
 
@@ -21,6 +22,7 @@ if TYPE_CHECKING:
     from semantic_kernel.connectors.ai.prompt_execution_settings import PromptExecutionSettings
 
 
+
 def _format_user_message(message: ChatMessageContent) -> dict[str, Any]:
     """Format a user message to the expected object for the Anthropic client.
 
@@ -30,10 +32,22 @@ def _format_user_message(message: ChatMessageContent) -> dict[str, Any]:
     Returns:
         The formatted user message.
     """
-    return {
-        "role": "user",
-        "content": message.content,
-    }
+    if not any(isinstance(item, (ImageContent)) for item in message.items):
+        return {"role": "user","content": message.content}
+    else:
+        content_items :list[dict] = []
+        for content in message.items:
+            if isinstance(content, TextContent):
+                content_items.append({"type": "text", "text": content.text})
+            elif isinstance(content, ImageContent) and (content.data):
+                content_items.append({"type":"image","source":{"type": "base64","data":content.data_string,"media_type":content.mime_type if content.mime_type else content.default_mime_type}})
+            elif isinstance(content, ImageContent) and (content.uri):
+                content_items.append({"type":"image","source":{"type":"url","url":f"{content.uri}"}})
+            else:
+                logger.warning(
+                    "Unsupported item type in User message while formatting chat history for Anthropic AI"
+                    f" Inference: {type(content)}")
+        return {"role": "user","content": content_items}
 
 
 def _format_assistant_message(message: ChatMessageContent) -> dict[str, Any]:

--- a/python/semantic_kernel/connectors/ai/anthropic/services/utils.py
+++ b/python/semantic_kernel/connectors/ai/anthropic/services/utils.py
@@ -32,21 +32,22 @@ def _format_user_message(message: ChatMessageContent) -> dict[str, Any]:
     Returns:
         The formatted user message.
     """
-    if not any(isinstance(item, (ImageContent)) for item in message.items):
+    if not any(isinstance(item,ImageContent) for item in message.items):
         return {"role": "user","content": message.content}
     else:
-        content_items :list[dict] = []
+        content_items: list[dict[str, Any]] = []
         for content in message.items:
             if isinstance(content, TextContent):
                 content_items.append({"type": "text", "text": content.text})
-            elif isinstance(content, ImageContent) and (content.data):
-                content_items.append({"type":"image","source":{"type": "base64","data":content.data_string,"media_type":content.mime_type if content.mime_type else content.default_mime_type}})
-            elif isinstance(content, ImageContent) and (content.uri):
-                content_items.append({"type":"image","source":{"type":"url","url":f"{content.uri}"}})
-            else:
-                logger.warning(
-                    "Unsupported item type in User message while formatting chat history for Anthropic AI"
-                    f" Inference: {type(content)}")
+            elif isinstance(content, ImageContent):
+                if (content.data):
+                    content_items.append({"type":"image","source":{"type": "base64","data":content.data_string,"media_type":content.mime_type if content.mime_type else content.default_mime_type}})    
+                elif (content.uri):
+                    content_items.append({"type":"image","source":{"type":"url","url":f"{content.uri}"}})
+                else:
+                    logger.warning(
+                        "Unsupported item type in User message while formatting chat history for Anthropic AI"
+                        f" Inference: {type(content)}")
         return {"role": "user","content": content_items}
 
 


### PR DESCRIPTION
should resolve Issue https://github.com/microsoft/semantic-kernel/issues/12944

Description
The _format_user_message function in python/semantic_kernel/connectors/ai/anthropic/services/utils.py has been updated to correctly parse base64 image data and format it into the expected Anthropic API structure.

Implementation Details:
*Iterates through message.items to check for ImageContent.

If no ImageContent is found, it returns the standard text-only dictionary, preserving existing behavior.
If ImageContent with item.data is present, it unpacks the message items into a list of dictionaries formatted to meet the [Anthropic Vision API specifications](https://platform.claude.com/docs/en/build-with-claude/vision).
Note: This implementation targets both base64 and url image uploads.
Resolves: #https://github.com/microsoft/semantic-kernel/issues/12944

Motivation and Context
Please help reviewers and future users, providing the following information:

1. Why is this change required?

To allow Image Uploads (only by user messages) for Anthropic Models

2. What problem does it solve?

You can now upload images with claude models

3. What scenario does it contribute to?

Should you have a Chatbot application built with semantic kernel, now anthropic llms can take image uploads

4. If it fixes an open issue, please link to the issue here.

This should Resolve issue https://github.com/microsoft/semantic-kernel/issues/12944

Contribution Checklist
[Y ] The code builds clean without any errors or warnings
[Y ] The PR follows the [SK Contribution Guidelines](https://github.com/microsoft/semantic-kernel/blob/main/CONTRIBUTING.md) and the [pre-submission formatting script](https://github.com/microsoft/semantic-kernel/blob/main/CONTRIBUTING.md#development-scripts) raises no violations
[Y ] All unit tests pass, and I have added new tests where possible
[Y] I didn't break anyone 😄

Modified version of PR#14061 which is now closed
