### PR TITLE
Python: Bump Python version to 1.44.0 for a release

### DIFF
--- a/python/semantic_kernel/__init__.py
+++ b/python/semantic_kernel/__init__.py
@@ -2,7 +2,7 @@
 
 from semantic_kernel.kernel import Kernel
 
-__version__ = "1.43.1"
+__version__ = "1.44.0"
 
 DEFAULT_RC_VERSION = f"{__version__}-rc9"
 


### PR DESCRIPTION
### Motivation and Context

Bumps the Python package version for the next release.

### Description

Updates `semantic_kernel.__version__` from `1.43.1` to `1.44.0`.

### Contribution Checklist

- [x] The code builds clean without any errors or warnings
- [x] The PR follows the SK Contribution Guidelines and the pre-submission formatting script raises no violations
- [x] All unit tests pass, and I have added new tests where possible
- [x] I did not break anyone :smile: