### PR TITLE
.NET: Support custom audio-to-text endpoints

### DIFF
--- a/dotnet/samples/Concepts/AudioToText/OpenAI_AudioToText.cs
+++ b/dotnet/samples/Concepts/AudioToText/OpenAI_AudioToText.cs
@@ -50,4 +50,26 @@ public sealed class OpenAI_AudioToText(ITestOutputHelper output) : BaseTest(outp
         // Output the transcribed text
         Console.WriteLine(textContent.Text);
     }
+
+    [Fact(Skip = "Requires a local OpenAI-compatible audio-to-text server, such as FunASR.")]
+    public async Task OpenAICompatibleAudioToTextAsync()
+    {
+        // FunASR exposes the OpenAI-compatible endpoint at /v1/audio/transcriptions.
+        var kernel = Kernel.CreateBuilder()
+            .AddOpenAIAudioToText(
+                modelId: "sensevoice",
+                endpoint: new Uri("http://localhost:8000/v1"))
+            .Build();
+
+        var audioToTextService = kernel.GetRequiredService<IAudioToTextService>();
+        await using var audioFileStream = EmbeddedResource.ReadStream(AudioFilename);
+        var audioFileBinaryData = await BinaryData.FromStreamAsync(audioFileStream!);
+        AudioContent audioContent = new(audioFileBinaryData, mimeType: null);
+
+        var textContent = await audioToTextService.GetTextContentAsync(
+            audioContent,
+            new OpenAIAudioToTextExecutionSettings(AudioFilename));
+
+        Console.WriteLine(textContent.Text);
+    }
 }

--- a/dotnet/src/Connectors/Connectors.OpenAI.UnitTests/Extensions/KernelBuilderExtensionsTests.cs
+++ b/dotnet/src/Connectors/Connectors.OpenAI.UnitTests/Extensions/KernelBuilderExtensionsTests.cs
@@ -146,6 +146,16 @@ public class KernelBuilderExtensionsTests
     }
 
     [Fact]
+    public void ItThrowsWhenAddingAudioToTextServiceWithoutCustomEndpoint()
+    {
+        // Arrange
+        var sut = Kernel.CreateBuilder();
+
+        // Act & Assert
+        Assert.Throws<ArgumentNullException>(() => sut.AddOpenAIAudioToText("model", endpoint: null!));
+    }
+
+    [Fact]
     public void ItCanAddAudioToTextServiceWithOpenAIClient()
     {
         // Arrange

--- a/dotnet/src/Connectors/Connectors.OpenAI.UnitTests/Extensions/KernelBuilderExtensionsTests.cs
+++ b/dotnet/src/Connectors/Connectors.OpenAI.UnitTests/Extensions/KernelBuilderExtensionsTests.cs
@@ -130,6 +130,22 @@ public class KernelBuilderExtensionsTests
     }
 
     [Fact]
+    public void ItCanAddAudioToTextServiceWithCustomEndpoint()
+    {
+        // Arrange
+        var endpoint = new Uri("http://localhost:10095/v1");
+        var sut = Kernel.CreateBuilder();
+
+        // Act
+        var service = sut.AddOpenAIAudioToText("model", endpoint)
+            .Build()
+            .GetRequiredService<IAudioToTextService>();
+
+        // Assert
+        Assert.Equal(endpoint.ToString(), service.Attributes[AIServiceExtensions.EndpointKey]);
+    }
+
+    [Fact]
     public void ItCanAddAudioToTextServiceWithOpenAIClient()
     {
         // Arrange

--- a/dotnet/src/Connectors/Connectors.OpenAI.UnitTests/Extensions/ServiceCollectionExtensionsTests.cs
+++ b/dotnet/src/Connectors/Connectors.OpenAI.UnitTests/Extensions/ServiceCollectionExtensionsTests.cs
@@ -158,6 +158,22 @@ public class ServiceCollectionExtensionsTests
     }
 
     [Fact]
+    public void ItCanAddAudioToTextServiceWithCustomEndpoint()
+    {
+        // Arrange
+        var endpoint = new Uri("http://localhost:10095/v1");
+        var sut = new ServiceCollection();
+
+        // Act
+        var service = sut.AddOpenAIAudioToText("model", endpoint)
+            .BuildServiceProvider()
+            .GetRequiredService<IAudioToTextService>();
+
+        // Assert
+        Assert.Equal(endpoint.ToString(), service.Attributes[AIServiceExtensions.EndpointKey]);
+    }
+
+    [Fact]
     public void ItCanAddAudioToTextServiceWithOpenAIClient()
     {
         // Arrange

--- a/dotnet/src/Connectors/Connectors.OpenAI.UnitTests/Extensions/ServiceCollectionExtensionsTests.cs
+++ b/dotnet/src/Connectors/Connectors.OpenAI.UnitTests/Extensions/ServiceCollectionExtensionsTests.cs
@@ -174,6 +174,16 @@ public class ServiceCollectionExtensionsTests
     }
 
     [Fact]
+    public void ItThrowsWhenAddingAudioToTextServiceWithoutCustomEndpoint()
+    {
+        // Arrange
+        var sut = new ServiceCollection();
+
+        // Act & Assert
+        Assert.Throws<ArgumentNullException>(() => sut.AddOpenAIAudioToText("model", endpoint: null!));
+    }
+
+    [Fact]
     public void ItCanAddAudioToTextServiceWithOpenAIClient()
     {
         // Arrange

--- a/dotnet/src/Connectors/Connectors.OpenAI.UnitTests/Services/OpenAIAudioToTextServiceTests.cs
+++ b/dotnet/src/Connectors/Connectors.OpenAI.UnitTests/Services/OpenAIAudioToTextServiceTests.cs
@@ -46,6 +46,27 @@ public sealed class OpenAIAudioToTextServiceTests : IDisposable
     }
 
     [Fact]
+    public async Task ItUsesCustomEndpointWithoutApiKeyAsync()
+    {
+        // Arrange
+        var endpoint = new Uri("http://localhost:10095/v1");
+        var service = new OpenAIAudioToTextService("model-id", endpoint, httpClient: this._httpClient);
+        this._messageHandlerStub.ResponseToReturn = new HttpResponseMessage(System.Net.HttpStatusCode.OK)
+        {
+            Content = new StringContent("Test audio-to-text response")
+        };
+
+        // Act
+        await service.GetTextContentsAsync(
+            new AudioContent(new BinaryData("data"), mimeType: null),
+            new OpenAIAudioToTextExecutionSettings("file.mp3"));
+
+        // Assert
+        Assert.Equal("http://localhost:10095/v1/audio/transcriptions", this._messageHandlerStub.RequestUri!.ToString());
+        Assert.Equal(endpoint.ToString(), service.Attributes["Endpoint"]);
+    }
+
+    [Fact]
     public void ItThrowsIfModelIdIsNotProvided()
     {
         // Act & Assert

--- a/dotnet/src/Connectors/Connectors.OpenAI.UnitTests/Services/OpenAIAudioToTextServiceTests.cs
+++ b/dotnet/src/Connectors/Connectors.OpenAI.UnitTests/Services/OpenAIAudioToTextServiceTests.cs
@@ -67,6 +67,14 @@ public sealed class OpenAIAudioToTextServiceTests : IDisposable
     }
 
     [Fact]
+    public void ItThrowsIfCustomEndpointIsNotProvided()
+    {
+        // Act & Assert
+        var exception = Assert.Throws<ArgumentNullException>(() => new OpenAIAudioToTextService("model-id", endpoint: null!));
+        Assert.Equal("endpoint", exception.ParamName);
+    }
+
+    [Fact]
     public void ItThrowsIfModelIdIsNotProvided()
     {
         // Act & Assert

--- a/dotnet/src/Connectors/Connectors.OpenAI/Extensions/OpenAIKernelBuilderExtensions.cs
+++ b/dotnet/src/Connectors/Connectors.OpenAI/Extensions/OpenAIKernelBuilderExtensions.cs
@@ -271,6 +271,43 @@ public static class OpenAIKernelBuilderExtensions
     }
 
     /// <summary>
+    /// Adds an OpenAI-compatible audio-to-text service with a custom endpoint to the list.
+    /// </summary>
+    /// <param name="builder">The <see cref="IKernelBuilder"/> instance to augment.</param>
+    /// <param name="modelId">Model name.</param>
+    /// <param name="endpoint">OpenAI-compatible API endpoint.</param>
+    /// <param name="apiKey">Optional API key.</param>
+    /// <param name="orgId">OpenAI organization id.</param>
+    /// <param name="serviceId">A local identifier for the given AI service.</param>
+    /// <param name="httpClient">The HttpClient to use with this service.</param>
+    /// <returns>The same instance as <paramref name="builder"/>.</returns>
+    [Experimental("SKEXP0010")]
+    public static IKernelBuilder AddOpenAIAudioToText(
+        this IKernelBuilder builder,
+        string modelId,
+        Uri endpoint,
+        string? apiKey = null,
+        string? orgId = null,
+        string? serviceId = null,
+        HttpClient? httpClient = null)
+    {
+        Verify.NotNull(builder);
+        Verify.NotNullOrWhiteSpace(modelId);
+
+        Func<IServiceProvider, object?, OpenAIAudioToTextService> factory = (serviceProvider, _) =>
+            new(modelId,
+                endpoint,
+                apiKey,
+                orgId,
+                HttpClientProvider.GetHttpClient(httpClient, serviceProvider),
+                serviceProvider.GetService<ILoggerFactory>());
+
+        builder.Services.AddKeyedSingleton<IAudioToTextService>(serviceId, factory);
+
+        return builder;
+    }
+
+    /// <summary>
     /// Adds the OpenAI audio-to-text service to the list.
     /// </summary>
     /// <param name="builder">The <see cref="IKernelBuilder"/> instance to augment.</param>

--- a/dotnet/src/Connectors/Connectors.OpenAI/Extensions/OpenAIKernelBuilderExtensions.cs
+++ b/dotnet/src/Connectors/Connectors.OpenAI/Extensions/OpenAIKernelBuilderExtensions.cs
@@ -293,6 +293,7 @@ public static class OpenAIKernelBuilderExtensions
     {
         Verify.NotNull(builder);
         Verify.NotNullOrWhiteSpace(modelId);
+        Verify.NotNull(endpoint);
 
         Func<IServiceProvider, object?, OpenAIAudioToTextService> factory = (serviceProvider, _) =>
             new(modelId,

--- a/dotnet/src/Connectors/Connectors.OpenAI/Extensions/OpenAIServiceCollectionExtensions.cs
+++ b/dotnet/src/Connectors/Connectors.OpenAI/Extensions/OpenAIServiceCollectionExtensions.cs
@@ -187,6 +187,41 @@ public static partial class OpenAIServiceCollectionExtensions
     }
 
     /// <summary>
+    /// Adds an OpenAI-compatible audio-to-text service with a custom endpoint to the list.
+    /// </summary>
+    /// <param name="services">The <see cref="IServiceCollection"/> instance to augment.</param>
+    /// <param name="modelId">Model name.</param>
+    /// <param name="endpoint">OpenAI-compatible API endpoint.</param>
+    /// <param name="apiKey">Optional API key.</param>
+    /// <param name="orgId">OpenAI organization id.</param>
+    /// <param name="serviceId">A local identifier for the given AI service.</param>
+    /// <returns>The same instance as <paramref name="services"/>.</returns>
+    [Experimental("SKEXP0010")]
+    public static IServiceCollection AddOpenAIAudioToText(
+        this IServiceCollection services,
+        string modelId,
+        Uri endpoint,
+        string? apiKey = null,
+        string? orgId = null,
+        string? serviceId = null)
+    {
+        Verify.NotNull(services);
+        Verify.NotNullOrWhiteSpace(modelId);
+
+        Func<IServiceProvider, object?, OpenAIAudioToTextService> factory = (serviceProvider, _) =>
+            new(modelId,
+                endpoint,
+                apiKey,
+                orgId,
+                HttpClientProvider.GetHttpClient(serviceProvider),
+                serviceProvider.GetService<ILoggerFactory>());
+
+        services.AddKeyedSingleton<IAudioToTextService>(serviceId, factory);
+
+        return services;
+    }
+
+    /// <summary>
     /// Adds the OpenAI audio-to-text service to the list.
     /// </summary>
     /// <param name="services">The <see cref="IServiceCollection"/> instance to augment.</param>

--- a/dotnet/src/Connectors/Connectors.OpenAI/Extensions/OpenAIServiceCollectionExtensions.cs
+++ b/dotnet/src/Connectors/Connectors.OpenAI/Extensions/OpenAIServiceCollectionExtensions.cs
@@ -207,6 +207,7 @@ public static partial class OpenAIServiceCollectionExtensions
     {
         Verify.NotNull(services);
         Verify.NotNullOrWhiteSpace(modelId);
+        Verify.NotNull(endpoint);
 
         Func<IServiceProvider, object?, OpenAIAudioToTextService> factory = (serviceProvider, _) =>
             new(modelId,

--- a/dotnet/src/Connectors/Connectors.OpenAI/Services/OpenAIAudioToTextService.cs
+++ b/dotnet/src/Connectors/Connectors.OpenAI/Services/OpenAIAudioToTextService.cs
@@ -1,5 +1,6 @@
 ﻿// Copyright (c) Microsoft. All rights reserved.
 
+using System;
 using System.Collections.Generic;
 using System.Diagnostics.CodeAnalysis;
 using System.Net.Http;
@@ -12,13 +13,13 @@ using OpenAI;
 namespace Microsoft.SemanticKernel.Connectors.OpenAI;
 
 /// <summary>
-/// OpenAI text-to-audio service.
+/// OpenAI audio-to-text service.
 /// </summary>
 [Experimental("SKEXP0010")]
 public sealed class OpenAIAudioToTextService : IAudioToTextService
 {
     /// <summary>
-    /// OpenAI text-to-audio client for HTTP operations.
+    /// OpenAI audio-to-text client for HTTP operations.
     /// </summary>
     private readonly ClientCore _client;
 
@@ -42,6 +43,27 @@ public sealed class OpenAIAudioToTextService : IAudioToTextService
     {
         Verify.NotNullOrWhiteSpace(modelId, nameof(modelId));
         this._client = new(modelId, apiKey, organization, null, httpClient, loggerFactory?.CreateLogger(typeof(OpenAIAudioToTextService)));
+    }
+
+    /// <summary>
+    /// Initializes a new instance of the <see cref="OpenAIAudioToTextService"/> class for a custom OpenAI-compatible endpoint.
+    /// </summary>
+    /// <param name="modelId">Model name.</param>
+    /// <param name="endpoint">OpenAI-compatible API endpoint.</param>
+    /// <param name="apiKey">Optional API key.</param>
+    /// <param name="organization">OpenAI Organization Id (usually optional).</param>
+    /// <param name="httpClient">Custom <see cref="HttpClient"/> for HTTP requests.</param>
+    /// <param name="loggerFactory">The <see cref="ILoggerFactory"/> to use for logging. If null, no logging will be performed.</param>
+    public OpenAIAudioToTextService(
+        string modelId,
+        Uri endpoint,
+        string? apiKey = null,
+        string? organization = null,
+        HttpClient? httpClient = null,
+        ILoggerFactory? loggerFactory = null)
+    {
+        Verify.NotNullOrWhiteSpace(modelId, nameof(modelId));
+        this._client = new(modelId, apiKey, organization, endpoint, httpClient, loggerFactory?.CreateLogger(typeof(OpenAIAudioToTextService)));
     }
 
     /// <summary>

--- a/dotnet/src/Connectors/Connectors.OpenAI/Services/OpenAIAudioToTextService.cs
+++ b/dotnet/src/Connectors/Connectors.OpenAI/Services/OpenAIAudioToTextService.cs
@@ -63,6 +63,7 @@ public sealed class OpenAIAudioToTextService : IAudioToTextService
         ILoggerFactory? loggerFactory = null)
     {
         Verify.NotNullOrWhiteSpace(modelId, nameof(modelId));
+        Verify.NotNull(endpoint);
         this._client = new(modelId, apiKey, organization, endpoint, httpClient, loggerFactory?.CreateLogger(typeof(OpenAIAudioToTextService)));
     }
 


### PR DESCRIPTION
### Motivation and Context

The existing .NET audio-to-text connector can use a custom `OpenAIClient`, but the standard kernel-builder and dependency-injection paths do not expose a custom endpoint and their API-key overload requires a key. This makes local OpenAI-compatible transcription services unnecessarily difficult to configure.

This change enables self-hosted speech-to-text servers, including FunASR, through the existing `IAudioToTextService` abstraction without adding provider-specific dependencies.

Closes #14067

### Description

- Add a custom `Uri endpoint` overload to `OpenAIAudioToTextService`.
- Expose equivalent overloads through `IKernelBuilder` and `IServiceCollection`.
- Allow the API key to be omitted for local endpoints.
- Verify that requests use `{endpoint}/audio/transcriptions`.
- Add a Concepts sample using FunASR at `http://localhost:8000/v1` with the `sensevoice` model.

The implementation follows the existing custom-endpoint pattern used by `OpenAIChatCompletionService`.

### Validation

- OpenAI connector unit tests: **499 passed, 1 existing skip, 0 failed**
- `Connectors.OpenAI` build/package: **net10.0, net8.0, netstandard2.0; 0 warnings, 0 errors**
- Concepts sample build: **0 warnings, 0 errors**
- `dotnet format --verify-no-changes`: passed
- `git diff --check`: passed

### Contribution Checklist

- [x] The code builds clean without any errors or warnings
- [x] The PR follows the SK Contribution Guidelines and the pre-submission formatting script raises no violations
- [x] All unit tests pass, and I have added new tests where possible
- [x] I did not break anyone