### PR TITLE
Fix PostgreSQL vector search filter rendering

### DIFF
--- a/python/semantic_kernel/connectors/postgres.py
+++ b/python/semantic_kernel/connectors/postgres.py
@@ -795,9 +795,11 @@ class PostgresCollection(
 
         if where_clauses := self._build_filter(options.filter):  # type: ignore
             query += (
-                sql.SQL("WHERE {clause}").format(clause=sql.SQL(" AND ").join(where_clauses))
+                sql.SQL("WHERE {clause}").format(
+                    clause=sql.SQL(" AND ").join(sql.SQL(clause) for clause in where_clauses)
+                )
                 if isinstance(where_clauses, list)
-                else sql.SQL("WHERE {clause}").format(clause=where_clauses)
+                else sql.SQL("WHERE {clause}").format(clause=sql.SQL(where_clauses))
             )
 
         query += sql.SQL(" ORDER BY {dist_col} LIMIT {limit}").format(

--- a/python/tests/unit/connectors/memory/test_postgres_store.py
+++ b/python/tests/unit/connectors/memory/test_postgres_store.py
@@ -17,7 +17,13 @@ from semantic_kernel.connectors.postgres import (
     PostgresSettings,
     PostgresStore,
 )
-from semantic_kernel.data.vector import DistanceFunction, IndexKind, VectorStoreField, vectorstoremodel
+from semantic_kernel.data.vector import (
+    DistanceFunction,
+    IndexKind,
+    VectorSearchOptions,
+    VectorStoreField,
+    vectorstoremodel,
+)
 
 
 @fixture(scope="function")
@@ -320,6 +326,18 @@ async def test_vector_search(
         )
 
     assert statement_str == expected_statement
+
+
+async def test_vector_search_filter_is_rendered_as_sql(vector_store: PostgresStore) -> None:
+    collection = vector_store.get_collection(collection_name="test_collection", record_type=SimpleDataModel)
+    assert isinstance(collection, PostgresCollection)
+
+    query, _, _ = collection._construct_vector_query(
+        [1.0, 2.0, 3.0],
+        VectorSearchOptions(filter="lambda x: x.id == 1"),
+    )
+
+    assert 'WHERE "id" = 1' in query.as_string()
 
 
 async def test_model_post_init_conflicting_distance_column_name(vector_store: PostgresStore) -> None:


### PR DESCRIPTION
Fixes #14311.\n\nPostgresCollection builds filter clauses as SQL text, but passing plain strings to psycopg SQL.format treats them as quoted literal values. Wrap single and combined clauses with sql.SQL so filters produce executable predicates instead of invalid WHERE string literals.\n\nAdded a regression test covering a rendered equality filter.\n\nValidation: git diff --check and python3 -m py_compile passed. The targeted pytest could not be collected locally because the checkout is missing the OpenTelemetry dependency.