### PR TITLE
fix(python): compose Postgres filters as SQL

### DIFF
--- a/python/semantic_kernel/connectors/postgres.py
+++ b/python/semantic_kernel/connectors/postgres.py
@@ -794,11 +794,12 @@ class PostgresCollection(
         )
 
         if where_clauses := self._build_filter(options.filter):  # type: ignore
-            query += (
-                sql.SQL("WHERE {clause}").format(clause=sql.SQL(" AND ").join(where_clauses))
+            clause = (
+                sql.SQL(" AND ").join(sql.SQL(where_clause) for where_clause in where_clauses)
                 if isinstance(where_clauses, list)
-                else sql.SQL("WHERE {clause}").format(clause=where_clauses)
+                else sql.SQL(where_clauses)
             )
+            query += sql.SQL(" WHERE {clause}").format(clause=clause)
 
         query += sql.SQL(" ORDER BY {dist_col} LIMIT {limit}").format(
             dist_col=sql.Identifier(self._distance_column_name),

--- a/python/tests/unit/connectors/memory/test_postgres_store.py
+++ b/python/tests/unit/connectors/memory/test_postgres_store.py
@@ -17,7 +17,13 @@ from semantic_kernel.connectors.postgres import (
     PostgresSettings,
     PostgresStore,
 )
-from semantic_kernel.data.vector import DistanceFunction, IndexKind, VectorStoreField, vectorstoremodel
+from semantic_kernel.data.vector import (
+    DistanceFunction,
+    IndexKind,
+    VectorSearchOptions,
+    VectorStoreField,
+    vectorstoremodel,
+)
 
 
 @fixture(scope="function")
@@ -320,6 +326,32 @@ async def test_vector_search(
         )
 
     assert statement_str == expected_statement
+
+
+@pytest.mark.parametrize(
+    "filter_, expected_clause",
+    [
+        ("lambda x: x.id == 1", 'WHERE "id" = 1'),
+        (["lambda x: x.id == 1", "lambda x: x.id > 0"], 'WHERE "id" = 1 AND "id" > 0'),
+    ],
+)
+def test_vector_search_filter_is_composed_as_sql(filter_, expected_clause) -> None:
+    """Filter predicates must remain SQL fragments instead of quoted string literals."""
+    pool = AsyncConnectionPool(open=False)
+    collection = PostgresCollection(
+        collection_name="test_collection",
+        record_type=SimpleDataModel,
+        connection_pool=pool,
+    )
+
+    query, _, _ = collection._construct_vector_query(
+        vector=[1.0, 2.0, 3.0],
+        options=VectorSearchOptions(filter=filter_, top=3),
+    )
+
+    query_string = query.as_string()
+    assert f'FROM "public"."test_collection" {expected_clause} ORDER BY' in query_string
+    assert '\'"id"' not in query_string
 
 
 async def test_model_post_init_conflicting_distance_column_name(vector_store: PostgresStore) -> None:


### PR DESCRIPTION
## Summary

- Compose `PostgresCollection` filter fragments as `psycopg.sql.SQL` instead of passing pre-built predicates as plain strings that psycopg quotes as values.
- Preserve the separator between the table name and `WHERE` when a filter is present.
- Add regression coverage for both a single lambda filter and multiple filters.

Fixes #14311

## Validation

- `python -m pytest python/tests/unit/connectors/memory/test_postgres_store.py -q` (22 passed)
- `ruff check --config python/pyproject.toml python/semantic_kernel/connectors/postgres.py` (passed)
- `ruff format --config python/pyproject.toml --check python/semantic_kernel/connectors/postgres.py python/tests/unit/connectors/memory/test_postgres_store.py` (passed)
- `python -m compileall -q python/semantic_kernel/connectors/postgres.py python/tests/unit/connectors/memory/test_postgres_store.py` (passed)

The regression is verified offline by rendering the psycopg query; no live PostgreSQL service is required.
