### PR TITLE
Python: Fix Agent Framework tool parameter defaults

### DIFF
--- a/python/semantic_kernel/functions/kernel_function.py
+++ b/python/semantic_kernel/functions/kernel_function.py
@@ -447,13 +447,15 @@ class KernelFunction(KernelBaseModel):
         fields = {}
         for param in self.parameters:
             if param.include_in_function_choices:
-                if param.default_value is not None:
+                # Requiredness is explicit metadata: None can be a legitimate
+                # default for optional parameters and must remain a Pydantic default.
+                if param.is_required:
+                    fields[param.name] = (param.type_, Field(description=param.description))
+                else:
                     fields[param.name] = (
                         param.type_,
                         Field(description=param.description, default=param.default_value),
                     )
-                else:
-                    fields[param.name] = (param.type_, Field(description=param.description))
         input_model = create_model("InputModel", **fields)  # type: ignore
 
         async def wrapper(*args: Any, **kwargs: Any) -> Any:

--- a/python/semantic_kernel/functions/kernel_function.py
+++ b/python/semantic_kernel/functions/kernel_function.py
@@ -452,7 +452,8 @@ class KernelFunction(KernelBaseModel):
                         param.type_,
                         Field(description=param.description, default=param.default_value),
                     )
-                fields[param.name] = (param.type_, Field(description=param.description))
+                else:
+                    fields[param.name] = (param.type_, Field(description=param.description))
         input_model = create_model("InputModel", **fields)  # type: ignore
 
         async def wrapper(*args: Any, **kwargs: Any) -> Any:

--- a/python/tests/unit/functions/test_kernel_function_from_method.py
+++ b/python/tests/unit/functions/test_kernel_function_from_method.py
@@ -140,6 +140,25 @@ def test_init_native_function_from_kernel_function_decorator_defaults():
     assert len(native_function.parameters) == 0
 
 
+def test_as_agent_framework_tool_preserves_optional_parameter_default(monkeypatch):
+    class MockAIFunction:
+        def __init__(self, *, input_model: Any, **kwargs: Any):
+            self.input_model = input_model
+
+    monkeypatch.setitem(__import__("sys").modules, "agent_framework", Mock(AIFunction=MockAIFunction))
+
+    @kernel_function()
+    def function(count: int = 5) -> int:
+        return count
+
+    native_function = KernelFunction.from_method(method=function, plugin_name="MockPlugin")
+    tool = native_function.as_agent_framework_tool(kernel=Mock())
+    field = tool.input_model.model_fields["count"]
+
+    assert field.default == 5
+    assert not field.is_required()
+
+
 def test_init_method_is_none():
     with pytest.raises(FunctionInitializationError):
         KernelFunction.from_method(method=None, plugin_name="MockPlugin")

--- a/python/tests/unit/functions/test_kernel_function_from_method.py
+++ b/python/tests/unit/functions/test_kernel_function_from_method.py
@@ -148,15 +148,18 @@ def test_as_agent_framework_tool_preserves_optional_parameter_default(monkeypatc
     monkeypatch.setitem(__import__("sys").modules, "agent_framework", Mock(AIFunction=MockAIFunction))
 
     @kernel_function()
-    def function(count: int = 5) -> int:
+    def function(count: int = 5, label: str | None = None) -> int:
         return count
 
     native_function = KernelFunction.from_method(method=function, plugin_name="MockPlugin")
     tool = native_function.as_agent_framework_tool(kernel=Mock())
-    field = tool.input_model.model_fields["count"]
+    count_field = tool.input_model.model_fields["count"]
+    label_field = tool.input_model.model_fields["label"]
 
-    assert field.default == 5
-    assert not field.is_required()
+    assert count_field.default == 5
+    assert not count_field.is_required()
+    assert label_field.default is None
+    assert not label_field.is_required()
 
 
 def test_init_method_is_none():


### PR DESCRIPTION
### Motivation and Context

`KernelFunction.as_agent_framework_tool()` currently builds a field with a parameter default and then immediately overwrites it with a required field. As a result, optional Semantic Kernel parameters become required in the Agent Framework tool schema.

### Description

- preserve every optional field by using `is_required` as the source of truth, including explicit `None` defaults
- add a focused regression test that verifies both `default=5` and `default=None` remain optional

Validation:

- `uv run pytest tests/unit/functions/test_kernel_function_from_method.py -q` — 37 passed
- `uv run ruff check semantic_kernel/functions/kernel_function.py tests/unit/functions/test_kernel_function_from_method.py` — passed
- `uv run ruff format --check semantic_kernel/functions/kernel_function.py tests/unit/functions/test_kernel_function_from_method.py` — passed
- `git diff --check` — passed

### Contribution Checklist

- [x] I added a focused regression test for the corrected behavior
- [x] I reviewed the change against the SK Contribution Guidelines
- [x] I didn't break anyone :smile:

