### PR TITLE
.NET: Bump Testcontainers packages

### DIFF
--- a/dotnet/Directory.Packages.props
+++ b/dotnet/Directory.Packages.props
@@ -183,8 +183,8 @@
     <PackageVersion Include="Fluid.Core" Version="2.31.0" />
     <!-- Memory stores -->
     <PackageVersion Include="Milvus.Client" Version="2.3.0-preview.1" />
-    <PackageVersion Include="Testcontainers.Milvus" Version="4.8.1" />
-    <PackageVersion Include="Testcontainers.MongoDB" Version="4.6.0" />
+    <PackageVersion Include="Testcontainers.Milvus" Version="4.14.0" />
+    <PackageVersion Include="Testcontainers.MongoDB" Version="4.14.0" />
     <!-- VectorData Dependencies -->
     <PackageVersion Include="CommunityToolkit.VectorData.AzureAISearch" Version="1.0.0" />
     <PackageVersion Include="CommunityToolkit.VectorData.CosmosMongoDB" Version="1.0.0" />


### PR DESCRIPTION
### Motivation and Context

Resolves the SSH.NET high-severity vulnerability reported by NuGet auditing.

### Description

Updates Testcontainers.Milvus and Testcontainers.MongoDB to 4.14.0, which uses the patched SSH.NET 2026.0.0 dependency.

### Contribution Checklist

- [ ] The code builds clean without any errors or warnings
- [ ] The PR follows the [SK Contribution Guidelines](https://github.com/microsoft/semantic-kernel/blob/main/CONTRIBUTING.md) and the [pre-submission formatting script](https://github.com/microsoft/semantic-kernel/blob/main/CONTRIBUTING.md#development-scripts) raises no violations
- [ ] All unit tests pass, and I have added new tests where possible
- [x] I didn't break anyone :smile: