### PR TITLE
Python: fix TypeError in the mixed_chat_images sample (credential not passed to the kernel helper)

### DIFF
--- a/python/samples/concepts/agents/mixed_chat/mixed_chat_images.py
+++ b/python/samples/concepts/agents/mixed_chat/mixed_chat_images.py
@@ -57,7 +57,7 @@ async def main():
 
     service_id = "summary"
     summary_agent = ChatCompletionAgent(
-        kernel=_create_kernel_with_chat_completion(service_id=service_id),
+        kernel=_create_kernel_with_chat_completion(service_id=service_id, credential=credential),
         instructions="Summarize the entire conversation for the user in natural language.",
         name="Summarizer",
     )


### PR DESCRIPTION
### Motivation and Context

`python/samples/concepts/agents/mixed_chat/mixed_chat_images.py` cannot run. Its local
helper is

```python
def _create_kernel_with_chat_completion(service_id: str, credential: TokenCredential) -> Kernel:
```

but the one call site passes only `service_id`:

```python
summary_agent = ChatCompletionAgent(
    kernel=_create_kernel_with_chat_completion(service_id=service_id),   # line 60
    ...
)
```

so the sample raises

```
TypeError: _create_kernel_with_chat_completion() missing 1 required positional argument: 'credential'
```

right after the assistant is created — i.e. after the Azure client and the assistant
definition have already been provisioned, and before any of the image content the sample
is meant to demonstrate is produced.

`credential` is already in scope: `main()` builds `credential = AzureCliCredential()` on
its first line and passes it to `AzureAssistantAgent.create_client(credential=credential)`
a few lines above. Only the kernel helper call was missed.

The four sibling samples in the same directory all pass it:

| sample | call | binds? |
|---|---|---|
| `mixed_chat_agents_plugins.py:90` | `_create_kernel_with_chat_completion("artdirector", credential)` | ✅ |
| `mixed_chat_files.py:73` | `_create_kernel_with_chat_completion(service_id=service_id, credential=credential)` | ✅ |
| **`mixed_chat_images.py:60`** | `_create_kernel_with_chat_completion(service_id=service_id)` | ❌ `TypeError` |
| `mixed_chat_reset.py:46` | `_create_kernel_with_chat_completion("chat", credential)` | ✅ |
| `mixed_chat_streaming.py:50` | `_create_kernel_with_chat_completion("artdirector", credential)` | ✅ |

### Description

One line: pass `credential` at the call site, making it byte-identical to the
`mixed_chat_files.py:73` form.

Verified by replaying every `_create_kernel_with_chat_completion` call site in
`samples/concepts/agents/mixed_chat/` against a stub built from that file's own `def`
with `inspect.Signature.bind` — before the change one of five call sites fails, after it
all five bind:

```
                              before                          after
mixed_chat_agents_plugins.py :90   OK                         OK
mixed_chat_files.py          :73   OK                         OK
mixed_chat_images.py         :60   TypeError: missing a       OK
                                   required argument:
                                   'credential'
mixed_chat_reset.py          :46   OK                         OK
mixed_chat_streaming.py      :50   OK                         OK
```

The sample still needs live Azure OpenAI resources to run end to end, so it was not
executed against a real deployment; the failure being fixed is a pure call-signature
mismatch that is reproducible without one.

### Contribution Checklist

- [x] The code builds clean without any errors or warnings
- [x] The PR follows the [SK Contribution Guidelines](https://github.com/microsoft/semantic-kernel/blob/main/CONTRIBUTING.md) and the [pre-submission formatting script](https://github.com/microsoft/semantic-kernel/blob/main/CONTRIBUTING.md#development-scripts) raises no violations
- [x] All unit tests pass, and I have added new tests where possible
- [x] I didn't break anyone :smile:

🤖 Generated with [Claude Code](https://claude.com/claude-code)
