### PR TITLE
.Net: feat(ollama): add Think property to OllamaPromptExecutionSettings

### DIFF
--- a/dotnet/Directory.Packages.props
+++ b/dotnet/Directory.Packages.props
@@ -93,7 +93,7 @@
     <PackageVersion Include="Newtonsoft.Json" Version="13.0.4" />
     <PackageVersion Include="Npgsql" Version="10.0.2" />
     <PackageVersion Include="OData2Linq" Version="2.2.0" />
-    <PackageVersion Include="OllamaSharp" Version="5.4.12" />
+    <PackageVersion Include="OllamaSharp" Version="5.4.25" />
     <PackageVersion Include="OpenAI" Version="2.10.0" />
     <PackageVersion Include="OpenTelemetry" Version="1.15.3" />
     <PackageVersion Include="OpenTelemetry.Api" Version="1.15.3" />

--- a/dotnet/src/Connectors/Connectors.Ollama.UnitTests/Services/OllamaTextGenerationTests.cs
+++ b/dotnet/src/Connectors/Connectors.Ollama.UnitTests/Services/OllamaTextGenerationTests.cs
@@ -188,6 +188,57 @@ public sealed class OllamaTextGenerationTests : IDisposable
         Assert.Equal(ollamaExecutionSettings.TopK, requestPayload.Options.TopK);
     }
 
+    [Theory]
+    [InlineData(true)]
+    [InlineData(false)]
+    public async Task GetTextContentsShouldSendThinkSettingAsync(bool thinkValue)
+    {
+        // Arrange
+        var sut = new OllamaTextGenerationService("fake-model", httpClient: this._httpClient);
+        var settings = new OllamaPromptExecutionSettings { Think = thinkValue };
+
+        // Act
+        await sut.GetTextContentsAsync("Any prompt", settings);
+
+        // Assert
+        var requestPayload = JsonSerializer.Deserialize<GenerateRequest>(this._messageHandlerStub.RequestContent);
+        Assert.NotNull(requestPayload);
+        Assert.Equal(thinkValue, (bool?)requestPayload.Think);
+    }
+
+    [Fact]
+    public async Task GetTextContentsShouldNotSendThinkWhenNotSetAsync()
+    {
+        // Arrange
+        var sut = new OllamaTextGenerationService("fake-model", httpClient: this._httpClient);
+
+        // Act
+        await sut.GetTextContentsAsync("Any prompt");
+
+        // Assert
+        var requestPayload = JsonSerializer.Deserialize<GenerateRequest>(this._messageHandlerStub.RequestContent);
+        Assert.NotNull(requestPayload);
+        Assert.Null(requestPayload.Think);
+    }
+
+    [Theory]
+    [InlineData(true)]
+    [InlineData(false)]
+    public async Task GetStreamingTextContentsShouldSendThinkSettingAsync(bool thinkValue)
+    {
+        // Arrange
+        var sut = new OllamaTextGenerationService("fake-model", httpClient: this._httpClient);
+        var settings = new OllamaPromptExecutionSettings { Think = thinkValue };
+
+        // Act
+        await sut.GetStreamingTextContentsAsync("Any prompt", settings).GetAsyncEnumerator().MoveNextAsync();
+
+        // Assert
+        var requestPayload = JsonSerializer.Deserialize<GenerateRequest>(this._messageHandlerStub.RequestContent);
+        Assert.NotNull(requestPayload);
+        Assert.Equal(thinkValue, (bool?)requestPayload.Think);
+    }
+
     /// <summary>
     /// Disposes resources used by this class.
     /// </summary>

--- a/dotnet/src/Connectors/Connectors.Ollama.UnitTests/Settings/OllamaPromptExecutionSettingsTests.cs
+++ b/dotnet/src/Connectors/Connectors.Ollama.UnitTests/Settings/OllamaPromptExecutionSettingsTests.cs
@@ -41,6 +41,7 @@ public class OllamaPromptExecutionSettingsTests
         Assert.Null(ollamaExecutionSettings.Temperature);
         Assert.Null(ollamaExecutionSettings.TopP);
         Assert.Null(ollamaExecutionSettings.TopK);
+        Assert.Null(ollamaExecutionSettings.Think);
     }
 
     [Fact]
@@ -185,6 +186,45 @@ public class OllamaPromptExecutionSettingsTests
         Assert.Equal(testSettings.ServiceId, cloned.ServiceId);
         Assert.Equal(testSettings.ModelId, cloned.ModelId);
         Assert.Equal(testSettings.Temperature, cloned.Temperature);
+    }
+
+    [Theory]
+    [InlineData(true)]
+    [InlineData(false)]
+    public void ThinkPropertyRoundTripsViaSerialization(bool thinkValue)
+    {
+        // Arrange
+        string jsonSettings = $$"""{ "think": {{thinkValue.ToString().ToLower()}} }""";
+
+        // Act
+        var executionSettings = JsonSerializer.Deserialize<OllamaPromptExecutionSettings>(jsonSettings);
+
+        // Assert
+        Assert.Equal(thinkValue, executionSettings!.Think);
+    }
+
+    [Fact]
+    public void ThinkPropertyIsPreservedByClone()
+    {
+        // Arrange
+        var settings = new OllamaPromptExecutionSettings { Think = false };
+
+        // Act
+        var clone = (OllamaPromptExecutionSettings)settings.Clone();
+
+        // Assert
+        Assert.Equal(false, clone.Think);
+    }
+
+    [Fact]
+    public void ThinkPropertyThrowsWhenFrozen()
+    {
+        // Arrange
+        var settings = new OllamaPromptExecutionSettings();
+        settings.Freeze();
+
+        // Act & Assert
+        Assert.Throws<InvalidOperationException>(() => settings.Think = true);
     }
 
     [Fact]

--- a/dotnet/src/Connectors/Connectors.Ollama.UnitTests/Settings/OllamaPromptExecutionSettingsTests.cs
+++ b/dotnet/src/Connectors/Connectors.Ollama.UnitTests/Settings/OllamaPromptExecutionSettingsTests.cs
@@ -194,7 +194,7 @@ public class OllamaPromptExecutionSettingsTests
     public void ThinkPropertyRoundTripsViaSerialization(bool thinkValue)
     {
         // Arrange
-        string jsonSettings = $$"""{ "think": {{thinkValue.ToString().ToLower()}} }""";
+        string jsonSettings = $$"""{ "think": {{thinkValue.ToString().ToLowerInvariant()}} }""";
 
         // Act
         var executionSettings = JsonSerializer.Deserialize<OllamaPromptExecutionSettings>(jsonSettings);

--- a/dotnet/src/Connectors/Connectors.Ollama/Services/OllamaTextGenerationService.cs
+++ b/dotnet/src/Connectors/Connectors.Ollama/Services/OllamaTextGenerationService.cs
@@ -148,7 +148,8 @@ public sealed class OllamaTextGenerationService : ServiceBase, ITextGenerationSe
                 NumPredict = settings.NumPredict
             },
             Model = selectedModel,
-            Stream = true
+            Stream = true,
+            Think = settings.Think.HasValue ? (OllamaSharp.Models.Chat.ThinkValue?)new OllamaSharp.Models.Chat.ThinkValue(settings.Think) : null
         };
 
         return request;

--- a/dotnet/src/Connectors/Connectors.Ollama/Services/OllamaTextGenerationService.cs
+++ b/dotnet/src/Connectors/Connectors.Ollama/Services/OllamaTextGenerationService.cs
@@ -149,7 +149,7 @@ public sealed class OllamaTextGenerationService : ServiceBase, ITextGenerationSe
             },
             Model = selectedModel,
             Stream = true,
-            Think = settings.Think.HasValue ? (OllamaSharp.Models.Chat.ThinkValue?)new OllamaSharp.Models.Chat.ThinkValue(settings.Think) : null
+            Think = settings.Think.HasValue ? (OllamaSharp.Models.Chat.ThinkValue?)settings.Think.Value : null
         };
 
         return request;

--- a/dotnet/src/Connectors/Connectors.Ollama/Settings/OllamaPromptExecutionSettings.cs
+++ b/dotnet/src/Connectors/Connectors.Ollama/Settings/OllamaPromptExecutionSettings.cs
@@ -131,6 +131,30 @@ public sealed class OllamaPromptExecutionSettings : PromptExecutionSettings
         }
     }
 
+    /// <summary>
+    /// Enables or disables thinking for reasoning models such as deepseek-r1, qwen3, and phi4-reasoning.
+    /// Set to <c>false</c> to disable thinking and receive a standard response when using a model that
+    /// enables thinking by default. Set to <c>true</c> to explicitly enable thinking.
+    /// When <c>null</c> (the default), the model's own default behavior is used.
+    /// </summary>
+    /// <remarks>
+    /// When thinking is active, the model's reasoning output lands in a separate thinking stream
+    /// rather than in the main response content. Setting this to <c>false</c> suppresses thinking
+    /// so that all output appears in the standard response field.
+    /// </remarks>
+    [JsonPropertyName("think")]
+    [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
+    public bool? Think
+    {
+        get => this._think;
+
+        set
+        {
+            this.ThrowIfFrozen();
+            this._think = value;
+        }
+    }
+
     /// <inheritdoc/>
     public override void Freeze()
     {
@@ -161,6 +185,7 @@ public sealed class OllamaPromptExecutionSettings : PromptExecutionSettings
             NumPredict = this.NumPredict,
             Stop = this.Stop is not null ? new List<string>(this.Stop) : null,
             FunctionChoiceBehavior = this.FunctionChoiceBehavior,
+            Think = this.Think,
         };
     }
 
@@ -171,6 +196,7 @@ public sealed class OllamaPromptExecutionSettings : PromptExecutionSettings
     private float? _topP;
     private int? _topK;
     private int? _numPredict;
+    private bool? _think;
 
     #endregion
 }


### PR DESCRIPTION
## Summary

- Adds `Think` (`bool?`) property to `OllamaPromptExecutionSettings` to control thinking for Ollama reasoning models (deepseek-r1, qwen3, phi4-reasoning)
- Maps `Think` to `GenerateRequest.Think` in `OllamaTextGenerationService.CreateRequest()`
- Bumps OllamaSharp from 5.4.12 to 5.4.25 which introduces `GenerateRequest.Think`

## Motivation

Fixes #14078. When a reasoning model has thinking enabled by default (e.g. qwen3, phi4-reasoning), the model output lands in a separate thinking stream rather than the standard response field. This causes `GetTextContentsAsync` to return empty content. The only way to get a usable response is to pass `think=false` to suppress thinking, but there was no way to set that from `OllamaPromptExecutionSettings`.

## Changes

### `OllamaPromptExecutionSettings.cs`
- New `Think` property with `bool?` type, JSON name `think`, `WhenWritingNull` ignore condition, `ThrowIfFrozen()` guard, and `Clone()` support

### `OllamaTextGenerationService.cs`
- `CreateRequest()` maps `settings.Think` to `GenerateRequest.Think` using `OllamaSharp.Models.Chat.ThinkValue`

### `Directory.Packages.props`
- OllamaSharp bumped from 5.4.12 to 5.4.25 (adds `GenerateRequest.Think` and `ThinkValue`)

### Tests
- `OllamaPromptExecutionSettingsTests`: serialization round-trip, Clone, Freeze guard for `Think`
- `OllamaTextGenerationTests`: verifies `Think` is present/absent in the serialized request payload for both `GetTextContentsAsync` and `GetStreamingTextContentsAsync`

## Test plan

- [ ] All 115 existing unit tests pass (1 pre-existing skip)
- [ ] `ThinkPropertyRoundTripsViaSerialization` - `true`/`false` round-trips via JSON
- [ ] `ThinkPropertyIsPreservedByClone` - Clone copies the value
- [ ] `ThinkPropertyThrowsWhenFrozen` - setter throws after Freeze
- [ ] `GetTextContentsShouldSendThinkSettingAsync` - request payload contains correct `think` field
- [ ] `GetTextContentsShouldNotSendThinkWhenNotSetAsync` - request payload omits `think` when null
- [ ] `GetStreamingTextContentsShouldSendThinkSettingAsync` - streaming path also sends `think`