### PR TITLE
Python: Fix FunctionResult.__str__ rendering falsy values (0, False, 0.0) as empty string

### DIFF
--- a/python/semantic_kernel/functions/function_result.py
+++ b/python/semantic_kernel/functions/function_result.py
@@ -37,9 +37,11 @@ class FunctionResult(KernelBaseModel):
 
     def __str__(self) -> str:
         """Get the string representation of the result."""
-        if self.value:
+        if self.value is not None:
             try:
                 if isinstance(self.value, list):
+                    if not self.value:
+                        return ""
                     return (
                         str(self.value[0])
                         if isinstance(self.value[0], KernelContent)
@@ -48,6 +50,8 @@ class FunctionResult(KernelBaseModel):
                 if isinstance(self.value, dict):
                     # TODO (eavanvalkenburg): remove this once function result doesn't include input args
                     # This is so an integration test can pass.
+                    if not self.value:
+                        return ""
                     return str(list(self.value.values())[-1])
                 return str(self.value)
             except Exception as e:

--- a/python/tests/unit/functions/test_function_result.py
+++ b/python/tests/unit/functions/test_function_result.py
@@ -63,6 +63,25 @@ def test_function_result_str_empty_value():
     assert str(result) == ""
 
 
+@pytest.mark.parametrize(
+    ("value", "expected"),
+    [
+        (0, "0"),
+        (0.0, "0.0"),
+        (False, "False"),
+        ("", ""),
+        ([], ""),
+        ({}, ""),
+    ],
+)
+def test_function_result_str_with_falsy_value(value, expected):
+    result = FunctionResult(
+        function=KernelFunctionMetadata(name="test_function", is_prompt=False, is_asynchronous=False),
+        value=value,
+    )
+    assert str(result) == expected
+
+
 def test_function_result_str_with_conversion_error():
     class Unconvertible:
         def __str__(self):

--- a/python/tests/unit/prompt_template/test_kernel_prompt_template.py
+++ b/python/tests/unit/prompt_template/test_kernel_prompt_template.py
@@ -121,6 +121,30 @@ async def test_it_renders_code_using_variables_async(kernel: Kernel):
     assert result == "foo-BAR-baz"
 
 
+async def test_it_renders_code_with_falsy_results(kernel: Kernel):
+    arguments = KernelArguments()
+
+    @kernel_function(name="subtract")
+    def subtract(a: int, b: int) -> int:
+        return a - b
+
+    @kernel_function(name="is_even")
+    def is_even(a: int) -> bool:
+        return a % 2 == 0
+
+    kernel.add_function("math", KernelFunction.from_method(subtract, "math"))
+    kernel.add_function("math", KernelFunction.from_method(is_even, "math"))
+
+    arguments["x"] = 5
+    arguments["y"] = 5
+    arguments["z"] = 3
+    template = "The result is: {{math.subtract a=$x b=$y}} and even={{math.is_even a=$z}}"
+    target = create_kernel_prompt_template(template, allow_dangerously_set_content=True)
+    result = await target.render(kernel, arguments)
+
+    assert result == "The result is: 0 and even=False"
+
+
 async def test_it_renders_code_error(kernel: Kernel):
     arguments = KernelArguments()
 


### PR DESCRIPTION
### Motivation and Context

`FunctionResult.__str__` starts with a truthiness check (`if self.value:`) where a `None`-check was intended. Any kernel function that legitimately returns a falsy scalar — `0`, `0.0`, or `False` — is rendered as an empty string wherever `str(FunctionResult)` is used, most visibly when the result is interpolated into a prompt template via `{{plugin.function ...}}` (`CodeBlock.render_code`).

Example: with a plugin whose functions return `5 - 5` and `3 % 2 == 0`, the template

```
The result is: {{math.subtract a=$x b=$y}} and even={{math.is_even a=$z}}
```

renders as `The result is:  and even=` instead of `The result is: 0 and even=False` — the prompt sent to the model is silently corrupted with no warning or error. The same conflation affects logging and any other consumer of `str(FunctionResult)`.

### Description

- Change the guard in `FunctionResult.__str__` from `if self.value:` to `if self.value is not None:` so falsy-but-meaningful values (`0`, `0.0`, `False`) render correctly.
- Add explicit empty guards for the `list` and `dict` branches, which are now reachable with empty containers: `[]` renders as `""` (previously it would index `self.value[0]`), and `{}` renders as `""` (previously `list(self.value.values())[-1]` would raise `FunctionResultError`).
- Behavior for `value=None` and `value=""` is unchanged (both still render as `""`), preserving the existing `test_function_result_str_empty_value` contract.
- Tests (written first, failing on `main`): parametrized unit tests for `0`, `0.0`, `False`, `""`, `[]`, `{}` in `test_function_result.py`, plus a `KernelPromptTemplate` render test in `test_kernel_prompt_template.py` asserting `The result is: 0 and even=False`.

Verified locally: `uv run --frozen pytest tests/unit/functions/test_function_result.py tests/unit/functions/test_kernel_function_from_method.py tests/unit/prompt_template tests/unit/template_engine` → 729 passed; `ruff check`/`ruff format --check`/`mypy` clean on the touched files.

### Contribution Checklist

- [x] The code builds clean without any errors or warnings
- [x] The PR follows the [SK Contribution Guidelines](https://github.com/microsoft/semantic-kernel/blob/main/CONTRIBUTING.md) and the [pre-submission formatting script](https://github.com/microsoft/semantic-kernel/blob/main/CONTRIBUTING.md#development-scripts) raises no violations
- [x] All unit tests pass, and I have added new tests where possible
- [x] I didn't break anyone :smile:
