### PR TITLE
Keep DevFlow publishing diagnostics in private storage

### DIFF
--- a/.github/workflows/devflow-pr-review.yml
+++ b/.github/workflows/devflow-pr-review.yml
@@ -28,6 +28,7 @@ env:
   TARGET_REPO_PATH: ${{ github.workspace }}/target-repo
   DEVFLOW_PATH: ${{ github.workspace }}/devflow
   MODEL_CONFIG_PATH: ${{ github.workspace }}/devflow/config.ci.yaml
+  DEVFLOW_REVIEW_DIAGNOSTICS_DIR: ${{ github.workspace }}/devflow/data/review-publish-failures
 
 jobs:
   review:
@@ -138,3 +139,10 @@ jobs:
             --pr-url "$PR_URL" \
             --github-username "$GITHUB_ACTOR" \
             --no-require-comment-selection
+
+      - name: Archive review diagnostics privately
+        if: ${{ failure() && steps.review.outcome == 'failure' }}
+        working-directory: ${{ env.DEVFLOW_PATH }}
+        env:
+          DEVFLOW_TOKEN: ${{ secrets.DEVFLOW_TOKEN }}
+        run: uv run python scripts/archive_review_diagnostics.py


### PR DESCRIPTION
Keep DevFlow publishing diagnostics in the configured private destination. Provide a dedicated local diagnostics directory and run the private archive helper after an unsuccessful review step, with its token scoped to the archive step.

The helper must be available in the configured DevFlow main branch before this change is merged. Public output stays generic; detailed diagnostics are not uploaded as public workflow artifacts.

Validation: workflow YAML and environment/condition wiring checked; git diff --check passes. Private destination checks and upload behavior are covered by the helper's unit tests.
