### PR TITLE
.Net: Fix structured output schema references for repeated types

### DIFF
--- a/dotnet/src/Connectors/Connectors.OpenAI.UnitTests/Services/OpenAIChatCompletionServiceTests.cs
+++ b/dotnet/src/Connectors/Connectors.OpenAI.UnitTests/Services/OpenAIChatCompletionServiceTests.cs
@@ -1344,6 +1344,45 @@ public sealed class OpenAIChatCompletionServiceTests : IDisposable
         Assert.Equal("string", itemsProperties.GetProperty("Output").GetProperty("type").GetString());
     }
 
+    [Fact]
+    public async Task GetChatMessageContentsMovesRepeatedTypeReferencesToTopLevelDefinitions()
+    {
+        // Arrange
+        var executionSettings = new OpenAIPromptExecutionSettings { ResponseFormat = typeof(ResponseWithRepeatedArrayItems) };
+
+        this._messageHandlerStub.ResponseToReturn = new HttpResponseMessage(HttpStatusCode.OK)
+        {
+            Content = new StringContent(File.ReadAllText("TestData/chat_completion_test_response.json"))
+        };
+
+        var sut = new OpenAIChatCompletionService("model-id", "api-key", httpClient: this._httpClient);
+
+        // Act
+        await sut.GetChatMessageContentsAsync(this._chatHistoryForTest, executionSettings);
+
+        // Assert
+        var actualRequestContent = Encoding.UTF8.GetString(this._messageHandlerStub.RequestContent!);
+        Assert.NotNull(actualRequestContent);
+
+        var requestJsonElement = JsonElement.Parse(actualRequestContent);
+        var schema = requestJsonElement.GetProperty("response_format").GetProperty("json_schema").GetProperty("schema");
+        var propertyBItems = schema.GetProperty("properties").GetProperty("PropertyB").GetProperty("items");
+
+        Assert.True(propertyBItems.TryGetProperty("$ref", out var propertyBItemsReferenceElement));
+
+        string? propertyBItemsReference = propertyBItemsReferenceElement.GetString();
+        Assert.NotNull(propertyBItemsReference);
+        Assert.True(propertyBItemsReference.StartsWith("#/$defs/", StringComparison.Ordinal), propertyBItemsReference);
+        Assert.DoesNotContain("#/properties/", propertyBItemsReference);
+
+        string definitionName = propertyBItemsReference.Substring("#/$defs/".Length);
+        var definition = schema.GetProperty("$defs").GetProperty(definitionName);
+
+        Assert.Equal("object", definition.GetProperty("type").GetString());
+        Assert.Equal("string", definition.GetProperty("properties").GetProperty("Property1").GetProperty("type").GetString());
+        Assert.Equal("integer", definition.GetProperty("properties").GetProperty("Property2").GetProperty("type").GetString());
+    }
+
     [Theory]
     [InlineData(typeof(TestStruct), "TestStruct")]
     [InlineData(typeof(TestStruct?), "TestStruct")]
@@ -1994,6 +2033,20 @@ public sealed class OpenAIChatCompletionServiceTests : IDisposable
         public string Explanation { get; set; }
 
         public string Output { get; set; }
+    }
+
+    private sealed class ResponseWithRepeatedArrayItems
+    {
+        public RepeatedArrayItem[] PropertyA { get; set; }
+
+        public RepeatedArrayItem[] PropertyB { get; set; }
+    }
+
+    private sealed class RepeatedArrayItem
+    {
+        public string Property1 { get; set; }
+
+        public int Property2 { get; set; }
     }
 
     private struct TestStruct

--- a/dotnet/src/Connectors/Connectors.OpenAI/Helpers/OpenAIChatResponseFormatBuilder.cs
+++ b/dotnet/src/Connectors/Connectors.OpenAI/Helpers/OpenAIChatResponseFormatBuilder.cs
@@ -1,8 +1,10 @@
 ﻿// Copyright (c) Microsoft. All rights reserved.
 
 using System;
+using System.Collections.Generic;
 using System.Text;
 using System.Text.Json;
+using System.Text.Json.Nodes;
 using OpenAI.Chat;
 
 namespace Microsoft.SemanticKernel.Connectors.OpenAI;
