### PR TITLE
Python: fix NamedArgBlock value parsing to match ValBlock

### DIFF
--- a/python/semantic_kernel/template_engine/blocks/named_arg_block.py
+++ b/python/semantic_kernel/template_engine/blocks/named_arg_block.py
@@ -18,7 +18,9 @@ if TYPE_CHECKING:
 
 logger: logging.Logger = logging.getLogger(__name__)
 
-NAMED_ARG_REGEX = r"^(?P<name>[0-9A-Za-z_]+)[=]{1}(?P<value>[${1}](?P<var_name>[0-9A-Za-z_]+)|(?P<quote>[\"'])(?P<val>.[^\"^']*)(?P=quote))$"  # noqa: E501
+NAMED_ARG_REGEX = (
+    r"^(?P<name>[0-9A-Za-z_]+)[=]{1}(?P<value>[${1}](?P<var_name>[0-9A-Za-z_]+)|(?P<quote>[\"'])(?P<val>.+)(?P=quote))$"
+)
 
 NAMED_ARG_MATCHER = compile(NAMED_ARG_REGEX)
 

--- a/python/tests/unit/template_engine/blocks/test_named_arg_block.py
+++ b/python/tests/unit/template_engine/blocks/test_named_arg_block.py
@@ -31,6 +31,22 @@ def test_init_with_val():
     assert isinstance(named_arg_block.value, ValBlock)
 
 
+@mark.parametrize(
+    ("content", "expected"),
+    [
+        ("test='2^10'", "2^10"),
+        ('test="it\'s"', "it's"),
+        ("test='a\"b'", 'a"b'),
+    ],
+    ids=["caret", "single_quote_in_double", "double_quote_in_single"],
+)
+def test_init_with_val_special_chars(content, expected):
+    # A quoted named-arg value may contain a caret or the other quote character;
+    # the value char class wrongly excluded them, raising NamedArgBlockSyntaxError.
+    named_arg_block = NamedArgBlock(content=content)
+    assert named_arg_block.value.value == expected
+
+
 def test_type_property():
     named_arg_block = NamedArgBlock(content="test=$test_var")
     assert named_arg_block.type == BlockTypes.NAMED_ARG


### PR DESCRIPTION
### Motivation and Context

`NamedArgBlock` (the `arg='value'` / `arg=$var` syntax inside `{{ ... }}` template expressions) rejected quoted values that a standalone `ValBlock` accepts. Its value char class `[^\"^']` excluded the double quote, a **stray literal caret** (`^` in the middle of a class is not negation — this is a typo for `[^\"']`), and the single quote. So calling a function with a value containing a caret, or the opposite quote character, crashed:

```
{{ p.f arg='2^10' }}    # NamedArgBlockSyntaxError
{{ p.f arg="it's" }}    # NamedArgBlockSyntaxError  (apostrophe in a double-quoted value)
```

A named-argument value is itself parsed into a `ValBlock` (whose value pattern is `(?P<value>.*)`), so the gate should accept what `ValBlock` accepts. Verified end-to-end: `CodeTokenizer.tokenize("p.echo text='2^10'")` now yields the expected `ValBlock` value instead of raising.

_No linked issue — found by reading the code._

### Description

Widen the value pattern to `.+` (mirrors `ValBlock`'s `.*`, kept non-empty so empty values stay rejected). Empty values (`arg=''`) and mismatched quotes (`arg='x"`) are still rejected. I checked the sibling block parsers (`ValBlock`, `VarBlock`, `FunctionIdBlock`) — this was the only regex with an over-restrictive value class, so no other block is affected.

### Contribution Checklist

- [x] The code builds clean without any errors or warnings
- [x] `ruff check` and `ruff format` (v0.9.6, the pinned pre-commit version) are clean on the changed files
- [x] All unit tests pass (`tests/unit/template_engine` + `tests/unit/prompt_template`, 680 passing); added regression tests for caret and either quote nested in the other
- [x] The change preserves API and behavioral compatibility (strict superset of previously-accepted input)
