### PR TITLE
Python: Fix broken links and anchors in sample READMEs

### DIFF
--- a/python/samples/concepts/README.md
+++ b/python/samples/concepts/README.md
@@ -225,9 +225,8 @@
 - [Simple Chatbot](./reasoning/simple_reasoning.py)
 - [Simple Function Calling](./reasoning/simple_reasoning_function_calling.py)
 
-### Search - Using [`Search`](https://github.com/microsoft/semantic-kernel/tree/main/python/semantic_kernel/connectors/search) services information
+### Search - Using [`Search`](https://github.com/microsoft/semantic-kernel/blob/main/python/semantic_kernel/connectors/search.py) services information
 
-- [Bing Text Search as Plugin](./search/bing_text_search_as_plugin.py)
 - [Brave Text Search as Plugin](./search/brave_text_search_as_plugin.py)
 - [Google Text Search as Plugin](./search/google_text_search_as_plugin.py)
 

--- a/python/samples/getting_started/CONFIGURING_THE_KERNEL.md
+++ b/python/samples/getting_started/CONFIGURING_THE_KERNEL.md
@@ -64,4 +64,4 @@ chat_completion = AzureChatCompletion(service_id="test", env_file_path=env_file_
 
 ### 4. Microsoft Entra Authentication
 
-To learn how to use a Microsoft Entra Authentication token to authenticate to your Azure OpenAI resource, please navigate to the following [guide](../concepts/README.md#microsoft-entra-token-authentication).
+To learn how to use a Microsoft Entra Authentication token to authenticate to your Azure OpenAI resource, please navigate to the following [guide](../concepts/README.md#azure-authentication).

--- a/python/samples/getting_started_with_agents/README.md
+++ b/python/samples/getting_started_with_agents/README.md
@@ -79,14 +79,14 @@ Example|Description
 Example|Description
 ---|---
 [step1_concurrent](../getting_started_with_agents/multi_agent_orchestration/step1_concurrent.py)|How to run agents in parallel on the same task.
-[step1a_concurrent_structure_output](../getting_started_with_agents/multi_agent_orchestration/step1a_concurrent_structure_output.py)|How to run agents in parallel on the same task and return structured output.
+[step1a_concurrent_structured_outputs](../getting_started_with_agents/multi_agent_orchestration/step1a_concurrent_structured_outputs.py)|How to run agents in parallel on the same task and return structured output.
 [step2_sequential](../getting_started_with_agents/multi_agent_orchestration/step2_sequential.py)|How to run agents in sequence to complete a task.
 [step2a_sequential_cancellation_token](../getting_started_with_agents/multi_agent_orchestration/step2a_sequential_cancellation_token.py)|How to cancel an invocation while it is in progress.
 [step3_group_chat](../getting_started_with_agents/multi_agent_orchestration/step3_group_chat.py)|How to run agents in a group chat to complete a task.
 [step3a_group_chat_human_in_the_loop](../getting_started_with_agents/multi_agent_orchestration/step3a_group_chat_human_in_the_loop.py)|How to run agents in a group chat with human in the loop.
 [step3b_group_chat_with_chat_completion_manager](../getting_started_with_agents/multi_agent_orchestration/step3b_group_chat_with_chat_completion_manager.py)|How to run agents in a group chat with a more dynamic manager.
 [step4_handoff](../getting_started_with_agents/multi_agent_orchestration/step4_handoff.py)|How to run agents in a handoff orchestration to complete a task.
-[step4a_handoff_structure_input](../getting_started_with_agents/multi_agent_orchestration/step4a_handoff_structure_input.py)|How to run agents in a handoff orchestration to complete a task with structured input.
+[step4a_handoff_structured_inputs](../getting_started_with_agents/multi_agent_orchestration/step4a_handoff_structured_inputs.py)|How to run agents in a handoff orchestration to complete a task with structured input.
 [step5_magentic](../getting_started_with_agents/multi_agent_orchestration/step5_magentic.py)|How to run agents in a Magentic orchestration to complete a task.
 
 ## Configuring the Kernel

--- a/python/samples/getting_started_with_agents/azure_ai_agent/README.md
+++ b/python/samples/getting_started_with_agents/azure_ai_agent/README.md
@@ -94,7 +94,7 @@ Now, you can create a thread, add chat messages to the agent, and invoke it with
 
 In certain scenarios, you may prefer to reuse an existing agent definition rather than creating a new one. This can be done by calling `await client.agents.get_agent(...)` instead of `await client.agents.create_agent(...)`. 
 
-For a practical example, refer to the [`step7_azure_ai_agent_retrieval`](./step7_azure_ai_agent_retrieval.py) sample.
+For a practical example, refer to the [`step07_azure_ai_agent_retrieval`](./step07_azure_ai_agent_retrieval.py) sample.
 
 ## Requests and Rate Limits
 

--- a/python/samples/getting_started_with_agents/multi_agent_orchestration/README.md
+++ b/python/samples/getting_started_with_agents/multi_agent_orchestration/README.md
@@ -8,7 +8,7 @@ The following samples are beneficial if you are just getting started with Semant
 
 - [Chat Completion](../../concepts/chat_completion/)
 - [Auto Function Calling](../../concepts/auto_function_calling/)
-- [Structured Output](../../concepts/structured_output/)
+- [Structured Output](../../concepts/structured_outputs/)
 - [Getting Started with Agents](../../getting_started_with_agents/)
 - [More advanced agent samples](../../concepts/agents/)
 


### PR DESCRIPTION
Fixes six broken relative links/anchors across the python sample READMEs (each verified against `git ls-files` / actual headings; `python/samples` is excluded from linkspector, which is why CI never caught them):

- `getting_started_with_agents/README.md`: `step1a_concurrent_structure_output.py` → `step1a_concurrent_structured_outputs.py`, `step4a_handoff_structure_input.py` → `step4a_handoff_structured_inputs.py`
- `getting_started_with_agents/azure_ai_agent/README.md`: `./step7_azure_ai_agent_retrieval.py` → `./step07_azure_ai_agent_retrieval.py`
- `getting_started_with_agents/multi_agent_orchestration/README.md`: `../../concepts/structured_output/` → `structured_outputs/`
- `concepts/README.md`: dropped the Bing bullet (`search/bing_text_search_as_plugin.py` no longer exists) and repointed the Search heading from the removed `connectors/search` tree to `connectors/search.py`
- `getting_started/CONFIGURING_THE_KERNEL.md`: anchor `#microsoft-entra-token-authentication` → `#azure-authentication` (actual heading)

Contribution checklist:
- [x] The code builds clean locally
- [x] CLU-specific checks (docs-only change)
