### PR TITLE
.Net: Reject mixed-separator UNC paths in DocumentPlugin

### DIFF
--- a/dotnet/src/Plugins/Plugins.Document/DocumentPlugin.cs
+++ b/dotnet/src/Plugins/Plugins.Document/DocumentPlugin.cs
@@ -161,14 +161,23 @@ public sealed class DocumentPlugin
             throw new ArgumentException("Invalid file path, UNC paths are not supported.", nameof(path));
         }
 
-        return PathUtilities.GetSafeFullPath(expanded);
+        // Resolve the full path first (a pure string operation that does not touch the
+        // filesystem). A relative path can still resolve to a UNC path here, for example
+        // when the current directory is a UNC share, so re-check before GetSafeFullPath
+        // probes the filesystem while resolving symbolic links.
+        var fullPath = Path.GetFullPath(expanded);
+        if (IsUncOrExtendedPath(fullPath))
+        {
+            throw new ArgumentException("Invalid file path, UNC paths are not supported.", nameof(path));
+        }
+
+        return PathUtilities.GetSafeFullPath(fullPath);
     }
 
-    private static bool IsUncOrExtendedPath(string path)
-    {
-        return path.StartsWith("\\\\", StringComparison.OrdinalIgnoreCase) ||
-            path.StartsWith("//", StringComparison.OrdinalIgnoreCase);
-    }
+    private static bool IsUncOrExtendedPath(string path) =>
+        path.Length >= 2 &&
+        (path[0] is '/' or '\\') &&
+        (path[1] is '/' or '\\');
 
     /// <summary>
     /// Checks whether a canonicalized file path falls within one of the allowed directories.

--- a/dotnet/src/Plugins/Plugins.UnitTests/Document/DocumentPluginTests.cs
+++ b/dotnet/src/Plugins/Plugins.UnitTests/Document/DocumentPluginTests.cs
@@ -192,6 +192,26 @@ public class DocumentPluginTests
         await Assert.ThrowsAnyAsync<Exception>(async () => await target.AppendTextAsync("text", "//UNC/server/folder/file.docx"));
     }
 
+    [Theory]
+    [InlineData("\\\\UNC\\server\\folder\\myfile.docx")]
+    [InlineData("//UNC/server/folder/myfile.docx")]
+    [InlineData("/\\UNC\\server\\folder\\myfile.docx")]
+    [InlineData("\\/UNC/server/folder/myfile.docx")]
+    public async Task ItRejectsUncOrExtendedPathsAsync(string path)
+    {
+        // Arrange
+        var fileSystemConnectorMock = new Mock<IFileSystemConnector>();
+        var documentConnectorMock = new Mock<IDocumentConnector>();
+        var target = new DocumentPlugin(documentConnectorMock.Object, fileSystemConnectorMock.Object)
+        {
+            AllowedDirectories = [Path.GetTempPath()]
+        };
+
+        // Act & Assert
+        await Assert.ThrowsAsync<ArgumentException>(() => target.ReadTextAsync(path));
+        await Assert.ThrowsAsync<ArgumentException>(() => target.AppendTextAsync("text", path));
+    }
+
     [Fact]
     public async Task ItDeniesDisallowedFoldersAsync()
     {


### PR DESCRIPTION
### Motivation and Context

PR #14166 (fixing #14157) rejected mixed-separator UNC paths such as `\/server/share` and `/\server\share` in FileIOPlugin and WebFileDownloadPlugin by replacing the `StartsWith`-based UNC check with a separator-class check, and re-checking the resolved full path before symlink resolution. DocumentPlugin contains the same `CanonicalizePath`/`IsUncOrExtendedPath` pair but was not included in that change, so it still accepts mixed-separator UNC paths that bypass the `AllowedDirectories` sandbox.

### Description

Applies the identical hardening from #14166 to DocumentPlugin: the `IsUncOrExtendedPath` helper now uses the length/char-class form catching any combination of `/` and `\` in the first two characters, and `CanonicalizePath` re-checks the `Path.GetFullPath` result before `PathUtilities.GetSafeFullPath` probes the filesystem. Ports #14166's four mixed-separator test cases to `DocumentPluginTests` against both `ReadTextAsync` and `AppendTextAsync`.

Test note: 3 pre-existing macOS-only environment failures in DocumentPluginTests (temp-dir symlink canonicalization) are present at HEAD before this change and unaffected by it; the 4 new cases pass and `dotnet format --verify-no-changes` is clean on both touched files.

### Contribution Checklist

- [x] The code builds clean without any errors or warnings
- [x] The PR follows the SK Contribution Guidelines (https://github.com/microsoft/semantic-kernel/blob/main/CONTRIBUTING.md)
- [x] All unit tests pass, and I have added new tests where possible
- [x] I didn't break anyone :smile:
