### PR TITLE
Python: Preserve falsy dynamic search filter defaults

### DIFF
--- a/python/semantic_kernel/data/_shared.py
+++ b/python/semantic_kernel/data/_shared.py
@@ -169,7 +169,7 @@ def default_dynamic_filter_function(
         new_filter = None
         if param.name in kwargs:
             new_filter = f"lambda x: x.{param.name} == {_format_filter_literal(kwargs[param.name])}"
-        elif param.default_value:
+        elif param.default_value is not None:
             new_filter = f"lambda x: x.{param.name} == {_format_filter_literal(param.default_value)}"
         if not new_filter:
             continue

--- a/python/tests/unit/data/test_text_search.py
+++ b/python/tests/unit/data/test_text_search.py
@@ -117,6 +117,32 @@ async def test_create_kernel_function_inner_with_options(kernel: Kernel):
     assert results.value == ["test"]
 
 
+@pytest.mark.parametrize(("default_value", "expected_literal"), [(0, "0"), (False, "False"), ("", "''")])
+async def test_create_kernel_function_applies_falsy_filter_defaults(
+    kernel: Kernel, default_value: int | bool | str, expected_literal: str
+):
+    test_search = TestSearch()
+    kernel_function = test_search.create_search_function(
+        parameters=[
+            KernelParameterMetadata(
+                name="category",
+                description="Category filter.",
+                type=type(default_value).__name__,
+                is_required=False,
+                default_value=default_value,
+                type_object=type(default_value),
+            )
+        ]
+    )
+
+    with patch.object(test_search, "search", wraps=test_search.search) as mock_search:
+        await kernel_function.invoke(kernel)
+
+    mock_search.assert_awaited_once_with(
+        query="", output_type=str, filter=f"lambda x: x.category == {expected_literal}"
+    )
+
+
 async def test_create_kernel_function_inner_with_other_options_type(kernel: Kernel):
     test_search = TestSearch()
 


### PR DESCRIPTION
### Motivation and Context

Dynamic search parameters with a default value are documented as adding equality filters. The current truthiness check drops valid falsy defaults such as `0`, `False`, and an empty string, so invoking the generated search function without an override silently broadens the search.

### Description

Treat every non-`None` parameter default as an explicit filter value. The regression test exercises the public `create_search_function` path and verifies that all three falsy defaults reach the underlying search as filters.

OpenAI Codex assisted with identifying the edge case and preparing the focused change. The behavior, diff, and test results were verified locally.

### Validation

- `uv run pytest tests/unit/connectors/memory/test_in_memory.py tests/unit/data -ra` — 122 passed
- `uv run pre-commit run --files semantic_kernel/data/_shared.py tests/unit/data/test_text_search.py` — all hooks passed
- `uv run mypy -p semantic_kernel --config-file mypy.ini` — no issues in 555 source files

### Contribution Checklist

- [x] The code builds clean without any errors or warnings
- [x] The PR follows the SK Contribution Guidelines and the pre-submission formatting checks raise no violations
- [x] All relevant unit tests pass, and I added regression coverage
- [x] I didn't break anyone :smile:
