### PR TITLE
fix(python): preserve empty tool results

### DIFF
--- a/python/semantic_kernel/contents/chat_history.py
+++ b/python/semantic_kernel/contents/chat_history.py
@@ -215,11 +215,11 @@ class ChatHistory(KernelBaseModel):
 
     def _prepare_for_add(
         self, role: AuthorRole, content: str | None = None, items: list[KernelContent] | None = None, **kwargs: Any
-    ) -> dict[str, str]:
+    ) -> dict[str, Any]:
         """Prepare a message to be added to the history."""
         kwargs["role"] = role
 
-        if role == AuthorRole.TOOL and content is not None and not items:
+        if role == AuthorRole.TOOL and content and not items:
             tool_call_id = kwargs.pop("tool_call_id", None)
             function_name = kwargs.pop("function_name", "unknown")
             function_result_content = FunctionResultContent(

--- a/python/semantic_kernel/contents/chat_history.py
+++ b/python/semantic_kernel/contents/chat_history.py
@@ -219,7 +219,7 @@ class ChatHistory(KernelBaseModel):
         """Prepare a message to be added to the history."""
         kwargs["role"] = role
 
-        if role == AuthorRole.TOOL and content and not items:
+        if role == AuthorRole.TOOL and content is not None and not items:
             tool_call_id = kwargs.pop("tool_call_id", None)
             function_name = kwargs.pop("function_name", "unknown")
             function_result_content = FunctionResultContent(

--- a/python/tests/unit/contents/test_chat_history.py
+++ b/python/tests/unit/contents/test_chat_history.py
@@ -133,6 +133,22 @@ def test_add_tool_message_to_dict_succeeds(chat_history: ChatHistory):
     assert result["tool_call_id"] == "call_123"
 
 
+def test_add_empty_tool_message_to_dict_succeeds(chat_history: ChatHistory):
+    chat_history.add_tool_message("", tool_call_id="call_123", function_name="test_function")
+
+    msg = chat_history.messages[-1]
+    assert isinstance(msg.items[0], FunctionResultContent)
+    assert msg.items[0].result == ""
+    assert msg.items[0].function_name == "test_function"
+    assert msg.items[0].id == "call_123"
+    assert msg.items[0].call_id == "call_123"
+
+    result = msg.to_dict()
+    assert result["content"] == ""
+    assert result["role"] == AuthorRole.TOOL
+    assert result["tool_call_id"] == "call_123"
+
+
 def test_add_tool_message_list(chat_history: ChatHistory):
     content = [FunctionResultContent(id="test", result="Tool message")]
     chat_history.add_tool_message(content)


### PR DESCRIPTION
### Motivation and Context

Fixes #14359.

`ChatHistory.add_tool_message()` currently treats an empty string as absent content. This creates a tool message with no `FunctionResultContent`, loses the supplied tool-call correlation, and makes `ChatMessageContent.to_dict()` raise `IndexError`.

An empty string is a valid result for a successful command with no output or a no-op tool.

### Description

Change the tool-message preparation path to distinguish `None` from an empty string. Empty string results now create the same `FunctionResultContent` as other string results, preserving the result, `id`, `call_id`, and optional function name. Non-tool messages retain their existing truthiness behavior.

Added a focused regression test that verifies the content object fields and successful serialized tool-message dictionary.

This is backward compatible: non-empty tool results and all existing message forms are unchanged, and the fix only makes the documented string input work for the valid empty-string boundary case.

### Validation

- `uv run pytest tests/unit/contents/test_chat_history.py -k empty_tool_message -q --basetemp D:\\project\\tscodex\\github_pr\\tmp\\semantic-kernel-14359-pytest` — passed (1 test)
- `uv run pytest tests/unit/contents/test_chat_history.py -q --basetemp D:\\project\\tscodex\\github_pr\\tmp\\semantic-kernel-14359` — passed (56 tests)
- `uv run ruff check semantic_kernel/contents/chat_history.py tests/unit/contents/test_chat_history.py` — passed
- `uv run ruff format --check semantic_kernel/contents/chat_history.py tests/unit/contents/test_chat_history.py` — passed
- `uv run mypy semantic_kernel/contents/chat_history.py` — passed
- `uv run pre-commit run --files semantic_kernel/contents/chat_history.py tests/unit/contents/test_chat_history.py` — passed
- `git diff --check` — passed

The full Python unit suite was not run because this is a localized content-model change; no model, provider, credentials, database, or external service is required.

### Contribution Checklist

- [x] The code builds clean without any errors or warnings for the touched Python module
- [x] The PR follows the SK Contribution Guidelines and the pre-submission checks pass
- [x] The focused unit tests pass, including a regression test
- [x] The change is limited to the reported bug

### AI Disclosure

This contribution was prepared with AI assistance and reviewed against the repository source, issue reproduction, and local test results.
