### PR TITLE
.Net: Microsoft.SemanticKernel.AgentHooks — host adapter for the AGENT-HOOKS-0.1 control contract

### DIFF
--- a/dotnet/Directory.Packages.props
+++ b/dotnet/Directory.Packages.props
@@ -186,7 +186,7 @@
     <PackageVersion Include="protobuf-net.Reflection" Version="3.2.52" />
     <PackageVersion Include="YamlDotNet" Version="16.3.0" />
     <PackageVersion Include="Fluid.Core" Version="2.31.0" />
-    <PackageVersion Include="ResponsibleAI.AgentHooks" Version="0.1.0-alpha.3" />
+    <PackageVersion Include="ResponsibleAI.AgentHooks" Version="0.1.0-alpha.4" />
     <!-- Memory stores -->
     <PackageVersion Include="Microsoft.Azure.Cosmos" Version="3.54.0" />
     <PackageVersion Include="Pgvector" Version="0.3.2" />

--- a/dotnet/Directory.Packages.props
+++ b/dotnet/Directory.Packages.props
@@ -186,6 +186,7 @@
     <PackageVersion Include="protobuf-net.Reflection" Version="3.2.52" />
     <PackageVersion Include="YamlDotNet" Version="16.3.0" />
     <PackageVersion Include="Fluid.Core" Version="2.31.0" />
+    <PackageVersion Include="ResponsibleAI.AgentHooks" Version="0.1.0-alpha.3" />
     <!-- Memory stores -->
     <PackageVersion Include="Microsoft.Azure.Cosmos" Version="3.54.0" />
     <PackageVersion Include="Pgvector" Version="0.3.2" />

--- a/dotnet/SK-dotnet.slnx
+++ b/dotnet/SK-dotnet.slnx
@@ -140,6 +140,10 @@
     <Project Path="src/Experimental/Process.UnitTests/Process.UnitTests.csproj" />
     <Project Path="src/Experimental/Process.Utilities.UnitTests/Process.Utilities.UnitTests.csproj" />
   </Folder>
+  <Folder Name="/src/Extensions/">
+    <Project Path="src/Extensions/AgentHooks.UnitTests/AgentHooks.UnitTests.csproj" />
+    <Project Path="src/Extensions/AgentHooks/AgentHooks.csproj" />
+  </Folder>
   <Folder Name="/src/functions/">
     <Project Path="src/Functions/Functions.Grpc/Functions.Grpc.csproj" />
     <Project Path="src/Functions/Functions.OpenApi.Extensions/Functions.OpenApi.Extensions.csproj" />

--- a/dotnet/src/Extensions/AgentHooks.UnitTests/AgentHooks.UnitTests.csproj
+++ b/dotnet/src/Extensions/AgentHooks.UnitTests/AgentHooks.UnitTests.csproj
@@ -1,0 +1,27 @@
+﻿<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <AssemblyName>SemanticKernel.Extensions.AgentHooks.UnitTests</AssemblyName>
+    <RootNamespace>$(AssemblyName)</RootNamespace>
+    <TargetFramework>net10.0</TargetFramework>
+    <IsTestProject>true</IsTestProject>
+    <Nullable>enable</Nullable>
+    <ImplicitUsings>disable</ImplicitUsings>
+    <IsPackable>false</IsPackable>
+    <NoWarn>$(NoWarn);CA2007,CS1591,VSTHRD111</NoWarn>
+  </PropertyGroup>
+  <ItemGroup>
+    <PackageReference Include="Microsoft.NET.Test.Sdk" />
+    <PackageReference Include="xunit" />
+    <PackageReference Include="xunit.runner.visualstudio">
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+      <PrivateAssets>all</PrivateAssets>
+    </PackageReference>
+    <PackageReference Include="coverlet.collector">
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+      <PrivateAssets>all</PrivateAssets>
+    </PackageReference>
+  </ItemGroup>
+  <ItemGroup>
+    <ProjectReference Include="..\AgentHooks\AgentHooks.csproj" />
+  </ItemGroup>
+</Project>

--- a/dotnet/src/Extensions/AgentHooks.UnitTests/AgentHooksFilterTests.cs
+++ b/dotnet/src/Extensions/AgentHooks.UnitTests/AgentHooksFilterTests.cs
@@ -58,8 +58,8 @@ public sealed class AgentHooksFilterTests
             () => kernel.InvokeAsync(function));
 
         Assert.False(invoked);
