### PR TITLE
fix(python/redis): restore vector search broken by redisvl>=0.5 API change and KeyError on include_vectors=False

### DIFF
--- a/python/semantic_kernel/connectors/redis.py
+++ b/python/semantic_kernel/connectors/redis.py
@@ -3,6 +3,7 @@
 import ast
 import asyncio
 import contextlib
+import inspect
 import json
 import logging
 import sys
@@ -17,6 +18,7 @@ from redis.asyncio.client import Redis
 from redis.commands.search.field import Field as RedisField
 from redis.commands.search.field import NumericField, TagField, TextField, VectorField
 from redis.commands.search.index_definition import IndexDefinition, IndexType
+from redisvl.index import AsyncSearchIndex
 from redisvl.index.index import process_results
 from redisvl.query.filter import FilterExpression, Num, Tag, Text
 from redisvl.query.query import BaseQuery, VectorQuery
@@ -164,6 +166,36 @@ def _definition_to_redis_fields(
         elif collection_type == RedisCollectionTypes.JSON:
             fields.append(_field_to_redis_field_json(field.storage_name or field.name, field))  # type: ignore
     return fields
+
+
+async def _process_search_results(
+    results: Any,
+    query: BaseQuery,
+    collection_name: str,
+    redis_database: Redis,
+    collection_type: RedisCollectionTypes,
+) -> Any:
+    """Process RedisVL results across its old and current APIs."""
+    parameters = list(inspect.signature(process_results).parameters.values())
+    if len(parameters) < 3:
+        raise VectorSearchExecutionException(
+            "Unsupported redisvl process_results() signature."
+        )
+
+    third_parameter = parameters[2].name
+    if third_parameter == "storage_type":
+        return process_results(results, query, STORAGE_TYPE_MAP[collection_type])
+
+    if third_parameter == "schema":
+        index = await AsyncSearchIndex.from_existing(
+            name=collection_name,
+            redis_client=redis_database,
+        )
+        return process_results(results, query, index.schema)
+
+    raise VectorSearchExecutionException(
+        f"Unsupported redisvl process_results() parameter: {third_parameter}."
+    )
 
 
 @release_candidate
@@ -321,63 +353,20 @@ class RedisCollection(
         results = await self.redis_database.ft(self.collection_name).search(  # type: ignore
             query=query.query, query_params=query.params
         )
-        # redisvl >= 0.5.0 changed the third argument of process_results() from
-        # StorageType (an enum) to IndexSchema (an object). Detect which API is
-        # present at runtime so the connector works with both the old (<0.5) and
-        # current (>=0.5) redisvl versions.
-        #
-        # New API: process_results(results, query, schema: IndexSchema)
-        # Old API: process_results(results, query, storage_type: StorageType)
-        import inspect
-
-        sig = inspect.signature(process_results)
-        params = list(sig.parameters.values())
-        if len(params) >= 3 and params[2].annotation is not inspect.Parameter.empty:
-            annotation_name = getattr(params[2].annotation, "__name__", str(params[2].annotation))
-            uses_schema_api = "IndexSchema" in annotation_name or "Schema" in annotation_name
-        else:
-            # Fall back to duck-typing: try the new API first, then the old one
-            uses_schema_api = not hasattr(params[2].default if len(params) >= 3 else None, "value")
-
         try:
-            if uses_schema_api:
-                # redisvl >= 0.5: fetch the live IndexSchema and pass it
-                from redisvl.schema import IndexSchema
-
-                index_info = await self.redis_database.ft(self.collection_name).info()
-                schema = IndexSchema.from_dict(
-                    {
-                        "index": {
-                            "name": self.collection_name,
-                            "storage_type": STORAGE_TYPE_MAP[self.collection_type].value,
-                        },
-                        "fields": {},
-                    }
-                )
-                processed = process_results(results, query, schema)
-            else:
-                # redisvl < 0.5: pass the StorageType enum directly
-                processed = process_results(results, query, STORAGE_TYPE_MAP[self.collection_type])
-        except Exception as e:
-            # If the version sniffing produced the wrong branch, try the other
-            try:
-                if uses_schema_api:
-                    processed = process_results(results, query, STORAGE_TYPE_MAP[self.collection_type])
-                else:
-                    from redisvl.schema import IndexSchema
-
-                    schema = IndexSchema.from_dict(
-                        {
-                            "index": {
-                                "name": self.collection_name,
-                                "storage_type": STORAGE_TYPE_MAP[self.collection_type].value,
-                            },
-                            "fields": {},
-                        }
-                    )
-                    processed = process_results(results, query, schema)
-            except Exception:
-                raise VectorSearchExecutionException(f"An error occurred during the search: {e}") from e
+            processed = await _process_search_results(
+                results,
+                query,
+                self.collection_name,
+                self.redis_database,
+                self.collection_type,
+            )
+        except VectorSearchExecutionException:
+            raise
+        except Exception as exc:
+            raise VectorSearchExecutionException(
+                f"An error occurred during the search: {exc}"
+            ) from exc
         return KernelSearchResults(
             results=self._get_vector_search_results_from_results(desync_list(processed)),
             total_count=results.total,

--- a/python/semantic_kernel/connectors/redis.py
+++ b/python/semantic_kernel/connectors/redis.py
@@ -321,7 +321,63 @@ class RedisCollection(
         results = await self.redis_database.ft(self.collection_name).search(  # type: ignore
             query=query.query, query_params=query.params
         )
-        processed = process_results(results, query, STORAGE_TYPE_MAP[self.collection_type])
+        # redisvl >= 0.5.0 changed the third argument of process_results() from
+        # StorageType (an enum) to IndexSchema (an object). Detect which API is
+        # present at runtime so the connector works with both the old (<0.5) and
+        # current (>=0.5) redisvl versions.
+        #
+        # New API: process_results(results, query, schema: IndexSchema)
+        # Old API: process_results(results, query, storage_type: StorageType)
+        import inspect
+
+        sig = inspect.signature(process_results)
+        params = list(sig.parameters.values())
+        if len(params) >= 3 and params[2].annotation is not inspect.Parameter.empty:
+            annotation_name = getattr(params[2].annotation, "__name__", str(params[2].annotation))
+            uses_schema_api = "IndexSchema" in annotation_name or "Schema" in annotation_name
+        else:
+            # Fall back to duck-typing: try the new API first, then the old one
+            uses_schema_api = not hasattr(params[2].default if len(params) >= 3 else None, "value")
+
+        try:
+            if uses_schema_api:
+                # redisvl >= 0.5: fetch the live IndexSchema and pass it
+                from redisvl.schema import IndexSchema
+
+                index_info = await self.redis_database.ft(self.collection_name).info()
+                schema = IndexSchema.from_dict(
+                    {
+                        "index": {
+                            "name": self.collection_name,
+                            "storage_type": STORAGE_TYPE_MAP[self.collection_type].value,
+                        },
+                        "fields": {},
+                    }
+                )
+                processed = process_results(results, query, schema)
+            else:
+                # redisvl < 0.5: pass the StorageType enum directly
+                processed = process_results(results, query, STORAGE_TYPE_MAP[self.collection_type])
+        except Exception as e:
+            # If the version sniffing produced the wrong branch, try the other
+            try:
+                if uses_schema_api:
+                    processed = process_results(results, query, STORAGE_TYPE_MAP[self.collection_type])
+                else:
+                    from redisvl.schema import IndexSchema
+
+                    schema = IndexSchema.from_dict(
+                        {
+                            "index": {
+                                "name": self.collection_name,
+                                "storage_type": STORAGE_TYPE_MAP[self.collection_type].value,
+                            },
+                            "fields": {},
+                        }
+                    )
+                    processed = process_results(results, query, schema)
+            except Exception:
+                raise VectorSearchExecutionException(f"An error occurred during the search: {e}") from e
         return KernelSearchResults(
             results=self._get_vector_search_results_from_results(desync_list(processed)),
             total_count=results.total,
@@ -616,8 +672,15 @@ class RedisHashsetCollection(RedisCollection[TKey, TModel], Generic[TKey, TModel
                     case FieldTypes.KEY:
                         rec[field.name] = self._unget_redis_key(rec[field.name])
                     case "vector":
-                        dtype = DATATYPE_MAP_VECTOR[field.type_ or "default"]
-                        rec[field.name] = buffer_to_array(rec[field.name], dtype)
+                        # When include_vectors=False (the default for search), the vector
+                        # field is not returned by Redis and will be absent from `rec`.
+                        # Guard against KeyError before attempting to decode the buffer.
+                        storage_name = field.storage_name or field.name
+                        if storage_name in rec:
+                            dtype = DATATYPE_MAP_VECTOR[field.type_ or "default"]
+                            rec[field.name] = buffer_to_array(rec[storage_name], dtype)
+                        else:
+                            rec[field.name] = None
             results.append(rec)
         return results
 

--- a/python/tests/unit/connectors/memory/test_redis_store.py
+++ b/python/tests/unit/connectors/memory/test_redis_store.py
@@ -2,6 +2,8 @@
 
 from unittest.mock import AsyncMock, patch
 
+import semantic_kernel.connectors.redis as redis_module
+
 import numpy as np
 from pytest import fixture, mark, raises
 from redis.asyncio.client import Redis
@@ -306,3 +308,72 @@ async def test_create_index_manual(collection_hash, mock_ensure_collection_exist
 async def test_create_index_fail(collection_hash, mock_ensure_collection_exists):
     with raises(VectorStoreOperationException, match="Invalid index type supplied."):
         await collection_hash.ensure_collection_exists(index_definition="index_definition", fields="fields")
+
+
+async def test_process_search_results_with_legacy_redisvl_api():
+    results = object()
+    query = object()
+
+    def legacy_process_results(results_arg, query_arg, storage_type):
+        assert results_arg is results
+        assert query_arg is query
+        assert storage_type is redis_module.StorageType.HASH
+        return [{"id": "legacy"}]
+
+    with patch.object(
+        redis_module, "process_results", new=legacy_process_results
+    ):
+        processed = await redis_module._process_search_results(
+            results,
+            query,
+            "test",
+            object(),
+            redis_module.RedisCollectionTypes.HASHSET,
+        )
+
+    assert processed == [{"id": "legacy"}]
+
+
+async def test_process_search_results_with_current_redisvl_api():
+    results = object()
+    query = object()
+    schema = object()
+    index = type("Index", (), {"schema": schema})()
+    redis_database = object()
+
+    def current_process_results(results_arg, query_arg, schema_arg):
+        assert results_arg is results
+        assert query_arg is query
+        assert schema_arg is schema
+        return [{"id": "current"}]
+
+    with (
+        patch.object(
+            redis_module, "process_results", new=current_process_results
+        ),
+        patch.object(
+            redis_module.AsyncSearchIndex,
+            "from_existing",
+            new=AsyncMock(return_value=index),
+        ) as from_existing,
+    ):
+        processed = await redis_module._process_search_results(
+            results,
+            query,
+            "test",
+            redis_database,
+            redis_module.RedisCollectionTypes.HASHSET,
+        )
+
+    from_existing.assert_awaited_once_with(
+        name="test", redis_client=redis_database
+    )
+    assert processed == [{"id": "current"}]
+
+
+def test_hash_deserialization_handles_omitted_vector(collection_hash):
+    records = collection_hash._deserialize_store_models_to_dicts(
+        [{"id": "id1", "content": "content"}]
+    )
+
+    assert records[0]["vector"] is None


### PR DESCRIPTION
## Summary

Fixes #13896.

Vector search (`FT.SEARCH`) via the Python Redis connector was completely broken due to two independent bugs. Both have been fixed in this PR.

---

## Bug 1 — `process_results()` API break with redisvl >= 0.5

### Root cause

`redisvl` 0.5.0 changed the signature of `process_results()`:

```python
# redisvl < 0.5 (old API)
process_results(results, query, storage_type: StorageType)

# redisvl >= 0.5 (new API)
process_results(results, query, schema: IndexSchema)
```

The `pyproject.toml` pin `redisvl ~= 0.4` resolves to `>=0.4, <1.0` under PEP 440, so `uv.lock` silently picks up redisvl 0.15.x where the old API is gone. Every call to `collection.search()` raised:

```
VectorSearchExecutionException: An error occurred during the search:
'StorageType' object has no attribute 'index'
```

### Fix

Detect the redisvl API signature at runtime via `inspect.signature` by introspecting the third parameter name:
- If `third_parameter == "storage_type"` (redisvl < 0.5), pass the `StorageType` enum.
- If `third_parameter == "schema"` (redisvl >= 0.5), load the schema via `AsyncSearchIndex.from_existing(name=collection_name, redis_client=redis_database)` and pass `index.schema`.
- If an unsupported third parameter is encountered, raise `VectorSearchExecutionException` rather than guessing.

```python
parameters = list(inspect.signature(process_results).parameters.values())
if len(parameters) < 3:
    raise VectorSearchExecutionException("Unsupported redisvl process_results() signature.")

third_parameter = parameters[2].name
if third_parameter == "storage_type":
    return process_results(results, query, STORAGE_TYPE_MAP[collection_type])

if third_parameter == "schema":
    index = await AsyncSearchIndex.from_existing(
        name=collection_name,
        redis_client=redis_database,
    )
    return process_results(results, query, index.schema)

raise VectorSearchExecutionException(
    f"Unsupported redisvl process_results() parameter: {third_parameter}."
)
```

---

## Bug 2 — `KeyError` in `RedisHashsetCollection._deserialize_store_models_to_dicts`

### Root cause

The deserializer unconditionally decoded every vector field:

```python
case "vector":
    dtype = DATATYPE_MAP_VECTOR[field.type_ or "default"]
    rec[field.name] = buffer_to_array(rec[field.name], dtype)  # KeyError!
```

When `include_vectors=False` (the SDK default for search), Redis does not return vector fields in the result dict, so `rec[field.name]` raised `KeyError: 'vector'`.

### Fix

Guard with an existence check before decoding:

```python
case "vector":
    storage_name = field.storage_name or field.name
    if storage_name in rec:
        dtype = DATATYPE_MAP_VECTOR[field.type_ or "default"]
        rec[field.name] = buffer_to_array(rec[storage_name], dtype)
    else:
        rec[field.name] = None  # vector not requested — leave as None
```

---

## Impact

Both bugs affected **every** Python user using the Redis connector for vector search:
- Bug 1 blocked all search calls unconditionally.
- Bug 2 blocked hashset search whenever `include_vectors=False` (the default).

The connector was written against redisvl 0.4.x; the dependency pin allows installation of redisvl 0.15.x where the API changed.

---

## Testing

- Unit tests in `python/tests/unit/connectors/memory/test_redis_store.py`:
  - `test_process_search_results_with_legacy_redisvl_api`: verifies legacy `storage_type` parameter dispatch.
  - `test_process_search_results_with_current_redisvl_api`: verifies `AsyncSearchIndex.from_existing` and `schema` dispatch.
  - `test_hash_deserialization_handles_omitted_vector`: verifies hashset deserialization when `vector` is omitted.
- The fix is backward-compatible across supported redisvl versions without requiring a version pin change.
- Existing upsert/get/delete integration tests are unaffected.
