### PR TITLE
.Net: Fix GeminiPromptExecutionSettings.Clone dropping settable properties

### DIFF
--- a/dotnet/src/Connectors/Connectors.Google.UnitTests/GeminiPromptExecutionSettingsTests.cs
+++ b/dotnet/src/Connectors/Connectors.Google.UnitTests/GeminiPromptExecutionSettingsTests.cs
@@ -194,6 +194,7 @@ public sealed class GeminiPromptExecutionSettingsTests
         string json = $$"""
                         {
                           "model_id": "gemini-pro",
+                          "service_id": "gemini-service",
                           "temperature": 0.7,
                           "top_p": 0.7,
                           "top_k": 25,
@@ -213,13 +214,15 @@ public sealed class GeminiPromptExecutionSettingsTests
                         }
                         """;
         var executionSettings = JsonSerializer.Deserialize<GeminiPromptExecutionSettings>(json);
+        executionSettings!.FunctionChoiceBehavior = FunctionChoiceBehavior.Auto();
 
         // Act
-        var clone = executionSettings!.Clone() as GeminiPromptExecutionSettings;
+        var clone = executionSettings.Clone() as GeminiPromptExecutionSettings;
 
         // Assert
         Assert.NotNull(clone);
         Assert.Equal(executionSettings.ModelId, clone.ModelId);
+        Assert.Equal(executionSettings.ServiceId, clone.ServiceId);
         Assert.Equal(executionSettings.Temperature, clone.Temperature);
         Assert.Equivalent(executionSettings.ExtensionData, clone.ExtensionData);
         Assert.Equivalent(executionSettings.StopSequences, clone.StopSequences);
@@ -228,6 +231,7 @@ public sealed class GeminiPromptExecutionSettingsTests
         Assert.Equivalent(executionSettings.ThinkingConfig, clone.ThinkingConfig);
         Assert.Equivalent(executionSettings.Labels, clone.Labels);
         Assert.Equal(executionSettings.CachedContent, clone.CachedContent);
+        Assert.Same(executionSettings.FunctionChoiceBehavior, clone.FunctionChoiceBehavior);
     }
 
     [Fact]

--- a/dotnet/src/Connectors/Connectors.Google.UnitTests/GeminiPromptExecutionSettingsTests.cs
+++ b/dotnet/src/Connectors/Connectors.Google.UnitTests/GeminiPromptExecutionSettingsTests.cs
@@ -207,6 +207,8 @@ public sealed class GeminiPromptExecutionSettingsTests
                               "threshold": "{{threshold.Label}}"
                             }
                           ],
+                          "labels": { "env": "test", "team": "sk" },
+                          "cached_content": "projects/p/locations/l/cachedContents/c",
                           "thinking_config": {{thinkingConfigJson}}
                         }
                         """;
@@ -224,6 +226,8 @@ public sealed class GeminiPromptExecutionSettingsTests
         Assert.Equivalent(executionSettings.SafetySettings, clone.SafetySettings);
         Assert.Equal(executionSettings.AudioTimestamp, clone.AudioTimestamp);
         Assert.Equivalent(executionSettings.ThinkingConfig, clone.ThinkingConfig);
+        Assert.Equivalent(executionSettings.Labels, clone.Labels);
+        Assert.Equal(executionSettings.CachedContent, clone.CachedContent);
     }
 
     [Fact]

--- a/dotnet/src/Connectors/Connectors.Google/GeminiPromptExecutionSettings.cs
+++ b/dotnet/src/Connectors/Connectors.Google/GeminiPromptExecutionSettings.cs
@@ -338,6 +338,8 @@ public sealed class GeminiPromptExecutionSettings : PromptExecutionSettings
             AudioTimestamp = this.AudioTimestamp,
             ResponseMimeType = this.ResponseMimeType,
             ResponseSchema = this.ResponseSchema,
+            Labels = this.Labels is not null ? new Dictionary<string, string>(this.Labels) : null,
+            CachedContent = this.CachedContent,
             ThinkingConfig = this.ThinkingConfig?.Clone()
         };
     }

--- a/dotnet/src/Connectors/Connectors.Google/GeminiPromptExecutionSettings.cs
+++ b/dotnet/src/Connectors/Connectors.Google/GeminiPromptExecutionSettings.cs
@@ -326,6 +326,8 @@ public sealed class GeminiPromptExecutionSettings : PromptExecutionSettings
         return new GeminiPromptExecutionSettings()
         {
             ModelId = this.ModelId,
+            ServiceId = this.ServiceId,
+            FunctionChoiceBehavior = this.FunctionChoiceBehavior,
             ExtensionData = this.ExtensionData is not null ? new Dictionary<string, object>(this.ExtensionData) : null,
             Temperature = this.Temperature,
             TopP = this.TopP,


### PR DESCRIPTION
### Motivation and Context

`GeminiPromptExecutionSettings.Clone()` rebuilds the settings through an object initializer, and four settable, serialized properties are missing from it. The clone therefore silently loses function calling, the service identifier, the request labels and the explicit-cache reference.

Function calling is the one that bites hardest. `Kernel.CreateFunctionFromPrompt(...)` stores a frozen `Clone()` of the settings it is given (`dotnet/src/SemanticKernel.Abstractions/Functions/KernelFunction.cs:176`). At request time `GeminiPromptExecutionSettings.FromExecutionSettings` derives `ToolCallBehavior` from `FunctionChoiceBehavior`, and `GeminiChatCompletionClient` configures the request from `ToolCallBehavior`. If `FunctionChoiceBehavior` did not survive the clone, no tools are sent and the model just answers in prose, with no error to explain it.

The four dropped properties:

- `ServiceId` - `[JsonPropertyName("service_id")]`, `dotnet/src/SemanticKernel.Abstractions/AI/PromptExecutionSettings.cs:39`
- `FunctionChoiceBehavior` - `[JsonPropertyName("function_choice_behavior")]`, `dotnet/src/SemanticKernel.Abstractions/AI/PromptExecutionSettings.cs:91`
- `Labels` - `[JsonPropertyName("labels")]`, `dotnet/src/Connectors/Connectors.Google/GeminiPromptExecutionSettings.cs:153`
- `CachedContent` - `[JsonPropertyName("cached_content")]`, `dotnet/src/Connectors/Connectors.Google/GeminiPromptExecutionSettings.cs:272`

The first two are base-class properties that `PromptExecutionSettings.Clone()` itself copies (`PromptExecutionSettings.cs:153-154`), and that `OllamaPromptExecutionSettings.Clone()` copies as well (`OllamaPromptExecutionSettings.cs:180` and `:187`), so the Gemini override loses them rather than deliberately omitting them.

### Description

- Copy `ServiceId` and `FunctionChoiceBehavior` in `Clone()`, matching the base implementation.
- Copy `CachedContent`, and `Labels` as a new dictionary (matching how `ExtensionData` and `StopSequences` are cloned so the clone does not share the caller's instance).
- Extend `PromptExecutionSettingsCloneWorksAsExpected` so the source settings populate all four properties and the test asserts each one survives the clone.

Every other settable serialized property on `GeminiPromptExecutionSettings` and its base is now copied.

### Contribution Checklist

- [x] The code builds clean without any errors or warnings
- [x] The PR follows the [SK Contribution Guidelines](https://github.com/microsoft/semantic-kernel/blob/main/CONTRIBUTING.md)
- [x] The existing tests pass
- [x] New tests added
