### PR TITLE
Python: fix {{range}} handlebars helper crashing on consecutive invalid args

### DIFF
--- a/python/semantic_kernel/prompt_template/utils/handlebars_system_helpers.py
+++ b/python/semantic_kernel/prompt_template/utils/handlebars_system_helpers.py
@@ -74,13 +74,16 @@ def _array(this, *args, **kwargs):
 
 
 def _range(this, *args, **kwargs):
-    args = list(args)
-    for index, arg in enumerate(args):
-        if not isinstance(arg, int):
+    converted = []
+    for arg in args:
+        if isinstance(arg, int):
+            converted.append(arg)
+        else:
             try:
-                args[index] = int(arg)
-            except ValueError:
-                args.pop(index)
+                converted.append(int(arg))
+            except (ValueError, TypeError):
+                continue
+    args = converted
     if len(args) == 1:
         return list(range(args[0]))
     if len(args) == 2:

--- a/python/tests/unit/prompt_template/test_handlebars_prompt_template.py
+++ b/python/tests/unit/prompt_template/test_handlebars_prompt_template.py
@@ -140,6 +140,7 @@ async def test_it_renders_kernel_functions_arg_from_arguments(kernel: Kernel, de
         ("range", "0 5 2", "[0, 2, 4]"),
         ("range", "0 5 1 1", "[]"),
         ("range", "'a' 5", "[0, 1, 2, 3, 4]"),
+        ("range", "'a' 'b' 5", "[0, 1, 2, 3, 4]"),
         ("concat", "'test1' 'test2' 'test3'", "test1test2test3"),
         ("or", "true false", "true"),
         ("add", "1 2", "3.0"),


### PR DESCRIPTION
## Problem

`_range` (in `python/semantic_kernel/prompt_template/utils/handlebars_system_helpers.py`, backing the `{{range}}` helper) drops non-integer args by mutating the list **while iterating it**:

```python
args = list(args)
for index, arg in enumerate(args):
    if not isinstance(arg, int):
        try:
            args[index] = int(arg)
        except ValueError:
            args.pop(index)   # mutating during enumerate()
```

`args.pop(index)` shifts the remaining elements left, so the arg immediately after a dropped one is **skipped** and never validated/converted. That leftover string then reaches `range()`, raising `TypeError`.

A single invalid arg works (existing test: `{{range 'a' 5}}` → `[0, 1, 2, 3, 4]`), but two consecutive invalid args crash:

```
{{range 'a' 'b' 5}}  ->  TypeError: 'str' object cannot be interpreted as an integer
```

which contradicts the helper's drop-invalid-args behavior.

## Reproduction (real function)

```
_range(None, 'a', 5)        -> [0, 1, 2, 3, 4]
_range(None, 'a', 'b', 5)   -> TypeError   (expected [0, 1, 2, 3, 4])
```

## Fix

Build the converted list without mutating during iteration (and tolerate `int(None)` → `TypeError` alongside `ValueError`):

```python
converted = []
for arg in args:
    if isinstance(arg, int):
        converted.append(arg)
    else:
        try:
            converted.append(int(arg))
        except (ValueError, TypeError):
            continue
args = converted
```

All existing outputs are unchanged.

## Test

Adds `("range", "'a' 'b' 5", "[0, 1, 2, 3, 4]")` to the parametrized helper test in `python/tests/unit/prompt_template/test_handlebars_prompt_template.py` — it raises `TypeError` on the old code and passes after the fix.