### PR TITLE
Python: Add BGPT MCP sample using MCPStreamableHttpPlugin

### DIFF
--- a/python/samples/concepts/mcp/README.md
+++ b/python/samples/concepts/mcp/README.md
@@ -43,13 +43,14 @@ python <name>.py
 
 The `agent_with_bgpt_mcp_plugin.py` sample demonstrates how to connect
 Semantic Kernel to the BGPT MCP server using `MCPStreamableHttpPlugin`
-for scientific literature retrieval.
+for evidence-based scientific literature retrieval.
 
-Run it with:
+Before running the sample, configure the required Azure OpenAI
+environment variables as described in the sample file.
+
+Run the sample:
 
 ```bash
+cd python/samples/concepts/mcp
 python agent_with_bgpt_mcp_plugin.py
 ```
-
-The sample requires an Azure OpenAI configuration (see the environment
-variables documented in the sample).

--- a/python/samples/concepts/mcp/README.md
+++ b/python/samples/concepts/mcp/README.md
@@ -39,3 +39,17 @@ pip install semantic-kernel[mcp]
 cd python/samples/concepts/mcp
 python <name>.py
 ```
+### BGPT sample
+
+The `agent_with_bgpt_mcp_plugin.py` sample demonstrates how to connect
+Semantic Kernel to the BGPT MCP server using `MCPStreamableHttpPlugin`
+for scientific literature retrieval.
+
+Run it with:
+
+```bash
+python agent_with_bgpt_mcp_plugin.py
+```
+
+The sample requires an Azure OpenAI configuration (see the environment
+variables documented in the sample).

--- a/python/samples/concepts/mcp/agent_with_bgpt_mcp_plugin.py
+++ b/python/samples/concepts/mcp/agent_with_bgpt_mcp_plugin.py
@@ -1,0 +1,75 @@
+# Copyright (c) Microsoft. All rights reserved.
+
+import asyncio
+
+from azure.identity import AzureCliCredential
+
+from semantic_kernel.agents import ChatCompletionAgent, ChatHistoryAgentThread
+from semantic_kernel.connectors.ai.open_ai import AzureChatCompletion
+from semantic_kernel.connectors.mcp import MCPStreamableHttpPlugin
+
+"""
+This sample demonstrates how to connect a ChatCompletionAgent
+to the BGPT MCP Server using the MCPStreamableHttpPlugin.
+
+BGPT provides evidence-based retrieval over scientific literature
+through a remote MCP server.
+
+It uses the Azure OpenAI service to create an agent. Make sure the
+following environment variables are configured:
+
+- AZURE_OPENAI_CHAT_DEPLOYMENT_NAME
+- Optionally: AZURE_OPENAI_API_KEY
+
+If no API key is configured, AzureCliCredential can also be used.
+"""
+
+
+# Example biomedical question
+USER_INPUTS = [
+    "Find recent papers about CRISPR gene editing in wheat.",
+]
+
+
+async def main() -> None:
+    # Create the BGPT MCP plugin
+    async with MCPStreamableHttpPlugin(
+        name="BGPT",
+        description="BGPT Scientific Literature Search",
+        url="https://bgpt.pro/mcp/stream",
+    ) as bgpt_plugin:
+
+        # Create the agent
+        agent = ChatCompletionAgent(
+            service=AzureChatCompletion(
+                credential=AzureCliCredential(),
+            ),
+            name="BGPTAgent",
+            instructions=(
+                "You are a biomedical research assistant. "
+                "Use the BGPT MCP server to retrieve and summarize "
+                "scientific evidence."
+            ),
+            plugins=[bgpt_plugin],
+        )
+
+        for user_input in USER_INPUTS:
+            thread: ChatHistoryAgentThread | None = None
+
+            print(f"# User: {user_input}")
+
+            response = await agent.get_response(
+                messages=user_input,
+                thread=thread,
+            )
+
+            print(f"# {response.name}: {response}")
+
+            thread = response.thread
+
+            if thread:
+                await thread.delete()
+
+
+if __name__ == "__main__":
+    asyncio.run(main())


### PR DESCRIPTION
## Summary

This PR adds a new Python sample showing how to connect Semantic Kernel to the BGPT MCP server using `MCPStreamableHttpPlugin`.

### Changes

- Add a new sample: `agent_with_bgpt_mcp_plugin.py`
- Add documentation for the BGPT sample in `python/samples/concepts/mcp/README.md`

The sample demonstrates how to use a remote MCP server for evidence-based scientific literature retrieval.

Fixes #14076