@@ -58,7 +60,9 @@ internal static class OpenAIChatResponseFormatBuilder
         var type = formatObjectType.IsGenericType && formatObjectType.GetGenericTypeDefinition() == typeof(Nullable<>) ? Nullable.GetUnderlyingType(formatObjectType)! : formatObjectType;
 
         var schema = KernelJsonSchemaBuilder.Build(type, configuration: s_jsonSchemaCreateOptions);
-        var schemaBinaryData = BinaryData.FromString(schema.ToString());
+        var schemaNode = JsonNode.Parse(schema.ToString()) ?? throw new InvalidOperationException("Generated JSON schema cannot be parsed.");
+        MoveNestedReferencesToDefinitions(schemaNode);
+        var schemaBinaryData = BinaryData.FromString(schemaNode.ToJsonString());
 
         var typeName = GetTypeName(type);
 
@@ -85,6 +89,183 @@ internal static class OpenAIChatResponseFormatBuilder
 
         return $"{baseName}{argumentNames}";
     }
+
+    /// <summary>
+    /// Moves local references that point to nested schemas into top-level $defs entries.
+    /// </summary>
+    private static void MoveNestedReferencesToDefinitions(JsonNode schema)
+    {
+        if (schema is not JsonObject root)
+        {
+            return;
+        }
+
+        Dictionary<string, string> movedReferences = new(StringComparer.Ordinal);
+        HashSet<string> usedDefinitionNames = new(StringComparer.Ordinal);
+
+        if (root.TryGetPropertyValue("$defs", out JsonNode? existingDefinitions) && existingDefinitions is JsonObject definitions)
+        {
+            foreach (var definition in definitions)
+            {
+                usedDefinitionNames.Add(definition.Key);
+            }
+        }
+
+        while (MoveNestedReferencesToDefinitionsCore(schema, root, movedReferences, usedDefinitionNames))
+        {
+        }
+    }
+
+    private static bool MoveNestedReferencesToDefinitionsCore(
+        JsonNode? schema,
+        JsonObject root,
+        Dictionary<string, string> movedReferences,
+        HashSet<string> usedDefinitionNames)
+    {
+        bool moved = false;
+
+        switch (schema)
+        {
+            case JsonObject schemaObject:
+                if (schemaObject.TryGetPropertyValue("$ref", out JsonNode? referenceNode) &&
+                    referenceNode?.GetValueKind() == JsonValueKind.String)
+                {
+                    string reference = referenceNode.GetValue<string>();
+                    if (ShouldMoveReference(reference))
+                    {
+                        if (!movedReferences.TryGetValue(reference, out string? definitionName))
+                        {
+                            JsonNode? target = ResolveJsonPointer(root, reference);
+                            if (target is not null)
+                            {
+                                definitionName = CreateDefinitionName(reference, usedDefinitionNames);
+                                GetOrCreateDefinitions(root)[definitionName] = JsonNode.Parse(target.ToJsonString());
+                                movedReferences[reference] = definitionName;
+                                moved = true;
+                            }
+                        }
+
+                        if (definitionName is not null)
+                        {
+                            string topLevelReference = $"#/$defs/{EscapeJsonPointerSegment(definitionName)}";
+                            if (!StringComparer.Ordinal.Equals(reference, topLevelReference))
+                            {
+                                schemaObject["$ref"] = topLevelReference;
+                                moved = true;
+                            }
+                        }
+                    }
+                }
+
+                foreach (var property in new List<KeyValuePair<string, JsonNode?>>(schemaObject))
+                {
+                    moved |= MoveNestedReferencesToDefinitionsCore(property.Value, root, movedReferences, usedDefinitionNames);
+                }
+
+                break;
+
+            case JsonArray schemaArray:
+                foreach (JsonNode? item in schemaArray)
+                {
+                    moved |= MoveNestedReferencesToDefinitionsCore(item, root, movedReferences, usedDefinitionNames);
+                }
+
+                break;
+        }
+
+        return moved;
+    }
+
+    private static bool ShouldMoveReference(string reference)
+        => reference.StartsWith("#/", StringComparison.Ordinal) &&
+            !reference.StartsWith("#/$defs/", StringComparison.Ordinal) &&
+            !reference.StartsWith("#/definitions/", StringComparison.Ordinal);
+
+    private static JsonObject GetOrCreateDefinitions(JsonObject root)
+    {
+        if (root.TryGetPropertyValue("$defs", out JsonNode? definitionsNode) && definitionsNode is JsonObject definitions)
+        {
+            return definitions;
+        }
+
+        definitions = [];
+        root["$defs"] = definitions;
+
+        return definitions;
+    }
+
+    private static JsonNode? ResolveJsonPointer(JsonNode root, string reference)
+    {
+        JsonNode? current = root;
+        string[] segments = reference.Substring(2).Split('/');
+
+        foreach (string segment in segments)
+        {
+            string unescapedSegment = UnescapeJsonPointerSegment(segment);
+
+            switch (current)
+            {
+                case JsonObject currentObject when currentObject.TryGetPropertyValue(unescapedSegment, out JsonNode? propertyValue):
+                    current = propertyValue;
+                    break;
+
+                case JsonArray currentArray when int.TryParse(unescapedSegment, out int index) && index >= 0 && index < currentArray.Count:
+                    current = currentArray[index];
+                    break;
+
+                default:
+                    return null;
+            }
+        }
+
+        return current;
+    }
+
+    private static string CreateDefinitionName(string reference, HashSet<string> usedDefinitionNames)
+    {
+        string[] segments = reference.Substring(2).Split('/');
+        StringBuilder nameBuilder = new();
+
+        foreach (string segment in segments)
+        {
+            string unescapedSegment = UnescapeJsonPointerSegment(segment);
+
+            if (StringComparer.Ordinal.Equals(unescapedSegment, "properties"))
+            {
+                continue;
+            }
+
+            bool capitalizeNext = true;
+            foreach (char character in unescapedSegment)
+            {
+                if (!char.IsLetterOrDigit(character))
+                {
+                    capitalizeNext = true;
+                    continue;
+                }
+
+                nameBuilder.Append(capitalizeNext ? char.ToUpperInvariant(character) : character);
+                capitalizeNext = false;
+            }
+        }
+
+        string baseName = nameBuilder.Length > 0 ? nameBuilder.ToString() : "SchemaDefinition";
+        string name = baseName;
+        int suffix = 2;
+
+        while (!usedDefinitionNames.Add(name))
+        {
+            name = $"{baseName}{suffix++}";
+        }
+
+        return name;
+    }
+
+    private static string EscapeJsonPointerSegment(string segment)
+        => segment.Replace("~", "~0").Replace("/", "~1");
+
+    private static string UnescapeJsonPointerSegment(string segment)
+        => segment.Replace("~1", "/").Replace("~0", "~");
 
     #endregion
 }

--- a/dotnet/src/Connectors/Connectors.OpenAI/Helpers/OpenAIChatResponseFormatBuilder.cs
+++ b/dotnet/src/Connectors/Connectors.OpenAI/Helpers/OpenAIChatResponseFormatBuilder.cs
@@ -139,7 +139,7 @@ internal static class OpenAIChatResponseFormatBuilder
                             if (target is not null)
                             {
                                 definitionName = CreateDefinitionName(reference, usedDefinitionNames);
-                                GetOrCreateDefinitions(root)[definitionName] = JsonNode.Parse(target.ToJsonString());
+                                GetOrCreateDefinitions(root)[definitionName] = target.DeepClone();
                                 movedReferences[reference] = definitionName;
                                 moved = true;
                             }


### PR DESCRIPTION
## Summary
- Move nested local JSON schema references generated for typed OpenAI structured outputs into top-level `$defs` entries.
- Add a regression test for repeated array item types so generated schemas no longer reference `#/properties/.../items`.

Fixes #10142

## Testing
- `git diff --check`
- `dotnet test dotnet/src/Connectors/Connectors.OpenAI.UnitTests/Connectors.OpenAI.UnitTests.csproj --filter GetChatMessageContentsMovesRepeatedTypeReferencesToTopLevelDefinitions --no-restore` (not run: no .NET SDK installed in this environment)