### PR TITLE
Suppress CodeQL false positive in internal HTTP utility

### DIFF
--- a/dotnet/src/InternalUtilities/src/Http/HttpClientExtensions.cs
+++ b/dotnet/src/InternalUtilities/src/Http/HttpClientExtensions.cs
@@ -29,7 +29,7 @@ internal static class HttpClientExtensions
         HttpResponseMessage? response = null;
         try
         {
-            response = await client.SendAsync(request, completionOption, cancellationToken).ConfigureAwait(false);
+            response = await client.SendAsync(request, completionOption, cancellationToken).ConfigureAwait(false); // CodeQL [SM03781] Internal utility method; URI validation is the caller's responsibility upstream
         }
         catch (HttpRequestException e)
         {


### PR DESCRIPTION
Adds an inline CodeQL suppression comment for a confirmed false positive in an internal HTTP utility method. Input validation is handled by callers higher in the stack.