### PR TITLE
Python: Default MCP SSE server samples to loopback with host validation

### DIFF
--- a/python/samples/demos/mcp_server/README.md
+++ b/python/samples/demos/mcp_server/README.md
@@ -61,6 +61,20 @@ uv --directory=<path to sk project>/semantic-kernel/python/samples/demos/mcp_ser
 
 This will start a server that listens for incoming requests on port `8000`.
 
+> [!NOTE]
+> By default the SSE server binds to `127.0.0.1` (loopback) and only accepts requests
+> with a loopback `Host` header and, when present, a loopback `Origin` header. A local
+> MCP server exposes tools, plugins and model providers backed by your own credentials,
+> so it is good practice to keep it reachable only from your own machine. The
+> [MCP specification](https://modelcontextprotocol.io/) recommends validating `Origin`
+> and binding to loopback, in part to guard against [DNS rebinding](https://en.wikipedia.org/wiki/DNS_rebinding).
+>
+> You can override the bind address with `--host`, e.g. `--host 0.0.0.0` to expose the
+> server on the network. Do this only on a trusted network. The bundled Host/Origin
+> checks only allow loopback callers, so a non-loopback deployment needs proper
+> authentication - see the [`mcp_with_oauth`](../mcp_with_oauth/) sample for the
+> authenticated, Streamable-HTTP pattern recommended for production.
+
 ---
 
 In both cases, `uv` will ensure that `semantic-kernel` is installed with the `mcp` extra in a temporary virtual environment.

--- a/python/samples/demos/mcp_server/agent_as_server.py
+++ b/python/samples/demos/mcp_server/agent_as_server.py
@@ -66,6 +66,16 @@ def parse_arguments():
         default=None,
         help="Port to use for SSE transport (required if transport is 'sse').",
     )
+    parser.add_argument(
+        "--host",
+        type=str,
+        default="127.0.0.1",
+        help=(
+            "Host/interface to bind the SSE server to (default: 127.0.0.1). "
+            "Binding to anything other than loopback (e.g. 0.0.0.0) exposes the server "
+            "to the network and should only be done on a trusted network with authentication added."
+        ),
+    )
     return parser.parse_args()
 
 
@@ -88,7 +98,9 @@ class MenuPlugin:
         return "$9.99"
 
 
-async def run(transport: Literal["sse", "stdio"] = "stdio", port: int | None = None) -> None:
+async def run(
+    transport: Literal["sse", "stdio"] = "stdio", port: int | None = None, host: str = "127.0.0.1"
+) -> None:
     async with (
         # 1. Login to Azure and create a Azure AI Project Client
         AzureCliCredential() as creds,
@@ -110,7 +122,39 @@ async def run(transport: Literal["sse", "stdio"] = "stdio", port: int | None = N
             import uvicorn
             from mcp.server.sse import SseServerTransport
             from starlette.applications import Starlette
+            from starlette.middleware import Middleware
+            from starlette.middleware.trustedhost import TrustedHostMiddleware
+            from starlette.responses import PlainTextResponse
             from starlette.routing import Mount, Route
+            from starlette.types import ASGIApp, Receive, Scope, Send
+
+            # A local MCP server is a security boundary, not a generic web server: it exposes
+            # tools, plugins and model providers backed by the developer's credentials. Without
+            # Host/Origin validation a malicious web page could use DNS rebinding to reach this
+            # loopback listener from the victim's browser and invoke the exposed MCP tools.
+            # The MCP spec therefore requires servers to validate Origin and bind to loopback.
+            allowed_hosts = ["localhost", "127.0.0.1", f"localhost:{port}", f"127.0.0.1:{port}"]
+            allowed_origins = {
+                "http://localhost",
+                "http://127.0.0.1",
+                f"http://localhost:{port}",
+                f"http://127.0.0.1:{port}",
+            }
+
+            class OriginValidationMiddleware:
+                """Reject requests with an untrusted Origin header (DNS-rebinding defense)."""
+
+                def __init__(self, app: ASGIApp) -> None:
+                    self.app = app
+
+                async def __call__(self, scope: Scope, receive: Receive, send: Send) -> None:
+                    if scope["type"] == "http":
+                        origin = dict(scope["headers"]).get(b"origin")
+                        if origin is not None and origin.decode() not in allowed_origins:
+                            response = PlainTextResponse("Forbidden: invalid Origin header", status_code=403)
+                            await response(scope, receive, send)
+                            return
+                    await self.app(scope, receive, send)
 
             sse = SseServerTransport("/messages/")
 
@@ -122,14 +166,27 @@ async def run(transport: Literal["sse", "stdio"] = "stdio", port: int | None = N
                     await server.run(read_stream, write_stream, server.create_initialization_options())
 
             starlette_app = Starlette(
-                debug=True,
+                debug=False,
                 routes=[
                     Route("/sse", endpoint=handle_sse),
                     Mount("/messages/", app=sse.handle_post_message),
                 ],
+                middleware=[
+                    Middleware(TrustedHostMiddleware, allowed_hosts=allowed_hosts),
+                    Middleware(OriginValidationMiddleware),
+                ],
             )
+
+            if host not in ("127.0.0.1", "localhost"):
+                logger.warning(
+                    "Binding the MCP SSE server to %s exposes it beyond loopback. The bundled Host/Origin "
+                    "checks only allow loopback callers; for a network-reachable or credentialed deployment "
+                    "add proper authentication (see the mcp_with_oauth sample) before doing this.",
+                    host,
+                )
+
             nest_asyncio.apply()
-            uvicorn.run(starlette_app, host="0.0.0.0", port=port)  # nosec
+            uvicorn.run(starlette_app, host=host, port=port)  # nosec
         elif transport == "stdio":
             from mcp.server.stdio import stdio_server
 
@@ -142,4 +199,4 @@ async def run(transport: Literal["sse", "stdio"] = "stdio", port: int | None = N
 
 if __name__ == "__main__":
     args = parse_arguments()
-    anyio.run(run, args.transport, args.port)
+    anyio.run(run, args.transport, args.port, args.host)

--- a/python/samples/demos/mcp_server/agent_as_server.py
+++ b/python/samples/demos/mcp_server/agent_as_server.py
@@ -5,6 +5,7 @@
 # ///
 # Copyright (c) Microsoft. All rights reserved.
 import argparse
+import ipaddress
 import logging
 from typing import Annotated, Any, Literal
 
@@ -51,6 +52,16 @@ In both cases, uv will make sure to install semantic-kernel with the mcp extra f
 """
 
 
+def is_loopback_host(host: str) -> bool:
+    """Return True if the host refers to a loopback interface (incl. IPv6 ::1)."""
+    if host == "localhost":
+        return True
+    try:
+        return ipaddress.ip_address(host).is_loopback
+    except ValueError:
+        return False
+
+
 def parse_arguments():
     parser = argparse.ArgumentParser(description="Run the Semantic Kernel MCP server.")
     parser.add_argument(
@@ -76,7 +87,10 @@ def parse_arguments():
             "to the network and should only be done on a trusted network with authentication added."
         ),
     )
-    return parser.parse_args()
+    args = parser.parse_args()
+    if args.transport == "sse" and args.port is None:
+        parser.error("--port is required when --transport is 'sse'.")
+    return args
 
 
 # Define a simple plugin for the sample
@@ -133,12 +147,21 @@ async def run(
             # Host/Origin validation a malicious web page could use DNS rebinding to reach this
             # loopback listener from the victim's browser and invoke the exposed MCP tools.
             # The MCP spec therefore requires servers to validate Origin and bind to loopback.
-            allowed_hosts = ["localhost", "127.0.0.1", f"localhost:{port}", f"127.0.0.1:{port}"]
+            allowed_hosts = [
+                "localhost",
+                "127.0.0.1",
+                "[::1]",
+                f"localhost:{port}",
+                f"127.0.0.1:{port}",
+                f"[::1]:{port}",
+            ]
             allowed_origins = {
                 "http://localhost",
                 "http://127.0.0.1",
+                "http://[::1]",
                 f"http://localhost:{port}",
                 f"http://127.0.0.1:{port}",
+                f"http://[::1]:{port}",
             }
 
             class OriginValidationMiddleware:
@@ -150,10 +173,15 @@ async def run(
                 async def __call__(self, scope: Scope, receive: Receive, send: Send) -> None:
                     if scope["type"] == "http":
                         origin = dict(scope["headers"]).get(b"origin")
-                        if origin is not None and origin.decode() not in allowed_origins:
-                            response = PlainTextResponse("Forbidden: invalid Origin header", status_code=403)
-                            await response(scope, receive, send)
-                            return
+                        if origin is not None:
+                            try:
+                                origin_value = origin.decode("ascii")
+                            except UnicodeDecodeError:
+                                origin_value = None
+                            if origin_value not in allowed_origins:
+                                response = PlainTextResponse("Forbidden: invalid Origin header", status_code=403)
+                                await response(scope, receive, send)
+                                return
                     await self.app(scope, receive, send)
 
             sse = SseServerTransport("/messages/")
@@ -177,7 +205,7 @@ async def run(
                 ],
             )
 
-            if host not in ("127.0.0.1", "localhost"):
+            if not is_loopback_host(host):
                 logger.warning(
                     "Binding the MCP SSE server to %s exposes it beyond loopback. The bundled Host/Origin "
                     "checks only allow loopback callers; for a network-reachable or credentialed deployment "

--- a/python/samples/demos/mcp_server/agent_as_server.py
+++ b/python/samples/demos/mcp_server/agent_as_server.py
@@ -112,9 +112,7 @@ class MenuPlugin:
         return "$9.99"
 
 
-async def run(
-    transport: Literal["sse", "stdio"] = "stdio", port: int | None = None, host: str = "127.0.0.1"
-) -> None:
+async def run(transport: Literal["sse", "stdio"] = "stdio", port: int | None = None, host: str = "127.0.0.1") -> None:
     async with (
         # 1. Login to Azure and create a Azure AI Project Client
         AzureCliCredential() as creds,

--- a/python/samples/demos/mcp_server/sk_mcp_server.py
+++ b/python/samples/demos/mcp_server/sk_mcp_server.py
@@ -69,10 +69,20 @@ def parse_arguments():
         default=None,
         help="Port to use for SSE transport (required if transport is 'sse').",
     )
+    parser.add_argument(
+        "--host",
+        type=str,
+        default="127.0.0.1",
+        help=(
+            "Host/interface to bind the SSE server to (default: 127.0.0.1). "
+            "Binding to anything other than loopback (e.g. 0.0.0.0) exposes the server "
+            "to the network and should only be done on a trusted network with authentication added."
+        ),
+    )
     return parser.parse_args()
 
 
-def run(transport: Literal["sse", "stdio"] = "stdio", port: int | None = None) -> None:
+def run(transport: Literal["sse", "stdio"] = "stdio", port: int | None = None, host: str = "127.0.0.1") -> None:
     kernel = Kernel()
 
     @kernel_function()
@@ -112,7 +122,39 @@ def run(transport: Literal["sse", "stdio"] = "stdio", port: int | None = None) -
         import uvicorn
         from mcp.server.sse import SseServerTransport
         from starlette.applications import Starlette
+        from starlette.middleware import Middleware
+        from starlette.middleware.trustedhost import TrustedHostMiddleware
+        from starlette.responses import PlainTextResponse
         from starlette.routing import Mount, Route
+        from starlette.types import ASGIApp, Receive, Scope, Send
+
+        # A local MCP server is a security boundary, not a generic web server: it exposes
+        # tools, plugins and model providers backed by the developer's credentials. Without
+        # Host/Origin validation a malicious web page could use DNS rebinding to reach this
+        # loopback listener from the victim's browser and invoke the exposed MCP tools.
+        # The MCP spec therefore requires servers to validate Origin and bind to loopback.
+        allowed_hosts = ["localhost", "127.0.0.1", f"localhost:{port}", f"127.0.0.1:{port}"]
+        allowed_origins = {
+            "http://localhost",
+            "http://127.0.0.1",
+            f"http://localhost:{port}",
+            f"http://127.0.0.1:{port}",
+        }
+
+        class OriginValidationMiddleware:
+            """Reject requests with an untrusted Origin header (DNS-rebinding defense)."""
+
+            def __init__(self, app: ASGIApp) -> None:
+                self.app = app
+
+            async def __call__(self, scope: Scope, receive: Receive, send: Send) -> None:
+                if scope["type"] == "http":
+                    origin = dict(scope["headers"]).get(b"origin")
+                    if origin is not None and origin.decode() not in allowed_origins:
+                        response = PlainTextResponse("Forbidden: invalid Origin header", status_code=403)
+                        await response(scope, receive, send)
+                        return
+                await self.app(scope, receive, send)
 
         sse = SseServerTransport("/messages/")
 
@@ -121,14 +163,26 @@ def run(transport: Literal["sse", "stdio"] = "stdio", port: int | None = None) -
                 await server.run(read_stream, write_stream, server.create_initialization_options())
 
         starlette_app = Starlette(
-            debug=True,
+            debug=False,
             routes=[
                 Route("/sse", endpoint=handle_sse),
                 Mount("/messages/", app=sse.handle_post_message),
             ],
+            middleware=[
+                Middleware(TrustedHostMiddleware, allowed_hosts=allowed_hosts),
+                Middleware(OriginValidationMiddleware),
+            ],
         )
 
-        uvicorn.run(starlette_app, host="0.0.0.0", port=port)  # nosec
+        if host not in ("127.0.0.1", "localhost"):
+            logger.warning(
+                "Binding the MCP SSE server to %s exposes it beyond loopback. The bundled Host/Origin "
+                "checks only allow loopback callers; for a network-reachable or credentialed deployment "
+                "add proper authentication (see the mcp_with_oauth sample) before doing this.",
+                host,
+            )
+
+        uvicorn.run(starlette_app, host=host, port=port)  # nosec
     elif transport == "stdio":
         import anyio
         from mcp.server.stdio import stdio_server
@@ -142,4 +196,4 @@ def run(transport: Literal["sse", "stdio"] = "stdio", port: int | None = None) -
 
 if __name__ == "__main__":
     args = parse_arguments()
-    run(transport=args.transport, port=args.port)
+    run(transport=args.transport, port=args.port, host=args.host)

--- a/python/samples/demos/mcp_server/sk_mcp_server.py
+++ b/python/samples/demos/mcp_server/sk_mcp_server.py
@@ -5,6 +5,7 @@
 # ///
 # Copyright (c) Microsoft. All rights reserved.
 import argparse
+import ipaddress
 import logging
 from typing import Any, Literal
 
@@ -54,6 +55,16 @@ In both cases, uv will make sure to install semantic-kernel with the mcp extra f
 """
 
 
+def is_loopback_host(host: str) -> bool:
+    """Return True if the host refers to a loopback interface (incl. IPv6 ::1)."""
+    if host == "localhost":
+        return True
+    try:
+        return ipaddress.ip_address(host).is_loopback
+    except ValueError:
+        return False
+
+
 def parse_arguments():
     parser = argparse.ArgumentParser(description="Run the Semantic Kernel MCP server.")
     parser.add_argument(
@@ -79,7 +90,10 @@ def parse_arguments():
             "to the network and should only be done on a trusted network with authentication added."
         ),
     )
-    return parser.parse_args()
+    args = parser.parse_args()
+    if args.transport == "sse" and args.port is None:
+        parser.error("--port is required when --transport is 'sse'.")
+    return args
 
 
 def run(transport: Literal["sse", "stdio"] = "stdio", port: int | None = None, host: str = "127.0.0.1") -> None:
@@ -133,12 +147,21 @@ def run(transport: Literal["sse", "stdio"] = "stdio", port: int | None = None, h
         # Host/Origin validation a malicious web page could use DNS rebinding to reach this
         # loopback listener from the victim's browser and invoke the exposed MCP tools.
         # The MCP spec therefore requires servers to validate Origin and bind to loopback.
-        allowed_hosts = ["localhost", "127.0.0.1", f"localhost:{port}", f"127.0.0.1:{port}"]
+        allowed_hosts = [
+            "localhost",
+            "127.0.0.1",
+            "[::1]",
+            f"localhost:{port}",
+            f"127.0.0.1:{port}",
+            f"[::1]:{port}",
+        ]
         allowed_origins = {
             "http://localhost",
             "http://127.0.0.1",
+            "http://[::1]",
             f"http://localhost:{port}",
             f"http://127.0.0.1:{port}",
+            f"http://[::1]:{port}",
         }
 
         class OriginValidationMiddleware:
@@ -150,10 +173,15 @@ def run(transport: Literal["sse", "stdio"] = "stdio", port: int | None = None, h
             async def __call__(self, scope: Scope, receive: Receive, send: Send) -> None:
                 if scope["type"] == "http":
                     origin = dict(scope["headers"]).get(b"origin")
-                    if origin is not None and origin.decode() not in allowed_origins:
-                        response = PlainTextResponse("Forbidden: invalid Origin header", status_code=403)
-                        await response(scope, receive, send)
-                        return
+                    if origin is not None:
+                        try:
+                            origin_value = origin.decode("ascii")
+                        except UnicodeDecodeError:
+                            origin_value = None
+                        if origin_value not in allowed_origins:
+                            response = PlainTextResponse("Forbidden: invalid Origin header", status_code=403)
+                            await response(scope, receive, send)
+                            return
                 await self.app(scope, receive, send)
 
         sse = SseServerTransport("/messages/")
@@ -174,7 +202,7 @@ def run(transport: Literal["sse", "stdio"] = "stdio", port: int | None = None, h
             ],
         )
 
-        if host not in ("127.0.0.1", "localhost"):
+        if not is_loopback_host(host):
             logger.warning(
                 "Binding the MCP SSE server to %s exposes it beyond loopback. The bundled Host/Origin "
                 "checks only allow loopback callers; for a network-reachable or credentialed deployment "


### PR DESCRIPTION
## Motivation and Context

The Python MCP server demos under `python/samples/demos/mcp_server/` can optionally run over the SSE transport (`--transport sse`). This updates that sample wiring to follow the Model Context Protocol guidance for local development servers, so developers who use these demos as a starting point inherit sensible defaults.

## Description

- **Loopback by default**: the SSE samples now bind to `127.0.0.1` instead of `0.0.0.0`. A new `--host` argument makes binding to other interfaces an explicit opt-in that logs a warning.
- **Host/Origin validation**: added Starlette `TrustedHostMiddleware` plus a small Origin allowlist middleware so the local listener only serves loopback callers (requests without an `Origin` header are still allowed, for non-browser MCP clients).
- **Sample hygiene**: switched `Starlette(debug=True)` to `debug=False` so the demos don't ship verbose debug output.
- **Docs**: the README now describes the loopback-by-default behavior, the `--host` opt-in, and points to the existing `mcp_with_oauth` sample for authenticated, network-reachable deployments.

Applies to `sk_mcp_server.py` and `agent_as_server.py`. The stdio transport (the default) and the other stdio-only samples are unchanged.

## Contribution Checklist

- [x] The code builds clean without any errors or warnings
- [x] I didn't break anyone :smile: