### PR TITLE
Python: Map NoneType to JSON Schema "null" instead of "object" in schema builder

### DIFF
--- a/python/semantic_kernel/schema/kernel_json_schema_builder.py
+++ b/python/semantic_kernel/schema/kernel_json_schema_builder.py
@@ -18,6 +18,7 @@ TYPE_MAPPING = {
     dict: "object",
     set: "array",
     tuple: "array",
+    type(None): "null",
     "int": "integer",
     "str": "string",
     "bool": "boolean",
@@ -28,6 +29,8 @@ TYPE_MAPPING = {
     "tuple": "array",
     "object": "object",
     "array": "array",
+    "None": "null",
+    "NoneType": "null",
 }
 
 

--- a/python/tests/unit/schema/test_schema_builder.py
+++ b/python/tests/unit/schema/test_schema_builder.py
@@ -228,6 +228,27 @@ def test_build_optional():
     assert schema == {"type": ["integer", "null"]}
 
 
+def test_get_json_schema_none_type():
+    # NoneType maps to the JSON Schema "null" type, not "object".
+    assert KernelJsonSchemaBuilder.get_json_schema(type(None)) == {"type": "null"}
+
+
+def test_build_none_type():
+    assert KernelJsonSchemaBuilder.build(type(None)) == {"type": "null"}
+
+
+def test_build_union_with_none():
+    # A union of more than two members that includes None must represent the
+    # None member as {"type": "null"}, not {"type": "object"}.
+    schema = KernelJsonSchemaBuilder.build(Union[int, str, None])
+    assert schema == {"anyOf": [{"type": "integer"}, {"type": "string"}, {"type": "null"}]}
+
+
+def test_build_from_type_name_none():
+    assert KernelJsonSchemaBuilder.build_from_type_name("None") == {"type": "null"}
+    assert KernelJsonSchemaBuilder.build_from_type_name("NoneType") == {"type": "null"}
+
+
 def test_build_model_schema_for_many_types():
     schema = KernelJsonSchemaBuilder.build(MockModel)
     expected = """


### PR DESCRIPTION
## Motivation

`KernelJsonSchemaBuilder` omitted `NoneType` from `TYPE_MAPPING`, so `get_json_schema(type(None))` — and any union of 3+ members that includes `None` (e.g. `int | str | None`) — emitted `{"type": "object"}` for the `None` member instead of the correct `{"type": "null"}`. These schemas are sent to models during function calling / structured output, where an `object` type for a `None` member is misleading and can distort tool arguments.

The two-member `Optional[T]` path builds nullability separately and was already correct; this only affected `NoneType` reached directly or as one member of a 3+-member union.

## Fix

Add `NoneType` (and the `"None"` / `"NoneType"` string names used by `build_from_type_name`) to `TYPE_MAPPING`, so `None` maps to JSON Schema `{"type": "null"}`.

## Files
- `python/semantic_kernel/schema/kernel_json_schema_builder.py`
- `python/tests/unit/schema/test_schema_builder.py` — regression tests

## Verification
Added regression tests covering `type(None)` directly and a 3-member union containing `None`; they fail before the change (`{"type":"object"}`) and pass after (`{"type":"null"}`). Existing `Optional[T]` behavior is unchanged.
