### PR TITLE
Python: fix(python): honor None defaults in function metadata

### DIFF
--- a/python/semantic_kernel/functions/kernel_function_decorator.py
+++ b/python/semantic_kernel/functions/kernel_function_decorator.py
@@ -138,7 +138,7 @@ def _parse_parameter(name: str, param: Any, default: Any) -> dict[str, Any]:
     logger.debug(f"Parsing param: {name}")
     logger.debug(f"Parsing annotation: {param}")
     ret: dict[str, Any] = {"name": name}
-    if default != Parameter.empty:
+    if default is not Parameter.empty:
         ret["default_value"] = default
         ret["is_required"] = False
     else:

--- a/python/semantic_kernel/functions/kernel_function_decorator.py
+++ b/python/semantic_kernel/functions/kernel_function_decorator.py
@@ -71,7 +71,9 @@ def kernel_function(
         setattr(func, "__kernel_function_parameters__", annotations)
 
         return_annotation = (
-            _parse_parameter("return", func_sig.return_annotation, None) if func_sig.return_annotation else {}
+            _parse_parameter("return", func_sig.return_annotation, Parameter.empty)
+            if func_sig.return_annotation
+            else {}
         )
         setattr(func, "__kernel_function_return_type__", return_annotation.get("type_", "None"))
         setattr(func, "__kernel_function_return_type_object__", return_annotation.get("type_object", None))
@@ -120,8 +122,7 @@ def _process_signature(func_sig: Signature) -> list[dict[str, Any]]:
         if arg.name == "self":
             continue
         annotation = arg.annotation
-        default = arg.default if arg.default != arg.empty else None
-        parsed_annotation = _parse_parameter(arg.name, annotation, default)
+        parsed_annotation = _parse_parameter(arg.name, annotation, arg.default)
         if get_origin(annotation) is Annotated or get_origin(annotation) in {Union, types.UnionType}:
             underlying_type = _get_underlying_type(annotation)
         else:
@@ -137,7 +138,7 @@ def _parse_parameter(name: str, param: Any, default: Any) -> dict[str, Any]:
     logger.debug(f"Parsing param: {name}")
     logger.debug(f"Parsing annotation: {param}")
     ret: dict[str, Any] = {"name": name}
-    if default is not None:
+    if default != Parameter.empty:
         ret["default_value"] = default
         ret["is_required"] = False
     else:

--- a/python/tests/unit/functions/test_kernel_function_decorators.py
+++ b/python/tests/unit/functions/test_kernel_function_decorators.py
@@ -51,6 +51,10 @@ class MiscClass:
         return input
 
     @kernel_function
+    def func_input_none_default(self, input: str = None):
+        return input
+
+    @kernel_function
     def func_return_type(self, input: str) -> str:
         return input
 
@@ -137,6 +141,15 @@ def test_kernel_function_param_optional():
     assert my_func.__kernel_function_parameters__[0]["type_"] == "str"
     assert not my_func.__kernel_function_parameters__[0]["is_required"]
     assert my_func.__kernel_function_parameters__[0]["default_value"] == "test"
+    assert my_func.__kernel_function_parameters__[0]["name"] == "input"
+
+
+def test_kernel_function_param_none_default():
+    decorator_test = MiscClass()
+    my_func = getattr(decorator_test, "func_input_none_default")
+    assert my_func.__kernel_function_parameters__[0]["type_"] == "str"
+    assert not my_func.__kernel_function_parameters__[0]["is_required"]
+    assert my_func.__kernel_function_parameters__[0]["default_value"] is None
     assert my_func.__kernel_function_parameters__[0]["name"] == "input"
 
 

--- a/python/tests/unit/functions/test_kernel_function_decorators.py
+++ b/python/tests/unit/functions/test_kernel_function_decorators.py
@@ -18,6 +18,11 @@ class InputObject(KernelBaseModel):
     arg2: int
 
 
+class EqualityErrorDefault:
+    def __eq__(self, other):
+        raise ValueError("equality should not be called")
+
+
 class MiscClass:
     __test__ = False
 
@@ -52,6 +57,10 @@ class MiscClass:
 
     @kernel_function
     def func_input_none_default(self, input: str = None):
+        return input
+
+    @kernel_function
+    def func_input_custom_default(self, input: object = EqualityErrorDefault()):
         return input
 
     @kernel_function
@@ -150,6 +159,15 @@ def test_kernel_function_param_none_default():
     assert my_func.__kernel_function_parameters__[0]["type_"] == "str"
     assert not my_func.__kernel_function_parameters__[0]["is_required"]
     assert my_func.__kernel_function_parameters__[0]["default_value"] is None
+    assert my_func.__kernel_function_parameters__[0]["name"] == "input"
+
+
+def test_kernel_function_param_default_does_not_call_equality():
+    decorator_test = MiscClass()
+    my_func = getattr(decorator_test, "func_input_custom_default")
+    assert my_func.__kernel_function_parameters__[0]["type_"] == "object"
+    assert not my_func.__kernel_function_parameters__[0]["is_required"]
+    assert isinstance(my_func.__kernel_function_parameters__[0]["default_value"], EqualityErrorDefault)
     assert my_func.__kernel_function_parameters__[0]["name"] == "input"
 
 

--- a/python/tests/unit/functions/test_kernel_function_from_method.py
+++ b/python/tests/unit/functions/test_kernel_function_from_method.py
@@ -257,6 +257,20 @@ async def test_required_param_not_supplied(kernel: Kernel):
         await func.invoke(kernel=kernel, arguments=KernelArguments())
 
 
+async def test_none_default_param_not_supplied(kernel: Kernel):
+    @kernel_function()
+    def my_function(input: str = None) -> str | None:
+        return input
+
+    func = KernelFunction.from_method(my_function, "test")
+
+    result = await func.invoke(kernel=kernel, arguments=KernelArguments())
+
+    assert result.value is None
+    assert func.parameters[0].is_required is False
+    assert func.parameters[0].default_value is None
+
+
 async def test_service_execution_with_complex_object(kernel: Kernel):
     class InputObject(KernelBaseModel):
         arg1: str


### PR DESCRIPTION
## Summary
Fixes Python kernel function metadata so parameters with an explicit default value of `None` are treated as optional rather than required.

## Why this helps
Python functions can use `None` as a valid default value. Preserving that default in Semantic Kernel metadata keeps function invocation and generated function schemas aligned with the callable signature.

## Changes made
- Distinguish missing defaults from explicit `None` defaults in `@kernel_function` parameter parsing.
- Keep return annotation parsing on the existing no-default path.
- Add regression coverage for decorator metadata and invocation when an argument with `None` default is omitted.

## Testing
- `uv run pytest tests/unit/functions/test_kernel_function_decorators.py tests/unit/functions/test_kernel_function_from_method.py`
- `uv run pytest tests/unit/functions`
- `uv run ruff check semantic_kernel/functions/kernel_function_decorator.py tests/unit/functions/test_kernel_function_decorators.py tests/unit/functions/test_kernel_function_from_method.py`

## Related issue
No related issue.