### PR TITLE
Python: Fix Cosmos DB MongoDB vector index kind mapping (#14104)

### DIFF
--- a/python/semantic_kernel/connectors/azure_cosmos_db.py
+++ b/python/semantic_kernel/connectors/azure_cosmos_db.py
@@ -399,7 +399,7 @@ class CosmosMongoCollection(MongoDBAtlasCollection[TKey, TModel], Generic[TKey, 
                     f"Distance function '{field.distance_function}' is not supported by Azure Cosmos DB for MongoDB."
                 )
             index_name = f"{field.storage_name or field.name}_"
-            index_kind = DISTANCE_FUNCTION_MAP_MONGODB[field.distance_function]
+            index_kind = INDEX_KIND_MAP_MONGODB[field.index_kind]
             index: dict[str, Any] = {
                 "name": index_name,
                 FieldTypes.KEY: {field.storage_name or field.name: "cosmosSearch"},

--- a/python/tests/unit/connectors/memory/azure_cosmos_db/test_azure_cosmos_db_mongodb_collection.py
+++ b/python/tests/unit/connectors/memory/azure_cosmos_db/test_azure_cosmos_db_mongodb_collection.py
@@ -98,8 +98,8 @@ async def test_ensure_collection_exists_calls_database_methods(definition) -> No
     # Check the vector field index creation
     assert command_args["indexes"][1]["name"] == "vector_"
     assert command_args["indexes"][1]["key"] == {"vector": "cosmosSearch"}
-    assert command_args["indexes"][1]["cosmosSearchOptions"]["kind"] == "COS"
-    assert command_args["indexes"][1]["cosmosSearchOptions"]["similarity"] is not None
+    assert command_args["indexes"][1]["cosmosSearchOptions"]["kind"] == "vector-hnsw"
+    assert command_args["indexes"][1]["cosmosSearchOptions"]["similarity"] == "COS"
     assert command_args["indexes"][1]["cosmosSearchOptions"]["dimensions"] == 5
 
 

--- a/python/tests/unit/connectors/memory/azure_cosmos_db/test_azure_cosmos_db_mongodb_collection.py
+++ b/python/tests/unit/connectors/memory/azure_cosmos_db/test_azure_cosmos_db_mongodb_collection.py
@@ -84,10 +84,10 @@ async def test_ensure_collection_exists_calls_database_methods(definition) -> No
     )
 
     # Act
-    await collection.ensure_collection_exists(customArg="customValue")
+    await collection.ensure_collection_exists(customArg="customValue", m=16, efConstruction=64)
 
     # Assert
-    mock_database.create_collection.assert_awaited_once_with("test_collection", customArg="customValue")
+    mock_database.create_collection.assert_awaited_once_with("test_collection", customArg="customValue", m=16, efConstruction=64)
     mock_database.command.assert_awaited()
     command_args = mock_database.command.call_args.kwargs["command"]
 
@@ -101,6 +101,8 @@ async def test_ensure_collection_exists_calls_database_methods(definition) -> No
     assert command_args["indexes"][1]["cosmosSearchOptions"]["kind"] == "vector-hnsw"
     assert command_args["indexes"][1]["cosmosSearchOptions"]["similarity"] == "COS"
     assert command_args["indexes"][1]["cosmosSearchOptions"]["dimensions"] == 5
+    assert command_args["indexes"][1]["cosmosSearchOptions"]["m"] == 16
+    assert command_args["indexes"][1]["cosmosSearchOptions"]["efConstruction"] == 64
 
 
 async def test_context_manager_calls_aconnect_and_close_when_managed(mock_model) -> None:


### PR DESCRIPTION
### Motivation and Context

Fixes #14104.

In `python/semantic_kernel/connectors/azure_cosmos_db.py`, `CosmosMongoCollection._get_index_definitions` assigned `index_kind` from `DISTANCE_FUNCTION_MAP_MONGODB[field.distance_function]` instead of `INDEX_KIND_MAP_MONGODB[field.index_kind]`.

This caused three issues:
1. `cosmosSearchOptions["kind"]` was sent as a similarity string (e.g. `"COS"`) rather than a valid vector index kind (`"vector-hnsw"`, `"vector-ivf"`, `"vector-diskann"`), leading to index creation failure on Azure Cosmos DB for MongoDB vCore.
2. The `match index_kind:` block never matched any `vector-*` pattern, so HNSW/IVF tuning parameters (`m`, `efConstruction`, `numList`) were silently dropped.
3. `INDEX_KIND_MAP_MONGODB` was validated for membership but its mapped value was never used.

### Description

Updated `CosmosMongoCollection._get_index_definitions` to correctly map `field.index_kind` via `INDEX_KIND_MAP_MONGODB[field.index_kind]`.

Also updated the unit test in `test_azure_cosmos_db_mongodb_collection.py` to assert that `cosmosSearchOptions["kind"] == "vector-hnsw"` and `cosmosSearchOptions["similarity"] == "COS"`.

### Contribution Checklist

- [x] The code builds clean without any errors or warnings
- [x] The PR follows the [SK Contribution Guidelines](https://github.com/microsoft/semantic-kernel/blob/main/CONTRIBUTING.md) and the [pre-submission formatting script](https://github.com/microsoft/semantic-kernel/blob/main/CONTRIBUTING.md#development-scripts) raises no violations
- [x] All unit tests pass, and I have added new tests where possible
- [x] I didn't break anyone :smile: