### PR TITLE
Python: Document x5t certificate thumbprint hashing in Copilot Studio agent

### DIFF
--- a/python/semantic_kernel/agents/copilot_studio/copilot_studio_agent.py
+++ b/python/semantic_kernel/agents/copilot_studio/copilot_studio_agent.py
@@ -181,7 +181,10 @@ class _CopilotStudioAgentTokenFactory:
 
         pem_bytes = Path(cert_path).read_bytes()
         der_bytes = ssl.PEM_cert_to_DER_cert(pem_bytes.decode())
-        return hashlib.sha1(der_bytes, usedforsecurity=False).hexdigest().upper()
+        # SHA-1 is not used here as a security primitive: it computes the X.509 certificate thumbprint
+        # (the `x5t` JWT header value), which MSAL and Microsoft Entra ID mandate to be SHA-1 for the
+        # `thumbprint` client credential. Hence the `usedforsecurity=False` flag.
+        return hashlib.sha1(der_bytes, usedforsecurity=False).hexdigest().upper()  # CodeQL [SM02167] x5t thumbprint
 
 
 # endregion

--- a/python/semantic_kernel/agents/copilot_studio/copilot_studio_agent.py
+++ b/python/semantic_kernel/agents/copilot_studio/copilot_studio_agent.py
@@ -181,8 +181,8 @@ class _CopilotStudioAgentTokenFactory:
 
         pem_bytes = Path(cert_path).read_bytes()
         der_bytes = ssl.PEM_cert_to_DER_cert(pem_bytes.decode())
-        # SHA-1 is not used here as a security primitive: it computes the X.509 certificate thumbprint
-        # (the `x5t` JWT header value), which MSAL and Microsoft Entra ID mandate to be SHA-1 for the
+        # SHA-1 is not used here as a security primitive; it is required to compute the X.509 certificate thumbprint
+        # (the `x5t` JWT header value), which MSAL and Microsoft Entra ID mandate to be a SHA-1 digest for the
         # `thumbprint` client credential. Hence the `usedforsecurity=False` flag.
         return hashlib.sha1(der_bytes, usedforsecurity=False).hexdigest().upper()  # CodeQL [SM02167] x5t thumbprint
 


### PR DESCRIPTION
### Motivation and Context

`_CopilotStudioAgentTokenFactory._cert_thumbprint` computes the X.509 certificate thumbprint that is passed to MSAL as the `thumbprint` client credential. This value is the JWT `x5t` header, which MSAL and Microsoft Entra ID require to be a SHA-1 digest - any other digest would be rejected by the token endpoint.

Because it is a plain digest call, static analysis tooling flags it even though the hash is used purely as a certificate identifier, not as a cryptographic/security primitive (the call already passes `usedforsecurity=False`).

### Description

Adds a comment explaining why SHA-1 is required here and annotates the call so static analysis does not flag it. No behavior change.

Note: MSAL itself carries the same annotation on its own `x5t` fingerprint computation.

### Contribution Checklist

- [x] The code builds clean without any errors or warnings
- [x] The PR follows the [SK Contribution Guidelines](https://github.com/microsoft/semantic-kernel/blob/main/CONTRIBUTING.md) and the [pre-submission formatting script](https://github.com/microsoft/semantic-kernel/blob/main/CONTRIBUTING.md#development-scripts) raises no violations
- [x] All unit tests pass, and I have added new tests where possible
- [x] I didn't break anyone :smile:
