### PR TITLE
python: add emem geospatial memory MCP example for Streamable HTTP

### DIFF
--- a/python/samples/concepts/mcp/emem_mcp_geospatial_agent.py
+++ b/python/samples/concepts/mcp/emem_mcp_geospatial_agent.py
@@ -47,23 +47,19 @@ async def main() -> None:
             instructions=(
                 "You are a geospatial verification agent grounded in emem's signed Earth memory. "
                 "For every place query: "
-                "1. Call emem_locate to resolve the place to a canonical cell64 address. "
-                "2. Call emem_recall to read signed facts (air quality, elevation, flood extent, etc.). "
-                "3. Report the emem:fact: receipt so the user can verify it offline. "
-                "Always cite the fact_cid from the receipt."
+                "1. Use emem's locate tool to resolve the place to a canonical cell64 address. "
+                "2. Use emem's recall tool to read signed facts (air quality, elevation, flood extent, etc.). "
+                "3. Report the emem:fact: receipt so the user can verify it offline, including the fact_cid."
             ),
             plugins=[emem_plugin],
         )
 
-        thread: ChatHistoryAgentThread | None = None
-
         for user_input in USER_INPUTS:
+            thread = ChatHistoryAgentThread()
             print(f"\n# User: {user_input}")
             response = await agent.get_response(messages=user_input, thread=thread)
             print(f"# {response.name}: {response}")
-            thread = response.thread
-
-        await thread.delete() if thread else None
+            await thread.delete()
 
 
 if __name__ == "__main__":

--- a/python/samples/concepts/mcp/emem_mcp_geospatial_agent.py
+++ b/python/samples/concepts/mcp/emem_mcp_geospatial_agent.py
@@ -1,0 +1,70 @@
+"""Semantic Kernel + emem MCP example — multi-step verification: locate, recall, verify.
+
+Connects a Microsoft Semantic Kernel agent to the emem MCP server over
+Streamable HTTP and runs a multi-step verification chain for South Mumbai:
+resolve the place, recall elevation, then verify the receipt/fact CID.
+
+Install:
+    pip install semantic-kernel
+
+Usage:
+    export OPENAI_API_KEY="sk-..."
+    python emem_mcp_geospatial_agent.py
+
+The agent will resolve South Mumbai, recall its elevation, then verify
+the receipt/fact CID, showing each step in the chain.
+"""
+
+import asyncio
+import os
+
+from semantic_kernel.agents import ChatCompletionAgent, ChatHistoryAgentThread
+from semantic_kernel.connectors.ai.open_ai import OpenAIChatCompletion
+from semantic_kernel.connectors.mcp import MCPStreamableHttpPlugin
+
+EMEM_MCP_URL = os.getenv("EMEM_MCP_URL", "https://emem.dev/mcp")
+
+USER_INPUTS = [
+    (
+        "Using emem, resolve South Mumbai, recall its elevation "
+        "(copdem30m.elevation_mean), then verify the receipt/fact CID. "
+        "Show each step: locate, recall, verify."
+    ),
+    "Is the air quality in Delhi safe for outdoor exercise right now? Give me a signed fact with a receipt I can cite.",
+    "Has there been recent deforestation near the Amazon at -3.47° N, -62.22° W?",
+]
+
+
+async def main() -> None:
+    async with MCPStreamableHttpPlugin(
+        name="emem",
+        description="Shared, verifiable Earth memory — signed facts for any place on Earth",
+        url=EMEM_MCP_URL,
+    ) as emem_plugin:
+        agent = ChatCompletionAgent(
+            service=OpenAIChatCompletion(ai_model_id="gpt-4o"),
+            name="GeospatialAgent",
+            instructions=(
+                "You are a geospatial verification agent grounded in emem's signed Earth memory. "
+                "For every place query: "
+                "1. Call emem_locate to resolve the place to a canonical cell64 address. "
+                "2. Call emem_recall to read signed facts (air quality, elevation, flood extent, etc.). "
+                "3. Report the emem:fact: receipt so the user can verify it offline. "
+                "Always cite the fact_cid from the receipt."
+            ),
+            plugins=[emem_plugin],
+        )
+
+        thread: ChatHistoryAgentThread | None = None
+
+        for user_input in USER_INPUTS:
+            print(f"\n# User: {user_input}")
+            response = await agent.get_response(messages=user_input, thread=thread)
+            print(f"# {response.name}: {response}")
+            thread = response.thread
+
+        await thread.delete() if thread else None
+
+
+if __name__ == "__main__":
+    asyncio.run(main())

--- a/python/samples/concepts/mcp/emem_mcp_geospatial_agent.py
+++ b/python/samples/concepts/mcp/emem_mcp_geospatial_agent.py
@@ -1,18 +1,19 @@
-"""Semantic Kernel + emem MCP example — multi-step verification: locate, recall, verify.
+"""Semantic Kernel + emem MCP example — multi-step geospatial verification.
 
 Connects a Microsoft Semantic Kernel agent to the emem MCP server over
-Streamable HTTP and runs a multi-step verification chain for South Mumbai:
-resolve the place, recall elevation, then verify the receipt/fact CID.
+Streamable HTTP. For each query the agent: resolves a place to a canonical
+cell64 address, recalls signed Earth-observation facts, and reports the
+emem:fact: receipt so the answer can be verified offline.
 
 Install:
     pip install semantic-kernel
 
 Usage:
     export OPENAI_API_KEY="sk-..."
+    export OPENAI_CHAT_MODEL_ID="gpt-4o"   # optional, defaults to gpt-4o
     python emem_mcp_geospatial_agent.py
 
-The agent will resolve South Mumbai, recall its elevation, then verify
-the receipt/fact CID, showing each step in the chain.
+No API key is needed for emem — reads are anonymous (Apache 2.0).
 """
 
 import asyncio
@@ -42,7 +43,7 @@ async def main() -> None:
         url=EMEM_MCP_URL,
     ) as emem_plugin:
         agent = ChatCompletionAgent(
-            service=OpenAIChatCompletion(ai_model_id="gpt-4o"),
+            service=OpenAIChatCompletion(),
             name="GeospatialAgent",
             instructions=(
                 "You are a geospatial verification agent grounded in emem's signed Earth memory. "

--- a/python/samples/concepts/mcp/emem_mcp_geospatial_agent.py
+++ b/python/samples/concepts/mcp/emem_mcp_geospatial_agent.py
@@ -1,3 +1,5 @@
+# Copyright (c) Microsoft. All rights reserved.
+
 """Semantic Kernel + emem MCP example — multi-step geospatial verification.
 
 Connects a Microsoft Semantic Kernel agent to the emem MCP server over
@@ -48,8 +50,8 @@ async def main() -> None:
             instructions=(
                 "You are a geospatial verification agent grounded in emem's signed Earth memory. "
                 "For every place query: "
-                "1. Use emem's locate tool to resolve the place to a canonical cell64 address. "
-                "2. Use emem's recall tool to read signed facts (air quality, elevation, flood extent, etc.). "
+                "1. Use the available emem tools to resolve the place to a canonical cell64 address. "
+                "2. Use the available emem tools to read signed facts (air quality, elevation, flood extent, etc.). "
                 "3. Report the emem:fact: receipt so the user can verify it offline, including the fact_cid."
             ),
             plugins=[emem_plugin],


### PR DESCRIPTION
## Description

Adds a sample showing how to use `MCPStreamableHttpPlugin` with **emem** — a public, no-auth, Streamable HTTP MCP server providing Ed25519-signed Earth observation facts for any place on Earth.

**emem** ([emem.dev](https://emem.dev)) is a good fit for an MCP sample because:
- It uses **Streamable HTTP transport** (the `MCPStreamableHttpPlugin` path, as opposed to stdio or SSE)
- **No API key, no signup, no local server setup** — works out of the box with just `pip install semantic-kernel`
- Demonstrates a realistic multi-step agent flow: locate → recall → verify receipt

## Sample walkthrough

```
python/samples/concepts/mcp/emem_mcp_geospatial_agent.py
```

The agent runs three example queries:
1. Resolve South Mumbai → recall elevation → verify the `fact_cid` receipt
2. "Is the air quality in Delhi safe for outdoor exercise right now?"
3. "Has there been recent deforestation near the Amazon at -3.47° N, -62.22° W?"

Each response includes an `emem:fact:` token that can be verified offline without calling emem again.

## Checklist

- [x] Follows the same pattern as `agent_with_http_mcp_plugin.py`
- [x] Uses `MCPStreamableHttpPlugin` (Streamable HTTP transport)
- [x] Uses `ChatCompletionAgent` + `OpenAIChatCompletion`
- [x] No local server or Docker required — remote endpoint at `https://emem.dev/mcp`
- [x] No API key required for emem reads (Apache 2.0)
- [x] `EMEM_MCP_URL` env var override supported

## Testing

```bash
export OPENAI_API_KEY="sk-..."
cd python/samples/concepts/mcp
python emem_mcp_geospatial_agent.py
```