### PR TITLE
Python: Handle empty chat message function results

### DIFF
--- a/python/semantic_kernel/contents/function_result_content.py
+++ b/python/semantic_kernel/contents/function_result_content.py
@@ -8,7 +8,6 @@ from typing_extensions import deprecated
 
 from semantic_kernel.const import DEFAULT_FULLY_QUALIFIED_NAME_SEPARATOR
 from semantic_kernel.contents.const import FUNCTION_RESULT_CONTENT_TAG, TEXT_CONTENT_TAG, ContentTypes
-from semantic_kernel.contents.image_content import ImageContent
 from semantic_kernel.contents.kernel_content import KernelContent
 from semantic_kernel.contents.text_content import TextContent
 from semantic_kernel.contents.utils.author_role import AuthorRole
@@ -138,12 +137,6 @@ class FunctionResultContent(KernelContent):
         if isinstance(result, TextContent):
             res = result.text
         elif isinstance(result, ChatMessageContent):
-            if isinstance(result.items[0], TextContent):
-                res = result.items[0].text
-            elif isinstance(result.items[0], ImageContent):
-                res = result.items[0].data_uri
-            elif isinstance(result.items[0], FunctionResultContent):
-                res = result.items[0].result
             res = str(result)
         else:
             res = result

--- a/python/tests/unit/contents/test_function_result_content.py
+++ b/python/tests/unit/contents/test_function_result_content.py
@@ -116,6 +116,16 @@ def test_from_fcc_and_result(result: any):
     assert frc.metadata == {"test": "test", "test2": "test2"}
 
 
+def test_from_fcc_and_empty_chat_message_result():
+    fcc = FunctionCallContent(id="test", name="test-function")
+    result = ChatMessageContent(role="assistant")
+
+    frc = FunctionResultContent.from_function_call_content_and_result(fcc, result)
+
+    assert frc.result == ""
+    assert frc.inner_content is result
+
+
 def test_to_cmc():
     frc = FunctionResultContent(id="test", name="test-function", result="test-result")
     cmc = frc.to_chat_message_content()


### PR DESCRIPTION
### Motivation and Context

`FunctionResultContent.from_function_call_content_and_result()` raises `IndexError` when a tool returns a valid empty `ChatMessageContent`, because it reads `result.items[0]` before converting the message to text.

This is distinct from #14359 / #14364, which handle an empty string passed through `ChatHistory.add_tool_message()`; that change does not affect this factory path.

### Description

Remove the item inspection from the `ChatMessageContent` branch. Those extracted values were immediately overwritten by `str(result)`, so non-empty behavior is unchanged while an empty message now becomes an empty function result. A focused regression covers the empty result and retained `inner_content`.

### Validation

- `uv run pytest -q tests/unit/contents/test_function_result_content.py --maxfail=1`
- `uv run pytest -q tests/unit/contents/test_chat_history.py tests/unit/kernel/test_kernel.py --maxfail=1`
- `uv run pytest -q tests/unit/contents --maxfail=1`
- `uv run pre-commit run --files semantic_kernel/contents/function_result_content.py tests/unit/contents/test_function_result_content.py`
- `git diff --check`

The complete Python unit suite was attempted but could not collect because the optional `autogen` extra is not installed; all relevant and package-level contents tests passed.

This is backward compatible and changes no public API.

