### PR TITLE
Bump Scriban from 7.2.0 to 7.2.5 to fix NU1902 vulnerability

### DIFF
--- a/dotnet/Directory.Packages.props
+++ b/dotnet/Directory.Packages.props
@@ -107,7 +107,7 @@
     <PackageVersion Include="PdfPig" Version="0.1.13" />
     <PackageVersion Include="Pinecone.Client" Version="3.1.0" />
     <PackageVersion Include="Prompty.Core" Version="0.2.3-beta" />
-    <PackageVersion Include="Scriban" Version="7.2.0" />
+    <PackageVersion Include="Scriban" Version="7.2.5" />
     <PackageVersion Include="PuppeteerSharp" Version="20.2.5" />
     <PackageVersion Include="System.Diagnostics.DiagnosticSource" Version="10.0.2" />
     <PackageVersion Include="System.IdentityModel.Tokens.Jwt" Version="8.16.0" />


### PR DESCRIPTION
Fixes CI failure caused by NU1902 errors due to known moderate severity vulnerabilities in Scriban 7.2.0 (GHSA-6q7j-xr26-3h2c, GHSA-q6rr-fm2g-g5x8).