### PR TITLE
.Net: Update package version to 1.78.0

### DIFF
--- a/dotnet/nuget/nuget-package.props
+++ b/dotnet/nuget/nuget-package.props
@@ -1,7 +1,7 @@
 <Project>
   <PropertyGroup>
     <!-- Central version prefix - applies to all nuget packages. -->
-    <VersionPrefix>1.77.0</VersionPrefix>
+    <VersionPrefix>1.78.0</VersionPrefix>
     <PackageVersion Condition="'$(VersionSuffix)' != ''">$(VersionPrefix)-$(VersionSuffix)</PackageVersion>
     <PackageVersion Condition="'$(VersionSuffix)' == ''">$(VersionPrefix)</PackageVersion>
 
@@ -9,7 +9,7 @@
     <IsPackable>true</IsPackable>
 
     <!-- Package validation. Baseline Version should be the latest version available on NuGet. -->
-    <PackageValidationBaselineVersion>1.76.0</PackageValidationBaselineVersion>
+    <PackageValidationBaselineVersion>1.77.0</PackageValidationBaselineVersion>
     <!-- Validate assembly attributes only for Publish builds -->
     <NoWarn Condition="'$(Configuration)' != 'Publish'">$(NoWarn);CP0003</NoWarn>
     <!-- Do not validate reference assemblies -->

--- a/dotnet/src/Functions/Functions.OpenApi/CompatibilitySuppressions.xml
+++ b/dotnet/src/Functions/Functions.OpenApi/CompatibilitySuppressions.xml
@@ -3,50 +3,8 @@
 <Suppressions xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:xsd="http://www.w3.org/2001/XMLSchema">
   <Suppression>
     <DiagnosticId>CP0002</DiagnosticId>
-    <Target>M:Microsoft.SemanticKernel.Plugins.OpenApi.RestApiOperationServerUrlValidationOptions.get_AllowedSchemes</Target>
-    <Left>lib/net10.0/Microsoft.SemanticKernel.Plugins.OpenApi.dll</Left>
-    <Right>lib/net10.0/Microsoft.SemanticKernel.Plugins.OpenApi.dll</Right>
-    <IsBaselineSuppression>true</IsBaselineSuppression>
-  </Suppression>
-  <Suppression>
-    <DiagnosticId>CP0002</DiagnosticId>
-    <Target>M:Microsoft.SemanticKernel.Plugins.OpenApi.RestApiOperationServerUrlValidationOptions.set_AllowedSchemes(System.Collections.Generic.IReadOnlyList{System.String})</Target>
-    <Left>lib/net10.0/Microsoft.SemanticKernel.Plugins.OpenApi.dll</Left>
-    <Right>lib/net10.0/Microsoft.SemanticKernel.Plugins.OpenApi.dll</Right>
-    <IsBaselineSuppression>true</IsBaselineSuppression>
-  </Suppression>
-  <Suppression>
-    <DiagnosticId>CP0002</DiagnosticId>
-    <Target>M:Microsoft.SemanticKernel.Plugins.OpenApi.RestApiOperationServerUrlValidationOptions.get_AllowedSchemes</Target>
-    <Left>lib/net8.0/Microsoft.SemanticKernel.Plugins.OpenApi.dll</Left>
-    <Right>lib/net8.0/Microsoft.SemanticKernel.Plugins.OpenApi.dll</Right>
-    <IsBaselineSuppression>true</IsBaselineSuppression>
-  </Suppression>
-  <Suppression>
-    <DiagnosticId>CP0002</DiagnosticId>
-    <Target>M:Microsoft.SemanticKernel.Plugins.OpenApi.RestApiOperationServerUrlValidationOptions.set_AllowedSchemes(System.Collections.Generic.IReadOnlyList{System.String})</Target>
-    <Left>lib/net8.0/Microsoft.SemanticKernel.Plugins.OpenApi.dll</Left>
-    <Right>lib/net8.0/Microsoft.SemanticKernel.Plugins.OpenApi.dll</Right>
-    <IsBaselineSuppression>true</IsBaselineSuppression>
-  </Suppression>
-  <Suppression>
-    <DiagnosticId>CP0002</DiagnosticId>
     <Target>F:Microsoft.SemanticKernel.Plugins.OpenApi.OpenApiKernelFunctionContext.KernelFunctionContextKey</Target>
     <Left>lib/netstandard2.0/Microsoft.SemanticKernel.Plugins.OpenApi.dll</Left>
     <Right>lib/net8.0/Microsoft.SemanticKernel.Plugins.OpenApi.dll</Right>
-  </Suppression>
-  <Suppression>
-    <DiagnosticId>CP0002</DiagnosticId>
-    <Target>M:Microsoft.SemanticKernel.Plugins.OpenApi.RestApiOperationServerUrlValidationOptions.get_AllowedSchemes</Target>
-    <Left>lib/netstandard2.0/Microsoft.SemanticKernel.Plugins.OpenApi.dll</Left>
-    <Right>lib/netstandard2.0/Microsoft.SemanticKernel.Plugins.OpenApi.dll</Right>
-    <IsBaselineSuppression>true</IsBaselineSuppression>
-  </Suppression>
-  <Suppression>
-    <DiagnosticId>CP0002</DiagnosticId>
-    <Target>M:Microsoft.SemanticKernel.Plugins.OpenApi.RestApiOperationServerUrlValidationOptions.set_AllowedSchemes(System.Collections.Generic.IReadOnlyList{System.String})</Target>
-    <Left>lib/netstandard2.0/Microsoft.SemanticKernel.Plugins.OpenApi.dll</Left>
-    <Right>lib/netstandard2.0/Microsoft.SemanticKernel.Plugins.OpenApi.dll</Right>
-    <IsBaselineSuppression>true</IsBaselineSuppression>
   </Suppression>
 </Suppressions>


### PR DESCRIPTION
Bumps the SK package version in preparation for the next release.

- VersionPrefix: 1.77.0 -> 1.78.0
- PackageValidationBaselineVersion: 1.76.0 -> 1.77.0