### PR TITLE
docs: add TokenLab custom endpoint example

### DIFF
--- a/dotnet/docs/OPENAI-CONNECTOR-MIGRATION.md
+++ b/dotnet/docs/OPENAI-CONNECTOR-MIGRATION.md
@@ -74,7 +74,7 @@ We have the two only specific cases where we attempted to auto-correct the endpo
    ```
 
    For example, an OpenAI-compatible provider such as TokenLab should be
-   configured with its root compatible endpoint:
+   configured with its OpenAI-compatible base URL:
 
    ```diff
    - https://api.tokenlab.sh

--- a/dotnet/docs/OPENAI-CONNECTOR-MIGRATION.md
+++ b/dotnet/docs/OPENAI-CONNECTOR-MIGRATION.md
@@ -73,6 +73,14 @@ We have the two only specific cases where we attempted to auto-correct the endpo
    + http://any-host-and-port/v1
    ```
 
+   For example, an OpenAI-compatible provider such as TokenLab should be
+   configured with its root compatible endpoint:
+
+   ```diff
+   - https://api.tokenlab.sh
+   + https://api.tokenlab.sh/v1
+   ```
+
 ## 6. SemanticKernel MetaPackage
 
 To be retro compatible with the new OpenAI and AzureOpenAI Connectors, our `Microsoft.SemanticKernel` meta package changed its dependency to use the new `Microsoft.SemanticKernel.Connectors.AzureOpenAI` package that depends on the `Microsoft.SemanticKernel.Connectors.OpenAI` package. This way if you are using the metapackage, no change is needed to get access to `Azure` related types.


### PR DESCRIPTION
## Summary
- Document TokenLab as an OpenAI-compatible custom endpoint for Semantic Kernel OpenAI connector migration.
- Use TokenLab's OpenAI-compatible base URL: https://api.tokenlab.sh/v1
- No runtime behavior changes; documentation only.

## Verification
- git diff --check