### PR TITLE
fix: apply Redis JSON collection key prefixes on delete

### DIFF
--- a/python/semantic_kernel/connectors/redis.py
+++ b/python/semantic_kernel/connectors/redis.py
@@ -706,7 +706,9 @@ class RedisJsonCollection(RedisCollection[TKey, TModel], Generic[TKey, TModel]):
 
     @override
     async def _inner_delete(self, keys: Sequence[str], **kwargs: Any) -> None:
-        await asyncio.gather(*[self.redis_database.json().delete(key, **kwargs) for key in keys])
+        await asyncio.gather(
+            *[self.redis_database.json().delete(self._get_redis_key(key), **kwargs) for key in keys]
+        )
 
     @override
     def _serialize_dicts_to_store_models(

--- a/python/tests/unit/connectors/memory/test_redis_store.py
+++ b/python/tests/unit/connectors/memory/test_redis_store.py
@@ -276,6 +276,12 @@ async def test_delete(collection_hash, collection_json, type_):
     await collection._inner_delete(["id1"])
 
 
+async def test_delete_json_applies_collection_prefix(collection_with_prefix_json, mock_delete_json):
+    await collection_with_prefix_json._inner_delete(["id1"])
+
+    mock_delete_json.assert_awaited_once_with("test:id1")
+
+
 async def test_collection_exists(collection_hash, mock_collection_exists):
     await collection_hash.collection_exists()
 


### PR DESCRIPTION
Closes #13904

`RedisJsonCollection._inner_delete` now resolves keys through the same collection-prefix helper used by upsert and get. This prevents deletes from silently targeting the unprefixed key when `prefix_collection_name_to_key_names=True`, with a regression test for the prefixed JSON collection.

Validation:
- `python3 -m compileall -q python/semantic_kernel/connectors/redis.py python/tests/unit/connectors/memory/test_redis_store.py`
- `git diff --check`
- The targeted pytest could not run locally because the environment is missing `opentelemetry`.