### PR TITLE
Python: Preserve metadata when merging streaming text content

### DIFF
--- a/python/semantic_kernel/contents/streaming_text_content.py
+++ b/python/semantic_kernel/contents/streaming_text_content.py
@@ -49,7 +49,7 @@ class StreamingTextContent(StreamingContentMixin, TextContent):
             choice_index=self.choice_index,
             inner_content=self._merge_inner_contents(other.inner_content),
             ai_model_id=self.ai_model_id,
-            metadata=self.metadata,
+            metadata=self.metadata | other.metadata,
             text=(self.text or "") + (other.text or ""),
             encoding=self.encoding,
         )

--- a/python/tests/unit/contents/test_streaming_text_content.py
+++ b/python/tests/unit/contents/test_streaming_text_content.py
@@ -1,0 +1,26 @@
+# Copyright (c) Microsoft. All rights reserved.
+
+from semantic_kernel.contents.streaming_text_content import StreamingTextContent
+
+
+def test_stc_add_combines_metadata():
+    chunk1 = StreamingTextContent(choice_index=0, text="Hello, ", metadata={"id": "cmpl-1"})
+    chunk2 = StreamingTextContent(choice_index=0, text="world!", metadata={"usage": {"prompt_tokens": 5}})
+
+    combined = chunk1 + chunk2
+
+    assert combined.text == "Hello, world!"
+    assert combined.metadata == {"id": "cmpl-1", "usage": {"prompt_tokens": 5}}
+
+    # Make sure the original metadata is preserved
+    assert chunk1.metadata == {"id": "cmpl-1"}
+    assert chunk2.metadata == {"usage": {"prompt_tokens": 5}}
+
+
+def test_stc_add_metadata_conflicting_keys_other_wins():
+    chunk1 = StreamingTextContent(choice_index=0, text="Hello, ", metadata={"id": "cmpl-1", "logprobs": None})
+    chunk2 = StreamingTextContent(choice_index=0, text="world!", metadata={"logprobs": {"tokens": ["world!"]}})
+
+    combined = chunk1 + chunk2
+
+    assert combined.metadata == {"id": "cmpl-1", "logprobs": {"tokens": ["world!"]}}


### PR DESCRIPTION
### Motivation and Context

`StreamingTextContent.__add__` documents that metadata is combined, but it currently retains only the left operand's metadata. Streaming connectors can attach response metadata to different chunks—for example, an identifier on an early chunk and usage or log-probability data on a later one—so accumulating chunks can silently lose the later metadata.

No matching open issue or pull request was found for this narrow bug. The contribution guide permits skipping an issue for a trivial change.

### Description

- Merge both metadata dictionaries when adding `StreamingTextContent`, with the right operand winning on conflicting keys. This matches the existing behavior of sibling streaming content types.
- Add regression tests for disjoint metadata, right-side conflict precedence, and preservation of both input objects.

### Validation

- Focused regression tests: 2 passed.
- Full content unit suite: 396 passed.
- Full repository pre-commit checks: passed.
- Ruff lint and format checks: passed.
- Python source distribution and wheel builds: passed.

### Contribution Checklist

- [x] The code builds clean without any errors or warnings
- [x] The PR follows the [SK Contribution Guidelines](https://github.com/microsoft/semantic-kernel/blob/main/CONTRIBUTING.md) and the [pre-submission formatting script](https://github.com/microsoft/semantic-kernel/blob/main/CONTRIBUTING.md#development-scripts) raises no violations
- [x] All relevant unit tests pass, and I have added new tests where possible
- [x] I didn't break anyone :smile:
