### PR TITLE
.Net: Reject mixed-separator UNC paths in file plugins

### DIFF
--- a/dotnet/src/Plugins/Plugins.Core/FileIOPlugin.cs
+++ b/dotnet/src/Plugins/Plugins.Core/FileIOPlugin.cs
@@ -125,7 +125,17 @@ public sealed class FileIOPlugin
             throw new ArgumentException("Invalid file path, a fully qualified file location must be specified.", nameof(path));
         }
 
-        canonicalPath = PathUtilities.GetSafeFullPath(path);
+        // Resolve the full path first (a pure string operation that does not touch the
+        // filesystem). A relative path can still resolve to a UNC path here, for example
+        // when the current directory is a UNC share, so re-check before GetSafeFullPath
+        // probes the filesystem while resolving symbolic links.
+        canonicalPath = Path.GetFullPath(path);
+        if (IsUncOrExtendedPath(canonicalPath))
+        {
+            throw new ArgumentException("Invalid file path, UNC paths are not supported.", nameof(path));
+        }
+
+        canonicalPath = PathUtilities.GetSafeFullPath(canonicalPath);
 
         if (File.Exists(canonicalPath) && File.GetAttributes(canonicalPath).HasFlag(FileAttributes.ReadOnly))
         {

--- a/dotnet/src/Plugins/Plugins.Core/FileIOPlugin.cs
+++ b/dotnet/src/Plugins/Plugins.Core/FileIOPlugin.cs
@@ -113,7 +113,7 @@ public sealed class FileIOPlugin
         Verify.NotNullOrWhiteSpace(path);
         canonicalPath = string.Empty;
 
-        if (path.StartsWith("\\\\", StringComparison.OrdinalIgnoreCase))
+        if (IsUncOrExtendedPath(path))
         {
             throw new ArgumentException("Invalid file path, UNC paths are not supported.", nameof(path));
         }
@@ -162,5 +162,10 @@ public sealed class FileIOPlugin
 
         return false;
     }
+
+    private static bool IsUncOrExtendedPath(string path) =>
+        path.Length >= 2 &&
+        (path[0] is '/' or '\\') &&
+        (path[1] is '/' or '\\');
     #endregion
 }

--- a/dotnet/src/Plugins/Plugins.UnitTests/Core/FileIOPluginTests.cs
+++ b/dotnet/src/Plugins/Plugins.UnitTests/Core/FileIOPluginTests.cs
@@ -144,6 +144,41 @@ public class FileIOPluginTests
         await Assert.ThrowsAsync<ArgumentException>(async () => await plugin.ReadAsync(Path.Combine("", Path.GetRandomFileName())));
     }
 
+    [Theory]
+    [InlineData("\\\\UNC\\server\\folder\\myfile.txt")]
+    [InlineData("//UNC/server/folder/myfile.txt")]
+    [InlineData("/\\UNC\\server\\folder\\myfile.txt")]
+    [InlineData("\\/UNC/server/folder/myfile.txt")]
+    public async Task ItRejectsUncOrExtendedPathsOnReadAsync(string path)
+    {
+        // Arrange
+        var plugin = new FileIOPlugin()
+        {
+            AllowedFolders = [Path.GetTempPath()]
+        };
+
+        // Act & Assert
+        await Assert.ThrowsAsync<ArgumentException>(() => plugin.ReadAsync(path));
+    }
+
+    [Theory]
+    [InlineData("\\\\UNC\\server\\folder\\myfile.txt")]
+    [InlineData("//UNC/server/folder/myfile.txt")]
+    [InlineData("/\\UNC\\server\\folder\\myfile.txt")]
+    [InlineData("\\/UNC/server/folder/myfile.txt")]
+    public async Task ItRejectsUncOrExtendedPathsOnWriteAsync(string path)
+    {
+        // Arrange
+        var plugin = new FileIOPlugin()
+        {
+            AllowedFolders = [Path.GetTempPath()],
+            DisableFileOverwrite = false
+        };
+
+        // Act & Assert
+        await Assert.ThrowsAsync<ArgumentException>(() => plugin.WriteAsync(path, "hello world"));
+    }
+
     [Fact]
     public async Task ItCannotReadThroughSymlinkOutsideAllowedFoldersAsync()
     {

--- a/dotnet/src/Plugins/Plugins.UnitTests/Web/WebFileDownloadPluginTests.cs
+++ b/dotnet/src/Plugins/Plugins.UnitTests/Web/WebFileDownloadPluginTests.cs
@@ -230,6 +230,26 @@ public sealed class WebFileDownloadPluginTests : IDisposable
         await Assert.ThrowsAsync<InvalidOperationException>(async () => await webFileDownload.DownloadToFileAsync(validUri, "myfile.txt"));
     }
 
+    [Theory]
+    [InlineData("\\\\UNC\\server\\folder\\myfile.txt")]
+    [InlineData("//UNC/server/folder/myfile.txt")]
+    [InlineData("/\\UNC\\server\\folder\\myfile.txt")]
+    [InlineData("\\/UNC/server/folder/myfile.txt")]
+    public async Task DownloadToFileRejectsUncOrExtendedPathsAsync(string filePath)
+    {
+        // Arrange
+        var uri = new Uri("https://raw.githubusercontent.com/microsoft/semantic-kernel/refs/heads/main/docs/images/sk_logo.png");
+        var folderPath = Path.Combine(Path.GetTempPath(), Guid.NewGuid().ToString());
+        var webFileDownload = new WebFileDownloadPlugin()
+        {
+            AllowedDomains = ["raw.githubusercontent.com"],
+            AllowedFolders = [folderPath]
+        };
+
+        // Act & Assert
+        await Assert.ThrowsAsync<ArgumentException>(() => webFileDownload.DownloadToFileAsync(uri, filePath));
+    }
+
     [Fact]
     public async Task DownloadToFileUsesCaseSensitiveAllowListComparisonOnLinuxAsync()
     {

--- a/dotnet/src/Plugins/Plugins.Web/WebFileDownloadPlugin.cs
+++ b/dotnet/src/Plugins/Plugins.Web/WebFileDownloadPlugin.cs
@@ -224,11 +224,10 @@ public sealed class WebFileDownloadPlugin
         return PathUtilities.GetSafeFullPath(expanded);
     }
 
-    private static bool IsUncOrExtendedPath(string path)
-    {
-        return path.StartsWith("\\\\", StringComparison.OrdinalIgnoreCase) ||
-            path.StartsWith("//", StringComparison.OrdinalIgnoreCase);
-    }
+    private static bool IsUncOrExtendedPath(string path) =>
+        path.Length >= 2 &&
+        (path[0] is '/' or '\\') &&
+        (path[1] is '/' or '\\');
 
     /// <summary>
     /// If a list of allowed folder has been provided, the folder of the provided filePath is checked
@@ -239,7 +238,7 @@ public sealed class WebFileDownloadPlugin
     {
         Verify.NotNullOrWhiteSpace(path);
 
-        if (path.StartsWith("\\\\", StringComparison.OrdinalIgnoreCase))
+        if (IsUncOrExtendedPath(path))
         {
             throw new ArgumentException("Invalid file path, UNC paths are not supported.", nameof(path));
         }

--- a/dotnet/src/Plugins/Plugins.Web/WebFileDownloadPlugin.cs
+++ b/dotnet/src/Plugins/Plugins.Web/WebFileDownloadPlugin.cs
@@ -221,7 +221,17 @@ public sealed class WebFileDownloadPlugin
             throw new ArgumentException("Invalid file path, UNC paths are not supported.", nameof(path));
         }
 
-        return PathUtilities.GetSafeFullPath(expanded);
+        // Resolve the full path first (a pure string operation that does not touch the
+        // filesystem). A relative path can still resolve to a UNC path here, for example
+        // when the current directory is a UNC share, so re-check before GetSafeFullPath
+        // probes the filesystem while resolving symbolic links.
+        var fullPath = Path.GetFullPath(expanded);
+        if (IsUncOrExtendedPath(fullPath))
+        {
+            throw new ArgumentException("Invalid file path, UNC paths are not supported.", nameof(path));
+        }
+
+        return PathUtilities.GetSafeFullPath(fullPath);
     }
 
     private static bool IsUncOrExtendedPath(string path) =>


### PR DESCRIPTION
### Motivation and Context

`FileIOPlugin` and `WebFileDownloadPlugin` rejected only some UNC path prefixes before path canonicalization. On Windows, mixed `/\` and `\/` prefixes resolve to UNC paths too, so those forms could reach filesystem path resolution before the allow-list rejected them.

Fixes #14157.

### Description

- Treat any two leading `/` or `\` characters as a UNC or extended-path prefix in both plugins.
- Reject those paths before canonicalization, `File.Exists`, or `File.GetAttributes` can probe the filesystem.
- Add read, write, and download regressions for all four separator combinations.

The change is limited to the two plugins named in the issue. Single-separator rooted paths, normal local paths, allow-list behavior, symlink handling, overwrite checks, and download limits are unchanged.

### Verification

```bash
dotnet test dotnet/src/Plugins/Plugins.UnitTests/Plugins.UnitTests.csproj --filter "FullyQualifiedName~ItRejectsUncOrExtendedPathsOnReadAsync|FullyQualifiedName~ItRejectsUncOrExtendedPathsOnWriteAsync|FullyQualifiedName~DownloadToFileRejectsUncOrExtendedPathsAsync"
dotnet test dotnet/src/Plugins/Plugins.UnitTests/Plugins.UnitTests.csproj --filter "FullyQualifiedName~FileIOPluginTests"
dotnet test dotnet/src/Plugins/Plugins.UnitTests/Plugins.UnitTests.csproj --filter "FullyQualifiedName!~DownloadToFileSucceedsAsync&FullyQualifiedName!~DownloadToFileFailsForInvalidParametersAsync"
dotnet format dotnet/src/Plugins/Plugins.UnitTests/Plugins.UnitTests.csproj --verify-no-changes --no-restore
```

The focused regressions pass 12/12, all `FileIOPluginTests` pass 21/21, and the deterministic Plugins unit-test suite passes 409/409. The two excluded Web tests use a live HTTPS request and fail on unmodified `main` in this macOS environment because certificate revocation status is unavailable.

### Contribution Checklist

- [x] The code builds clean without any errors or warnings
- [x] The PR follows the [SK Contribution Guidelines](https://github.com/microsoft/semantic-kernel/blob/main/CONTRIBUTING.md) and the [pre-submission formatting script](https://github.com/microsoft/semantic-kernel/blob/main/CONTRIBUTING.md#development-scripts) raises no violations
- [ ] All unit tests pass, and I have added new tests where possible (409 deterministic tests pass; two live-network baseline tests are environment-limited as noted above)
- [x] I didn't break anyone :smile:
