### PR TITLE
Python: Align docstrings with actual signatures

### DIFF
--- a/python/semantic_kernel/agents/bedrock/bedrock_agent.py
+++ b/python/semantic_kernel/agents/bedrock/bedrock_agent.py
@@ -698,7 +698,6 @@ class BedrockAgent(BedrockAgentBase):
         """Create a ChatHistoryChannel.
 
         Args:
-            chat_history: The chat history for the channel. If None, a new ChatHistory instance will be created.
             thread_id: The ID of the thread. If None, a new thread will be created.
 
         Returns:

--- a/python/semantic_kernel/agents/orchestration/group_chat.py
+++ b/python/semantic_kernel/agents/orchestration/group_chat.py
@@ -201,7 +201,6 @@ class GroupChatManager(KernelBaseModel, ABC):
 
         Args:
             chat_history (ChatHistory): The chat history of the group chat.
-            participant_descriptions (dict[str, str]): The descriptions of the participants in the group chat.
         """
         ...
 

--- a/python/semantic_kernel/connectors/ai/open_ai/exceptions/content_filter_ai_exception.py
+++ b/python/semantic_kernel/connectors/ai/open_ai/exceptions/content_filter_ai_exception.py
@@ -31,7 +31,6 @@ class ContentFilterResult:
         """Creates a ContentFilterResult from the inner error results.
 
         Args:
-            key (str): The key to get the inner error result from.
             inner_error_results (Dict[str, Any]): The inner error results.
 
         Returns:

--- a/python/semantic_kernel/contents/chat_message_content.py
+++ b/python/semantic_kernel/contents/chat_message_content.py
@@ -235,9 +235,6 @@ class ChatMessageContent(KernelContent):
     def to_element(self) -> "Element":
         """Convert the ChatMessageContent to an XML Element.
 
-        Args:
-            root_key: str - The key to use for the root of the XML Element.
-
         Returns:
             Element - The XML Element representing the ChatMessageContent.
         """

--- a/python/semantic_kernel/contents/streaming_chat_message_content.py
+++ b/python/semantic_kernel/contents/streaming_chat_message_content.py
@@ -208,9 +208,6 @@ class StreamingChatMessageContent(ChatMessageContent, StreamingContentMixin):
     def to_element(self) -> "Element":
         """Convert the StreamingChatMessageContent to an XML Element.
 
-        Args:
-            root_key: str - The key to use for the root of the XML Element.
-
         Returns:
             Element - The XML Element representing the StreamingChatMessageContent.
         """

--- a/python/semantic_kernel/data/vector.py
+++ b/python/semantic_kernel/data/vector.py
@@ -1335,7 +1335,7 @@ class VectorStoreCollection(VectorStoreRecordHandler[TKey, TModel], Generic[TKey
         """Get records based on the ordering and selection criteria.
 
         Args:
-            include_vectors: Include the vectors in the response. Default is True.
+            include_vectors: Include the vectors in the response. Default is False.
                 Some vector stores do not support retrieving without vectors, even when set to false.
                 Some vector stores have specific parameters to control that behavior, when
                 that parameter is set, include_vectors is ignored.
@@ -1370,7 +1370,7 @@ class VectorStoreCollection(VectorStoreRecordHandler[TKey, TModel], Generic[TKey
 
         Args:
             key: The key to get.
-            include_vectors: Include the vectors in the response. Default is True.
+            include_vectors: Include the vectors in the response. Default is False.
                 Some vector stores do not support retrieving without vectors, even when set to false.
                 Some vector stores have specific parameters to control that behavior, when
                 that parameter is set, include_vectors is ignored.
@@ -1396,7 +1396,7 @@ class VectorStoreCollection(VectorStoreRecordHandler[TKey, TModel], Generic[TKey
 
         Args:
             keys: The keys to get, if keys are provided, key is ignored.
-            include_vectors: Include the vectors in the response. Default is True.
+            include_vectors: Include the vectors in the response. Default is False.
                 Some vector stores do not support retrieving without vectors, even when set to false.
                 Some vector stores have specific parameters to control that behavior, when
                 that parameter is set, include_vectors is ignored.
@@ -1423,7 +1423,7 @@ class VectorStoreCollection(VectorStoreRecordHandler[TKey, TModel], Generic[TKey
         Args:
             key: The key to get.
             keys: The keys to get, if keys are provided, key is ignored.
-            include_vectors: Include the vectors in the response. Default is True.
+            include_vectors: Include the vectors in the response. Default is False.
                 Some vector stores do not support retrieving without vectors, even when set to false.
                 Some vector stores have specific parameters to control that behavior, when
                 that parameter is set, include_vectors is ignored.

--- a/python/semantic_kernel/kernel.py
+++ b/python/semantic_kernel/kernel.py
@@ -596,7 +596,6 @@ class Kernel(KernelFilterExtension, KernelFunctionExtension, KernelServicesExten
         These need to be set to the function name, without the plugin_name.
 
         Args:
-            kernel: The kernel instance to use.
             prompts: A list of prompt templates to expose as prompts.
             server_name: The name of the server.
             version: The version of the server.

--- a/python/semantic_kernel/memory/semantic_text_memory_base.py
+++ b/python/semantic_kernel/memory/semantic_text_memory_base.py
@@ -99,7 +99,6 @@ class SemanticTextMemoryBase(KernelBaseModel):
             query (str): The query to search for.
             limit (int): The maximum number of results to return. (default: {1})
             min_relevance_score (float): The minimum relevance score to return. (default: {0.7})
-            with_embeddings (bool): Whether to return the embeddings of the results. (default: {False})
 
         Returns:
             List[MemoryQueryResult]: The list of MemoryQueryResult found.

--- a/python/semantic_kernel/memory/semantic_text_memory_base.py
+++ b/python/semantic_kernel/memory/semantic_text_memory_base.py
@@ -98,7 +98,7 @@ class SemanticTextMemoryBase(KernelBaseModel):
             collection (str): The collection to search in.
             query (str): The query to search for.
             limit (int): The maximum number of results to return. (default: {1})
-            min_relevance_score (float): The minimum relevance score to return. (default: {0.0})
+            min_relevance_score (float): The minimum relevance score to return. (default: {0.7})
             with_embeddings (bool): Whether to return the embeddings of the results. (default: {False})
 
         Returns:


### PR DESCRIPTION
Docstring-only fix: removes documented parameters that don't exist in the actual signatures and corrects two wrong documented defaults. Each item verified against the signature directly above it:

- `data/vector.py`: four `include_vectors` Args entries said "Default is True" while every signature declares `include_vectors: bool = False` (the sibling docstring already said False)
- `orchestration/group_chat.py`: `filter_results` documented `participant_descriptions`, which it does not take (its sibling `select_next_speaker` legitimately does — untouched)
- `kernel.py`: `as_mcp_server` documented a `kernel` parameter it does not take
- `memory/semantic_text_memory_base.py`: `min_relevance_score` documented default `{0.0}`, actual default is `0.7`
- `contents/chat_message_content.py` + `contents/streaming_chat_message_content.py`: `to_element()` documented a `root_key` argument it does not take
- `agents/bedrock/bedrock_agent.py`: `create_channel` documented `chat_history`, which it does not take
- `connectors/ai/open_ai/exceptions/content_filter_ai_exception.py`: `from_inner_error_result` documented a `key` parameter it does not take

One deliberate non-change, for the record: the identical if/else arms in the `response_format` validators (`open_ai_prompt_execution_settings.py`, `azure_ai_inference_prompt_execution_settings.py`) look like a bug but are not — the non-BaseModel `type` path is a supported input consumed by `_handle_structured_output` Case 2 (schema built from the bare type), so both arms intentionally set `structured_json_response = True`.

Contribution checklist:
- [x] The code builds clean locally
- [x] All unit tests pass (docstring-only change)
