### PR TITLE
Python: map Anthropic stop_sequence finish reason and fall back safely for unknown stop reasons

### DIFF
--- a/python/semantic_kernel/connectors/ai/anthropic/services/anthropic_chat_completion.py
+++ b/python/semantic_kernel/connectors/ai/anthropic/services/anthropic_chat_completion.py
@@ -62,6 +62,7 @@ if TYPE_CHECKING:
 ANTHROPIC_TO_SEMANTIC_KERNEL_FINISH_REASON_MAP = {
     "end_turn": SemanticKernelFinishReason.STOP,
     "max_tokens": SemanticKernelFinishReason.LENGTH,
+    "stop_sequence": SemanticKernelFinishReason.STOP,
     "tool_use": SemanticKernelFinishReason.TOOL_CALLS,
 }
 
@@ -270,7 +271,7 @@ class AnthropicChatCompletion(ChatCompletionClientBase):
 
         finish_reason = None
         if response.stop_reason:
-            finish_reason = ANTHROPIC_TO_SEMANTIC_KERNEL_FINISH_REASON_MAP[response.stop_reason]
+            finish_reason = ANTHROPIC_TO_SEMANTIC_KERNEL_FINISH_REASON_MAP.get(response.stop_reason)
 
         return ChatMessageContent(
             inner_content=response,
@@ -308,7 +309,7 @@ class AnthropicChatCompletion(ChatCompletionClientBase):
                 )
             )
         elif isinstance(stream_event, RawMessageDeltaEvent):
-            finish_reason = ANTHROPIC_TO_SEMANTIC_KERNEL_FINISH_REASON_MAP[str(stream_event.delta.stop_reason)]
+            finish_reason = ANTHROPIC_TO_SEMANTIC_KERNEL_FINISH_REASON_MAP.get(str(stream_event.delta.stop_reason))
             output_tokens = stream_event.usage.output_tokens
             if metadata is None:
                 metadata = {"usage": {"output_tokens": output_tokens}}

--- a/python/tests/unit/connectors/ai/anthropic/services/test_anthropic_chat_completion.py
+++ b/python/tests/unit/connectors/ai/anthropic/services/test_anthropic_chat_completion.py
@@ -3,7 +3,8 @@ from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
 from anthropic import AsyncAnthropic
-from anthropic.types import Message
+from anthropic.types import Message, MessageDeltaUsage, RawMessageDeltaEvent, RawMessageStartEvent, TextBlock, Usage
+from anthropic.types.raw_message_delta_event import Delta
 
 from semantic_kernel.connectors.ai.anthropic.prompt_execution_settings.anthropic_prompt_execution_settings import (
     AnthropicChatPromptExecutionSettings,
@@ -18,6 +19,7 @@ from semantic_kernel.contents.chat_history import ChatHistory
 from semantic_kernel.contents.chat_message_content import ChatMessageContent, FunctionCallContent, TextContent
 from semantic_kernel.contents.streaming_chat_message_content import StreamingChatMessageContent
 from semantic_kernel.contents.utils.author_role import AuthorRole
+from semantic_kernel.contents.utils.finish_reason import FinishReason
 from semantic_kernel.exceptions import (
     ServiceInitializationError,
     ServiceInvalidExecutionSettingsError,
@@ -547,3 +549,110 @@ def test_chat_completion_reset_settings(
 
     assert settings.tools is None
     assert settings.tool_choice is None
+
+
+@pytest.mark.parametrize(
+    "stop_reason,expected_finish_reason",
+    [
+        pytest.param("end_turn", FinishReason.STOP, id="end_turn"),
+        pytest.param("max_tokens", FinishReason.LENGTH, id="max_tokens"),
+        pytest.param("tool_use", FinishReason.TOOL_CALLS, id="tool_use"),
+        pytest.param("stop_sequence", FinishReason.STOP, id="stop_sequence"),
+        pytest.param("refusal", None, id="unknown_stop_reason_returns_none"),
+    ],
+)
+async def test_finish_reason_from_stop_reason(
+    kernel: Kernel,
+    mock_settings: AnthropicChatPromptExecutionSettings,
+    stop_reason: str,
+    expected_finish_reason: FinishReason | None,
+):
+    response = Message(
+        id="test_message_id",
+        content=[TextBlock(text="test", type="text")],
+        model="test_model_id",
+        role="assistant",
+        stop_reason=stop_reason,
+        stop_sequence=None,
+        type="message",
+        usage=Usage(input_tokens=10, output_tokens=10),
+    )
+    client = MagicMock(spec=AsyncAnthropic)
+    messages_mock = MagicMock()
+    messages_mock.create = AsyncMock(return_value=response)
+    client.messages = messages_mock
+
+    chat_history = ChatHistory()
+    chat_history.add_user_message("test_user_message")
+
+    chat_completion_base = AnthropicChatCompletion(
+        ai_model_id="test_model_id", service_id="test", api_key="", async_client=client
+    )
+    contents: list[ChatMessageContent] = await chat_completion_base.get_chat_message_contents(
+        chat_history=chat_history, settings=mock_settings, kernel=kernel, arguments=KernelArguments()
+    )
+
+    assert contents[0].finish_reason is expected_finish_reason
+
+
+@pytest.mark.parametrize(
+    "stop_reason,expected_finish_reason",
+    [
+        pytest.param("stop_sequence", FinishReason.STOP, id="stop_sequence"),
+        pytest.param("refusal", None, id="unknown_stop_reason_returns_none"),
+    ],
+)
+async def test_finish_reason_from_stop_reason_stream(
+    kernel: Kernel,
+    mock_settings: AnthropicChatPromptExecutionSettings,
+    stop_reason: str,
+    expected_finish_reason: FinishReason | None,
+):
+    stream_events = [
+        RawMessageStartEvent(
+            message=Message(
+                id="test_message_id",
+                content=[],
+                model="test_model_id",
+                role="assistant",
+                stop_reason=None,
+                stop_sequence=None,
+                type="message",
+                usage=Usage(input_tokens=10, output_tokens=2),
+            ),
+            type="message_start",
+        ),
+        RawMessageDeltaEvent(
+            delta=Delta(stop_reason=stop_reason, stop_sequence=None),
+            type="message_delta",
+            usage=MessageDeltaUsage(output_tokens=10),
+        ),
+    ]
+
+    async def async_generator():
+        for event in stream_events:
+            yield event
+
+    stream_mock = AsyncMock()
+    stream_mock.__aenter__.return_value = async_generator()
+
+    client = MagicMock(spec=AsyncAnthropic)
+    messages_mock = MagicMock()
+    messages_mock.stream.return_value = stream_mock
+    client.messages = messages_mock
+
+    chat_history = ChatHistory()
+    chat_history.add_user_message("test_user_message")
+
+    chat_completion_base = AnthropicChatCompletion(
+        ai_model_id="test_model_id", service_id="test", api_key="", async_client=client
+    )
+
+    last_content: StreamingChatMessageContent | None = None
+    async for content in chat_completion_base.get_streaming_chat_message_contents(
+        chat_history, mock_settings, kernel=kernel, arguments=KernelArguments()
+    ):
+        last_content = content[0]
+
+    assert last_content is not None
+    assert last_content.finish_reason is expected_finish_reason


### PR DESCRIPTION
### Motivation and Context

The Anthropic connector translates Anthropic `stop_reason` values into Semantic Kernel `FinishReason` via `ANTHROPIC_TO_SEMANTIC_KERNEL_FINISH_REASON_MAP`, but the map is missing `"stop_sequence"` and both lookup sites index into it directly:

- Non-streaming: `finish_reason = ANTHROPIC_TO_SEMANTIC_KERNEL_FINISH_REASON_MAP[response.stop_reason]`
- Streaming: on every `RawMessageDeltaEvent`, `finish_reason = ANTHROPIC_TO_SEMANTIC_KERNEL_FINISH_REASON_MAP[str(stream_event.delta.stop_reason)]`

`AnthropicChatPromptExecutionSettings` supports `stop_sequences`. When a request sets them and Anthropic ends the turn because a stop sequence was hit (`stop_reason="stop_sequence"`), the non-streaming path raises `KeyError`, and the streaming path raises `KeyError` on the final delta event.

The Bedrock connector already handles unknown stop reasons defensively (`finish_reason_from_bedrock_to_semantic_kernel` uses `.get()`), so this aligns the Anthropic connector with that existing pattern.

### Description

- Add `"stop_sequence": SemanticKernelFinishReason.STOP` to `ANTHROPIC_TO_SEMANTIC_KERNEL_FINISH_REASON_MAP` (consistent with OpenAI semantics, where hitting a stop sequence reports finish reason `stop`).
- Switch both lookup sites to `.get(...)`, so unknown or future stop reasons degrade to `finish_reason=None` instead of raising `KeyError`.

### Verification

- Before: `ANTHROPIC_TO_SEMANTIC_KERNEL_FINISH_REASON_MAP["stop_sequence"]` raises `KeyError`.
- After: `"stop_sequence"` maps to `FinishReason.STOP`; `MAP.get("refusal")` / `MAP.get("pause_turn")` return `None`; the existing `end_turn` / `max_tokens` / `tool_use` mappings are unchanged.
- `pytest tests/unit/connectors/ai/anthropic` — 35 passed (18 non-streaming chat completion + 9 request settings + 8 streaming).
- `ruff check` and `ruff format --check` pass on the changed file.
- No new tests added in this PR; the existing Anthropic chat completion suite exercises both changed lookup paths (non-streaming and streaming). Happy to add a regression test if preferred.

No linked issue — found while reviewing the connector code.

### Contribution Checklist

- [x] The code builds clean without any errors or warnings
- [x] The PR follows the [SK Contribution Guidelines](https://github.com/microsoft/semantic-kernel/blob/main/CONTRIBUTING.md) and the [pre-submission formatting script](https://github.com/microsoft/semantic-kernel/blob/main/CONTRIBUTING.md#development-scripts) raises no violations
- [x] All unit tests pass, and I have added new tests where possible
- [x] I didn't break anyone :smile:
