### PR TITLE
fix(python): return local timezone info from TimePlugin timeZoneOffset/timeZoneName

### DIFF
--- a/python/semantic_kernel/core_plugins/time_plugin.py
+++ b/python/semantic_kernel/core_plugins/time_plugin.py
@@ -226,9 +226,13 @@ class TimePlugin(KernelBaseModel):
         """Get the current time zone offset.
 
         Example:
-            {{time.timeZoneOffset}} => -08:00
+            {{time.timeZoneOffset}} => -0800
         """
         now = datetime.datetime.now()
+        if now.tzinfo is None:
+            # astimezone() attaches the local timezone to a naive datetime;
+            # on a naive datetime strftime("%z") returns an empty string.
+            now = now.astimezone()
         return now.strftime("%z")
 
     @kernel_function(description="Get the current time zone name", name="timeZoneName")
@@ -239,4 +243,6 @@ class TimePlugin(KernelBaseModel):
             {{time.timeZoneName}} => PST
         """
         now = datetime.datetime.now()
+        if now.tzinfo is None:
+            now = now.astimezone()
         return now.strftime("%Z")

--- a/python/tests/unit/core_plugins/test_time_plugin.py
+++ b/python/tests/unit/core_plugins/test_time_plugin.py
@@ -178,9 +178,39 @@ def test_time_zone_offset():
         assert plugin.time_zone_offset() == "+0000"
 
 
+def test_time_zone_offset_naive_now_is_not_empty():
+    """strftime('%z') on a naive datetime returns '' (Python docs); the plugin
+    must attach the local timezone instead of returning an empty string."""
+    plugin = TimePlugin()
+    naive_now = datetime.datetime(2031, 1, 12, 12, 24, 56)
+
+    with mock.patch("datetime.datetime", wraps=datetime.datetime) as dt:
+        dt.now.return_value = naive_now
+        offset = plugin.time_zone_offset()
+
+    # The expected value cancels out the machine's local timezone because
+    # both sides run astimezone() on the same naive datetime.
+    assert offset == naive_now.astimezone().strftime("%z")
+    assert offset != ""
+
+
 def test_time_zone_name():
     plugin = TimePlugin()
 
     with mock.patch("datetime.datetime", wraps=datetime.datetime) as dt:
         dt.now.return_value = test_mock_now
         assert plugin.time_zone_name() == "UTC"
+
+
+def test_time_zone_name_naive_now_is_not_empty():
+    """strftime('%Z') on a naive datetime returns '' (Python docs); the plugin
+    must attach the local timezone instead of returning an empty string."""
+    plugin = TimePlugin()
+    naive_now = datetime.datetime(2031, 1, 12, 12, 24, 56)
+
+    with mock.patch("datetime.datetime", wraps=datetime.datetime) as dt:
+        dt.now.return_value = naive_now
+        name = plugin.time_zone_name()
+
+    assert name == naive_now.astimezone().strftime("%Z")
+    assert name != ""


### PR DESCRIPTION
## Problem

`TimePlugin.time_zone_offset()` and `time_zone_name()` call `strftime("%z")`/`strftime("%Z")` on `datetime.datetime.now()`, which returns a **naive** datetime. Per the Python docs, `%z` and `%Z` format to an **empty string** on naive datetimes, so both kernel functions always return `""`:

```python
>>> import datetime
>>> datetime.datetime.now().strftime("%z")
''
```

## Fix

Attach the local timezone via `astimezone()` when the datetime is naive; aware datetimes are rendered as-is (the existing aware-mock tests keep passing unchanged). Also corrects the method docstring example from `-08:00` to `-0800` to match the actual `%z` output format (the class-level docstring already used `-0800`).

## Testing

- Two new regression tests mock a **naive** `now()` and assert the rendered offset/name is non-empty and equals the `astimezone()` reference. Expected values are computed through the same reference, so they hold on any machine and timezone. Both tests fail on the unfixed code.
- Full `pytest tests/unit/core_plugins/` passes; `ruff check` / `ruff format --check` clean.

## Notes

`%Z` renders the OS-localized timezone name (standard `strftime` behavior); the function contract ("current time zone name") is unchanged.
