### PR TITLE
Revise reasoning effort values in OpenAIPromptExecutionSettings

### DIFF
--- a/dotnet/src/Connectors/Connectors.OpenAI/Settings/OpenAIPromptExecutionSettings.cs
+++ b/dotnet/src/Connectors/Connectors.OpenAI/Settings/OpenAIPromptExecutionSettings.cs
@@ -26,7 +26,7 @@ public class OpenAIPromptExecutionSettings : PromptExecutionSettings
     /// Constrains effort on reasoning for reasoning models.
     /// Reducing reasoning effort can result in faster responses and fewer tokens used on reasoning in a response.
     /// Possible values are:
-    /// <para>- <see cref="string"/> values: <c>"low"</c>, <c>"medium"</c>, <c>"high"</c>, <c>"minimal"</c>;</para>
+    /// <para>- <see cref="string"/> values: <c>"none"</c>, <c>"minimal"</c>, <c>"low"</c>, <c>"medium"</c>, <c>"high"</c>, <c>"xhigh"</c>;</para>
     /// <para>- <see cref="ChatReasoningEffortLevel"/> object;</para>
     /// </remarks>
     [JsonPropertyName("reasoning_effort")]


### PR DESCRIPTION
Updated the documentation for reasoning effort values to include 'none' and 'xhigh'.

### Motivation and Context
The `reasoning_effort` values currently documented for the GPT-5 series include `none`, `minimal`, `low`, `medium`, `high`, `xhigh`, and `max`, with support varying by model. The current remarks list only `low`, `medium`, `high`, and `minimal`, so callers have no indication that `none` (and others) are valid. 
`none` in particular is not a niche value — it is required for some Chat Completions scenarios on newer models.

### Description

This property is object and REST level, none and xhigh are also available.
https://learn.microsoft.com/en-us/rest/api/microsoft-foundry/azureopenai/chat?view=rest-microsoft-foundry-v1#openaireasoningeffort
<img width="485" height="195" alt="image" src="https://github.com/user-attachments/assets/172e9ff0-d5f8-4bb3-895c-733f7c4e3134" />


### Contribution Checklist

<!-- Before submitting this PR, please make sure: -->

- [x ] The code builds clean without any errors or warnings
- [x ] The PR follows the [SK Contribution Guidelines](https://github.com/microsoft/semantic-kernel/blob/main/CONTRIBUTING.md) and the [pre-submission formatting script](https://github.com/microsoft/semantic-kernel/blob/main/CONTRIBUTING.md#development-scripts) raises no violations
- [ x] All unit tests pass, and I have added new tests where possible
- [ x] I didn't break anyone :smile:
