### PR TITLE
.Net: Harden FileIOPlugin UNC path rejection to cover all separator forms

### DIFF
--- a/dotnet/src/Plugins/Plugins.Core/FileIOPlugin.cs
+++ b/dotnet/src/Plugins/Plugins.Core/FileIOPlugin.cs
@@ -175,14 +175,14 @@ public sealed class FileIOPlugin
     /// <c>//server/share</c>) or an extended-length / device path (e.g., <c>\\?\</c>, <c>\\.\</c>).
     /// Windows treats any two leading directory separators, in any combination of <c>\</c> and
     /// <c>/</c>, as such a root, so all combinations are rejected for consistency with the other
-    /// file plugins.
+    /// file plugins. Both separator characters are checked explicitly so the result does not
+    /// depend on the current operating system's separator.
     /// </summary>
     private static bool IsUncOrExtendedPath(string path)
     {
         return path.Length >= 2 && IsDirectorySeparator(path[0]) && IsDirectorySeparator(path[1]);
     }
 
-    private static bool IsDirectorySeparator(char c)
-        => c == Path.DirectorySeparatorChar || c == Path.AltDirectorySeparatorChar;
+    private static bool IsDirectorySeparator(char c) => c is '\\' or '/';
     #endregion
 }

--- a/dotnet/src/Plugins/Plugins.Core/FileIOPlugin.cs
+++ b/dotnet/src/Plugins/Plugins.Core/FileIOPlugin.cs
@@ -113,7 +113,7 @@ public sealed class FileIOPlugin
         Verify.NotNullOrWhiteSpace(path);
         canonicalPath = string.Empty;
 
-        if (path.StartsWith("\\\\", StringComparison.OrdinalIgnoreCase))
+        if (IsUncOrExtendedPath(path))
         {
             throw new ArgumentException("Invalid file path, UNC paths are not supported.", nameof(path));
         }
@@ -126,6 +126,13 @@ public sealed class FileIOPlugin
         }
 
         canonicalPath = PathUtilities.GetSafeFullPath(path);
+
+        // Re-check after canonicalization: resolving the path could produce a UNC
+        // or extended-path prefix that was not present in the original input.
+        if (IsUncOrExtendedPath(canonicalPath))
+        {
+            throw new ArgumentException("Invalid file path, UNC paths are not supported.", nameof(path));
+        }
 
         if (File.Exists(canonicalPath) && File.GetAttributes(canonicalPath).HasFlag(FileAttributes.ReadOnly))
         {
@@ -162,5 +169,20 @@ public sealed class FileIOPlugin
 
         return false;
     }
+
+    /// <summary>
+    /// Determines whether the provided path is a UNC path (e.g., <c>\\server\share</c> or
+    /// <c>//server/share</c>) or an extended-length / device path (e.g., <c>\\?\</c>, <c>\\.\</c>).
+    /// Windows treats any two leading directory separators, in any combination of <c>\</c> and
+    /// <c>/</c>, as such a root, so all combinations are rejected for consistency with the other
+    /// file plugins.
+    /// </summary>
+    private static bool IsUncOrExtendedPath(string path)
+    {
+        return path.Length >= 2 && IsDirectorySeparator(path[0]) && IsDirectorySeparator(path[1]);
+    }
+
+    private static bool IsDirectorySeparator(char c)
+        => c == Path.DirectorySeparatorChar || c == Path.AltDirectorySeparatorChar;
     #endregion
 }

--- a/dotnet/src/Plugins/Plugins.UnitTests/Core/FileIOPluginTests.cs
+++ b/dotnet/src/Plugins/Plugins.UnitTests/Core/FileIOPluginTests.cs
@@ -154,8 +154,11 @@ public class FileIOPluginTests
         // Arrange
         var plugin = new FileIOPlugin() { AllowedFolders = [Path.GetTempPath()] };
 
-        // Act & Assert
-        await Assert.ThrowsAsync<ArgumentException>(() => plugin.ReadAsync(uncPath));
+        // Act
+        var exception = await Assert.ThrowsAsync<ArgumentException>(() => plugin.ReadAsync(uncPath));
+
+        // Assert - the UNC guard (not another validation) must be what rejected the path
+        Assert.Contains("UNC paths are not supported", exception.Message, StringComparison.Ordinal);
     }
 
     [Theory]
@@ -172,8 +175,11 @@ public class FileIOPluginTests
             DisableFileOverwrite = false
         };
 
-        // Act & Assert
-        await Assert.ThrowsAsync<ArgumentException>(() => plugin.WriteAsync(uncPath, "hello world"));
+        // Act
+        var exception = await Assert.ThrowsAsync<ArgumentException>(() => plugin.WriteAsync(uncPath, "hello world"));
+
+        // Assert - the UNC guard (not another validation) must be what rejected the path
+        Assert.Contains("UNC paths are not supported", exception.Message, StringComparison.Ordinal);
     }
 
     [Fact]

--- a/dotnet/src/Plugins/Plugins.UnitTests/Core/FileIOPluginTests.cs
+++ b/dotnet/src/Plugins/Plugins.UnitTests/Core/FileIOPluginTests.cs
@@ -144,6 +144,38 @@ public class FileIOPluginTests
         await Assert.ThrowsAsync<ArgumentException>(async () => await plugin.ReadAsync(Path.Combine("", Path.GetRandomFileName())));
     }
 
+    [Theory]
+    [InlineData("\\\\server\\share\\file.txt")]
+    [InlineData("//server/share/file.txt")]
+    [InlineData("\\/server\\share\\file.txt")]
+    [InlineData("/\\server/share/file.txt")]
+    public async Task ItCannotReadFromUncPathsAsync(string uncPath)
+    {
+        // Arrange
+        var plugin = new FileIOPlugin() { AllowedFolders = [Path.GetTempPath()] };
+
+        // Act & Assert
+        await Assert.ThrowsAsync<ArgumentException>(() => plugin.ReadAsync(uncPath));
+    }
+
+    [Theory]
+    [InlineData("\\\\server\\share\\file.txt")]
+    [InlineData("//server/share/file.txt")]
+    [InlineData("\\/server\\share\\file.txt")]
+    [InlineData("/\\server/share/file.txt")]
+    public async Task ItCannotWriteToUncPathsAsync(string uncPath)
+    {
+        // Arrange
+        var plugin = new FileIOPlugin()
+        {
+            AllowedFolders = [Path.GetTempPath()],
+            DisableFileOverwrite = false
+        };
+
+        // Act & Assert
+        await Assert.ThrowsAsync<ArgumentException>(() => plugin.WriteAsync(uncPath, "hello world"));
+    }
+
     [Fact]
     public async Task ItCannotReadThroughSymlinkOutsideAllowedFoldersAsync()
     {


### PR DESCRIPTION
## Motivation and Context

`FileIOPlugin` restricts file operations to a configured set of allowed folders. Before validating against that allow list, the path is canonicalized. The pre-canonicalization guard rejected only the uniform backslash UNC form (`\\`), so other equivalent forms that Windows resolves to a UNC/device root could reach path canonicalization before the allowed folder check ran.

The sibling file plugins (`DocumentPlugin`, `WebFileDownloadPlugin`, `CloudDrivePlugin`) already reject both slash forms. This change aligns `FileIOPlugin` with them and makes the guard robust to every separator combination.

## Description

- Replace the single `StartsWith("\\")` guard with an `IsUncOrExtendedPath` helper that flags any path whose first two characters are both directory separators, in any combination of `\` and `/` (covers `\\`, `//`, `\/`, `/\`, and extended/device prefixes like `\\?\` and `\\.\`).
- Add a post-canonicalization re-check so a resolved path that becomes a UNC/device root is also rejected.
- Add unit tests covering all separator forms for both read and write.

## Validation

- `FileIOPluginTests`: 21/21 pass.
- Full `Plugins.UnitTests` suite: 403 pass, no regressions.
- `dotnet format --verify-no-changes` clean on the changed projects.

## Contribution Checklist

- [x] The code builds clean without any errors or warnings
- [x] The PR follows the [SK Contribution Guidelines](https://github.com/microsoft/semantic-kernel/blob/main/CONTRIBUTING.md)
- [x] All unit tests pass, and I have added new tests where possible