### PR TITLE
fix(Plugins.Web): Tavily max_results must not subtract Skip

### DIFF
--- a/dotnet/src/Plugins/Plugins.UnitTests/Web/Tavily/TavilyTextSearchTests.cs
+++ b/dotnet/src/Plugins/Plugins.UnitTests/Web/Tavily/TavilyTextSearchTests.cs
@@ -496,6 +496,26 @@ public sealed class TavilyTextSearchTests : IDisposable
         Assert.Contains("\"max_results\":5", requestBodyJson);
     }
 
+    [Fact]
+    public async Task SkipIsNotSubtractedFromMaxResultsAsync()
+    {
+        // Arrange
+        this._messageHandlerStub.AddJsonResponse(File.ReadAllText(SiteFilterDevBlogsResponseJson));
+        ITextSearch<TavilyWebPage> textSearch = new TavilyTextSearch(apiKey: "ApiKey", options: new() { HttpClient = this._httpClient });
+
+        // Act - Tavily has no offset parameter, so max_results must equal Top regardless of Skip.
+        var searchOptions = new TextSearchOptions<TavilyWebPage>
+        {
+            Top = 5,
+            Skip = 2
+        };
+        await textSearch.SearchAsync("What is the Semantic Kernel?", searchOptions);
+
+        // Assert
+        var requestBodyJson = Encoding.UTF8.GetString(this._messageHandlerStub.RequestContents[0]!);
+        Assert.Contains("\"max_results\":5", requestBodyJson);
+    }
+
     #endregion
 
     #region private

--- a/dotnet/src/Plugins/Plugins.UnitTests/Web/Tavily/TavilyTextSearchTests.cs
+++ b/dotnet/src/Plugins/Plugins.UnitTests/Web/Tavily/TavilyTextSearchTests.cs
@@ -496,8 +496,11 @@ public sealed class TavilyTextSearchTests : IDisposable
         Assert.Contains("\"max_results\":5", requestBodyJson);
     }
 
-    [Fact]
-    public async Task SkipIsNotSubtractedFromMaxResultsAsync()
+    [Theory]
+    [InlineData(5, 2, 5)]   // Top > Skip
+    [InlineData(2, 2, 2)]   // Top == Skip
+    [InlineData(1, 5, 1)]   // Top < Skip
+    public async Task SkipIsNotSubtractedFromMaxResultsAsync(int top, int skip, int expectedMaxResults)
     {
         // Arrange
         this._messageHandlerStub.AddJsonResponse(File.ReadAllText(SiteFilterDevBlogsResponseJson));
@@ -506,14 +509,14 @@ public sealed class TavilyTextSearchTests : IDisposable
         // Act - Tavily has no offset parameter, so max_results must equal Top regardless of Skip.
         var searchOptions = new TextSearchOptions<TavilyWebPage>
         {
-            Top = 5,
-            Skip = 2
+            Top = top,
+            Skip = skip
         };
         await textSearch.SearchAsync("What is the Semantic Kernel?", searchOptions);
 
         // Assert
         var requestBodyJson = Encoding.UTF8.GetString(this._messageHandlerStub.RequestContents[0]!);
-        Assert.Contains("\"max_results\":5", requestBodyJson);
+        Assert.Contains($"\"max_results\":{expectedMaxResults}", requestBodyJson);
     }
 
     #endregion

--- a/dotnet/src/Plugins/Plugins.Web/Tavily/TavilyTextSearch.cs
+++ b/dotnet/src/Plugins/Plugins.Web/Tavily/TavilyTextSearch.cs
@@ -676,7 +676,7 @@ public sealed class TavilyTextSearch : ITextSearch, ITextSearch<TavilyWebPage>
         string? topic = null;
         string? timeRange = null;
         int? days = null;
-        int? maxResults = top - skip;
+        int? maxResults = top;
         IList<string>? includeDomains = null;
         IList<string>? excludeDomains = null;
 


### PR DESCRIPTION
## Summary
`TavilyTextSearch` set `max_results = top - skip`. Tavily has no offset parameter — `max_results` is its page size — so subtracting `skip` under-fetched results when paging (`Top=5, Skip=2` sent `max_results=3`), and `Skip >= Top` sent `max_results <= 0`.

## Impact
A caller paginating with `Skip > 0` gets too few (or zero) results. Sibling `BingTextSearch` correctly uses `count={top}&offset={skip}`; Tavily must send `top` directly.

## Fix
`int? maxResults = top;`

## Test
Added `SkipIsNotSubtractedFromMaxResultsAsync` to `TavilyTextSearchTests.cs`. Asserts the request body contains `"max_results":5` for `Top=5, Skip=2`. FAILS before the fix (`max_results:3`), PASSES after; full Tavily suite = 31 passed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
Co-Authored-By: Claude Sonnet 4.6 <noreply@anthropic.com>