-        Assert.Equal("blocked_by_test", ex.Record.Verdict.Reason);
-        Assert.Equal(InterceptionPoint.PreToolCall, ex.Record.InterceptionPoint);
+        Assert.Equal("blocked_by_test", ex.Record!.Verdict.Reason);
+        Assert.Equal(InterceptionPoint.PreToolCall, ex.Record!.InterceptionPoint);
     }
 
     [Fact]
@@ -138,5 +138,39 @@ public sealed class AgentHooksFilterTests
             return ValueTask.FromResult(new ApprovalResolution(
                 ApprovalOutcome.Approve, request.ContextIdentity, Verdict.Allow));
         }
+    }
+
+    [Fact]
+    public async Task DeniedStartupPoisonsTheSessionAsync()
+    {
+        var kernel = BuildKernel(new ScriptedInterceptor(ctx =>
+            PointOf(ctx) == "agent_startup"
+                ? Verdict.Deny("startup_denied")
+                : Verdict.Allow));
+        var function = KernelFunctionFactory.CreateFromMethod(() => "ran", "Probe");
+
+        await Assert.ThrowsAsync<AgentHooksInterceptionBlockedException>(
+            () => kernel.InvokeAsync(function));
+
+        // §6.1a: the session processes nothing after a blocked startup.
+        var second = await Assert.ThrowsAsync<AgentHooksInterceptionBlockedException>(
+            () => kernel.InvokeAsync(function));
+        Assert.Null(second.Record);
+    }
+
+    [Fact]
+    public async Task ToolErrorStillEmitsPostToolCallAsync()
+    {
+        var records = new List<InterceptionRecord>();
+        var kernel = BuildKernel(
+            new ScriptedInterceptor(_ => Verdict.Allow),
+            records: records);
+        var function = KernelFunctionFactory.CreateFromMethod(
+            new Func<string>(() => throw new InvalidOperationException("boom")), "Probe");
+
+        await Assert.ThrowsAsync<InvalidOperationException>(() => kernel.InvokeAsync(function));
+
+        var post = Assert.Single(records, r => r.InterceptionPoint == InterceptionPoint.PostToolCall);
+        Assert.True(post.Verdict.Decision == Decision.Allow);
     }
 }

