### PR TITLE
Add custom message selection for AggregatorAgent

### DIFF
--- a/dotnet/src/Agents/Abstractions/AggregatorAgent.cs
+++ b/dotnet/src/Agents/Abstractions/AggregatorAgent.cs
@@ -25,6 +25,11 @@ public enum AggregatorMode
     /// A nested embedding the aggregated chat within another chat.
     /// </summary>
     Nested,
+
+    /// <summary>
+    /// A custom selection of the aggregated chat messages.
+    /// </summary>
+    Custom,
 }
 
 /// <summary>
@@ -43,6 +48,12 @@ public sealed class AggregatorAgent(Func<AgentChat> chatProvider) : Agent
     /// with which <see cref="AggregatorAgent"/> is participating. The default value is <see cref="AggregatorMode.Flat"/>.
     /// </value>
     public AggregatorMode Mode { get; init; } = AggregatorMode.Flat;
+
+    /// <summary>
+    /// Gets the callback used to select the message exposed to the owning chat when <see cref="Mode"/> is <see cref="AggregatorMode.Custom"/>.
+    /// The messages are ordered newest first, matching the aggregated chat history.
+    /// </summary>
+    public Func<IReadOnlyList<ChatMessageContent>, ChatMessageContent?>? MessageSelector { get; init; }
 
     /// <inheritdoc/>
     public override IAsyncEnumerable<AgentResponseItem<ChatMessageContent>> InvokeAsync(
@@ -82,7 +93,7 @@ public sealed class AggregatorAgent(Func<AgentChat> chatProvider) : Agent
         this.Logger.LogAggregatorAgentCreatingChannel(nameof(CreateChannelAsync), nameof(AggregatorChannel));
 
         AgentChat chat = chatProvider.Invoke();
-        AggregatorChannel channel = new(chat);
+        AggregatorChannel channel = new(chat, this.MessageSelector);
 
         this.Logger.LogAggregatorAgentCreatedChannel(nameof(CreateChannelAsync), nameof(AggregatorChannel), this.Mode, chat.GetType());
 
@@ -100,7 +111,7 @@ public sealed class AggregatorAgent(Func<AgentChat> chatProvider) : Agent
             throw new KernelException("Unable to restore channel: invalid state.");
 
         await chat.DeserializeAsync(agentChatState).ConfigureAwait(false); ;
-        AggregatorChannel channel = new(chat);
+        AggregatorChannel channel = new(chat, this.MessageSelector);
 
         this.Logger.LogOpenAIAssistantAgentRestoredChannel(nameof(CreateChannelAsync), nameof(AggregatorChannel));
 

--- a/dotnet/src/Agents/Abstractions/AggregatorChannel.cs
+++ b/dotnet/src/Agents/Abstractions/AggregatorChannel.cs
@@ -1,6 +1,8 @@
 ﻿// Copyright (c) Microsoft. All rights reserved.
+using System;
 using System.Collections.Generic;
 using System.Diagnostics.CodeAnalysis;
+using System.Linq;
 using System.Runtime.CompilerServices;
 using System.Text.Json;
 using System.Threading;
@@ -15,6 +17,13 @@ namespace Microsoft.SemanticKernel.Agents;
 internal sealed class AggregatorChannel(AgentChat chat) : AgentChannel<AggregatorAgent>
 {
     private readonly AgentChat _chat = chat;
+    private readonly Func<IReadOnlyList<ChatMessageContent>, ChatMessageContent?>? _messageSelector = null;
+
+    public AggregatorChannel(AgentChat chat, Func<IReadOnlyList<ChatMessageContent>, ChatMessageContent?>? messageSelector)
+        : this(chat)
+    {
+        this._messageSelector = messageSelector;
+    }
 
     /// <inheritdoc/>
     protected internal override IAsyncEnumerable<ChatMessageContent> GetHistoryAsync(CancellationToken cancellationToken = default)
@@ -25,6 +34,7 @@ internal sealed class AggregatorChannel(AgentChat chat) : AgentChannel<Aggregato
     /// <inheritdoc/>
     protected internal override async IAsyncEnumerable<(bool IsVisible, ChatMessageContent Message)> InvokeAsync(AggregatorAgent agent, [EnumeratorCancellation] CancellationToken cancellationToken = default)
     {
+        List<ChatMessageContent>? messages = agent.Mode == AggregatorMode.Custom ? [] : null;
         ChatMessageContent? lastMessage = null;
 
         await foreach (ChatMessageContent message in this._chat.InvokeAsync(cancellationToken).ConfigureAwait(false))
@@ -34,6 +44,8 @@ internal sealed class AggregatorChannel(AgentChat chat) : AgentChannel<Aggregato
             {
                 yield return (IsVisible: true, message);
             }
+
+            messages?.Add(message);
 
             lastMessage = message;
         }
@@ -49,6 +61,15 @@ internal sealed class AggregatorChannel(AgentChat chat) : AgentChannel<Aggregato
                 };
 
             yield return (IsVisible: true, message);
+        }
+
+        if (agent.Mode == AggregatorMode.Custom)
+        {
+            ChatMessageContent? selected = this.SelectMessage(messages!);
+            if (selected is not null)
+            {
+                yield return (IsVisible: true, selected);
+            }
         }
     }
 
@@ -90,6 +111,16 @@ internal sealed class AggregatorChannel(AgentChat chat) : AgentChannel<Aggregato
                 yield return new StreamingChatMessageContent(finalMessage.Role, finalMessage.Content) { AuthorName = finalMessage.AuthorName };
                 messages.Add(finalMessage);
             }
+            else if (agent.Mode == AggregatorMode.Custom)
+            {
+                IReadOnlyList<ChatMessageContent> generatedMessages = history.Take(history.Count - initialCount).ToList();
+                ChatMessageContent? selected = this.SelectMessage(generatedMessages);
+                if (selected is not null)
+                {
+                    yield return new StreamingChatMessageContent(selected.Role, selected.Content) { AuthorName = selected.AuthorName };
+                    messages.Add(selected);
+                }
+            }
         }
     }
 
@@ -108,4 +139,15 @@ internal sealed class AggregatorChannel(AgentChat chat) : AgentChannel<Aggregato
 
     protected internal override string Serialize() =>
         JsonSerializer.Serialize(this._chat.Serialize());
+
+    private ChatMessageContent? SelectMessage(IReadOnlyList<ChatMessageContent> messages)
+    {
+        if (this._messageSelector is null)
+        {
+            throw new InvalidOperationException(
+                $"{nameof(AggregatorAgent.MessageSelector)} must be configured when {nameof(AggregatorAgent.Mode)} is {AggregatorMode.Custom}.");
+        }
+
+        return this._messageSelector(messages);
+    }
 }

--- a/dotnet/src/Agents/UnitTests/AggregatorAgentTests.cs
+++ b/dotnet/src/Agents/UnitTests/AggregatorAgentTests.cs
@@ -23,6 +23,7 @@ public class AggregatorAgentTests
     [Theory]
     [InlineData(AggregatorMode.Nested, 0)]
     [InlineData(AggregatorMode.Flat, 2)]
+    [InlineData(AggregatorMode.Custom, 0)]
     public async Task VerifyAggregatorAgentUsageAsync(AggregatorMode mode, int modeOffset)
     {
         // Arrange
@@ -43,7 +44,11 @@ public class AggregatorAgentTests
                     }
             };
 
-        AggregatorAgent uberAgent = new(() => groupChat) { Mode = mode };
+        AggregatorAgent uberAgent = new(() => groupChat)
+        {
+            Mode = mode,
+            MessageSelector = mode == AggregatorMode.Custom ? messages => messages[0] : null,
+        };
         AgentGroupChat uberChat = new();
 
         // Add message to outer chat (no agent has joined)


### PR DESCRIPTION
Fixes #10411\n\nSummary:\n- Add AggregatorMode.Custom for selecting which aggregated message is exposed to the parent chat.\n- Add a configurable MessageSelector callback with support for discrete and streaming invocations.\n- Extend AggregatorAgent coverage for custom selection.\n\nTests:\n- git diff --check passed.\n- .NET build could not run because dotnet is not installed in the environment.