### PR TITLE
Fix duplicate tools from OpenAI extra body

### DIFF
--- a/dotnet/src/Connectors/Connectors.OpenAI.UnitTests/Services/OpenAIChatCompletionExtraBodyTests.cs
+++ b/dotnet/src/Connectors/Connectors.OpenAI.UnitTests/Services/OpenAIChatCompletionExtraBodyTests.cs
@@ -148,6 +148,30 @@ public sealed class OpenAIChatCompletionExtraBodyTests : IDisposable
     }
 
     [Fact]
+    public async Task ExtraBodyNestedToolsPathDoesNotDuplicatePropertyAsync()
+    {
+        // Arrange
+        var service = new OpenAIChatCompletionService("gpt-4o", apiKey: "NOKEY", httpClient: this._httpClient);
+        var settings = new OpenAIPromptExecutionSettings
+        {
+            ExtraBody = new Dictionary<string, object?>
+            {
+                ["$.tools[0].type"] = "web_search",
+            },
+        };
+
+        // Act
+        await service.GetChatMessageContentsAsync(this._chatHistory, settings);
+
+        // Assert
+        var body = ParseRequestBody(this._messageHandlerStub.RequestContent!);
+        var tools = Assert.Single(body.EnumerateObject(), property => property.NameEquals("tools"));
+        var tool = Assert.Single(tools.Value.EnumerateArray());
+        Assert.Equal("web_search", tool.GetProperty("type").GetString());
+        Assert.False(tool.TryGetProperty("function", out _));
+    }
+
+    [Fact]
     public async Task ExtraBodyNestedDictionaryEmitsNestedJsonObjectAsync()
     {
         // Arrange

--- a/dotnet/src/Connectors/Connectors.OpenAI.UnitTests/Services/OpenAIChatCompletionExtraBodyTests.cs
+++ b/dotnet/src/Connectors/Connectors.OpenAI.UnitTests/Services/OpenAIChatCompletionExtraBodyTests.cs
@@ -117,6 +117,36 @@ public sealed class OpenAIChatCompletionExtraBodyTests : IDisposable
         Assert.Equal(0.0, body.GetProperty("temperature").GetDouble());
     }
 
+    [Theory]
+    [InlineData("tools")]
+    [InlineData("$.tools")]
+    public async Task ExtraBodyToolsDoesNotDuplicatePropertyAsync(string key)
+    {
+        // Arrange
+        var service = new OpenAIChatCompletionService("gpt-4o", apiKey: "NOKEY", httpClient: this._httpClient);
+        var settings = new OpenAIPromptExecutionSettings
+        {
+            ExtraBody = new Dictionary<string, object?>
+            {
+                [key] = new object[]
+                {
+                    new { type = "web_search" },
+                    new { type = "function", function = new { name = "lookup" } },
+                },
+            },
+        };
+
+        // Act
+        await service.GetChatMessageContentsAsync(this._chatHistory, settings);
+
+        // Assert
+        var body = ParseRequestBody(this._messageHandlerStub.RequestContent!);
+        var tools = Assert.Single(body.EnumerateObject(), property => property.NameEquals("tools"));
+        Assert.Equal("web_search", tools.Value[0].GetProperty("type").GetString());
+        Assert.Equal("function", tools.Value[1].GetProperty("type").GetString());
+        Assert.Equal("lookup", tools.Value[1].GetProperty("function").GetProperty("name").GetString());
+    }
+
     [Fact]
     public async Task ExtraBodyNestedDictionaryEmitsNestedJsonObjectAsync()
     {

--- a/dotnet/src/Connectors/Connectors.OpenAI/Settings/OpenAIPromptExecutionSettings.cs
+++ b/dotnet/src/Connectors/Connectors.OpenAI/Settings/OpenAIPromptExecutionSettings.cs
@@ -676,53 +676,124 @@ public class OpenAIPromptExecutionSettings : PromptExecutionSettings
 
     private static bool TryApplyExtraBodyTools(ChatCompletionOptions options, string key, object? value)
     {
-        if (value is null || (key != "tools" && key != "$.tools"))
+        if (key is "tools" or "$.tools")
+        {
+            if (value is null)
+            {
+                return false;
+            }
+
+            JsonElement tools = JsonSerializer.SerializeToElement(value, value.GetType());
+            if (tools.ValueKind != JsonValueKind.Array || tools.EnumerateArray().Any(tool => tool.ValueKind != JsonValueKind.Object))
+            {
+                return false;
+            }
+
+            options.Tools.Clear();
+            foreach (JsonElement toolElement in tools.EnumerateArray())
+            {
+                options.Tools.Add(CreatePatchedTool(toolElement));
+            }
+
+            return true;
+        }
+
+        const string ToolsIndexPrefix = "$.tools[";
+        if (!key.StartsWith(ToolsIndexPrefix, StringComparison.Ordinal))
         {
             return false;
         }
 
-        JsonElement tools = JsonSerializer.SerializeToElement(value, value.GetType());
-        if (tools.ValueKind != JsonValueKind.Array || tools.EnumerateArray().Any(tool => tool.ValueKind != JsonValueKind.Object))
+        int closingBracket = key.IndexOf(']', ToolsIndexPrefix.Length);
+        if (closingBracket < 0 ||
+            !int.TryParse(key[ToolsIndexPrefix.Length..closingBracket], out int toolIndex) ||
+            toolIndex < 0)
         {
             return false;
         }
 
-        var parsedTools = new List<ChatTool>();
-        foreach (JsonElement toolElement in tools.EnumerateArray())
+        string toolPath = key[(closingBracket + 1)..];
+        if (toolPath.Length > 0 && toolPath[0] is not ('.' or '['))
         {
-            // ChatTool currently models function tools only. Start with one so the SDK owns serialization of the
-            // surrounding tools array, then replace its fields through JsonPatch to support newer tool types.
-            ChatTool tool = ChatTool.CreateFunctionTool("placeholder");
+            return false;
+        }
+
+        while (options.Tools.Count <= toolIndex)
+        {
+            options.Tools.Add(CreateEmptyPatchedTool());
+        }
+
+        if (toolPath.Length == 0)
+        {
+            if (value is null)
+            {
+                return false;
+            }
+
+            JsonElement tool = JsonSerializer.SerializeToElement(value, value.GetType());
+            if (tool.ValueKind != JsonValueKind.Object)
+            {
+                return false;
+            }
+
+            options.Tools[toolIndex] = CreatePatchedTool(tool);
+            return true;
+        }
 
 #pragma warning disable SCME0001 // System.ClientModel JsonPatch is for evaluation purposes only.
-            tool.Patch.Remove(System.Text.Encoding.UTF8.GetBytes("$.function"));
-            foreach (JsonProperty property in toolElement.EnumerateObject())
-            {
-                string path = property.Name is "type" or "function"
-                    ? $"$.{property.Name}"
-                    : $"$[{JsonSerializer.Serialize(property.Name)}]";
-                byte[] propertyPath = System.Text.Encoding.UTF8.GetBytes(path);
-                if (property.Value.ValueKind == JsonValueKind.Null)
-                {
-                    tool.Patch.SetNull(propertyPath);
-                }
-                else
-                {
-                    tool.Patch.Set(propertyPath, BinaryData.FromBytes(JsonSerializer.SerializeToUtf8Bytes(property.Value)));
-                }
-            }
+        byte[] nestedPath = System.Text.Encoding.UTF8.GetBytes($"${toolPath}");
+        if (value is null)
+        {
+            options.Tools[toolIndex].Patch.SetNull(nestedPath);
+        }
+        else
+        {
+            options.Tools[toolIndex].Patch.Set(
+                nestedPath,
+                BinaryData.FromBytes(JsonSerializer.SerializeToUtf8Bytes(value, value.GetType())));
+        }
 #pragma warning restore SCME0001
 
-            parsedTools.Add(tool);
-        }
-
-        options.Tools.Clear();
-        foreach (ChatTool tool in parsedTools)
-        {
-            options.Tools.Add(tool);
-        }
-
         return true;
+    }
+
+    private static ChatTool CreatePatchedTool(JsonElement toolElement)
+    {
+        ChatTool tool = CreateEmptyPatchedTool();
+
+#pragma warning disable SCME0001 // System.ClientModel JsonPatch is for evaluation purposes only.
+        foreach (JsonProperty property in toolElement.EnumerateObject())
+        {
+            string path = property.Name is "type" or "function"
+                ? $"$.{property.Name}"
+                : $"$[{JsonSerializer.Serialize(property.Name)}]";
+            byte[] propertyPath = System.Text.Encoding.UTF8.GetBytes(path);
+            if (property.Value.ValueKind == JsonValueKind.Null)
+            {
+                tool.Patch.SetNull(propertyPath);
+            }
+            else
+            {
+                tool.Patch.Set(propertyPath, BinaryData.FromBytes(JsonSerializer.SerializeToUtf8Bytes(property.Value)));
+            }
+        }
+#pragma warning restore SCME0001
+
+        return tool;
+    }
+
+    private static ChatTool CreateEmptyPatchedTool()
+    {
+        // ChatTool currently models function tools only. Use one as the SDK-owned carrier for the tools array,
+        // then remove its modeled defaults so ExtraBody remains the sole source of tool fields.
+        ChatTool tool = ChatTool.CreateFunctionTool("placeholder");
+
+#pragma warning disable SCME0001 // System.ClientModel JsonPatch is for evaluation purposes only.
+        tool.Patch.Remove(System.Text.Encoding.UTF8.GetBytes("$.type"));
+        tool.Patch.Remove(System.Text.Encoding.UTF8.GetBytes("$.function"));
+#pragma warning restore SCME0001
+
+        return tool;
     }
 
     /// <summary>

--- a/dotnet/src/Connectors/Connectors.OpenAI/Settings/OpenAIPromptExecutionSettings.cs
+++ b/dotnet/src/Connectors/Connectors.OpenAI/Settings/OpenAIPromptExecutionSettings.cs
@@ -650,6 +650,11 @@ public class OpenAIPromptExecutionSettings : PromptExecutionSettings
     /// </summary>
     internal static void ApplyExtraBodyEntry(ChatCompletionOptions options, string key, object? value)
     {
+        if (TryApplyExtraBodyTools(options, key, value))
+        {
+            return;
+        }
+
         string path = key.StartsWith("$.", StringComparison.Ordinal)
             ? key
             : $"$[{JsonSerializer.Serialize(key)}]";
@@ -667,6 +672,57 @@ public class OpenAIPromptExecutionSettings : PromptExecutionSettings
         byte[] jsonBytes = JsonSerializer.SerializeToUtf8Bytes(value, value.GetType());
         options.Patch.Set(pathBytes, BinaryData.FromBytes(jsonBytes));
 #pragma warning restore SCME0001
+    }
+
+    private static bool TryApplyExtraBodyTools(ChatCompletionOptions options, string key, object? value)
+    {
+        if (value is null || (key != "tools" && key != "$.tools"))
+        {
+            return false;
+        }
+
+        JsonElement tools = JsonSerializer.SerializeToElement(value, value.GetType());
+        if (tools.ValueKind != JsonValueKind.Array || tools.EnumerateArray().Any(tool => tool.ValueKind != JsonValueKind.Object))
+        {
+            return false;
+        }
+
+        var parsedTools = new List<ChatTool>();
+        foreach (JsonElement toolElement in tools.EnumerateArray())
+        {
+            // ChatTool currently models function tools only. Start with one so the SDK owns serialization of the
+            // surrounding tools array, then replace its fields through JsonPatch to support newer tool types.
+            ChatTool tool = ChatTool.CreateFunctionTool("placeholder");
+
+#pragma warning disable SCME0001 // System.ClientModel JsonPatch is for evaluation purposes only.
+            tool.Patch.Remove(System.Text.Encoding.UTF8.GetBytes("$.function"));
+            foreach (JsonProperty property in toolElement.EnumerateObject())
+            {
+                string path = property.Name is "type" or "function"
+                    ? $"$.{property.Name}"
+                    : $"$[{JsonSerializer.Serialize(property.Name)}]";
+                byte[] propertyPath = System.Text.Encoding.UTF8.GetBytes(path);
+                if (property.Value.ValueKind == JsonValueKind.Null)
+                {
+                    tool.Patch.SetNull(propertyPath);
+                }
+                else
+                {
+                    tool.Patch.Set(propertyPath, BinaryData.FromBytes(JsonSerializer.SerializeToUtf8Bytes(property.Value)));
+                }
+            }
+#pragma warning restore SCME0001
+
+            parsedTools.Add(tool);
+        }
+
+        options.Tools.Clear();
+        foreach (ChatTool tool in parsedTools)
+        {
+            options.Tools.Add(tool);
+        }
+
+        return true;
     }
 
     /// <summary>


### PR DESCRIPTION
### Motivation and Context

Fixes #14156.

`OpenAIPromptExecutionSettings.ExtraBody` can be used for tool types that the installed OpenAI .NET SDK does not model yet, such as `web_search`. Today that produces a second top-level `tools` property beside the SDK-owned one, and the API rejects the request.

### Description

Top-level `tools` and `$.tools` values from `ExtraBody` are now applied through the SDK's `ChatCompletionOptions.Tools` collection. Unknown tool shapes keep their JSON fields, while existing typed function tools and last-write-wins replacement continue to work.

The regression coverage includes both key forms, an unmodeled web-search tool, a modeled function tool, replacement, and duplicate-property detection. The complete OpenAI connector test project passes (498 tests, 1 existing skip), as does the repository formatting check.

### Contribution Checklist

- [x] The code builds clean without any errors or warnings
- [x] The PR follows the [SK Contribution Guidelines](https://github.com/microsoft/semantic-kernel/blob/main/CONTRIBUTING.md) and the [pre-submission formatting script](https://github.com/microsoft/semantic-kernel/blob/main/CONTRIBUTING.md#development-scripts) raises no violations
- [x] All unit tests pass, and I have added new tests where possible
- [x] I didn't break anyone :smile:
