### PR TITLE
Python: Add OrcaRouter as a named chat completion service

### DIFF
--- a/python/samples/concepts/chat_completion/simple_chatbot.py
+++ b/python/samples/concepts/chat_completion/simple_chatbot.py
@@ -23,6 +23,7 @@ from semantic_kernel.contents import ChatHistory
 # - Services.ONNX
 # - Services.VERTEX_AI
 # - Services.DEEPSEEK
+# - Services.ORCAROUTER
 # Please make sure you have configured your environment correctly for the selected chat completion service.
 chat_completion_service, request_settings = get_chat_completion_service_and_request_settings(Services.OPENAI)
 

--- a/python/samples/concepts/setup/chat_completion_services.py
+++ b/python/samples/concepts/setup/chat_completion_services.py
@@ -1,13 +1,38 @@
 # Copyright (c) Microsoft. All rights reserved.
 
 from enum import Enum
-from typing import TYPE_CHECKING
+from typing import TYPE_CHECKING, ClassVar
+
+from pydantic import SecretStr
 
 from semantic_kernel.exceptions.service_exceptions import ServiceInitializationError
+from semantic_kernel.kernel_pydantic import KernelBaseSettings
 
 if TYPE_CHECKING:
     from semantic_kernel.connectors.ai.chat_completion_client_base import ChatCompletionClientBase
     from semantic_kernel.connectors.ai.prompt_execution_settings import PromptExecutionSettings
+
+
+class OrcaRouterSettings(KernelBaseSettings):
+    """OrcaRouter model settings.
+
+    The settings are first loaded from environment variables with the prefix 'ORCAROUTER_'. If the
+    environment variables are not found, the settings can be loaded from a .env file with the
+    encoding 'utf-8'. If the settings are not found in the .env file, the settings are ignored;
+    however, validation will fail alerting that the settings are missing.
+
+    Optional settings for prefix 'ORCAROUTER_' are:
+    - api_key: SecretStr - OrcaRouter API key, see https://www.orcarouter.ai
+        (Env var ORCAROUTER_API_KEY)
+    - chat_model_id: str | None - The OrcaRouter chat model ID to use.
+        (Env var ORCAROUTER_CHAT_MODEL_ID)
+    - env_file_path: if provided, the .env settings are read from this file path location
+    """
+
+    env_prefix: ClassVar[str] = "ORCAROUTER_"
+
+    api_key: SecretStr | None = None
+    chat_model_id: str | None = None
 
 
 class Services(str, Enum):
@@ -28,6 +53,7 @@ class Services(str, Enum):
     ONNX = "onnx"
     VERTEX_AI = "vertex_ai"
     DEEPSEEK = "deepseek"
+    ORCAROUTER = "orcarouter"
     NVIDIA = "nvidia"
 
 
@@ -65,6 +91,7 @@ def get_chat_completion_service_and_request_settings(
         Services.ONNX: lambda: get_onnx_chat_completion_service_and_request_settings(),
         Services.VERTEX_AI: lambda: get_vertex_ai_chat_completion_service_and_request_settings(),
         Services.DEEPSEEK: lambda: get_deepseek_chat_completion_service_and_request_settings(),
+        Services.ORCAROUTER: lambda: get_orcarouter_chat_completion_service_and_request_settings(),
         Services.NVIDIA: lambda: get_nvidia_chat_completion_service_and_request_settings(),
     }
 
@@ -401,6 +428,53 @@ def get_deepseek_chat_completion_service_and_request_settings() -> tuple[
         async_client=AsyncOpenAI(
             api_key=openai_settings.api_key.get_secret_value(),
             base_url="https://api.deepseek.com",
+        ),
+    )
+    request_settings = OpenAIChatPromptExecutionSettings(service_id=service_id)
+
+    return chat_service, request_settings
+
+
+def get_orcarouter_chat_completion_service_and_request_settings() -> tuple[
+    "ChatCompletionClientBase", "PromptExecutionSettings"
+]:
+    """Return OrcaRouter chat completion service and request settings.
+
+    The service credentials can be read by 3 ways:
+    1. Via the constructor
+    2. Via the environment variables
+    3. Via an environment file
+
+    The OrcaRouter endpoint can be accessed via the OpenAI connector, as the OrcaRouter API is
+    compatible with the OpenAI API.
+    Set the `ORCAROUTER_API_KEY` environment variable to the OrcaRouter API key.
+    Set the `ORCAROUTER_CHAT_MODEL_ID` environment variable to the OrcaRouter model ID.
+
+    The request settings control the behavior of the service. The default settings are sufficient to get started.
+    However, you can adjust the settings to suit your needs.
+    Note: Some of the settings are NOT meant to be set by the user.
+    Please refer to the Semantic Kernel Python documentation for more information:
+    https://learn.microsoft.com/en-us/python/api/semantic-kernel/semantic_kernel?view=semantic-kernel-python
+    """
+    from openai import AsyncOpenAI
+
+    from semantic_kernel.connectors.ai.open_ai import (
+        OpenAIChatCompletion,
+        OpenAIChatPromptExecutionSettings,
+    )
+
+    orcarouter_settings = OrcaRouterSettings()
+    if not orcarouter_settings.api_key:
+        raise ServiceInitializationError("The OrcaRouter API key is required.")
+    if not orcarouter_settings.chat_model_id:
+        raise ServiceInitializationError("The OrcaRouter model ID is required.")
+
+    chat_service = OpenAIChatCompletion(
+        ai_model_id=orcarouter_settings.chat_model_id,
+        service_id=service_id,
+        async_client=AsyncOpenAI(
+            api_key=orcarouter_settings.api_key.get_secret_value(),
+            base_url="https://api.orcarouter.ai/v1",
         ),
     )
     request_settings = OpenAIChatPromptExecutionSettings(service_id=service_id)


### PR DESCRIPTION
### Motivation and Context

Semantic Kernel is a model-agnostic SDK that empowers developers to build, orchestrate, and deploy AI agents and multi-agent systems, and one of its headline features is model flexibility — "connect to any LLM." Today the Python samples let you pick a provider by name from `Services` (OpenAI, Azure OpenAI, Anthropic, Mistral AI, Ollama, NVIDIA NIM, DeepSeek, ...), and each named provider is wired through a settings class with its own environment-variable prefix.

[OrcaRouter](https://www.orcarouter.ai) is an OpenAI-compatible AI gateway built for both models and agents. Like OpenRouter, it exposes a provider/model namespace across many models — but it also combines adaptive routing, automatic failover, zero-markup inference, observability, guardrails, and agent-tool governance behind the same endpoint. Adding `orcarouter` as a first-class provider means this project's users can use that stack directly, without treating OrcaRouter as an anonymous custom base URL. It also runs gateway-level, zero-trust security for AI agents on the same endpoint — screening every prompt/response and governing every tool call on a default-deny basis, with no application code changes.

### Description

This PR mirrors the existing DeepSeek entry (`Services.DEEPSEEK` → `get_deepseek_chat_completion_service_and_request_settings`) in `python/samples/concepts/setup/chat_completion_services.py` and adds an equivalent named `OrcaRouter` provider:

- `Services.ORCAROUTER = "orcarouter"` in the `Services` enum.
- `OrcaRouterSettings(KernelBaseSettings)` with the `ORCAROUTER_` env prefix (`ORCAROUTER_API_KEY`, `ORCAROUTER_CHAT_MODEL_ID`).
- `get_orcarouter_chat_completion_service_and_request_settings()` which builds an `OpenAIChatCompletion` backed by an `AsyncOpenAI` client pointed at `https://api.orcarouter.ai/v1`, exactly like the DeepSeek wiring.
- `Services.ORCAROUTER` listed in the `simple_chatbot.py` sample's selectable-service comment.

Verified locally:

- `ruff check` and `ruff format --check` pass on both modified files.
- `mypy` reports no errors in the new code (the single existing `mypy` warning is a pre-existing Onnx type issue in `chat_completion_services.py`, unrelated to this change).
- L3 live test: with `ORCAROUTER_API_KEY` set and `ORCAROUTER_CHAT_MODEL_ID=orcarouter/free`, calling `get_chat_completion_service_and_request_settings(Services.ORCAROUTER)` and invoking the resulting service returned a successful chat completion.

Discord: discord.gg/YEubt8enRA · X: https://x.com/OrcaRouter

### Contribution Checklist

- [x] The code builds clean without any errors or warnings
- [x] The PR follows the [SK Contribution Guidelines](https://github.com/microsoft/semantic-kernel/blob/main/CONTRIBUTING.md) and the [pre-submission formatting script](https://github.com/microsoft/semantic-kernel/blob/main/CONTRIBUTING.md#development-scripts) raises no violations
- [x] All unit tests pass, and I have added new tests where possible
- [x] I didn't break anyone :smile:

---

I'm an engineer on the OrcaRouter team.