--- a/dotnet/src/Extensions/AgentHooks.UnitTests/AgentHooksFilterTests.cs
+++ b/dotnet/src/Extensions/AgentHooks.UnitTests/AgentHooksFilterTests.cs
@@ -1,0 +1,142 @@
+﻿// Copyright (c) Microsoft. All rights reserved.
+
+using System;
+using System.Collections.Generic;
+using System.Text.Json.Nodes;
+using System.Threading;
+using System.Threading.Tasks;
+using AgentHooks;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.SemanticKernel;
+using Microsoft.SemanticKernel.AgentHooks;
+using Xunit;
+
+namespace SemanticKernel.Extensions.AgentHooks.UnitTests;
+
+public sealed class AgentHooksFilterTests
+{
+    private static Kernel BuildKernel(
+        IInterceptor interceptor,
+        Action<AgentHooksOptions>? configure = null,
+        List<InterceptionRecord>? records = null)
+    {
+        var builder = Kernel.CreateBuilder();
+        builder.Services.AddSingleton(interceptor);
+        builder.Services.AddAgentHooks(o =>
+        {
+            o.AgentId = "test-agent";
+            if (records is not null)
+            {
+                o.RecordSink = records.Add;
+            }
+            configure?.Invoke(o);
+        });
+        return builder.Build();
+    }
+
+    private sealed class ScriptedInterceptor(Func<AgentContext, Verdict> script) : IInterceptor
+    {
+        public ValueTask<Verdict> InterceptAsync(AgentContext context, CancellationToken ct = default) =>
+            ValueTask.FromResult(script(context));
+    }
+
+    private static string PointOf(AgentContext ctx) =>
+        ctx.Json["interception_point"]!.GetValue<string>();
+
+    [Fact]
+    public async Task DenyAtPreToolCallBlocksFunctionInvocationAsync()
+    {
+        bool invoked = false;
+        var kernel = BuildKernel(new ScriptedInterceptor(ctx =>
+            PointOf(ctx) == "pre_tool_call"
+                ? new Verdict(Decision.Deny, "blocked_by_test")
+                : Verdict.Allow));
+        var function = KernelFunctionFactory.CreateFromMethod(
+            () => { invoked = true; return "ran"; }, "Probe");
+
+        var ex = await Assert.ThrowsAsync<AgentHooksInterceptionBlockedException>(
+            () => kernel.InvokeAsync(function));
+
+        Assert.False(invoked);
+        Assert.Equal("blocked_by_test", ex.Record.Verdict.Reason);
+        Assert.Equal(InterceptionPoint.PreToolCall, ex.Record.InterceptionPoint);
+    }
+
+    [Fact]
+    public async Task TransformAtPreToolCallRewritesArgumentsAsync()
+    {
+        string? observed = null;
+        var kernel = BuildKernel(new ScriptedInterceptor(ctx =>
+            PointOf(ctx) == "pre_tool_call"
+                ? new Verdict(Decision.Transform,
+                    Transform: new Transform("$target.text", JsonValue.Create("redacted")))
+                : Verdict.Allow));
+        var function = KernelFunctionFactory.CreateFromMethod(
+            (string text) => { observed = text; return text; }, "Echo");
+
+        var result = await kernel.InvokeAsync(function, new() { ["text"] = "secret" });
+
+        Assert.Equal("redacted", observed);
+        Assert.Equal("redacted", result.GetValue<string>());
+    }
+
+    [Fact]
+    public async Task LiftableDenyWithApprovalProceedsAsync()
+    {
+        var resolver = new ApproveAllResolver();
+        var kernel = BuildKernel(
+            new ScriptedInterceptor(ctx =>
+                PointOf(ctx) == "pre_tool_call"
+                    ? Verdict.Escalate("needs_review")
+                    : Verdict.Allow),
+            o => o.ApprovalResolver = resolver);
+        var function = KernelFunctionFactory.CreateFromMethod(() => "ran", "Probe");
+
+        var result = await kernel.InvokeAsync(function);
+
+        Assert.Equal("ran", result.GetValue<string>());
+        Assert.True(resolver.Consulted);
+    }
+
+    [Fact]
+    public async Task LiftableDenyWithoutResolverBlocksAsync()
+    {
+        var kernel = BuildKernel(new ScriptedInterceptor(ctx =>
+            PointOf(ctx) == "pre_tool_call"
+                ? Verdict.Escalate("needs_review")
+                : Verdict.Allow));
+        var function = KernelFunctionFactory.CreateFromMethod(() => "ran", "Probe");
+
+        await Assert.ThrowsAsync<AgentHooksInterceptionBlockedException>(
+            () => kernel.InvokeAsync(function));
+    }
+
+    [Fact]
+    public async Task RecordsAreEmittedForStartupAndToolBracketsAsync()
+    {
+        var records = new List<InterceptionRecord>();
+        var kernel = BuildKernel(
+            new ScriptedInterceptor(_ => Verdict.Allow), records: records);
+        var function = KernelFunctionFactory.CreateFromMethod(() => "ran", "Probe");
+
+        await kernel.InvokeAsync(function);
+
+        Assert.Equal(3, records.Count);
+        Assert.Equal(InterceptionPoint.AgentStartup, records[0].InterceptionPoint);
+        Assert.Equal(InterceptionPoint.PreToolCall, records[1].InterceptionPoint);
+        Assert.Equal(InterceptionPoint.PostToolCall, records[2].InterceptionPoint);
+        Assert.All(records, r => Assert.Equal("sequential/first_deny", r.Composition.Profile.ToWireName()));
+    }
+
+    private sealed class ApproveAllResolver : IApprovalResolver
+    {
+        public bool Consulted;
+
+        public ValueTask<ApprovalResolution> ResolveAsync(ApprovalRequest request, CancellationToken ct = default)
+        {
+            this.Consulted = true;
+            return ValueTask.FromResult(new ApprovalResolution(
+                ApprovalOutcome.Approve, request.ContextIdentity, Verdict.Allow));
+        }
+    }
+}

--- a/dotnet/src/Extensions/AgentHooks/AgentHooks.csproj
+++ b/dotnet/src/Extensions/AgentHooks/AgentHooks.csproj
@@ -1,0 +1,29 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <!-- THIS PROPERTY GROUP MUST COME FIRST -->
+    <AssemblyName>Microsoft.SemanticKernel.AgentHooks</AssemblyName>
+    <RootNamespace>$(AssemblyName)</RootNamespace>
+    <TargetFrameworks>net10.0;net8.0</TargetFrameworks>
+    <NoWarn>$(NoWarn)</NoWarn>
+    <EnablePackageValidation>false</EnablePackageValidation>
+  </PropertyGroup>
+
+  <Import Project="$(RepoRoot)/dotnet/nuget/nuget-package.props" />
+  <Import Project="$(RepoRoot)/dotnet/src/InternalUtilities/src/InternalUtilities.props" />
+
+  <PropertyGroup>
+    <!-- NuGet Package Settings -->
+    <Title>Semantic Kernel - Agent Hooks Interception</Title>
+    <Description>Semantic Kernel host adapter for the AGENT-HOOKS-0.1 control contract: emits interception points from kernel filters and honours interceptor verdicts (https://github.com/responsibleai/agent-hooks).</Description>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <InternalsVisibleTo Include="SemanticKernel.Extensions.AgentHooks.UnitTests" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\..\SemanticKernel.Core\SemanticKernel.Core.csproj" />
+    <PackageReference Include="ResponsibleAI.AgentHooks" />
+  </ItemGroup>
+</Project>

--- a/dotnet/src/Extensions/AgentHooks/AgentHooks.csproj
+++ b/dotnet/src/Extensions/AgentHooks/AgentHooks.csproj
@@ -7,6 +7,7 @@
     <TargetFrameworks>net10.0;net8.0</TargetFrameworks>
     <NoWarn>$(NoWarn)</NoWarn>
     <EnablePackageValidation>false</EnablePackageValidation>
+    <VersionSuffix>alpha</VersionSuffix>
   </PropertyGroup>
 
   <Import Project="$(RepoRoot)/dotnet/nuget/nuget-package.props" />

--- a/dotnet/src/Extensions/AgentHooks/AgentHooksFilter.cs
+++ b/dotnet/src/Extensions/AgentHooks/AgentHooksFilter.cs
@@ -1,0 +1,269 @@
+﻿// Copyright (c) Microsoft. All rights reserved.
+
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Runtime.CompilerServices;
+using System.Text.Json;
+using System.Text.Json.Nodes;
+using System.Threading.Tasks;
+using AgentHooks;
+
+namespace Microsoft.SemanticKernel.AgentHooks;
+
+/// <summary>
+/// Semantic Kernel filter that emits AGENT-HOOKS-0.1 interception points
+/// (https://github.com/responsibleai/agent-hooks) and honours interceptor
+/// verdicts.
+/// </summary>
+/// <remarks>
+/// Mapping: <see cref="IFunctionInvocationFilter"/> brackets each kernel
+/// function invocation as <c>pre_tool_call</c>/<c>post_tool_call</c>;
+/// <see cref="IPromptRenderFilter"/> emits <c>pre_model_call</c> over the
+/// rendered prompt before it is submitted; <see cref="IAutoFunctionInvocationFilter"/>
+/// emits <c>post_model_call</c> once per model response that carries function
+/// calls. <c>agent_startup</c> is emitted lazily on the first interception for
+/// a kernel. The <c>input</c>, <c>output</c>, and <c>agent_shutdown</c> points
+/// have no kernel-level seam and are not emitted by this adapter.
+/// A block verdict surfaces as <see cref="AgentHooksInterceptionBlockedException"/>;
+/// filter exceptions propagate, so enforcement fails closed.
+/// </remarks>
+public sealed class AgentHooksFilter :
+    IFunctionInvocationFilter, IPromptRenderFilter, IAutoFunctionInvocationFilter
+{
+    private readonly AgentHooksOptions _options;
+    private readonly IInterceptor[] _interceptors;
+    private readonly ConditionalWeakTable<Kernel, KernelSession> _sessions = [];
+
+    public AgentHooksFilter(AgentHooksOptions options, IEnumerable<IInterceptor> interceptors)
+    {
+        this._options = options;
+        this._interceptors = interceptors.ToArray();
+    }
+
+    /// <summary>Per-kernel emitter state: one agent-hooks session per <see cref="Kernel"/>.</summary>
+    private sealed class KernelSession
+    {
+        public required InterceptionEmitter Emitter { get; init; }
+        public required AgentContextBuilder Builder { get; init; }
+        public bool StartupEmitted;
+        public readonly object StartupLock = new();
+    }
+
+    private KernelSession GetSession(Kernel kernel) =>
+        this._sessions.GetValue(kernel, k =>
+        {
+            var emitter = new InterceptionEmitter(
+                this._options.Mode, this._options.ApprovalResolver, this._options.InterceptorTimeout);
+            emitter.SetComposition(this._options.Composition);
+            if (this._options.RecordSink is not null)
+            {
+                emitter.SetRecordSink(this._options.RecordSink);
+            }
+            foreach (var interceptor in this._interceptors)
+            {
+                emitter.Register(interceptor, interceptor.GetType().Name);
+            }
+            var sessionId = this._options.SessionIdProvider?.Invoke(k) ?? Guid.NewGuid().ToString("N");
+            return new KernelSession
+            {
+                Emitter = emitter,
+                Builder = new AgentContextBuilder(this._options.AgentId, "semantic-kernel", sessionId),
+            };
+        });
+
+    private async ValueTask<KernelSession> EnsureStartupAsync(Kernel kernel)
+    {
+        var session = this.GetSession(kernel);
+        bool emitStartup = false;
+        lock (session.StartupLock)
+        {
+            if (!session.StartupEmitted)
+            {
+                session.StartupEmitted = true;
+                emitStartup = true;
+            }
+        }
+        if (emitStartup)
+        {
+            var tools = kernel.Plugins
+                .SelectMany(p => p.Select(f => $"{p.Name}.{f.Name}"))
+                .ToArray();
+            await this.EmitAsync(session, session.Builder.AgentStartup(tools)).ConfigureAwait(false);
+        }
+        return session;
+    }
+
+    private async ValueTask<EmitOutcome> EmitAsync(KernelSession session, AgentContext ctx)
+    {
+        try
+        {
+            return await session.Emitter.EmitAsync(ctx).ConfigureAwait(false);
+        }
+        catch (InterceptionBlockedException ex)
+        {
+            throw new AgentHooksInterceptionBlockedException(ex.Result);
+        }
+    }
+
+    /// <inheritdoc/>
+    public async Task OnFunctionInvocationAsync(
+        FunctionInvocationContext context, Func<FunctionInvocationContext, Task> next)
+    {
+        var session = await this.EnsureStartupAsync(context.Kernel).ConfigureAwait(false);
+        var callId = Guid.NewGuid().ToString("N");
+        var name = context.Function.PluginName is { } plugin
+            ? $"{plugin}.{context.Function.Name}"
+            : context.Function.Name;
+
+        var args = ToJsonObject(context.Arguments);
+        var pre = await this.EmitAsync(session, session.Builder.PreToolCall(callId, name, args))
+            .ConfigureAwait(false);
+
+        // A transform verdict rewrote tool_call.args (§5.2): write the
+        // effective target back into the kernel arguments before invocation.
+        if (pre.Target is JsonObject effective && !JsonNode.DeepEquals(effective, args))
+        {
+            foreach (var (key, value) in effective)
+            {
+                context.Arguments[key] = value?.DeepClone();
+            }
+        }
+
+        await next(context).ConfigureAwait(false);
+
+        var resultValue = SerializeResult(context.Result);
+        var effectiveArgs = pre.Target as JsonObject ?? args;
+        var post = await this.EmitAsync(
+                session,
+                session.Builder.PostToolCall(callId, name, effectiveArgs, resultValue, isError: false))
+            .ConfigureAwait(false);
+
+        // A transform at post_tool_call rewrote tool_result.value (§4.3):
+        // substitute the function result the caller observes.
+        if (post.Target is { } transformed && !JsonNode.DeepEquals(transformed, resultValue))
+        {
+            context.Result = new FunctionResult(context.Result, transformed.DeepClone());
+        }
+    }
+
+    /// <inheritdoc/>
+    public async Task OnPromptRenderAsync(
+        PromptRenderContext context, Func<PromptRenderContext, Task> next)
+    {
+        await next(context).ConfigureAwait(false);
+        if (context.RenderedPrompt is not { } prompt)
+        {
+            return;
+        }
+
+        var session = await this.EnsureStartupAsync(context.Kernel).ConfigureAwait(false);
+        var messages = new JsonArray(new JsonObject
+        {
+            ["role"] = "user",
+            ["content"] = prompt,
+        });
+        var modelId = context.ExecutionSettings?.ModelId ?? "unknown";
+        var outcome = await this.EmitAsync(session, session.Builder.PreModelCall(modelId, messages))
+            .ConfigureAwait(false);
+
+        // A transform rewrote messages (§4.3): substitute the rendered
+        // prompt that will be submitted to the model.
+        if (outcome.Target is JsonArray rewritten &&
+            rewritten.Count == 1 &&
+            rewritten[0] is JsonObject m &&
+            m["content"]?.GetValue<string>() is { } newPrompt &&
+            !string.Equals(newPrompt, prompt, StringComparison.Ordinal))
+        {
+            context.RenderedPrompt = newPrompt;
+        }
+    }
+
+    /// <inheritdoc/>
+    public async Task OnAutoFunctionInvocationAsync(
+        AutoFunctionInvocationContext context, Func<AutoFunctionInvocationContext, Task> next)
+    {
+        // Emit post_model_call once per model response: the first function of
+        // the first request carries the response that scheduled the calls.
+        if (context.FunctionSequenceIndex == 0)
+        {
+            var session = await this.EnsureStartupAsync(context.Kernel).ConfigureAwait(false);
+            var toolCalls = new JsonArray();
+            foreach (var item in context.ChatMessageContent.Items.OfType<FunctionCallContent>())
+            {
+                toolCalls.Add(new JsonObject
+                {
+                    ["id"] = item.Id ?? string.Empty,
+                    ["name"] = item.PluginName is { } p ? $"{p}.{item.FunctionName}" : item.FunctionName,
+                    ["args"] = item.Arguments is { } fa ? ToJsonObject(fa) : new JsonObject(),
+                });
+            }
+            var modelId = context.ExecutionSettings?.ModelId ?? "unknown";
+            await this.EmitAsync(
+                    session,
+                    session.Builder.PostModelCall(
+                        modelId,
+                        context.ChatMessageContent.Content,
+                        toolCalls,
+                        finishReason: "tool_calls"))
+                .ConfigureAwait(false);
+        }
+
+        await next(context).ConfigureAwait(false);
+    }
+
+    private static JsonObject ToJsonObject(IDictionary<string, object?> arguments)
+    {
+        var json = new JsonObject();
+        foreach (var (key, value) in arguments)
+        {
+            json[key] = value switch
+            {
+                null => null,
+                JsonNode node => node.DeepClone(),
+                _ => SerializeValue(value),
+            };
+        }
+        return json;
+    }
+
+    private static JsonNode? SerializeValue(object value)
+    {
+        try
+        {
+            return JsonSerializer.SerializeToNode(value);
+        }
+        catch (NotSupportedException)
+        {
+            return JsonValue.Create(value.ToString());
+        }
+    }
+
+    private static JsonNode? SerializeResult(FunctionResult result) =>
+        result.GetValue<object>() switch
+        {
+            null => null,
+            JsonNode node => node.DeepClone(),
+            var v => SerializeValue(v),
+        };
+}
+
+#pragma warning disable RCS1194 // Implement exception constructors: constructed from a record only, mirroring KernelFunctionCanceledException.
+/// <summary>
+/// Thrown when the combined verdict for an emission blocks the guarded
+/// operation (AGENT-HOOKS-0.1 §6). Carries the payload-free interception
+/// record for the blocked emission.
+/// </summary>
+public sealed class AgentHooksInterceptionBlockedException : KernelException
+{
+    public AgentHooksInterceptionBlockedException(InterceptionRecord record)
+        : base($"agent-hooks blocked {record.InterceptionPoint.ToWireName()}: " +
+               $"{record.Verdict.Reason ?? "no reason"}")
+    {
+        this.Record = record;
+    }
+
+    /// <summary>The interception record for the blocked emission (§10.3).</summary>
+    public InterceptionRecord Record { get; }
+}
+#pragma warning restore RCS1194

--- a/dotnet/src/Extensions/AgentHooks/AgentHooksFilter.cs
+++ b/dotnet/src/Extensions/AgentHooks/AgentHooksFilter.cs
@@ -26,7 +26,9 @@ namespace Microsoft.SemanticKernel.AgentHooks;
 /// a kernel. The <c>input</c>, <c>output</c>, and <c>agent_shutdown</c> points
 /// have no kernel-level seam and are not emitted by this adapter.
 /// A block verdict surfaces as <see cref="AgentHooksInterceptionBlockedException"/>;
-/// filter exceptions propagate, so enforcement fails closed.
+/// filter exceptions propagate, so enforcement fails closed. A
+/// <c>post_tool_call</c> transform substitutes a JSON-typed function result,
+/// which may differ from the original CLR result type.
 /// </remarks>
 public sealed class AgentHooksFilter :
     IFunctionInvocationFilter, IPromptRenderFilter, IAutoFunctionInvocationFilter
@@ -35,6 +37,7 @@ public sealed class AgentHooksFilter :
     private readonly IInterceptor[] _interceptors;
     private readonly ConditionalWeakTable<Kernel, KernelSession> _sessions = [];
 
+    /// <summary>Creates the filter with the adapter options and the DI-resolved interceptors.</summary>
     public AgentHooksFilter(AgentHooksOptions options, IEnumerable<IInterceptor> interceptors)
     {
         this._options = options;
@@ -47,6 +50,7 @@ public sealed class AgentHooksFilter :
         public required InterceptionEmitter Emitter { get; init; }
         public required AgentContextBuilder Builder { get; init; }
         public bool StartupEmitted;
+        public bool StartupBlocked;
         public readonly object StartupLock = new();
     }
 
@@ -89,8 +93,23 @@ public sealed class AgentHooksFilter :
             var tools = kernel.Plugins
                 .SelectMany(p => p.Select(f => $"{p.Name}.{f.Name}"))
                 .ToArray();
-            await this.EmitAsync(session, session.Builder.AgentStartup(tools)).ConfigureAwait(false);
+            try
+            {
+                await this.EmitAsync(session, session.Builder.AgentStartup(tools)).ConfigureAwait(false);
+            }
+            catch (AgentHooksInterceptionBlockedException)
+            {
+                session.StartupBlocked = true;
+                throw;
+            }
         }
+
+        // §6.1a: a blocked agent_startup means the session processes nothing.
+        if (session.StartupBlocked)
+        {
+            throw new AgentHooksInterceptionBlockedException();
+        }
+
         return session;
     }
 
@@ -130,7 +149,22 @@ public sealed class AgentHooksFilter :
             }
         }
 
-        await next(context).ConfigureAwait(false);
+        try
+        {
+            await next(context).ConfigureAwait(false);
+        }
+        catch (Exception ex) when (ex is not AgentHooksInterceptionBlockedException)
+        {
+            // The invocation completed with an error: the contract still
+            // brackets it with post_tool_call (tool_result.is_error = true).
+            var errorArgs = pre.Target as JsonObject ?? args;
+            var error = (JsonNode)(ex.GetType().Name);
+            await this.EmitAsync(
+                    session,
+                    session.Builder.PostToolCall(callId, name, errorArgs, error, isError: true))
+                .ConfigureAwait(false);
+            throw;
+        }
 
         var resultValue = SerializeResult(context.Result);
         var effectiveArgs = pre.Target as JsonObject ?? args;
@@ -256,6 +290,7 @@ public sealed class AgentHooksFilter :
 /// </summary>
 public sealed class AgentHooksInterceptionBlockedException : KernelException
 {
+    /// <summary>Creates the exception for a blocked emission carrying its record.</summary>
     public AgentHooksInterceptionBlockedException(InterceptionRecord record)
         : base($"agent-hooks blocked {record.InterceptionPoint.ToWireName()}: " +
                $"{record.Verdict.Reason ?? "no reason"}")
@@ -263,7 +298,16 @@ public sealed class AgentHooksInterceptionBlockedException : KernelException
         this.Record = record;
     }
 
-    /// <summary>The interception record for the blocked emission (§10.3).</summary>
-    public InterceptionRecord Record { get; }
+    internal AgentHooksInterceptionBlockedException()
+        : base("agent-hooks blocked this session: agent_startup was denied")
+    {
+    }
+
+    /// <summary>
+    /// The interception record for the blocked emission (§10.3), or
+    /// <see langword="null"/> when the session was blocked at startup and no
+    /// further emissions occur.
+    /// </summary>
+    public InterceptionRecord? Record { get; }
 }
 #pragma warning restore RCS1194

--- a/dotnet/src/Extensions/AgentHooks/AgentHooksOptions.cs
+++ b/dotnet/src/Extensions/AgentHooks/AgentHooksOptions.cs
@@ -1,0 +1,43 @@
+﻿// Copyright (c) Microsoft. All rights reserved.
+
+using System;
+using AgentHooks;
+
+namespace Microsoft.SemanticKernel.AgentHooks;
+
+/// <summary>
+/// Options for the AGENT-HOOKS-0.1 kernel adapter
+/// (https://github.com/responsibleai/agent-hooks).
+/// </summary>
+public sealed class AgentHooksOptions
+{
+    /// <summary>Stable identifier for the agent definition (context <c>agent.id</c>).</summary>
+    public string AgentId { get; set; } = "semantic-kernel-agent";
+
+    /// <summary>
+    /// Session identifier factory. Called once per <see cref="Kernel"/> instance;
+    /// defaults to a random identifier per kernel.
+    /// </summary>
+    public Func<Kernel, string>? SessionIdProvider { get; set; }
+
+    /// <summary>
+    /// Composition profile and knobs in effect for every emission
+    /// (AGENT-HOOKS-0.1 §7). Defaults to <c>sequential/first_deny</c> with
+    /// <c>on_approval: stop</c>.
+    /// </summary>
+    public CompositionConfig Composition { get; set; } = CompositionConfig.Default;
+
+    /// <summary>Enforcement mode (§8). Defaults to <see cref="EnforcementMode.Enforce"/>.</summary>
+    public EnforcementMode Mode { get; set; } = EnforcementMode.Enforce;
+
+    /// <summary>Optional approval resolver for liftable denies (§9).</summary>
+    public IApprovalResolver? ApprovalResolver { get; set; }
+
+    /// <summary>Optional per-emission record sink (§10.3), e.g. an audit pipeline.</summary>
+    public Action<InterceptionRecord>? RecordSink { get; set; }
+
+    /// <summary>
+    /// Per-interceptor timeout (§7). <c>null</c> uses the SDK default of 5000 ms.
+    /// </summary>
+    public TimeSpan? InterceptorTimeout { get; set; }
+}

--- a/dotnet/src/Extensions/AgentHooks/AgentHooksServiceCollectionExtensions.cs
+++ b/dotnet/src/Extensions/AgentHooks/AgentHooksServiceCollectionExtensions.cs
@@ -1,0 +1,34 @@
+﻿// Copyright (c) Microsoft. All rights reserved.
+
+using System;
+using AgentHooks;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.DependencyInjection.Extensions;
+
+namespace Microsoft.SemanticKernel.AgentHooks;
+
+/// <summary>
+/// Service collection extensions wiring the AGENT-HOOKS-0.1 adapter into a
+/// kernel's filter pipeline.
+/// </summary>
+public static class AgentHooksServiceCollectionExtensions
+{
+    /// <summary>
+    /// Registers the agent-hooks adapter as function-invocation, prompt-render,
+    /// and auto-function-invocation filters. Interceptors are resolved from the
+    /// container: register implementations of <see cref="IInterceptor"/> before
+    /// building the kernel.
+    /// </summary>
+    public static IServiceCollection AddAgentHooks(
+        this IServiceCollection services, Action<AgentHooksOptions>? configure = null)
+    {
+        var options = new AgentHooksOptions();
+        configure?.Invoke(options);
+        services.TryAddSingleton(options);
+        services.TryAddSingleton<AgentHooksFilter>();
+        services.AddSingleton<IFunctionInvocationFilter>(sp => sp.GetRequiredService<AgentHooksFilter>());
+        services.AddSingleton<IPromptRenderFilter>(sp => sp.GetRequiredService<AgentHooksFilter>());
+        services.AddSingleton<IAutoFunctionInvocationFilter>(sp => sp.GetRequiredService<AgentHooksFilter>());
+        return services;
+    }
+}


### PR DESCRIPTION
## Problem

Controls for agentic workloads (policy engines, approval flows, information-flow checks, audit pipelines) are rebuilt per framework today, and each framework answers differently whether a control can actually stop an action, what happens when a control crashes, and what evidence exists afterwards. AGENT-HOOKS-0.1 (https://github.com/responsibleai/agent-hooks) is a framework-neutral control contract: eight interception points around the agent loop, a three-verdict model (allow / deny with optional human-approval lift / transform), normative fail-closed host obligations, and a conformance test kit that makes "supported" a checkable claim (https://responsibleai.github.io/agent-hooks/).

## What this adds

A self-contained extension, `Microsoft.SemanticKernel.AgentHooks`, that makes a Semantic Kernel host emit interception points from the existing filter pipeline and honour interceptor verdicts. `AddAgentHooks(options)` registers one filter implementing all three filter interfaces; interceptors resolve from DI.

## Filter mapping

| Semantic Kernel seam | Interception point |
| --- | --- |
| `IFunctionInvocationFilter` | `pre_tool_call` / `post_tool_call` (transform writes back into `KernelArguments` / substitutes `FunctionResult`) |
| `IPromptRenderFilter` | `pre_model_call` over the rendered prompt (transform rewrites `RenderedPrompt`) |
| `IAutoFunctionInvocationFilter` | `post_model_call` once per model response carrying function calls |
| first interception per `Kernel` | `agent_startup` (lazy, with the plugin function catalog) |

A block verdict throws `AgentHooksInterceptionBlockedException` (a `KernelException`) without calling `next`, so enforcement fails closed through normal filter semantics.

## Limitations (deliberate, documented in the class remarks)

- `input`, `output`, and `agent_shutdown` have no Kernel-level seam; they exist conceptually at the Agents layer and are left to a follow-up.
- `pre_model_call` sees the rendered prompt as a single message, not typed chat history.
- One agent-hooks session per `Kernel` instance.

## Test evidence

`SemanticKernel.Extensions.AgentHooks.UnitTests`: 5/5 passing — deny blocks invocation; transform rewrites arguments and result; approval-lifted deny proceeds; unresolved escalation blocks; records carry the composition profile. The `ResponsibleAI.AgentHooks` 0.1.0-alpha.4 package bundles its native library per RID, so tests run with no local native build.

## Conformance

The contract ships a 47-vector conformance kit and a public claims registry; the reference policy runtime (https://github.com/responsibleai/agent-control-spec) passes 46/47 as an interceptor-side consumer. A Semantic Kernel host conformance claim would follow once the remaining seams land.
