### PR TITLE
Python: Clarify remote MCP setup in sample guide

### DIFF
--- a/python/samples/concepts/mcp/README.md
+++ b/python/samples/concepts/mcp/README.md
@@ -16,7 +16,7 @@ The samples support Stdio, SSE, and Streamable HTTP transports. A Stdio server r
 
 Some other common runners are [uvx](https://docs.astral.sh/uv/guides/tools/), for python servers and [docker](https://www.docker.com/), for containerized servers.
 
-The code shown works the same for a Sse server, only then a MCPSsePlugin needs to be used instead of the MCPStdioPlugin. For Streamable HTTP server, MCPStreamableHttpPlugin can be used.
+The code shown works the same for an SSE server, only then a MCPSsePlugin needs to be used instead of the MCPStdioPlugin. For Streamable HTTP server, MCPStreamableHttpPlugin can be used.
 
 The reverse, using Semantic Kernel as a server, can be found in the [demos/mcp_server](../../demos/mcp_server/) folder.
 
@@ -34,10 +34,10 @@ async with MCPStreamableHttpPlugin(
     name="ParallelSearch",
     url="https://search.parallel.ai/mcp",
     load_prompts=False,
-) as plugin:
+) as mcp_plugin:
     kernel = Kernel()
-    functions = kernel.add_plugin(plugin)
-    print(sorted(functions.functions))
+    plugin = kernel.add_plugin(mcp_plugin)
+    print(sorted(plugin.functions))
 ```
 
 This discovers the server's tools. To let an agent use them, pass `plugins=[plugin]` to the agent and invoke it inside the context manager, as in [the HTTP sample](agent_with_http_mcp_plugin.py). That sample's Azure configuration is still required when using its agent. Omit the plugin from the agent to disable access.

--- a/python/samples/concepts/mcp/README.md
+++ b/python/samples/concepts/mcp/README.md
@@ -12,13 +12,37 @@ Those can then be used with function calling in a chat or agent.
 
 ## Server types
 
-There are two types of servers, Stdio and Sse based. The sample shows how to use the Stdio based server, which get's run locally, in this case by using [npx](https://docs.npmjs.com/cli/v8/commands/npx).
+The samples support Stdio, SSE, and Streamable HTTP transports. A Stdio server runs locally, for example by using [npx](https://docs.npmjs.com/cli/v8/commands/npx).
 
 Some other common runners are [uvx](https://docs.astral.sh/uv/guides/tools/), for python servers and [docker](https://www.docker.com/), for containerized servers.
 
 The code shown works the same for a Sse server, only then a MCPSsePlugin needs to be used instead of the MCPStdioPlugin. For Streamable HTTP server, MCPStreamableHttpPlugin can be used.
 
 The reverse, using Semantic Kernel as a server, can be found in the [demos/mcp_server](../../demos/mcp_server/) folder.
+
+### Connecting to a remote Streamable HTTP server
+
+`MCPStreamableHttpPlugin` connects directly to a hosted server without a local server process. For example, [Parallel Search MCP](https://docs.parallel.ai/integrations/mcp/search-mcp) provides `web_search` and `web_fetch` without a Parallel account or API key. Anonymous access is rate limited.
+
+After installing Semantic Kernel as described below, use this inside an async function:
+
+```python
+from semantic_kernel import Kernel
+from semantic_kernel.connectors.mcp import MCPStreamableHttpPlugin
+
+async with MCPStreamableHttpPlugin(
+    name="ParallelSearch",
+    url="https://search.parallel.ai/mcp",
+    load_prompts=False,
+) as plugin:
+    kernel = Kernel()
+    functions = kernel.add_plugin(plugin)
+    print(sorted(functions.functions))
+```
+
+This discovers the server's tools. To let an agent use them, pass `plugins=[plugin]` to the agent and invoke it inside the context manager, as in [the HTTP sample](agent_with_http_mcp_plugin.py). That sample's Azure configuration is still required when using its agent. Omit the plugin from the agent to disable access.
+
+An agent with these tools may call them during its work. Search queries, requested URLs, and any supplied objectives or context are sent to Parallel when tools run.
 
 ## Running the samples
 


### PR DESCRIPTION
### Motivation and Context

The MCP sample guide names `MCPStreamableHttpPlugin` but does not show how to connect to a hosted server without starting a local process. This adds a short usage example with Parallel Search MCP using the existing client API.

SK doesn't enable a search provider automatically: the [Kernel starts with no plugins](https://github.com/microsoft/semantic-kernel/blob/f8c5ba7aec210c986086a997fc4eef65190666eb/python/semantic_kernel/functions/kernel_function_extension.py#L45-L57), and apps [register web-search connectors explicitly](https://github.com/microsoft/semantic-kernel/blob/f8c5ba7aec210c986086a997fc4eef65190666eb/dotnet/src/Plugins/Plugins.Web/WebServiceCollectionExtensions.cs). Of the existing Bing, Google, Brave, and Tavily connectors, Brave and Tavily appear on Artificial Analysis's leaderboard. These are API connectors, not bundled search MCP servers.

The scores are a good reason to make Parallel easier to try. In [Artificial Analysis's Search API benchmark](https://artificialanalysis.ai/agents/search-api), checked September 4, Parallel advanced scores **74.8 overall**, compared with **65.6 for Tavily basic** and **64.6 for Brave web**. The biggest gaps are in specific tasks: **80.6 vs. 62.3** on DeepSearchQA F1 against Brave web, and **76.5% vs. 58.5%** on BrowseComp accuracy against Tavily basic. Enable the Brave web and Tavily basic rows in the leaderboard to see those comparisons.

Brave web matches [the endpoint used here](https://github.com/microsoft/semantic-kernel/blob/f8c5ba7aec210c986086a997fc4eef65190666eb/dotnet/src/Plugins/Plugins.Web/Brave/BraveTextSearch.cs#L427); AA does not report Tavily advanced. These are [API results in AA's own search-agent harness](https://artificialanalysis.ai/methodology/search-api), not a benchmark of this free MCP connection or SK agents. They support trying the integration, without promising the same scores here.

### Description

The README shows anonymous connection and tool registration, links to the existing HTTP agent sample, and explains that agent credentials are separate from Parallel access. It also corrects the transport list to include Streamable HTTP.

The example exposes `web_search` and `web_fetch`. When tools run, queries, requested URLs, and supplied context go to Parallel. Anonymous access is rate limited. Existing samples and runtime behavior are unchanged.

I work at Parallel, which operates this service.

Validation: ran the exact README snippet with Semantic Kernel 1.44.1 and MCP 1.29.1, then invoked both tools through `Kernel.invoke` without Parallel credentials. Search returned 10 results and fetch returned one page. Tool discovery, registration, and context cleanup passed. The relevant installed MCP and Kernel source files match the inspected repository revision. Snippet syntax, public/relative links, and `git diff --check` also pass.

The repository was not built and the full test suite was not run. Runtime dependencies used prebuilt wheels except `pybars4` and `PyMeta3`, whose published pure-Python sources were loaded directly without running their setup scripts. A wheels-only installation could not resolve those dependencies.

### Contribution Checklist

- [ ] The code builds clean without any errors or warnings
- [ ] The PR follows the [SK Contribution Guidelines](https://github.com/microsoft/semantic-kernel/blob/main/CONTRIBUTING.md) and the [pre-submission formatting script](https://github.com/microsoft/semantic-kernel/blob/main/CONTRIBUTING.md#development-scripts) raises no violations
- [ ] All unit tests pass, and I have added new tests where possible
- [ ] I didn't break anyone :smile:

This is a README-only clarification of existing APIs under the trivial-change exception. Broad build/test checklist items remain unchecked because they were not run.
