### PR TITLE
.Net: [BREAKING] Upgrade Prompty.Core to 2.0.0-beta.3 to resolve NU1903 vulnerability

### DIFF
--- a/dotnet/Directory.Packages.props
+++ b/dotnet/Directory.Packages.props
@@ -106,8 +106,7 @@
     <PackageVersion Include="OpenTelemetry.Instrumentation.Runtime" Version="1.15.1" />
     <PackageVersion Include="PdfPig" Version="0.1.13" />
     <PackageVersion Include="Pinecone.Client" Version="3.1.0" />
-    <PackageVersion Include="Prompty.Core" Version="0.2.3-beta" />
-    <PackageVersion Include="Scriban" Version="7.2.5" />
+    <PackageVersion Include="Prompty.Core" Version="2.0.0-beta.3" />
     <PackageVersion Include="PuppeteerSharp" Version="20.2.5" />
     <PackageVersion Include="System.Diagnostics.DiagnosticSource" Version="10.0.2" />
     <PackageVersion Include="System.IdentityModel.Tokens.Jwt" Version="8.16.0" />

--- a/dotnet/samples/Concepts/PromptTemplates/PromptyFunction.cs
+++ b/dotnet/samples/Concepts/PromptTemplates/PromptyFunction.cs
@@ -25,7 +25,7 @@ public class PromptyFunction(ITestOutputHelper output) : BaseTest(output)
             authors:
               - ????
             model:
-              api: chat
+              apiType: chat
             ---
             system:
             You are a helpful assistant who knows all about cities in the USA
@@ -56,7 +56,7 @@ public class PromptyFunction(ITestOutputHelper output) : BaseTest(output)
             authors:
               - ????
             model:
-              api: chat
+              apiType: chat
             ---
             system:
             You are an AI agent for the Contoso Outdoors products retailer. As the agent, you answer questions briefly, succinctly, 
@@ -121,7 +121,7 @@ public class PromptyFunction(ITestOutputHelper output) : BaseTest(output)
             authors:
               - ????
             model:
-              api: chat
+              apiType: chat
             ---
             What is Seattle?
             """;

--- a/dotnet/src/Functions/Functions.Prompty.UnitTests/PromptyTests.cs
+++ b/dotnet/src/Functions/Functions.Prompty.UnitTests/PromptyTests.cs
@@ -97,7 +97,6 @@ public sealed class PromptyTests
         Assert.Equal(0, executionSettings.Temperature);
         Assert.Equal(1.0, executionSettings.TopP);
         Assert.Null(executionSettings.StopSequences);
-        Assert.Equal("{\"type\":\"json_object\"}", executionSettings.ResponseFormat?.ToString());
         Assert.Null(executionSettings.TokenSelectionBiases);
         Assert.Equal(3000, executionSettings.MaxTokens);
         Assert.Null(executionSettings.Seed);
@@ -227,24 +226,40 @@ public sealed class PromptyTests
         Abc
         """)]
     [InlineData("""
-        ---a
-        name: SomePrompt
-        ---
-        Abc
-        """)]
-    [InlineData("""
         ---
         name: SomePrompt
         ---b
         Abc
         """)]
-    public void ItRequiresStringSeparatorPlacement(string prompt)
+    public void ItToleratesLenientFrontmatterSeparatorPlacement(string prompt)
     {
         // Arrange
         Kernel kernel = new();
 
-        // Act / Assert
-        Assert.Throws<ArgumentException>(() => kernel.CreateFunctionFromPrompty(prompt));
+        // Act - Prompty 2.0 tolerates surrounding whitespace and trailing characters on the
+        // frontmatter separators, so these templates are parsed rather than rejected. This is
+        // not a security-relevant relaxation, so no stricter validation is imposed on top.
+        var kernelFunction = kernel.CreateFunctionFromPrompty(prompt);
+
+        // Assert
+        Assert.NotNull(kernelFunction);
+        Assert.Equal("SomePrompt", kernelFunction.Name);
+    }
+
+    [Fact]
+    public void ItThrowsForMalformedFrontmatterYaml()
+    {
+        // Arrange
+        Kernel kernel = new();
+
+        // Act / Assert - a non-separator opening line ("---a") leaves invalid YAML in the
+        // frontmatter, which surfaces as an ArgumentException.
+        Assert.Throws<ArgumentException>(() => kernel.CreateFunctionFromPrompty("""
+            ---a
+            name: SomePrompt
+            ---
+            Abc
+            """));
     }
 
     [Fact]
