### PR TITLE
.NET: Bump package version to 1.80.1

### DIFF
--- a/dotnet/nuget/nuget-package.props
+++ b/dotnet/nuget/nuget-package.props
@@ -1,7 +1,7 @@
 <Project>
   <PropertyGroup>
     <!-- Central version prefix - applies to all nuget packages. -->
-    <VersionPrefix>1.80.0</VersionPrefix>
+    <VersionPrefix>1.80.1</VersionPrefix>
     <PackageVersion Condition="'$(VersionSuffix)' != ''">$(VersionPrefix)-$(VersionSuffix)</PackageVersion>
     <PackageVersion Condition="'$(VersionSuffix)' == ''">$(VersionPrefix)</PackageVersion>
 
@@ -9,7 +9,7 @@
     <IsPackable>true</IsPackable>
 
     <!-- Package validation. Baseline Version should be the latest version available on NuGet. -->
-    <PackageValidationBaselineVersion>1.79.0</PackageValidationBaselineVersion>
+    <PackageValidationBaselineVersion>1.80.0</PackageValidationBaselineVersion>
     <!-- Validate assembly attributes only for Publish builds -->
     <NoWarn Condition="'$(Configuration)' != 'Publish'">$(NoWarn);CP0003</NoWarn>
     <!-- Do not validate reference assemblies -->


### PR DESCRIPTION
## Summary
- bump SK .NET packages from 1.80.0 to 1.80.1
- update the package validation baseline from 1.79.0 to 1.80.0

## Rationale
Changes since dotnet-1.80.0 are maintenance updates without new public APIs or features, so this is a patch release.