### PR TITLE
Update Microsoft.AspNetCore.OData to 9.5.0

### DIFF
--- a/dotnet/Directory.Packages.props
+++ b/dotnet/Directory.Packages.props
@@ -57,7 +57,9 @@
     <PackageVersion Include="Microsoft.Agents.AI.Workflows" Version="1.0.0" />
     <PackageVersion Include="Microsoft.Agents.CopilotStudio.Client" Version="1.1.107-beta" />
     <PackageVersion Include="Microsoft.AspNetCore.Mvc.Testing" Version="8.0.13" />
+    <PackageVersion Include="Microsoft.AspNetCore.OData" Version="9.5.0" />
     <PackageVersion Include="Microsoft.AspNetCore.OpenApi" Version="8.0.14" />
+    <PackageVersion Include="Microsoft.AspNetCore.SignalR.Client" Version="10.0.2" />
     <PackageVersion Include="Microsoft.Azure.Functions.Worker" Version="2.0.0" />
     <PackageVersion Include="Microsoft.Azure.Functions.Worker.Extensions.Http" Version="3.3.0" />
     <PackageVersion Include="Microsoft.Azure.Functions.Worker.Extensions.Http.AspNetCore" Version="2.0.0" />
@@ -87,7 +89,6 @@
     <PackageVersion Include="Microsoft.SemanticKernel.Core" Version="1.71.0" />
     <PackageVersion Include="Microsoft.SemanticKernel.Planners.OpenAI" Version="1.47.0-preview" />
     <PackageVersion Include="Microsoft.VisualStudio.Threading" Version="17.14.15" />
-    <PackageVersion Include="Microsoft.AspNetCore.SignalR.Client" Version="10.0.2" />
     <PackageVersion Include="ModelContextProtocol" Version="0.4.0-preview.3" />
     <PackageVersion Include="MSTest.TestFramework" Version="3.8.0" />
     <PackageVersion Include="Newtonsoft.Json" Version="13.0.4" />

--- a/dotnet/src/Plugins/Plugins.StructuredData.EntityFramework/Plugins.StructuredData.EntityFramework.csproj
+++ b/dotnet/src/Plugins/Plugins.StructuredData.EntityFramework/Plugins.StructuredData.EntityFramework.csproj
@@ -44,6 +44,8 @@
   </ItemGroup>
   <ItemGroup Condition="'$(TargetFrameworkIdentifier)' == '.NETCoreApp'">
     <PackageReference Include="OData2Linq" />
+    <PackageReference Include="Microsoft.AspNetCore.OData" />
+    <FrameworkReference Include="Microsoft.AspNetCore.App" />
   </ItemGroup>
 
 </Project>


### PR DESCRIPTION
Pin `Microsoft.AspNetCore.OData` to version 9.5.0 in `Directory.Packages.props`. This overrides the transitive dependency brought in by `OData2Linq 2.2.0` used in the Entity Framework structured data plugin.