### PR TITLE
Python: join the split Weaviate settings error messages into one argument

### DIFF
--- a/python/semantic_kernel/connectors/weaviate.py
+++ b/python/semantic_kernel/connectors/weaviate.py
@@ -160,13 +160,13 @@ class WeaviateSettings(KernelBaseSettings):
 
             if enabled == 0:
                 raise ServiceInvalidExecutionSettingsError(
-                    "Weaviate settings must specify either a ",
-                    "Weaviate Cloud instance, a local Weaviate instance, or the client embedding options.",
+                    "Weaviate settings must specify either a Weaviate Cloud instance, a local Weaviate "
+                    "instance, or the client embedding options."
                 )
             if enabled > 1:
                 raise ServiceInvalidExecutionSettingsError(
-                    "Weaviate settings must specify only one of the following: ",
-                    "Weaviate Cloud instance, a local Weaviate instance, or the client embedding options.",
+                    "Weaviate settings must specify only one of the following: Weaviate Cloud instance, "
+                    "a local Weaviate instance, or the client embedding options."
                 )
 
         return data
@@ -278,8 +278,8 @@ class WeaviateCollection(
                     async_client = use_async_with_embedded()
                 else:
                     raise NotImplementedError(
-                        "Weaviate settings must specify either a custom client, a Weaviate Cloud instance,",
-                        " a local Weaviate instance, or the client embedding options.",
+                        "Weaviate settings must specify either a custom client, a Weaviate Cloud "
+                        "instance, a local Weaviate instance, or the client embedding options."
                     )
             except Exception as e:
                 raise VectorStoreInitializationException(f"Failed to initialize Weaviate client: {e}")
@@ -749,8 +749,8 @@ class WeaviateStore(VectorStore):
                     async_client = use_async_with_embedded()
                 else:
                     raise NotImplementedError(
-                        "Weaviate settings must specify either a custom client, a Weaviate Cloud instance,",
-                        " a local Weaviate instance, or the client embedding options.",
+                        "Weaviate settings must specify either a custom client, a Weaviate Cloud "
+                        "instance, a local Weaviate instance, or the client embedding options."
                     )
             except Exception as e:
                 raise VectorStoreInitializationException(f"Failed to initialize Weaviate client: {e}")

--- a/python/tests/unit/connectors/memory/weaviate/test_weaviate_collection.py
+++ b/python/tests/unit/connectors/memory/weaviate/test_weaviate_collection.py
@@ -106,7 +106,7 @@ def test_weaviate_collection_init_with_invalid_settings_more_than_one_backends(
     """Test the initialization of a WeaviateCollection object with multiple backend options enabled."""
     collection_name = "TestCollection"
 
-    with pytest.raises(ServiceInvalidExecutionSettingsError):
+    with pytest.raises(ServiceInvalidExecutionSettingsError, match="only one of the following"):
         WeaviateCollection(
             record_type=record_type,
             definition=definition,
@@ -123,7 +123,7 @@ def test_weaviate_collection_init_with_invalid_settings_no_backends(
     """Test the initialization of a WeaviateCollection object with no backend options enabled."""
     collection_name = "TestCollection"
 
-    with pytest.raises(ServiceInvalidExecutionSettingsError):
+    with pytest.raises(ServiceInvalidExecutionSettingsError, match="must specify either a Weaviate Cloud"):
         WeaviateCollection(
             record_type=record_type,
             definition=definition,

--- a/python/tests/unit/connectors/memory/weaviate/test_weaviate_store.py
+++ b/python/tests/unit/connectors/memory/weaviate/test_weaviate_store.py
@@ -73,7 +73,7 @@ def test_weaviate_store_init_with_invalid_settings_more_than_one_backends(
     weaviate_unit_test_env,
 ) -> None:
     """Test the initialization of a WeaviateStore object with multiple backend options enabled."""
-    with pytest.raises(ServiceInvalidExecutionSettingsError):
+    with pytest.raises(ServiceInvalidExecutionSettingsError, match="only one of the following"):
         WeaviateStore(
             env_file_path="fake_env_file_path.env",
         )
@@ -83,7 +83,7 @@ def test_weaviate_store_init_with_invalid_settings_no_backends(
     clear_weaviate_env,
 ) -> None:
     """Test the initialization of a WeaviateStore object with no backend options enabled."""
-    with pytest.raises(ServiceInvalidExecutionSettingsError):
+    with pytest.raises(ServiceInvalidExecutionSettingsError, match="must specify either a Weaviate Cloud"):
         WeaviateStore(
             env_file_path="fake_env_file_path.env",
         )


### PR DESCRIPTION
### Motivation and Context

Four `raise` sites in `connectors/weaviate.py` pass two string literals to the exception constructor instead of one concatenated message. Python puts each into `args`, so `str(e)` renders the tuple repr:

```
('Weaviate settings must specify either a ', 'Weaviate Cloud instance, a local Weaviate instance, or the client embedding options.')
```

instead of

```
Weaviate settings must specify either a Weaviate Cloud instance, a local Weaviate instance, or the client embedding options.
```

Anything that logs or displays the exception shows quotes, a comma and parentheses around the sentence. That message is the only thing telling a user which of the three mutually exclusive Weaviate backends to configure, so it's the one place the wording matters.

Sites:

| line | exception |
|---|---|
| 162 | `ServiceInvalidExecutionSettingsError` — no backend configured |
| 167 | `ServiceInvalidExecutionSettingsError` — more than one backend configured |
| 280 | `NotImplementedError` — `WeaviateCollection.__init__` |
| 751 | `NotImplementedError` — `WeaviateStore.__init__` |

### Description

Concatenated the adjacent literals at each site. No control flow or exception types change.

An AST sweep over `semantic_kernel/` for `raise X("...", "...")` — every `Raise` whose call has two or more string-constant/f-string arguments — reports 4 before this change and 0 after, so these were the only occurrences.

### How did you test it?

The four existing weaviate init tests already asserted the exception type; I added `match=` so the message shape is pinned too:

- `test_weaviate_collection_init_with_invalid_settings_no_backends` → `match="must specify either a Weaviate Cloud"`
- `test_weaviate_collection_init_with_invalid_settings_more_than_one_backends` → `match="only one of the following"`
- the two equivalents in `test_weaviate_store.py`

Stashing only `weaviate.py` fails the two "no backends" tests with `AssertionError: Regex pattern did not match.` The two "more than one" tests pass on both sides — `pytest.raises(match=...)` searches `str(e)`, and `"only one of the following: "` is the *first* tuple element, so the substring is still present in the mangled repr. They're in the diff as controls, not as evidence.

With the change, `tests/unit/connectors/memory/weaviate` is 23 passed. `ruff check` and `ruff format --check` clean.

### Notes for the reviewer

Wording is unchanged apart from the join — I kept the original phrasing verbatim rather than rewriting the sentences.

### Checklist

- [x] The code builds clean without any errors or warnings
- [x] The PR follows the [SK Contribution Guidelines](https://github.com/microsoft/semantic-kernel/blob/main/CONTRIBUTING.md) and the [pre-submission formatting script](https://github.com/microsoft/semantic-kernel/blob/main/CONTRIBUTING.md#development-scripts) raises no violations
- [x] All unit tests pass, and I have added new tests where possible
- [x] I didn't break anyone :smile:
