### PR TITLE
Bump .NET SDK from 10.0.301 to 10.0.302

### DIFF
--- a/dotnet/global.json
+++ b/dotnet/global.json
@@ -1,6 +1,6 @@
 {
   "sdk": {
-    "version": "10.0.301",
+    "version": "10.0.302",
     "rollForward": "major",
     "allowPrerelease": false
   }


### PR DESCRIPTION
Bumps the pinned .NET SDK version in `dotnet/global.json` from 10.0.301 to the patched 10.0.302 release to mitigate a security vulnerability in older 10.0 SDKs. Version-only change; no functional impact. See https://aka.ms/dotnet-security-notes for details.