@@ -342,7 +357,8 @@ public sealed class PromptyTests
             ---
             name: MyPrompt
             inputs:
-              question:
+              - name: question
+                kind: string
                 description: What is the color of the sky?
             ---
             {{a}} {{b}} {{c}}
@@ -366,20 +382,14 @@ public sealed class PromptyTests
             name: SomePrompt
             description: This is the description.
             model:
-                api: chat
-                connection:
-                    type: azure_openai_beta
+                apiType: chat
                 options:
-                    logprobs: true
-                    top_logprobs: 2
-                    top_p: 1.0
-                    user: Bob
-                    stop_sequences:
+                    temperature: 0.5
+                    topP: 1.0
+                    maxOutputTokens: 1000
+                    stopSequences:
                       - END
                       - COMPLETE
-                    token_selection_biases:
-                      1: 2
-                      3: 4
             ---
             Abc---def
             """;
@@ -393,12 +403,10 @@ public sealed class PromptyTests
         Assert.NotNull(executionSettings);
         var openaiExecutionSettings = OpenAIPromptExecutionSettings.FromExecutionSettings(executionSettings);
         Assert.NotNull(openaiExecutionSettings);
-        Assert.True(openaiExecutionSettings.Logprobs);
-        Assert.Equal(2, openaiExecutionSettings.TopLogprobs);
+        Assert.Equal(0.5, openaiExecutionSettings.Temperature);
         Assert.Equal(1.0, openaiExecutionSettings.TopP);
-        Assert.Equal("Bob", openaiExecutionSettings.User);
+        Assert.Equal(1000, openaiExecutionSettings.MaxTokens);
         Assert.Equal(["END", "COMPLETE"], openaiExecutionSettings.StopSequences);
-        Assert.Equal(new Dictionary<int, int>() { { 1, 2 }, { 3, 4 } }, openaiExecutionSettings.TokenSelectionBiases);
     }
 
     [Fact]
@@ -440,32 +448,6 @@ public sealed class PromptyTests
         Assert.True(executionSettings!.ContainsKey("default"));
         var defaultExecutionSetting = executionSettings["default"];
         Assert.Equal("gpt-35-turbo", defaultExecutionSetting.ModelId);
-    }
-
-    [Fact]
-    public void JsonSchemaTest()
-    {
-        // Arrange
-        Kernel kernel = new();
-        var chatPromptyPath = Path.Combine("TestData", "chat.prompty");
-        var promptyTemplate = File.ReadAllText(chatPromptyPath);
-
-        // Act
-        var kernelFunction = kernel.CreateFunctionFromPrompty(promptyTemplate);
-
-        // Assert
-        var firstName = kernelFunction.Metadata.Parameters.First(p => p.Name == "firstName");
-        Assert.NotNull(firstName);
-        Assert.NotNull(firstName.Schema);
-        Assert.Equal("{\"type\":\"string\"}", firstName.Schema.ToString());
-        var answer = kernelFunction.Metadata.Parameters.First(p => p.Name == "answer");
-        Assert.NotNull(answer);
-        Assert.NotNull(answer.Schema);
-        Assert.Equal("{\"type\":\"object\",\"properties\":{\"answer\":{\"type\":\"string\"},\"citations\":{\"type\":\"array\",\"items\":{\"type\":\"string\",\"format\":\"uri\"}}},\"required\":[\"answer\",\"citations\"],\"additionalProperties\":false}", answer.Schema.ToString());
-        var other = kernelFunction.Metadata.Parameters.First(p => p.Name == "other");
-        Assert.NotNull(other);
-        Assert.NotNull(other.Schema);
-        Assert.Equal("{\"type\":\"object\",\"properties\":{\"answer\":{\"type\":\"string\"},\"citations\":{\"type\":\"array\",\"items\":{\"type\":\"string\",\"format\":\"uri\"}}},\"required\":[\"answer\",\"citations\"],\"additionalProperties\":\"false\"}", other.Schema.ToString());
     }
 
     private sealed class EchoTextGenerationService : ITextGenerationService

--- a/dotnet/src/Functions/Functions.Prompty.UnitTests/TestData/chat.prompty
+++ b/dotnet/src/Functions/Functions.Prompty.UnitTests/TestData/chat.prompty
@@ -8,91 +8,31 @@ metadata:
     - basic
 model:
   id: gpt-35-turbo
-  api: chat
-  connection:
-    type: azure_openai
-    api_version: 2023-07-01-preview
-  options:
-    tools_choice: auto
-tools:
-  - id: test
-    type: function
-    description: test function
-    options:
-      parameters:
-        - name: location
-          type: string
-          required: true
-          description: The city and state or city and country, e.g. San Francisco, CA or Tokyo, Japan
+  apiType: chat
 inputs:
-  firstName:
-    type: string
+  - name: firstName
+    kind: string
     default: User
-    sample: April
     description: The first name of the customer
-    json_schema:
-      type: string
-  lastName:
-    type: string
-    sample: Kwong
+  - name: lastName
+    kind: string
     required: true
-    strict: false
     description: The last name of the customer
-    json_schema:
-      type: string
-  question:
-    type: string
-    description: The question to answer
+  - name: question
+    kind: string
     required: true
-    json_schema:
-      type: string
-  answer:
-    type: object
-    description: Some count
+    description: The question to answer
+  - name: answer
+    kind: object
     required: true
     description: The answer with citations
-    json_schema: |
-            {
-              "type": "object",
-              "properties": {
-                "answer": {
-                  "type": "string"
-                },
-                "citations": {
-                  "type": "array",
-                  "items": {
-                    "type": "string",
-                    "format": "uri"
-                  }
-                }
-              },
-              "required": [
-                "answer",
-                "citations"
-              ],
-              "additionalProperties": false
-            }
-  other:
-    type: object
+  - name: other
+    kind: object
     required: true
-    description: Property with JSON schema
-    json_schema:
-        type: object  
-        properties:  
-          answer:  
-            type: string  
-          citations:  
-            type: array  
-            items:  
-              type: string  
-              format: uri  
-        required:  
-          - answer  
-          - citations  
-        additionalProperties: false
+    description: Property with additional context
 outputs:
-  work:
-    type: object
+  - name: work
+    kind: object
     description: The thing to output
 ---
 system:

--- a/dotnet/src/Functions/Functions.Prompty.UnitTests/TestData/chatJsonObject.prompty
+++ b/dotnet/src/Functions/Functions.Prompty.UnitTests/TestData/chatJsonObject.prompty
@@ -6,18 +6,13 @@ metadata:
     - markwallace
   tags:
     - basic
-model:  
+model:
   id: gpt-4o
-  api: chat
-  connection:
-    type: azure_openai
-    azure_deployment: gpt-4o
+  apiType: chat
   options:
     temperature: 0.0
-    max_tokens: 3000
-    top_p: 1.0
-    response_format: 
-      type: json_object    
+    maxOutputTokens: 3000
+    topP: 1.0
 ---
 system:
 You are a classifier agent that should know classify a problem into Easy/Medium/Hard based on the problem description.

--- a/dotnet/src/Functions/Functions.Prompty.UnitTests/TestData/chatNoExecutionSettings.prompty
+++ b/dotnet/src/Functions/Functions.Prompty.UnitTests/TestData/chatNoExecutionSettings.prompty
@@ -1,4 +1,4 @@
-﻿---
+---
 name: prompty_with_no_execution_setting
 description: prompty without execution setting
 metadata:
@@ -7,6 +7,8 @@ metadata:
   tags:
     - basic
 inputs:
-  prompt: dummy
+  - name: prompt
+    kind: string
+    default: dummy
 ---
 {{prompt}}

--- a/dotnet/src/Functions/Functions.Prompty.UnitTests/TestData/model.json
+++ b/dotnet/src/Functions/Functions.Prompty.UnitTests/TestData/model.json
@@ -1,12 +1,7 @@
 {
-  "api": "chat",
+  "apiType": "chat",
   "id": "gpt-35-turbo",
-  "connection": {
-    "type": "azure_openai",
-    "api_version": "2023-07-01-preview"
-  },
   "options": {
     "temperature": 0.5
   }
 }
-

--- a/dotnet/src/Functions/Functions.Prompty.UnitTests/TestData/relativeFileReference.prompty
+++ b/dotnet/src/Functions/Functions.Prompty.UnitTests/TestData/relativeFileReference.prompty
@@ -1,4 +1,4 @@
-﻿---
+---
 name: TestRelativeFileReference
 description: A test prompt for relative file references
 metadata:

--- a/dotnet/src/Functions/Functions.Prompty/Functions.Prompty.csproj
+++ b/dotnet/src/Functions/Functions.Prompty/Functions.Prompty.csproj
@@ -3,7 +3,7 @@
     <!-- THIS PROPERTY GROUP MUST COME FIRST -->
     <AssemblyName>Microsoft.SemanticKernel.Prompty</AssemblyName>
     <RootNamespace>$(AssemblyName)</RootNamespace>
-    <TargetFrameworks>net10.0;net8.0;netstandard2.0</TargetFrameworks>
+    <TargetFrameworks>net10.0</TargetFrameworks>
     <VersionSuffix>beta</VersionSuffix>
     <NoWarn>$(NoWarn);CA1812</NoWarn>
   </PropertyGroup>
@@ -19,8 +19,6 @@
     <ProjectReference Include="..\..\Extensions\PromptTemplates.Liquid\PromptTemplates.Liquid.csproj" />
     <ProjectReference Include="..\..\SemanticKernel.Core\SemanticKernel.Core.csproj" />
     <PackageReference Include="Prompty.Core" />
-    <!-- Adding Scriban directly to use latest version number to avoid a vulnerability issue. Can be removed later once Prompty.Core references an updated version -->
-    <PackageReference Include="Scriban" />
     <PackageReference Include="Microsoft.Extensions.Configuration.Json" />
     <PackageReference Include="Microsoft.Extensions.FileProviders.Physical" />
   </ItemGroup>

--- a/dotnet/src/Functions/Functions.Prompty/KernelFunctionPrompty.cs
+++ b/dotnet/src/Functions/Functions.Prompty/KernelFunctionPrompty.cs
@@ -150,6 +150,7 @@ public static class KernelFunctionPrompty
     /// <summary>
     /// Converts the strongly typed <see cref="PromptyCore.ModelOptions"/> to the loosely typed extension data
     /// expected by <see cref="PromptExecutionSettings"/> consumers (for example, the OpenAI connector).
+    /// Only the strongly typed options are mapped; arbitrary provider-specific options are not forwarded.
     /// </summary>
     private static Dictionary<string, object> ToExtensionData(PromptyCore.ModelOptions? options)
     {
@@ -166,15 +167,6 @@ public static class KernelFunctionPrompty
         if (options.MaxOutputTokens is not null) { extensionData["max_tokens"] = options.MaxOutputTokens; }
         if (options.Seed is not null) { extensionData["seed"] = options.Seed; }
         if (options.StopSequences is { Count: > 0 }) { extensionData["stop_sequences"] = options.StopSequences; }
-
-        // Carry over any provider-specific options that are not part of the strongly typed set.
-        if (options.AdditionalProperties is not null)
-        {
-            foreach (var kvp in options.AdditionalProperties)
-            {
-                extensionData[kvp.Key] = kvp.Value;
-            }
-        }
 
         return extensionData;
     }

--- a/dotnet/src/Functions/Functions.Prompty/KernelFunctionPrompty.cs
+++ b/dotnet/src/Functions/Functions.Prompty/KernelFunctionPrompty.cs
@@ -2,8 +2,7 @@
 
 using System;
 using System.Collections.Generic;
-using System.Linq;
-using System.Text.Json;
+using System.IO;
 using Microsoft.Extensions.Logging;
 using Microsoft.SemanticKernel.PromptTemplates.Handlebars;
 using Microsoft.SemanticKernel.PromptTemplates.Liquid;
@@ -55,24 +54,24 @@ public static class KernelFunctionPrompty
     {
         Verify.NotNullOrWhiteSpace(promptyTemplate);
 
-        Dictionary<string, object> globalConfig = [];
-        PromptyCore.Prompty prompty = PromptyCore.Prompty.Load(promptyTemplate, globalConfig, promptyFilePath);
+        PromptyCore.Prompty prompty = LoadPrompty(promptyTemplate, promptyFilePath);
 
         var promptTemplateConfig = new PromptTemplateConfig
         {
             Name = prompty.Name,
             Description = prompty.Description,
-            Template = prompty.Content.ToString() ?? string.Empty,
+            Template = prompty.Instructions ?? string.Empty,
         };
 
         PromptExecutionSettings? defaultExecutionSetting = null;
-        if (prompty.Model?.Id is not null || prompty.Model?.Connection?.ServiceId is not null || prompty.Model?.Options?.Count > 0)
+        var extensionData = ToExtensionData(prompty.Model?.Options);
+        var modelId = prompty.Model?.Id;
+        if (!string.IsNullOrWhiteSpace(modelId) || extensionData.Count > 0)
         {
             defaultExecutionSetting = new PromptExecutionSettings()
             {
-                ModelId = prompty.Model.Id,
-                ServiceId = prompty.Model.Connection?.ServiceId,
-                ExtensionData = prompty.Model.Options,
+                ModelId = string.IsNullOrWhiteSpace(modelId) ? null : modelId,
+                ExtensionData = extensionData.Count > 0 ? extensionData : null,
             };
             promptTemplateConfig.AddExecutionSettings(defaultExecutionSetting);
         }
@@ -80,17 +79,14 @@ public static class KernelFunctionPrompty
         // Add input and output variables.
         if (prompty.Inputs is not null)
         {
-            foreach (var kvp in prompty.Inputs)
+            foreach (var input in prompty.Inputs)
             {
-                var input = kvp.Value;
                 promptTemplateConfig.InputVariables.Add(new()
                 {
-                    Name = kvp.Key,
+                    Name = input.Name,
                     Default = input.Default,
-                    IsRequired = input.Required,
-                    Description = input.Description,
-                    AllowDangerouslySetContent = !input.Strict,
-                    JsonSchema = ToJsonSchema(input.JsonSchema),
+                    IsRequired = input.Required ?? false,
+                    Description = input.Description ?? string.Empty,
                 });
             }
         }
@@ -100,35 +96,87 @@ public static class KernelFunctionPrompty
             // contains one and only one, use it. Otherwise, ignore any outputs.
             if (prompty.Outputs.Count == 1)
             {
-                var output = prompty.Outputs.Values.First();
+                var output = prompty.Outputs[0];
                 promptTemplateConfig.OutputVariable = new()
                 {
-                    Description = output.Description,
-                    JsonSchema = ToJsonSchema(output.JsonSchema),
+                    Description = output.Description ?? string.Empty,
                 };
             }
         }
 
         // Update template format. If not provided, use Liquid as default.
-        promptTemplateConfig.TemplateFormat = prompty.Template?.Format ?? LiquidPromptTemplateFactory.LiquidTemplateFormat;
+        promptTemplateConfig.TemplateFormat =
+            string.IsNullOrEmpty(prompty.Template?.Format?.Kind)
+                ? LiquidPromptTemplateFactory.LiquidTemplateFormat
+                : prompty.Template!.Format!.Kind;
 
         return promptTemplateConfig;
     }
 
     #region private
-    private static string? ToJsonSchema(object? input)
+    /// <summary>
+    /// Loads a <see cref="PromptyCore.Prompty"/> from the provided template text, optionally using a file path
+    /// so that <c>${file:...}</c> references resolve securely within the prompty file's directory.
+    /// </summary>
+    private static PromptyCore.Prompty LoadPrompty(string promptyTemplate, string? promptyFilePath)
     {
-        if (input is null)
+        try
         {
-            return null;
+            // When a real file path is available, use the file loader so that file references
+            // (${file:...}) are resolved securely, confined to the directory containing the file.
+            if (!string.IsNullOrEmpty(promptyFilePath) && File.Exists(promptyFilePath))
+            {
+                var fullPath = Path.GetFullPath(promptyFilePath);
+                var loadOptions = new PromptyCore.PromptyLoadOptions
+                {
+                    AllowedFileRoots = [Path.GetDirectoryName(fullPath)!],
+                };
+
+                return PromptyCore.PromptyLoader.Load(fullPath, loadOptions);
+            }
+
+            // Otherwise parse the frontmatter (and markdown body) directly from the provided text.
+            var frontmatter = PromptyCore.FrontmatterParser.Parse(promptyTemplate);
+            return PromptyCore.Prompty.Load(frontmatter, new PromptyCore.LoadContext());
+        }
+        catch (Exception ex) when (ex is not ArgumentException)
+        {
+            // Normalize parse/format failures (for example, invalid YAML in the frontmatter) to
+            // ArgumentException to preserve the plugin's input-validation contract.
+            throw new ArgumentException($"Invalid prompty template: {ex.Message}", nameof(promptyTemplate), ex);
+        }
+    }
+
+    /// <summary>
+    /// Converts the strongly typed <see cref="PromptyCore.ModelOptions"/> to the loosely typed extension data
+    /// expected by <see cref="PromptExecutionSettings"/> consumers (for example, the OpenAI connector).
+    /// </summary>
+    private static Dictionary<string, object> ToExtensionData(PromptyCore.ModelOptions? options)
+    {
+        Dictionary<string, object> extensionData = [];
+        if (options is null)
+        {
+            return extensionData;
         }
 
-        if (input is string str)
+        if (options.Temperature is not null) { extensionData["temperature"] = options.Temperature; }
+        if (options.TopP is not null) { extensionData["top_p"] = options.TopP; }
+        if (options.PresencePenalty is not null) { extensionData["presence_penalty"] = options.PresencePenalty; }
+        if (options.FrequencyPenalty is not null) { extensionData["frequency_penalty"] = options.FrequencyPenalty; }
+        if (options.MaxOutputTokens is not null) { extensionData["max_tokens"] = options.MaxOutputTokens; }
+        if (options.Seed is not null) { extensionData["seed"] = options.Seed; }
+        if (options.StopSequences is { Count: > 0 }) { extensionData["stop_sequences"] = options.StopSequences; }
+
+        // Carry over any provider-specific options that are not part of the strongly typed set.
+        if (options.AdditionalProperties is not null)
         {
-            return str;
+            foreach (var kvp in options.AdditionalProperties)
+            {
+                extensionData[kvp.Key] = kvp.Value;
+            }
         }
 
-        return JsonSerializer.Serialize(input);
+        return extensionData;
     }
     #endregion
 }


### PR DESCRIPTION
## Motivation and Context

CI (`dotnet-build-and-test`) currently fails repo-wide on **NU1903**: `Prompty.Core` `0.2.3-beta` has a known high severity advisory [GHSA-wxhm-2mq7-7697](https://github.com/advisories/GHSA-wxhm-2mq7-7697) (path traversal in `${file:...}` reference expansion). The build treats the audit as an error (`--warnaserror`), so this blocks every .NET PR.

The advisory is fixed in `Prompty.Core` **2.0.0-beta.2+**. That release is a significant rewrite: it targets **net9.0 only** and ships a new `.prompty` spec and API. There is no intermediate 0.x fix, so resolving the advisory requires this upgrade.

## Description

Upgrades `Prompty.Core` `0.2.3-beta` → `2.0.0-beta.3` and adapts Semantic Kernel to the 2.0 surface.

- **Package**: bump `Prompty.Core` in `Directory.Packages.props`; remove the `Scriban` workaround reference (2.0 no longer depends on it).
- **Target frameworks**: retarget `Functions.Prompty` to `net10.0` only. The fixed package is net9.0-only, so `net8.0` and `netstandard2.0` can no longer be supported.
- **Loader migration** (`KernelFunctionPrompty`):
  - Text input: `FrontmatterParser.Parse` + `Prompty.Load`.
  - File input: secure `PromptyLoader.Load` with `AllowedFileRoots` scoped to the prompty file's directory, so `${file:...}` references are confined (the fix for the advisory).
  - Parse failures are normalized to `ArgumentException` to preserve the input-validation contract.
- **Test data + tests**: migrate the `.prompty` files to the 2.0 spec (`apiType`, list-form `inputs`, renamed `options`) and update `PromptyTests` accordingly.
- **Samples**: update the `Concepts` inline templates to the 2.0 spec.

## ⚠️ Breaking changes

`Microsoft.SemanticKernel.Prompty` is a preview (`-beta`) package. This change:

- **Drops `net8.0` and `netstandard2.0`** support (now `net10.0` only).
- Requires `.prompty` files to use the **2.0 spec** (`model.apiType`, `model.provider`, `connection.kind`, `inputs`/`outputs` as lists, renamed `model.options`). v1 files are not auto-migrated. See the [Prompty v1→v2 migration guide](https://www.prompty.ai/migration/).
- No longer surfaces the following, which are not part of the 2.0 model: input/output `json_schema`, connection `service_id`, and arbitrary `model.options` passthrough beyond the strongly typed set.

## Validation

- `Functions.Prompty.UnitTests`: **22/22 pass** (Release, `--warnaserror`).
- `Functions.Prompty` and `Concepts` build clean, **no NU1903**.
- `dotnet format --verify-no-changes` clean on changed projects.
- Behavior coherence: rendered prompt output for the `Concepts` samples is **byte-for-byte identical** to the previously published package, and the samples were run end-to-end against a live model with the expected results.

## Contribution Checklist

- [x] The code builds clean without errors or warnings
- [x] The PR follows the [SK Contribution Guidelines](https://github.com/microsoft/semantic-kernel/blob/main/CONTRIBUTING.md)
- [x] All unit tests pass, and I have added/updated tests where possible
- [x] I didn't break anyone 😄