### PR TITLE
.Net: Add Keenable web search connector

### DIFF
--- a/dotnet/samples/Concepts/Search/Keenable_TextSearch.cs
+++ b/dotnet/samples/Concepts/Search/Keenable_TextSearch.cs
@@ -152,12 +152,12 @@ public class Keenable_TextSearch(ITestOutputHelper output) : BaseTest(output)
             WriteHorizontalRule();
         }
 
-        // Example 2: Title.Contains appends terms to the query, combined with a publication date floor
-        Console.WriteLine("\n--- Example 2: Title Contains + Published After ---\n");
+        // Example 2: Compound AND filter, a site restriction combined with a publication date floor
+        Console.WriteLine("\n--- Example 2: Site + Published After ---\n");
         var compoundOptions = new TextSearchOptions<KeenableWebPage>
         {
             Top = 2,
-            Filter = page => page.Title != null && page.Title.Contains("Kernel") && page.PublishedAfter == "2025-01-01"
+            Filter = page => page.Site == "github.com" && page.PublishedAfter == "2025-01-01"
         };
         var compoundResults = await textSearch.GetSearchResultsAsync(query, compoundOptions);
         await foreach (KeenableWebPage page in compoundResults.Results)

--- a/dotnet/samples/Concepts/Search/Keenable_TextSearch.cs
+++ b/dotnet/samples/Concepts/Search/Keenable_TextSearch.cs
@@ -1,0 +1,201 @@
+﻿// Copyright (c) Microsoft. All rights reserved.
+
+using System.Text.Json;
+using Microsoft.SemanticKernel.Data;
+using Microsoft.SemanticKernel.Plugins.Web.Keenable;
+
+namespace Search;
+
+/// <summary>
+/// This example shows how to create and use a <see cref="KeenableTextSearch"/>.
+/// Keenable works without an API key: leave the "Keenable:ApiKey" setting unset and the public endpoint is used.
+/// A key lifts the per-IP rate limits of the public endpoint and is otherwise optional.
+/// </summary>
+public class Keenable_TextSearch(ITestOutputHelper output) : BaseTest(output)
+{
+#pragma warning disable CS0618 // Suppress obsolete warnings for legacy TextSearchOptions/TextSearchFilter usage
+    /// <summary>
+    /// Show how to create a <see cref="KeenableTextSearch"/> and use it to perform a text search.
+    /// </summary>
+    [Fact]
+    public async Task UsingKeenableTextSearch()
+    {
+        // Create a logging handler to output HTTP requests and responses
+        LoggingHandler handler = new(new HttpClientHandler(), this.Output);
+        using HttpClient httpClient = new(handler);
+
+        // Create an ITextSearch instance using Keenable search. The API key is optional.
+        var textSearch = new KeenableTextSearch(apiKey: GetApiKey(), options: new() { HttpClient = httpClient });
+
+        var query = "What is the Semantic Kernel?";
+
+        // Search and return results as a string items
+        KernelSearchResults<string> stringResults = await textSearch.SearchAsync(query, new() { Top = 4 });
+        Console.WriteLine("--- String Results ---\n");
+        await foreach (string result in stringResults.Results)
+        {
+            Console.WriteLine(result);
+            WriteHorizontalRule();
+        }
+
+        // Search and return results as TextSearchResult items
+        KernelSearchResults<TextSearchResult> textResults = await textSearch.GetTextSearchResultsAsync(query, new() { Top = 4 });
+        Console.WriteLine("\n--- Text Search Results ---\n");
+        await foreach (TextSearchResult result in textResults.Results)
+        {
+            Console.WriteLine($"Name:  {result.Name}");
+            Console.WriteLine($"Value: {result.Value}");
+            Console.WriteLine($"Link:  {result.Link}");
+            WriteHorizontalRule();
+        }
+
+        // Search and return results as KeenableSearchResult items
+        KernelSearchResults<object> fullResults = await textSearch.GetSearchResultsAsync(query, new() { Top = 4 });
+        Console.WriteLine("\n--- Keenable Search Results ---\n");
+        await foreach (KeenableSearchResult result in fullResults.Results)
+        {
+            Console.WriteLine($"Title:           {result.Title}");
+            Console.WriteLine($"Snippet:         {result.Snippet}");
+            Console.WriteLine($"Url:             {result.Url}");
+            Console.WriteLine($"PublishedAt:     {result.PublishedAt}");
+            WriteHorizontalRule();
+        }
+    }
+
+    /// <summary>
+    /// Show how to create a <see cref="KeenableTextSearch"/> with a shorter snippet length and a custom string mapper.
+    /// </summary>
+    [Fact]
+    public async Task UsingKeenableTextSearchWithACustomMapper()
+    {
+        // Create a logging handler to output HTTP requests and responses
+        LoggingHandler handler = new(new HttpClientHandler(), this.Output);
+        using HttpClient httpClient = new(handler);
+
+        // Create an ITextSearch instance using Keenable search
+        var textSearch = new KeenableTextSearch(apiKey: GetApiKey(), options: new()
+        {
+            HttpClient = httpClient,
+            SnippetMaxLength = 300,
+            StringMapper = new TestTextSearchStringMapper(),
+        });
+
+        var query = "What is the Semantic Kernel?";
+
+        // Search with TextSearchResult textResult type
+        KernelSearchResults<string> stringResults = await textSearch.SearchAsync(query, new() { Top = 2 });
+        Console.WriteLine("--- Serialized Results ---\n");
+        await foreach (string result in stringResults.Results)
+        {
+            Console.WriteLine(result);
+            WriteHorizontalRule();
+        }
+    }
+
+    /// <summary>
+    /// Show how to create a <see cref="KeenableTextSearch"/> and use it to perform a search restricted to a single site.
+    /// </summary>
+    [Fact]
+    public async Task UsingKeenableTextSearchWithASiteFilter()
+    {
+        // Create a logging handler to output HTTP requests and responses
+        LoggingHandler handler = new(new HttpClientHandler(), this.Output);
+        using HttpClient httpClient = new(handler);
+
+        // Create an ITextSearch instance using Keenable search
+        var textSearch = new KeenableTextSearch(apiKey: GetApiKey(), options: new() { HttpClient = httpClient });
+
+        var query = "What is the Semantic Kernel?";
+
+        // Search with a site filter and a publication date floor
+        TextSearchOptions searchOptions = new()
+        {
+            Top = 4,
+            Filter = new TextSearchFilter().Equality("site", "learn.microsoft.com").Equality("published_after", "2025-01-01")
+        };
+        KernelSearchResults<TextSearchResult> textResults = await textSearch.GetTextSearchResultsAsync(query, searchOptions);
+        Console.WriteLine("--- Microsoft Learn Results ---");
+        await foreach (TextSearchResult result in textResults.Results)
+        {
+            Console.WriteLine(result.Link);
+            WriteHorizontalRule();
+        }
+    }
+#pragma warning restore CS0618
+
+    /// <summary>
+    /// Show how to use LINQ filtering with KeenableTextSearch for type-safe searches.
+    /// </summary>
+    [Fact]
+    public async Task UsingKeenableTextSearchWithLinqFilteringAsync()
+    {
+        // Create a logging handler to output HTTP requests and responses
+        LoggingHandler handler = new(new HttpClientHandler(), this.Output);
+        using HttpClient httpClient = new(handler);
+
+        // Create an ITextSearch<KeenableWebPage> instance for type-safe LINQ filtering
+        ITextSearch<KeenableWebPage> textSearch = new KeenableTextSearch(apiKey: GetApiKey(), options: new() { HttpClient = httpClient });
+
+        var query = "Semantic Kernel AI";
+
+        // Example 1: Restrict results to a site
+        Console.WriteLine("--- Example 1: Site Filter ---\n");
+        var siteOptions = new TextSearchOptions<KeenableWebPage>
+        {
+            Top = 2,
+            Filter = page => page.Site == "learn.microsoft.com"
+        };
+        var siteResults = await textSearch.SearchAsync(query, siteOptions);
+        await foreach (string result in siteResults.Results)
+        {
+            Console.WriteLine(result);
+            WriteHorizontalRule();
+        }
+
+        // Example 2: Title.Contains appends terms to the query, combined with a publication date floor
+        Console.WriteLine("\n--- Example 2: Title Contains + Published After ---\n");
+        var compoundOptions = new TextSearchOptions<KeenableWebPage>
+        {
+            Top = 2,
+            Filter = page => page.Title != null && page.Title.Contains("Kernel") && page.PublishedAfter == "2025-01-01"
+        };
+        var compoundResults = await textSearch.GetSearchResultsAsync(query, compoundOptions);
+        await foreach (KeenableWebPage page in compoundResults.Results)
+        {
+            Console.WriteLine($"Title:       {page.Title}");
+            Console.WriteLine($"Snippet:     {page.Snippet}");
+            Console.WriteLine($"URL:         {page.Url}");
+            Console.WriteLine($"PublishedAt: {page.PublishedAt}");
+            WriteHorizontalRule();
+        }
+    }
+
+    #region private
+    /// <summary>
+    /// Read the optional API key. When the "Keenable" configuration section is absent the public endpoint is used.
+    /// </summary>
+    private static string? GetApiKey()
+    {
+        try
+        {
+            return TestConfiguration.Keenable.ApiKey;
+        }
+        catch (ConfigurationNotFoundException)
+        {
+            return null;
+        }
+    }
+
+    /// <summary>
+    /// Test mapper which converts an arbitrary search result to a string using JSON serialization.
+    /// </summary>
+    private sealed class TestTextSearchStringMapper : ITextSearchStringMapper
+    {
+        /// <inheritdoc />
+        public string MapFromResultToString(object result)
+        {
+            return JsonSerializer.Serialize(result);
+        }
+    }
+    #endregion
+}

--- a/dotnet/src/IntegrationTests/Plugins/Web/Keenable/KeenableTextSearchTests.cs
+++ b/dotnet/src/IntegrationTests/Plugins/Web/Keenable/KeenableTextSearchTests.cs
@@ -1,0 +1,54 @@
+﻿// Copyright (c) Microsoft. All rights reserved.
+
+#pragma warning disable CS0618 // ITextSearch is obsolete
+
+using System.Threading.Tasks;
+using Microsoft.Extensions.Configuration;
+using Microsoft.SemanticKernel.Data;
+using Microsoft.SemanticKernel.Plugins.Web.Keenable;
+using SemanticKernel.IntegrationTests.Data;
+using SemanticKernel.IntegrationTests.TestSettings;
+using Xunit;
+
+namespace SemanticKernel.IntegrationTests.Plugins.Web.Keenable;
+
+/// <summary>
+/// Integration tests for <see cref="KeenableTextSearch"/>.
+/// </summary>
+public class KeenableTextSearchTests : BaseTextSearchTests
+{
+    /// <inheritdoc/>
+    public override Task<ITextSearch> CreateTextSearchAsync()
+    {
+        // The API key is optional; without a "Keenable" section the public endpoint is used.
+        var configuration = this.Configuration.GetSection("Keenable").Get<KeenableConfiguration>();
+
+        return Task.FromResult<ITextSearch>(new KeenableTextSearch(apiKey: configuration?.ApiKey));
+    }
+
+    /// <inheritdoc/>
+    public override string GetQuery() => "What is the Semantic Kernel?";
+
+    /// <inheritdoc/>
+    public override TextSearchFilter GetTextSearchFilter() => new TextSearchFilter().Equality("site", "learn.microsoft.com");
+
+    /// <inheritdoc/>
+    public override bool VerifySearchResults(object[] results, string query, TextSearchFilter? filter = null)
+    {
+        Assert.NotNull(results);
+        Assert.NotEmpty(results);
+        Assert.Equal(4, results.Length);
+        foreach (var result in results)
+        {
+            Assert.NotNull(result);
+            var searchResult = Assert.IsType<KeenableSearchResult>(result);
+            Assert.NotEmpty(searchResult.Url);
+            if (filter is not null)
+            {
+                Assert.StartsWith("https://learn.microsoft.com/", searchResult.Url, System.StringComparison.Ordinal);
+            }
+        }
+
+        return true;
+    }
+}

--- a/dotnet/src/IntegrationTests/TestSettings/KeenableConfiguration.cs
+++ b/dotnet/src/IntegrationTests/TestSettings/KeenableConfiguration.cs
@@ -1,0 +1,11 @@
+﻿// Copyright (c) Microsoft. All rights reserved.
+namespace SemanticKernel.IntegrationTests.TestSettings;
+
+#pragma warning disable CA1812 // Configuration classes are instantiated through IConfiguration.
+internal sealed class KeenableConfiguration(string? apiKey = null)
+{
+    /// <summary>
+    /// Optional API key. When null or empty the public endpoint is used.
+    /// </summary>
+    public string? ApiKey { get; init; } = apiKey;
+}

--- a/dotnet/src/InternalUtilities/samples/InternalUtilities/TestConfiguration.cs
+++ b/dotnet/src/InternalUtilities/samples/InternalUtilities/TestConfiguration.cs
@@ -36,6 +36,7 @@ public sealed class TestConfiguration
     public static PineconeConfig Pinecone => LoadSection<PineconeConfig>();
     public static BingConfig Bing => LoadSection<BingConfig>();
     public static GoogleConfig Google => LoadSection<GoogleConfig>();
+    public static KeenableConfig Keenable => LoadSection<KeenableConfig>();
     public static TavilyConfig Tavily => LoadSection<TavilyConfig>();
     public static GithubConfig Github => LoadSection<GithubConfig>();
     public static PostgresConfig Postgres => LoadSection<PostgresConfig>();
@@ -189,6 +190,12 @@ public sealed class TestConfiguration
     {
         public string ApiKey { get; set; }
         public string SearchEngineId { get; set; }
+    }
+
+    public class KeenableConfig
+    {
+        public string Endpoint { get; set; } = "https://api.keenable.ai";
+        public string? ApiKey { get; set; }
     }
 
     public class TavilyConfig

--- a/dotnet/src/Plugins/Plugins.UnitTests/TestData/keenable_site_filter_what_is_the_semantic_kernel.json
+++ b/dotnet/src/Plugins/Plugins.UnitTests/TestData/keenable_site_filter_what_is_the_semantic_kernel.json
@@ -1,0 +1,26 @@
+{
+  "query": "What is the Semantic Kernel?",
+  "results": [
+    {
+      "title": "Understanding the kernel in Semantic Kernel",
+      "url": "https://learn.microsoft.com/en-us/semantic-kernel/concepts/kernel",
+      "description": "",
+      "snippet": "Understanding the kernel The kernel is the central component of Semantic Kernel. At its simplest, the kernel is a Dependency Injection container that manages all of the services and plugins necessary to run your AI application.",
+      "acquired_at": "2026-08-16T18:59:09Z"
+    },
+    {
+      "title": "Semantic Kernel Components",
+      "url": "https://learn.microsoft.com/en-us/semantic-kernel/concepts/semantic-kernel-components",
+      "description": "",
+      "snippet": "Tip For more information on using AI services see Adding AI services to Semantic Kernel. Vector Store (Memory) Connectors The Semantic Kernel Vector Store connectors provide an abstraction layer that exposes vector stores from different providers via a common interface.",
+      "acquired_at": "2026-08-15T23:44:16Z"
+    },
+    {
+      "title": "Introduction to Semantic Kernel",
+      "url": "https://learn.microsoft.com/en-us/semantic-kernel/overview",
+      "description": "",
+      "snippet": "When a request is made the model calls a function, and Semantic Kernel is the middleware translating the model’s request to a function call and passes the results back to the model.",
+      "acquired_at": "2026-08-20T22:24:03Z"
+    }
+  ]
+}

--- a/dotnet/src/Plugins/Plugins.UnitTests/TestData/keenable_what_is_the_semantic_kernel.json
+++ b/dotnet/src/Plugins/Plugins.UnitTests/TestData/keenable_what_is_the_semantic_kernel.json
@@ -1,0 +1,37 @@
+{
+  "query": "What is the Semantic Kernel?",
+  "results": [
+    {
+      "title": "Semantic Kernel",
+      "url": "https://aiwiki.ai/wiki/semantic_kernel",
+      "description": "",
+      "snippet": "[1][9] As of June 2026 the project has over 27,900 stars on GitHub and is licensed under the MIT License.[1] Semantic Kernel serves as middleware between enterprise application logic and AI model capabilities.[2] It is used internally by Microsoft to help power products such as Microsoft 365 Copilot and is adopted by ...",
+      "published_at": "2026-03-21T02:14:29Z",
+      "acquired_at": "2026-08-25T22:15:08Z"
+    },
+    {
+      "title": "Microsoft’s Semantic Kernel",
+      "url": "https://jacar.es/en/microsoft-semantic-kernel",
+      "description": "",
+      "snippet": "Conclusion Sources Semantic Kernel is the open-source kit with which Microsoft drops an AI model inside your C#, Python or Java application and lets it call your own code. The central piece, the kernel, acts as the middleman: it receives the model’s request, runs the right function and returns the result. In this ...",
+      "published_at": "2026-07-16T23:12:58Z",
+      "acquired_at": "2026-07-24T18:34:33Z"
+    },
+    {
+      "title": "Semantic Kernel",
+      "url": "https://geeksforgeeks.org/artificial-intelligence/semantic-kernel",
+      "description": "",
+      "snippet": "Machine Learning Deep Learning ML-Projects Robotics Semantic Kernel Last Updated : 22 Aug, 2025 Semantic Kernel (SK) is an open-source, lightweight SDK developed by Microsoft that acts as a powerful orchestration layer to build, deploy and manage intelligent AI applications and agents by integrating large language ...",
+      "published_at": "2025-08-22T11:56:00Z",
+      "acquired_at": "2026-08-18T23:44:15Z"
+    },
+    {
+      "title": "Semantic Kernel",
+      "url": "https://grokipedia.com/page/Semantic_Kernel",
+      "description": "",
+      "snippet": "Fact-checked by Grok 4 months ago Semantic Kernel Semantic Kernel is Microsoft’s open-source orchestration engine and software development kit (SDK) for integrating AI capabilities—such as prompts, embeddings, and vector search—along with large language models (LLMs) into applications, enabling the building of AI ...",
+      "published_at": "2026-03-27T14:27:17Z",
+      "acquired_at": "2026-08-22T11:55:12Z"
+    }
+  ]
+}

--- a/dotnet/src/Plugins/Plugins.UnitTests/Web/Keenable/KeenableTextSearchTests.cs
+++ b/dotnet/src/Plugins/Plugins.UnitTests/Web/Keenable/KeenableTextSearchTests.cs
@@ -1,0 +1,688 @@
+﻿// Copyright (c) Microsoft. All rights reserved.
+
+#pragma warning disable CS0618 // ITextSearch is obsolete
+#pragma warning disable CS8602 // Dereference of a possibly null reference - for LINQ expression properties
+
+using System;
+using System.IO;
+using System.Linq;
+using System.Net;
+using System.Net.Http;
+using System.Text;
+using System.Text.Json;
+using System.Threading.Tasks;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.SemanticKernel;
+using Microsoft.SemanticKernel.Data;
+using Microsoft.SemanticKernel.Plugins.Web.Keenable;
+using Xunit;
+
+namespace SemanticKernel.Plugins.UnitTests.Web.Keenable;
+
+public sealed class KeenableTextSearchTests : IDisposable
+{
+    /// <summary>
+    /// Initializes a new instance of the <see cref="KeenableTextSearchTests"/> class.
+    /// </summary>
+    public KeenableTextSearchTests()
+    {
+        this._messageHandlerStub = new MultipleHttpMessageHandlerStub();
+        this._httpClient = new HttpClient(this._messageHandlerStub, disposeHandler: false);
+        this._kernel = new Kernel();
+    }
+
+    [Fact]
+    public void AddKeenableTextSearchWithoutApiKeySucceeds()
+    {
+        // Arrange
+        var builder = Kernel.CreateBuilder();
+
+        // Act
+        builder.AddKeenableTextSearch();
+        var kernel = builder.Build();
+
+        // Assert
+        Assert.IsType<KeenableTextSearch>(kernel.Services.GetRequiredService<ITextSearch>());
+    }
+
+    [Fact]
+    public void AddKeenableTextSearchWithApiKeySucceeds()
+    {
+        // Arrange
+        var builder = Kernel.CreateBuilder();
+
+        // Act
+        builder.AddKeenableTextSearch(apiKey: "ApiKey");
+        var kernel = builder.Build();
+
+        // Assert
+        Assert.IsType<KeenableTextSearch>(kernel.Services.GetRequiredService<ITextSearch>());
+    }
+
+    [Fact]
+    public async Task SearchReturnsSuccessfullyAsync()
+    {
+        // Arrange
+        this._messageHandlerStub.AddJsonResponse(File.ReadAllText(WhatIsTheSKResponseJson));
+
+        // Create an ITextSearch instance using Keenable search
+        var textSearch = new KeenableTextSearch(options: new() { HttpClient = this._httpClient });
+
+        // Act
+        KernelSearchResults<string> result = await textSearch.SearchAsync("What is the Semantic Kernel?", new() { Top = 4, Skip = 0 });
+
+        // Assert
+        Assert.NotNull(result);
+        Assert.NotNull(result.Results);
+        var resultList = await result.Results.ToListAsync();
+        Assert.NotNull(resultList);
+        Assert.Equal(4, resultList.Count);
+        foreach (var stringResult in resultList)
+        {
+            Assert.NotEmpty(stringResult);
+        }
+    }
+
+    [Fact]
+    public async Task GetTextSearchResultsReturnsSuccessfullyAsync()
+    {
+        // Arrange
+        this._messageHandlerStub.AddJsonResponse(File.ReadAllText(WhatIsTheSKResponseJson));
+
+        // Create an ITextSearch instance using Keenable search
+        var textSearch = new KeenableTextSearch(options: new() { HttpClient = this._httpClient });
+
+        // Act
+        KernelSearchResults<TextSearchResult> result = await textSearch.GetTextSearchResultsAsync("What is the Semantic Kernel?", new() { Top = 4, Skip = 0 });
+
+        // Assert
+        Assert.NotNull(result);
+        Assert.NotNull(result.Results);
+        var resultList = await result.Results.ToListAsync();
+        Assert.NotNull(resultList);
+        Assert.Equal(4, resultList.Count);
+        foreach (var textSearchResult in resultList)
+        {
+            Assert.NotNull(textSearchResult.Name);
+            Assert.NotNull(textSearchResult.Value);
+            Assert.NotNull(textSearchResult.Link);
+            Assert.NotEmpty(textSearchResult.Value);
+        }
+
+        // The first result maps title, snippet and url to Name, Value and Link
+        Assert.Equal("Semantic Kernel", resultList[0].Name);
+        Assert.StartsWith("[1][9] As of June 2026", resultList[0].Value, StringComparison.Ordinal);
+        Assert.Equal("https://aiwiki.ai/wiki/semantic_kernel", resultList[0].Link);
+    }
+
+    [Fact]
+    public async Task GetSearchResultsReturnsSuccessfullyAsync()
+    {
+        // Arrange
+        this._messageHandlerStub.AddJsonResponse(File.ReadAllText(WhatIsTheSKResponseJson));
+
+        // Create an ITextSearch instance using Keenable search
+        var textSearch = new KeenableTextSearch(options: new() { HttpClient = this._httpClient });
+
+        // Act
+        KernelSearchResults<object> result = await textSearch.GetSearchResultsAsync("What is the Semantic Kernel?", new() { Top = 4, Skip = 0 });
+
+        // Assert
+        Assert.NotNull(result);
+        Assert.NotNull(result.Results);
+        var resultList = await result.Results.ToListAsync();
+        Assert.NotNull(resultList);
+        Assert.Equal(4, resultList.Count);
+        foreach (KeenableSearchResult searchResult in resultList)
+        {
+            Assert.NotEmpty(searchResult.Title);
+            Assert.NotEmpty(searchResult.Url);
+            Assert.NotNull(searchResult.Snippet);
+            Assert.NotEmpty(searchResult.Snippet);
+        }
+
+        Assert.NotNull(resultList.Cast<KeenableSearchResult>().First().PublishedAt);
+    }
+
+    [Fact]
+    public async Task TextSearchResultFallsBackToDescriptionWhenSnippetIsEmptyAsync()
+    {
+        // Arrange
+        this._messageHandlerStub.AddJsonResponse("""
+            {"query":"q","results":[
+              {"title":"Empty snippet","url":"https://example.com/a","description":"Description A","snippet":""},
+              {"title":"No snippet","url":"https://example.com/b","description":"Description B"},
+              {"title":"Has snippet","url":"https://example.com/c","description":"Description C","snippet":"Snippet C"}
+            ]}
+            """);
+        var textSearch = new KeenableTextSearch(options: new() { HttpClient = this._httpClient });
+
+        // Act
+        KernelSearchResults<TextSearchResult> result = await textSearch.GetTextSearchResultsAsync("q", new() { Top = 3 });
+        var resultList = await result.Results.ToListAsync();
+
+        // Assert
+        Assert.Equal(3, resultList.Count);
+        Assert.Equal("Description A", resultList[0].Value);
+        Assert.Equal("Description B", resultList[1].Value);
+        Assert.Equal("Snippet C", resultList[2].Value);
+    }
+
+    [Fact]
+    public async Task RequestWithoutApiKeyUsesPublicEndpointAndTitleHeaderAsync()
+    {
+        // Arrange
+        this._messageHandlerStub.AddJsonResponse(File.ReadAllText(WhatIsTheSKResponseJson));
+        var textSearch = new KeenableTextSearch(options: new() { HttpClient = this._httpClient });
+
+        // Act
+        await textSearch.SearchAsync("What is the Semantic Kernel?", new() { Top = 4 });
+
+        // Assert
+        Assert.Single(this._messageHandlerStub.RequestUris);
+        Assert.Equal(HttpMethod.Post, this._messageHandlerStub.Methods[0]);
+        Assert.Equal("https://api.keenable.ai/v1/search/public", this._messageHandlerStub.RequestUris[0]!.AbsoluteUri);
+
+        var headers = this._messageHandlerStub.RequestHeaders[0]!;
+        Assert.Equal("semantic-kernel", headers.GetValues("X-Keenable-Title").Single());
+        Assert.False(headers.Contains("X-API-Key"));
+
+        var requestBodyJson = Encoding.UTF8.GetString(this._messageHandlerStub.RequestContents[0]!);
+        Assert.Equal("{\"query\":\"What is the Semantic Kernel?\",\"max_results\":4}", requestBodyJson);
+    }
+
+    [Theory]
+    [InlineData("ApiKey")]
+    [InlineData("  ApiKey  ")]
+    public async Task RequestWithApiKeyUsesAuthenticatedEndpointAndApiKeyHeaderAsync(string apiKey)
+    {
+        // Arrange
+        this._messageHandlerStub.AddJsonResponse(File.ReadAllText(WhatIsTheSKResponseJson));
+        var textSearch = new KeenableTextSearch(apiKey: apiKey, options: new() { HttpClient = this._httpClient });
+
+        // Act
+        await textSearch.SearchAsync("What is the Semantic Kernel?", new() { Top = 4 });
+
+        // Assert
+        Assert.Single(this._messageHandlerStub.RequestUris);
+        Assert.Equal("https://api.keenable.ai/v1/search", this._messageHandlerStub.RequestUris[0]!.AbsoluteUri);
+
+        var headers = this._messageHandlerStub.RequestHeaders[0]!;
+        Assert.Equal(apiKey, headers.GetValues("X-API-Key").Single());
+        Assert.Equal("semantic-kernel", headers.GetValues("X-Keenable-Title").Single());
+
+        // The key travels in the header only, never in the body
+        var requestBodyJson = Encoding.UTF8.GetString(this._messageHandlerStub.RequestContents[0]!);
+        Assert.DoesNotContain("ApiKey", requestBodyJson);
+    }
+
+    [Theory]
+    [InlineData(null)]
+    [InlineData("")]
+    [InlineData("   ")]
+    public async Task EmptyApiKeyIsTreatedAsNoApiKeyAsync(string? apiKey)
+    {
+        // Arrange
+        this._messageHandlerStub.AddJsonResponse(File.ReadAllText(WhatIsTheSKResponseJson));
+        var textSearch = new KeenableTextSearch(apiKey: apiKey, options: new() { HttpClient = this._httpClient });
+
+        // Act
+        await textSearch.SearchAsync("What is the Semantic Kernel?", new() { Top = 4 });
+
+        // Assert
+        Assert.Equal("https://api.keenable.ai/v1/search/public", this._messageHandlerStub.RequestUris[0]!.AbsoluteUri);
+        Assert.False(this._messageHandlerStub.RequestHeaders[0]!.Contains("X-API-Key"));
+    }
+
+    [Theory]
+    [InlineData("https://search.example.com", false, "https://search.example.com/v1/search/public")]
+    [InlineData("https://search.example.com/", true, "https://search.example.com/v1/search")]
+    [InlineData("https://search.example.com/proxy", false, "https://search.example.com/proxy/v1/search/public")]
+    public async Task CustomEndpointIsUsedAsBaseAddressAsync(string endpoint, bool withApiKey, string expectedUri)
+    {
+        // Arrange
+        this._messageHandlerStub.AddJsonResponse(File.ReadAllText(WhatIsTheSKResponseJson));
+        var textSearch = new KeenableTextSearch(apiKey: withApiKey ? "ApiKey" : null, options: new() { HttpClient = this._httpClient, Endpoint = new Uri(endpoint) });
+
+        // Act
+        await textSearch.SearchAsync("What is the Semantic Kernel?", new() { Top = 4 });
+
+        // Assert
+        Assert.Equal(expectedUri, this._messageHandlerStub.RequestUris[0]!.AbsoluteUri);
+    }
+
+    [Fact]
+    public async Task SnippetMaxLengthIsSentInRequestAsync()
+    {
+        // Arrange
+        this._messageHandlerStub.AddJsonResponse(File.ReadAllText(WhatIsTheSKResponseJson));
+        var textSearch = new KeenableTextSearch(options: new() { HttpClient = this._httpClient, SnippetMaxLength = 300 });
+
+        // Act
+        await textSearch.SearchAsync("What is the Semantic Kernel?", new() { Top = 4 });
+
+        // Assert
+        var requestBodyJson = Encoding.UTF8.GetString(this._messageHandlerStub.RequestContents[0]!);
+        Assert.Equal("{\"query\":\"What is the Semantic Kernel?\",\"max_results\":4,\"snippet_max_length\":300}", requestBodyJson);
+    }
+
+    [Fact]
+    public async Task SkipIsAppliedToResultsAsync()
+    {
+        // Arrange
+        this._messageHandlerStub.AddJsonResponse(File.ReadAllText(WhatIsTheSKResponseJson));
+        var textSearch = new KeenableTextSearch(options: new() { HttpClient = this._httpClient });
+
+        // Act
+        KernelSearchResults<TextSearchResult> result = await textSearch.GetTextSearchResultsAsync("What is the Semantic Kernel?", new() { Top = 3, Skip = 1 });
+        var resultList = await result.Results.ToListAsync();
+
+        // Assert - the API has no offset, so top + skip results are requested and the first skip are dropped
+        var requestBodyJson = Encoding.UTF8.GetString(this._messageHandlerStub.RequestContents[0]!);
+        Assert.Contains("\"max_results\":4", requestBodyJson);
+        Assert.Equal(3, resultList.Count);
+        Assert.Equal("https://jacar.es/en/microsoft-semantic-kernel", resultList[0].Link);
+    }
+
+    [Theory]
+    [InlineData(0, 0)]
+    [InlineData(51, 0)]
+    [InlineData(4, -1)]
+    [InlineData(50, 1)]
+    public async Task InvalidTopOrSkipThrowsAsync(int top, int skip)
+    {
+        // Arrange
+        var textSearch = new KeenableTextSearch(options: new() { HttpClient = this._httpClient });
+
+        // Act & Assert
+        await Assert.ThrowsAsync<ArgumentOutOfRangeException>(async () => await textSearch.SearchAsync("What is the Semantic Kernel?", new() { Top = top, Skip = skip }));
+        Assert.Empty(this._messageHandlerStub.RequestUris);
+    }
+
+    [Theory]
+    [InlineData(HttpStatusCode.TooManyRequests)]
+    [InlineData(HttpStatusCode.BadRequest)]
+    [InlineData(HttpStatusCode.Unauthorized)]
+    [InlineData(HttpStatusCode.InternalServerError)]
+    public async Task NonSuccessStatusCodeThrowsAsync(HttpStatusCode statusCode)
+    {
+        // Arrange
+        this._messageHandlerStub.ResponsesToReturn.Add(new HttpResponseMessage(statusCode)
+        {
+            Content = new StringContent("{\"error\":\"rejected\"}", Encoding.UTF8, "application/json")
+        });
+        var textSearch = new KeenableTextSearch(options: new() { HttpClient = this._httpClient });
+
+        // Act & Assert - a rejected request must surface as an exception, not as an empty result set
+        var e = await Assert.ThrowsAsync<HttpOperationException>(async () => await textSearch.SearchAsync("What is the Semantic Kernel?", new() { Top = 4 }));
+        Assert.Equal(statusCode, e.StatusCode);
+    }
+
+    [Fact]
+    public async Task SearchWithCustomStringMapperReturnsSuccessfullyAsync()
+    {
+        // Arrange
+        this._messageHandlerStub.AddJsonResponse(File.ReadAllText(WhatIsTheSKResponseJson));
+
+        // Create an ITextSearch instance using Keenable search
+        var textSearch = new KeenableTextSearch(options: new() { HttpClient = this._httpClient, StringMapper = new TestTextSearchStringMapper() });
+
+        // Act
+        KernelSearchResults<string> result = await textSearch.SearchAsync("What is the Semantic Kernel?", new() { Top = 4, Skip = 0 });
+
+        // Assert
+        Assert.NotNull(result);
+        Assert.NotNull(result.Results);
+        var resultList = await result.Results.ToListAsync();
+        Assert.NotNull(resultList);
+        Assert.Equal(4, resultList.Count);
+        foreach (var stringResult in resultList)
+        {
+            Assert.NotEmpty(stringResult);
+            var searchResult = JsonSerializer.Deserialize<KeenableSearchResult>(stringResult);
+            Assert.NotNull(searchResult);
+        }
+    }
+
+    [Fact]
+    public async Task GetTextSearchResultsWithCustomResultMapperReturnsSuccessfullyAsync()
+    {
+        // Arrange
+        this._messageHandlerStub.AddJsonResponse(File.ReadAllText(WhatIsTheSKResponseJson));
+
+        // Create an ITextSearch instance using Keenable search
+        var textSearch = new KeenableTextSearch(options: new() { HttpClient = this._httpClient, ResultMapper = new TestTextSearchResultMapper() });
+
+        // Act
+        KernelSearchResults<TextSearchResult> result = await textSearch.GetTextSearchResultsAsync("What is the Semantic Kernel?", new() { Top = 4, Skip = 0 });
+
+        // Assert
+        Assert.NotNull(result);
+        Assert.NotNull(result.Results);
+        var resultList = await result.Results.ToListAsync();
+        Assert.NotNull(resultList);
+        Assert.Equal(4, resultList.Count);
+        foreach (var textSearchResult in resultList)
+        {
+            Assert.NotNull(textSearchResult);
+            Assert.Equal(textSearchResult.Name, textSearchResult.Name?.ToUpperInvariant());
+            Assert.Equal(textSearchResult.Value, textSearchResult.Value?.ToUpperInvariant());
+            Assert.Equal(textSearchResult.Link, textSearchResult.Link?.ToUpperInvariant());
+        }
+    }
+
+    [Theory]
+    [InlineData("site", "learn.microsoft.com", "{\"query\":\"What is the Semantic Kernel?\",\"max_results\":4,\"site\":\"learn.microsoft.com\"}")]
+    [InlineData("published_after", "2025-01-01", "{\"query\":\"What is the Semantic Kernel?\",\"max_results\":4,\"published_after\":\"2025-01-01\"}")]
+    [InlineData("published_before", "2025-12-31", "{\"query\":\"What is the Semantic Kernel?\",\"max_results\":4,\"published_before\":\"2025-12-31\"}")]
+    public async Task BuildsCorrectRequestForEqualityFilterAsync(string paramName, object paramValue, string request)
+    {
+        // Arrange
+        this._messageHandlerStub.AddJsonResponse(File.ReadAllText(SiteFilterSKResponseJson));
+
+        // Create an ITextSearch instance using Keenable search
+        var textSearch = new KeenableTextSearch(options: new() { HttpClient = this._httpClient });
+
+        // Act
+        TextSearchOptions searchOptions = new() { Top = 4, Skip = 0, Filter = new TextSearchFilter().Equality(paramName, paramValue) };
+        KernelSearchResults<object> result = await textSearch.GetSearchResultsAsync("What is the Semantic Kernel?", searchOptions);
+
+        // Assert
+        var requestContents = this._messageHandlerStub.RequestContents;
+        Assert.Single(requestContents);
+        Assert.NotNull(requestContents[0]);
+        Assert.Equal(request, Encoding.UTF8.GetString(requestContents[0]!));
+
+        var resultList = await result.Results.ToListAsync();
+        Assert.Equal(3, resultList.Count);
+        Assert.All(resultList, r => Assert.StartsWith("https://learn.microsoft.com/", ((KeenableSearchResult)r).Url, StringComparison.Ordinal));
+    }
+
+    [Fact]
+    public async Task BuildsCorrectRequestForDateFilterValuesAsync()
+    {
+        // Arrange
+        this._messageHandlerStub.AddJsonResponse(File.ReadAllText(SiteFilterSKResponseJson));
+        var textSearch = new KeenableTextSearch(options: new() { HttpClient = this._httpClient });
+
+        // Act - DateTime and DateTimeOffset values are formatted as YYYY-MM-DD
+        TextSearchOptions searchOptions = new()
+        {
+            Top = 4,
+            Filter = new TextSearchFilter()
+                .Equality("published_after", new DateTime(2025, 1, 2, 13, 0, 0, DateTimeKind.Utc))
+                .Equality("published_before", new DateTimeOffset(2025, 3, 4, 0, 0, 0, TimeSpan.Zero))
+        };
+        await textSearch.GetSearchResultsAsync("What is the Semantic Kernel?", searchOptions);
+
+        // Assert
+        var requestBodyJson = Encoding.UTF8.GetString(this._messageHandlerStub.RequestContents[0]!);
+        Assert.Equal("{\"query\":\"What is the Semantic Kernel?\",\"max_results\":4,\"published_after\":\"2025-01-02\",\"published_before\":\"2025-03-04\"}", requestBodyJson);
+    }
+
+    [Theory]
+    [InlineData("fooBar", "baz")]
+    public async Task DoesNotBuildRequestForInvalidQueryParameterAsync(string paramName, object paramValue)
+    {
+        // Arrange
+        this._messageHandlerStub.AddJsonResponse(File.ReadAllText(SiteFilterSKResponseJson));
+        TextSearchOptions searchOptions = new() { Top = 4, Skip = 0, Filter = new TextSearchFilter().Equality(paramName, paramValue) };
+
+        // Create an ITextSearch instance using Keenable search
+        var textSearch = new KeenableTextSearch(options: new() { HttpClient = this._httpClient });
+
+        // Act && Assert
+        var e = await Assert.ThrowsAsync<ArgumentException>(async () => await textSearch.GetSearchResultsAsync("What is the Semantic Kernel?", searchOptions));
+        Assert.Contains("Unknown equality filter clause field name 'fooBar'", e.Message);
+        Assert.Contains("site,published_after,published_before", e.Message);
+    }
+
+    [Fact]
+    public async Task DoesNotBuildRequestForInvalidQueryAsync()
+    {
+        // Arrange
+        this._messageHandlerStub.AddJsonResponse(File.ReadAllText(SiteFilterSKResponseJson));
+
+        // Create an ITextSearch instance using Keenable search
+        var textSearch = new KeenableTextSearch(options: new() { HttpClient = this._httpClient });
+
+        // Act && Assert
+        var e = await Assert.ThrowsAsync<ArgumentNullException>(async () => await textSearch.GetSearchResultsAsync(null!));
+        Assert.Equal("Value cannot be null. (Parameter 'query')", e.Message);
+    }
+
+    /// <inheritdoc/>
+    public void Dispose()
+    {
+        this._messageHandlerStub.Dispose();
+        this._httpClient.Dispose();
+        GC.SuppressFinalize(this);
+    }
+
+    #region Generic ITextSearch<KeenableWebPage> Interface Tests
+
+    [Fact]
+    public async Task LinqSearchAsyncReturnsResultsSuccessfullyAsync()
+    {
+        // Arrange
+        this._messageHandlerStub.AddJsonResponse(File.ReadAllText(SiteFilterSKResponseJson));
+        ITextSearch<KeenableWebPage> textSearch = new KeenableTextSearch(options: new() { HttpClient = this._httpClient });
+
+        // Act
+        var searchOptions = new TextSearchOptions<KeenableWebPage>
+        {
+            Top = 4,
+            Skip = 0
+        };
+        KernelSearchResults<string> result = await textSearch.SearchAsync("What is the Semantic Kernel?", searchOptions);
+
+        // Assert - Verify basic generic interface functionality
+        Assert.NotNull(result);
+        Assert.NotNull(result.Results);
+        var resultList = await result.Results.ToListAsync();
+        Assert.NotEmpty(resultList);
+
+        // Verify the request was made correctly
+        var requestContents = this._messageHandlerStub.RequestContents;
+        Assert.Single(requestContents);
+        Assert.NotNull(requestContents[0]);
+        var requestBodyJson = Encoding.UTF8.GetString(requestContents[0]!);
+        Assert.Contains("\"query\"", requestBodyJson);
+        Assert.Contains("\"max_results\":4", requestBodyJson);
+    }
+
+    [Fact]
+    public async Task LinqGetSearchResultsAsyncReturnsTypedResultsSuccessfullyAsync()
+    {
+        // Arrange
+        this._messageHandlerStub.AddJsonResponse(File.ReadAllText(SiteFilterSKResponseJson));
+        ITextSearch<KeenableWebPage> textSearch = new KeenableTextSearch(options: new() { HttpClient = this._httpClient });
+
+        // Act
+        var searchOptions = new TextSearchOptions<KeenableWebPage>
+        {
+            Top = 3,
+            Skip = 0
+        };
+        KernelSearchResults<KeenableWebPage> result = await textSearch.GetSearchResultsAsync("What is the Semantic Kernel?", searchOptions);
+
+        // Assert - Results are strongly typed as KeenableWebPage
+        Assert.NotNull(result);
+        Assert.NotNull(result.Results);
+        var resultList = await result.Results.ToListAsync();
+        Assert.Equal(3, resultList.Count);
+        foreach (var page in resultList)
+        {
+            Assert.NotNull(page.Title);
+            Assert.NotNull(page.Url);
+            Assert.Equal("learn.microsoft.com", page.Url.Host);
+            Assert.NotEmpty(page.Snippet!);
+        }
+
+        // Verify the request was made correctly
+        var requestBodyJson = Encoding.UTF8.GetString(this._messageHandlerStub.RequestContents[0]!);
+        Assert.Contains("\"max_results\":3", requestBodyJson);
+    }
+
+    [Fact]
+    public async Task LinqGetTextSearchResultsAsyncReturnsResultsSuccessfullyAsync()
+    {
+        // Arrange
+        this._messageHandlerStub.AddJsonResponse(File.ReadAllText(SiteFilterSKResponseJson));
+        ITextSearch<KeenableWebPage> textSearch = new KeenableTextSearch(options: new() { HttpClient = this._httpClient });
+
+        // Act
+        var searchOptions = new TextSearchOptions<KeenableWebPage>
+        {
+            Top = 5,
+            Skip = 0
+        };
+        KernelSearchResults<TextSearchResult> result = await textSearch.GetTextSearchResultsAsync("What is the Semantic Kernel?", searchOptions);
+
+        // Assert - Verify generic interface returns TextSearchResult objects
+        Assert.NotNull(result);
+        Assert.NotNull(result.Results);
+        var resultList = await result.Results.ToListAsync();
+        Assert.NotEmpty(resultList);
+        Assert.All(resultList, item => Assert.IsType<TextSearchResult>(item));
+
+        // Verify the request was made correctly
+        var requestBodyJson = Encoding.UTF8.GetString(this._messageHandlerStub.RequestContents[0]!);
+        Assert.Contains("\"max_results\":5", requestBodyJson);
+    }
+
+    [Fact]
+    public async Task LinqEqualityFiltersMapToRequestFieldsAsync()
+    {
+        // Arrange
+        this._messageHandlerStub.AddJsonResponse(File.ReadAllText(SiteFilterSKResponseJson));
+        ITextSearch<KeenableWebPage> textSearch = new KeenableTextSearch(options: new() { HttpClient = this._httpClient });
+
+        // Act
+        var searchOptions = new TextSearchOptions<KeenableWebPage>
+        {
+            Top = 4,
+            Skip = 0,
+            Filter = page => page.Site == "learn.microsoft.com" && page.PublishedAfter == "2025-01-01" && page.PublishedBefore == "2025-12-31"
+        };
+        await textSearch.SearchAsync("What is the Semantic Kernel?", searchOptions);
+
+        // Assert
+        var requestBodyJson = Encoding.UTF8.GetString(this._messageHandlerStub.RequestContents[0]!);
+        Assert.Equal("{\"query\":\"What is the Semantic Kernel?\",\"max_results\":4,\"published_after\":\"2025-01-01\",\"published_before\":\"2025-12-31\",\"site\":\"learn.microsoft.com\"}", requestBodyJson);
+    }
+
+    [Fact]
+    public async Task LinqUnsupportedPropertyThrowsNotSupportedExceptionAsync()
+    {
+        // Arrange
+        this._messageHandlerStub.AddJsonResponse(File.ReadAllText(SiteFilterSKResponseJson));
+        ITextSearch<KeenableWebPage> textSearch = new KeenableTextSearch(options: new() { HttpClient = this._httpClient });
+
+        // Act & Assert - Description is a result field, not a filter
+        var searchOptions = new TextSearchOptions<KeenableWebPage>
+        {
+            Top = 4,
+            Filter = page => page.Description == "anything"
+        };
+        var exception = await Assert.ThrowsAsync<NotSupportedException>(async () => await textSearch.SearchAsync("test", searchOptions));
+        Assert.Contains("Property 'Description' cannot be mapped", exception.Message);
+        Assert.Empty(this._messageHandlerStub.RequestUris);
+    }
+
+    [Fact]
+    public async Task CollectionContainsFilterThrowsNotSupportedExceptionAsync()
+    {
+        // Arrange - Tests both Enumerable.Contains (C# 13-) and MemoryExtensions.Contains (C# 14+)
+        // The same code array.Contains() resolves differently based on C# language version:
+        // - C# 13 and earlier: Enumerable.Contains (LINQ extension method)
+        // - C# 14 and later: MemoryExtensions.Contains (span-based optimization due to "first-class spans")
+        // Our implementation handles both identically since Keenable API has limited query operators
+        this._messageHandlerStub.AddJsonResponse(File.ReadAllText(SiteFilterSKResponseJson));
+        ITextSearch<KeenableWebPage> textSearch = new KeenableTextSearch(options: new() { HttpClient = this._httpClient });
+        string[] sites = ["microsoft.com", "github.com"];
+
+        // Act & Assert - Verify that collection Contains pattern throws clear exception
+        var searchOptions = new TextSearchOptions<KeenableWebPage>
+        {
+            Top = 5,
+            Skip = 0,
+            Filter = page => sites.Contains(page.Url!.ToString())  // Enumerable.Contains (C# 13-) or MemoryExtensions.Contains (C# 14+)
+        };
+
+        var exception = await Assert.ThrowsAsync<NotSupportedException>(async () =>
+        {
+            await textSearch.SearchAsync("test", searchOptions);
+        });
+
+        // Assert - Verify error message explains the limitation clearly
+        Assert.Contains("Collection Contains filters", exception.Message);
+        Assert.Contains("not supported", exception.Message);
+    }
+
+    [Fact]
+    public async Task StringContainsStillWorksWithLINQFiltersAsync()
+    {
+        // Arrange - Verify that String.Contains (instance method) still works
+        // String.Contains is NOT affected by C# 14 "first-class spans" - only arrays are
+        this._messageHandlerStub.AddJsonResponse(File.ReadAllText(SiteFilterSKResponseJson));
+        ITextSearch<KeenableWebPage> textSearch = new KeenableTextSearch(options: new() { HttpClient = this._httpClient });
+
+        // Act - Title.Contains appends to the query, Site.Contains maps to the site filter
+        var searchOptions = new TextSearchOptions<KeenableWebPage>
+        {
+            Top = 5,
+            Skip = 0,
+            Filter = page => page.Title.Contains("Kernel") && page.Site.Contains("learn.microsoft.com")
+        };
+        KernelSearchResults<string> result = await textSearch.SearchAsync("Semantic Kernel tutorial", searchOptions);
+
+        // Assert - Verify String.Contains works correctly
+        var requestBodyJson = Encoding.UTF8.GetString(this._messageHandlerStub.RequestContents[0]!);
+        Assert.Equal("{\"query\":\"Semantic Kernel tutorial Kernel\",\"max_results\":5,\"site\":\"learn.microsoft.com\"}", requestBodyJson);
+    }
+
+    #endregion
+
+    #region private
+    private const string WhatIsTheSKResponseJson = "./TestData/keenable_what_is_the_semantic_kernel.json";
+    private const string SiteFilterSKResponseJson = "./TestData/keenable_site_filter_what_is_the_semantic_kernel.json";
+
+    private readonly MultipleHttpMessageHandlerStub _messageHandlerStub;
+    private readonly HttpClient _httpClient;
+    private readonly Kernel _kernel;
+
+    /// <summary>
+    /// Test mapper which converts a KeenableSearchResult to a string using JSON serialization.
+    /// </summary>
+    private sealed class TestTextSearchStringMapper : ITextSearchStringMapper
+    {
+        /// <inheritdoc />
+        public string MapFromResultToString(object result)
+        {
+            return JsonSerializer.Serialize(result);
+        }
+    }
+
+    /// <summary>
+    /// Test mapper which converts a KeenableSearchResult to an upper-cased TextSearchResult.
+    /// </summary>
+    private sealed class TestTextSearchResultMapper : ITextSearchResultMapper
+    {
+        /// <inheritdoc />
+        public TextSearchResult MapFromResultToTextSearchResult(object result)
+        {
+            if (result is not KeenableSearchResult searchResult)
+            {
+                throw new ArgumentException("Result must be a KeenableSearchResult", nameof(result));
+            }
+
+            return new TextSearchResult(searchResult.Snippet?.ToUpperInvariant() ?? string.Empty)
+            {
+                Name = searchResult.Title?.ToUpperInvariant(),
+                Link = searchResult.Url?.ToUpperInvariant(),
+            };
+        }
+    }
+    #endregion
+}

--- a/dotnet/src/Plugins/Plugins.UnitTests/Web/Keenable/KeenableTextSearchTests.cs
+++ b/dotnet/src/Plugins/Plugins.UnitTests/Web/Keenable/KeenableTextSearchTests.cs
@@ -235,6 +235,32 @@ public sealed class KeenableTextSearchTests : IDisposable
     }
 
     [Theory]
+    [InlineData("http://search.example.com")]
+    [InlineData("ftp://search.example.com/")]
+    public void NonHttpsEndpointThrowsArgumentException(string endpoint)
+    {
+        // Act & Assert - the API key is sent as a header, so a clear-text endpoint is refused up front
+        var e = Assert.Throws<ArgumentException>(() => new KeenableTextSearch(apiKey: "ApiKey", options: new() { HttpClient = this._httpClient, Endpoint = new Uri(endpoint) }));
+        Assert.Contains("must use HTTPS", e.Message);
+        Assert.Equal("options", e.ParamName);
+    }
+
+    [Fact]
+    public async Task TotalCountIsNullBecauseTheApiDoesNotReportOneAsync()
+    {
+        // Arrange
+        this._messageHandlerStub.AddJsonResponse(File.ReadAllText(WhatIsTheSKResponseJson));
+        var textSearch = new KeenableTextSearch(options: new() { HttpClient = this._httpClient });
+
+        // Act
+        KernelSearchResults<TextSearchResult> result = await textSearch.GetTextSearchResultsAsync("What is the Semantic Kernel?", new() { Top = 4, IncludeTotalCount = true });
+
+        // Assert - four results come back, but TotalCount stays null like the Tavily connector
+        Assert.Equal(4, (await result.Results.ToListAsync()).Count);
+        Assert.Null(result.TotalCount);
+    }
+
+    [Theory]
     [InlineData("https://search.example.com", false, "https://search.example.com/v1/search/public")]
     [InlineData("https://search.example.com/", true, "https://search.example.com/v1/search")]
     [InlineData("https://search.example.com/proxy", false, "https://search.example.com/proxy/v1/search/public")]
@@ -587,6 +613,64 @@ public sealed class KeenableTextSearchTests : IDisposable
         };
         var exception = await Assert.ThrowsAsync<NotSupportedException>(async () => await textSearch.SearchAsync("test", searchOptions));
         Assert.Contains("Property 'Description' cannot be mapped", exception.Message);
+        Assert.Empty(this._messageHandlerStub.RequestUris);
+    }
+
+    [Fact]
+    public async Task LinqOrElseThrowsNotSupportedExceptionAsync()
+    {
+        // Arrange
+        this._messageHandlerStub.AddJsonResponse(File.ReadAllText(SiteFilterSKResponseJson));
+        ITextSearch<KeenableWebPage> textSearch = new KeenableTextSearch(options: new() { HttpClient = this._httpClient });
+
+        // Act & Assert - OR cannot be sent as one request; merging both sides would search only the last site
+        var searchOptions = new TextSearchOptions<KeenableWebPage>
+        {
+            Top = 4,
+            Filter = page => page.Site == "learn.microsoft.com" || page.Site == "github.com"
+        };
+        var exception = await Assert.ThrowsAsync<NotSupportedException>(async () => await textSearch.SearchAsync("test", searchOptions));
+        Assert.StartsWith("Logical OR (||) is not supported", exception.Message, StringComparison.Ordinal);
+        Assert.Contains("combined with &&", exception.Message);
+        Assert.Empty(this._messageHandlerStub.RequestUris);
+    }
+
+    [Fact]
+    public async Task LinqInequalityThrowsNotSupportedExceptionAsync()
+    {
+        // Arrange
+        this._messageHandlerStub.AddJsonResponse(File.ReadAllText(SiteFilterSKResponseJson));
+        ITextSearch<KeenableWebPage> textSearch = new KeenableTextSearch(options: new() { HttpClient = this._httpClient });
+
+        // Act & Assert
+        var searchOptions = new TextSearchOptions<KeenableWebPage>
+        {
+            Top = 4,
+            Filter = page => page.Site != "github.com"
+        };
+        var exception = await Assert.ThrowsAsync<NotSupportedException>(async () => await textSearch.SearchAsync("test", searchOptions));
+        Assert.StartsWith("Inequality operator (!=) on property 'Site' is not supported", exception.Message, StringComparison.Ordinal);
+        Assert.Contains("client-side or run multiple queries", exception.Message);
+        Assert.DoesNotContain("!(", exception.Message);
+        Assert.Empty(this._messageHandlerStub.RequestUris);
+    }
+
+    [Fact]
+    public async Task LinqNotThrowsNotSupportedExceptionAsync()
+    {
+        // Arrange
+        this._messageHandlerStub.AddJsonResponse(File.ReadAllText(SiteFilterSKResponseJson));
+        ITextSearch<KeenableWebPage> textSearch = new KeenableTextSearch(options: new() { HttpClient = this._httpClient });
+
+        // Act & Assert
+        var searchOptions = new TextSearchOptions<KeenableWebPage>
+        {
+            Top = 4,
+            Filter = page => !(page.Site == "github.com")
+        };
+        var exception = await Assert.ThrowsAsync<NotSupportedException>(async () => await textSearch.SearchAsync("test", searchOptions));
+        Assert.StartsWith("NOT operator (!)", exception.Message, StringComparison.Ordinal);
+        Assert.Contains("Only equality comparisons (==) on Site, PublishedAfter and PublishedBefore", exception.Message);
         Assert.Empty(this._messageHandlerStub.RequestUris);
     }
 

--- a/dotnet/src/Plugins/Plugins.Web/Keenable/KeenableSearchRequest.cs
+++ b/dotnet/src/Plugins/Plugins.Web/Keenable/KeenableSearchRequest.cs
@@ -1,0 +1,69 @@
+﻿// Copyright (c) Microsoft. All rights reserved.
+
+using System;
+using System.Text.Json.Serialization;
+
+namespace Microsoft.SemanticKernel.Plugins.Web.Keenable;
+
+/// <summary>
+/// Request body sent to the Keenable search API.
+/// </summary>
+internal sealed class KeenableSearchRequest
+{
+    /// <summary>
+    /// The search query to execute.
+    /// </summary>
+    [JsonPropertyName("query")]
+    [JsonRequired]
+    public string Query { get; set; }
+
+    /// <summary>
+    /// The maximum number of search results to return.
+    /// Required range: 1 - 50
+    /// </summary>
+    [JsonPropertyName("max_results")]
+    public int? MaxResults { get; set; }
+
+    /// <summary>
+    /// Requested maximum length, in characters, of each result snippet. Treated as a hint by the service.
+    /// </summary>
+    [JsonPropertyName("snippet_max_length")]
+    public int? SnippetMaxLength { get; set; }
+
+    /// <summary>
+    /// Restrict results to pages published on or after this date (YYYY-MM-DD).
+    /// </summary>
+    [JsonPropertyName("published_after")]
+    public string? PublishedAfter { get; set; }
+
+    /// <summary>
+    /// Restrict results to pages published on or before this date (YYYY-MM-DD).
+    /// </summary>
+    [JsonPropertyName("published_before")]
+    public string? PublishedBefore { get; set; }
+
+    /// <summary>
+    /// Restrict results to a single site, e.g. "learn.microsoft.com".
+    /// </summary>
+    [JsonPropertyName("site")]
+    public string? Site { get; set; }
+
+    /// <summary>
+    /// Initializes a new instance of the <see cref="KeenableSearchRequest" /> class.
+    /// </summary>
+    public KeenableSearchRequest(
+        string query,
+        int? maxResults,
+        int? snippetMaxLength,
+        string? publishedAfter,
+        string? publishedBefore,
+        string? site)
+    {
+        this.Query = query ?? throw new ArgumentNullException(nameof(query));
+        this.MaxResults = maxResults;
+        this.SnippetMaxLength = snippetMaxLength;
+        this.PublishedAfter = publishedAfter;
+        this.PublishedBefore = publishedBefore;
+        this.Site = site;
+    }
+}

--- a/dotnet/src/Plugins/Plugins.Web/Keenable/KeenableSearchResponse.cs
+++ b/dotnet/src/Plugins/Plugins.Web/Keenable/KeenableSearchResponse.cs
@@ -1,0 +1,26 @@
+﻿// Copyright (c) Microsoft. All rights reserved.
+
+using System.Collections.Generic;
+using System.Text.Json.Serialization;
+
+namespace Microsoft.SemanticKernel.Plugins.Web.Keenable;
+
+/// <summary>
+/// Represents a search response from Keenable.
+/// </summary>
+#pragma warning disable CA1812 // Instantiated by reflection
+internal sealed class KeenableSearchResponse
+{
+    /// <summary>
+    /// The search query that was executed.
+    /// </summary>
+    [JsonPropertyName("query")]
+    public string? Query { get; set; }
+
+    /// <summary>
+    /// The list of search results, ranked by relevance.
+    /// </summary>
+    [JsonPropertyName("results")]
+    public IList<KeenableSearchResult> Results { get; set; } = [];
+}
+#pragma warning restore CA1812 // Instantiated by reflection

--- a/dotnet/src/Plugins/Plugins.Web/Keenable/KeenableSearchResult.cs
+++ b/dotnet/src/Plugins/Plugins.Web/Keenable/KeenableSearchResult.cs
@@ -1,0 +1,63 @@
+﻿// Copyright (c) Microsoft. All rights reserved.
+
+using System;
+using System.Collections.Generic;
+using System.Text.Json.Serialization;
+
+namespace Microsoft.SemanticKernel.Plugins.Web.Keenable;
+
+/// <summary>
+/// Represents a search result from Keenable.
+/// </summary>
+[System.Diagnostics.CodeAnalysis.SuppressMessage("Design", "CA1056:URI-like properties should not be strings", Justification = "API definition")]
+public sealed class KeenableSearchResult
+{
+    /// <summary>
+    /// Only allow creation within this package.
+    /// </summary>
+    [JsonConstructor]
+    internal KeenableSearchResult()
+    {
+    }
+
+    /// <summary>
+    /// The title of the page.
+    /// </summary>
+    [JsonPropertyName("title")]
+    public string Title { get; set; } = string.Empty;
+
+    /// <summary>
+    /// The URL of the page.
+    /// </summary>
+    [JsonPropertyName("url")]
+    public string Url { get; set; } = string.Empty;
+
+    /// <summary>
+    /// A passage of the page text relevant to the query. This is the main text field of a result.
+    /// </summary>
+    [JsonPropertyName("snippet")]
+    public string? Snippet { get; set; }
+
+    /// <summary>
+    /// A short description of the page. May be empty; prefer <see cref="Snippet"/>.
+    /// </summary>
+    [JsonPropertyName("description")]
+    public string? Description { get; set; }
+
+    /// <summary>
+    /// When the page was published, if known.
+    /// </summary>
+    [JsonPropertyName("published_at")]
+    public DateTimeOffset? PublishedAt { get; set; }
+
+    /// <summary>
+    /// Additional properties that are not explicitly defined in the schema.
+    /// </summary>
+    [JsonExtensionData]
+    public IDictionary<string, object> AdditionalProperties { get; set; } = new Dictionary<string, object>();
+
+    /// <summary>
+    /// The text to use for this result: the snippet, or the description when the snippet is empty.
+    /// </summary>
+    internal string Text => string.IsNullOrEmpty(this.Snippet) ? this.Description ?? string.Empty : this.Snippet!;
+}

--- a/dotnet/src/Plugins/Plugins.Web/Keenable/KeenableTextSearch.cs
+++ b/dotnet/src/Plugins/Plugins.Web/Keenable/KeenableTextSearch.cs
@@ -1,0 +1,706 @@
+﻿// Copyright (c) Microsoft. All rights reserved.
+
+using System;
+using System.Collections.Generic;
+using System.Globalization;
+using System.Linq;
+using System.Linq.Expressions;
+using System.Net.Http;
+using System.Runtime.CompilerServices;
+using System.Text;
+using System.Text.Json;
+using System.Text.Json.Serialization;
+using System.Threading;
+using System.Threading.Tasks;
+using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Logging.Abstractions;
+using Microsoft.Extensions.VectorData;
+using Microsoft.SemanticKernel.Data;
+using Microsoft.SemanticKernel.Http;
+
+namespace Microsoft.SemanticKernel.Plugins.Web.Keenable;
+
+/// <summary>
+/// A Keenable Text Search implementation that can be used to perform searches using the Keenable Web Search API.
+/// </summary>
+/// <remarks>
+/// The API key is optional. Without a key the connector calls the public endpoint, which is rate limited per client IP.
+/// With a key the connector calls the authenticated endpoint, which lifts those limits.
+/// </remarks>
+#pragma warning disable CS0618 // ITextSearch is obsolete
+public sealed class KeenableTextSearch : ITextSearch, ITextSearch<KeenableWebPage>
+#pragma warning restore CS0618
+{
+    /// <summary>
+    /// Create an instance of the <see cref="KeenableTextSearch"/>.
+    /// </summary>
+    /// <param name="apiKey">Optional API key used to authenticate requests against the Search service. When null or empty the public endpoint is used.</param>
+    /// <param name="options">Options used when creating this instance of <see cref="KeenableTextSearch"/>.</param>
+    public KeenableTextSearch(string? apiKey = null, KeenableTextSearchOptions? options = null)
+    {
+        this._apiKey = string.IsNullOrWhiteSpace(apiKey) ? null : apiKey;
+        this._uri = BuildSearchUri(options?.Endpoint ?? new Uri(DefaultUri), this._apiKey is null);
+        this._searchOptions = options;
+        this._logger = options?.LoggerFactory?.CreateLogger(typeof(KeenableTextSearch)) ?? NullLogger.Instance;
+        this._httpClient = options?.HttpClient ?? HttpClientProvider.GetHttpClient();
+        this._httpClient.DefaultRequestHeaders.Add("User-Agent", HttpHeaderConstant.Values.UserAgent);
+        this._httpClient.DefaultRequestHeaders.Add(HttpHeaderConstant.Names.SemanticKernelVersion, HttpHeaderConstant.Values.GetAssemblyVersion(typeof(KeenableTextSearch)));
+        this._stringMapper = options?.StringMapper ?? s_defaultStringMapper;
+        this._resultMapper = options?.ResultMapper ?? s_defaultResultMapper;
+    }
+
+#pragma warning disable CS0618 // Obsolete ITextSearch, TextSearchOptions, TextSearchFilter, FilterClause
+
+    #region Legacy ITextSearch Implementation
+
+    /// <inheritdoc/>
+    public async Task<KernelSearchResults<string>> SearchAsync(string query, TextSearchOptions? searchOptions = null, CancellationToken cancellationToken = default)
+    {
+        searchOptions ??= new TextSearchOptions();
+        var filters = ExtractFiltersFromLegacy(searchOptions.Filter);
+        KeenableSearchResponse? searchResponse = await this.ExecuteSearchAsync(query, searchOptions.Top, searchOptions.Skip, filters, cancellationToken).ConfigureAwait(false);
+
+        long? totalCount = searchOptions.IncludeTotalCount ? searchResponse?.Results.Count : null;
+
+        return new KernelSearchResults<string>(this.GetResultsAsStringAsync(searchResponse, cancellationToken), totalCount, GetResultsMetadata(searchResponse));
+    }
+
+    /// <inheritdoc/>
+    public async Task<KernelSearchResults<TextSearchResult>> GetTextSearchResultsAsync(string query, TextSearchOptions? searchOptions = null, CancellationToken cancellationToken = default)
+    {
+        searchOptions ??= new TextSearchOptions();
+        var filters = ExtractFiltersFromLegacy(searchOptions.Filter);
+        KeenableSearchResponse? searchResponse = await this.ExecuteSearchAsync(query, searchOptions.Top, searchOptions.Skip, filters, cancellationToken).ConfigureAwait(false);
+
+        long? totalCount = searchOptions.IncludeTotalCount ? searchResponse?.Results.Count : null;
+
+        return new KernelSearchResults<TextSearchResult>(this.GetResultsAsTextSearchResultAsync(searchResponse, cancellationToken), totalCount, GetResultsMetadata(searchResponse));
+    }
+
+    /// <inheritdoc/>
+    public async Task<KernelSearchResults<object>> GetSearchResultsAsync(string query, TextSearchOptions? searchOptions = null, CancellationToken cancellationToken = default)
+    {
+        searchOptions ??= new TextSearchOptions();
+        var filters = ExtractFiltersFromLegacy(searchOptions.Filter);
+        KeenableSearchResponse? searchResponse = await this.ExecuteSearchAsync(query, searchOptions.Top, searchOptions.Skip, filters, cancellationToken).ConfigureAwait(false);
+
+        long? totalCount = searchOptions.IncludeTotalCount ? searchResponse?.Results.Count : null;
+
+        return new KernelSearchResults<object>(this.GetResultsAsObjectAsync(searchResponse, cancellationToken), totalCount, GetResultsMetadata(searchResponse));
+    }
+
+    #endregion
+
+#pragma warning restore CS0618
+
+    #region Generic ITextSearch<KeenableWebPage> Implementation
+
+    /// <inheritdoc/>
+    async Task<KernelSearchResults<string>> ITextSearch<KeenableWebPage>.SearchAsync(string query, TextSearchOptions<KeenableWebPage>? searchOptions, CancellationToken cancellationToken)
+    {
+        var (modifiedQuery, top, skip, includeTotalCount, filters) = ExtractSearchParameters(query, searchOptions);
+        KeenableSearchResponse? searchResponse = await this.ExecuteSearchAsync(modifiedQuery, top, skip, filters, cancellationToken).ConfigureAwait(false);
+
+        long? totalCount = includeTotalCount ? searchResponse?.Results.Count : null;
+
+        return new KernelSearchResults<string>(this.GetResultsAsStringAsync(searchResponse, cancellationToken), totalCount, GetResultsMetadata(searchResponse));
+    }
+
+    /// <inheritdoc/>
+    async Task<KernelSearchResults<TextSearchResult>> ITextSearch<KeenableWebPage>.GetTextSearchResultsAsync(string query, TextSearchOptions<KeenableWebPage>? searchOptions, CancellationToken cancellationToken)
+    {
+        var (modifiedQuery, top, skip, includeTotalCount, filters) = ExtractSearchParameters(query, searchOptions);
+        KeenableSearchResponse? searchResponse = await this.ExecuteSearchAsync(modifiedQuery, top, skip, filters, cancellationToken).ConfigureAwait(false);
+
+        long? totalCount = includeTotalCount ? searchResponse?.Results.Count : null;
+
+        return new KernelSearchResults<TextSearchResult>(this.GetResultsAsTextSearchResultAsync(searchResponse, cancellationToken), totalCount, GetResultsMetadata(searchResponse));
+    }
+
+    /// <inheritdoc/>
+    async Task<KernelSearchResults<KeenableWebPage>> ITextSearch<KeenableWebPage>.GetSearchResultsAsync(string query, TextSearchOptions<KeenableWebPage>? searchOptions, CancellationToken cancellationToken)
+    {
+        var (modifiedQuery, top, skip, includeTotalCount, filters) = ExtractSearchParameters(query, searchOptions);
+        KeenableSearchResponse? searchResponse = await this.ExecuteSearchAsync(modifiedQuery, top, skip, filters, cancellationToken).ConfigureAwait(false);
+
+        long? totalCount = includeTotalCount ? searchResponse?.Results.Count : null;
+
+        return new KernelSearchResults<KeenableWebPage>(this.GetResultsAsWebPageAsync(searchResponse, cancellationToken), totalCount, GetResultsMetadata(searchResponse));
+    }
+
+    #endregion
+
+    #region LINQ-to-Keenable Conversion Logic
+
+    /// <summary>
+    /// Extracts search parameters from generic <see cref="TextSearchOptions{TRecord}"/>.
+    /// This is the primary entry point for the LINQ-based filtering path.
+    /// Keenable supports query modification via Title.Contains() which appends terms to the query.
+    /// </summary>
+    private static (string ModifiedQuery, int Top, int Skip, bool IncludeTotalCount, List<(string FieldName, object Value)> Filters) ExtractSearchParameters<TRecord>(string query, TextSearchOptions<TRecord>? searchOptions)
+    {
+        var top = searchOptions?.Top ?? 3;
+        var skip = searchOptions?.Skip ?? 0;
+        var includeTotalCount = searchOptions?.IncludeTotalCount ?? false;
+
+        if (searchOptions?.Filter == null)
+        {
+            return (query, top, skip, includeTotalCount, []);
+        }
+
+        var filters = new List<(string FieldName, object Value)>();
+        var queryTerms = new List<string>();
+
+        ExtractFiltersFromExpression(searchOptions.Filter.Body, filters, queryTerms);
+
+        // Append query terms from Title.Contains() to the search query
+        var modifiedQuery = queryTerms.Count > 0
+            ? $"{query} {string.Join(" ", queryTerms)}".Trim()
+            : query;
+
+        return (modifiedQuery, top, skip, includeTotalCount, filters);
+    }
+
+    /// <summary>
+    /// Walks a LINQ expression tree and extracts Keenable API filter key-value pairs and query terms directly.
+    /// Supports equality expressions, Contains() method calls, and logical AND/OR operators.
+    /// </summary>
+    /// <param name="expression">The expression to analyze.</param>
+    /// <param name="filters">The list to add filter key-value pairs to.</param>
+    /// <param name="queryTerms">The list to add query modification terms to.</param>
+    private static void ExtractFiltersFromExpression(Expression expression, List<(string FieldName, object Value)> filters, List<string> queryTerms)
+    {
+        switch (expression)
+        {
+            case BinaryExpression { NodeType: ExpressionType.AndAlso or ExpressionType.OrElse } binaryExpr:
+                // Handle AND/OR expressions by recursively analyzing both sides
+                ExtractFiltersFromExpression(binaryExpr.Left, filters, queryTerms);
+                ExtractFiltersFromExpression(binaryExpr.Right, filters, queryTerms);
+                break;
+
+            case BinaryExpression { NodeType: ExpressionType.Equal } binaryExpr:
+                ProcessEqualityClause(binaryExpr, filters);
+                break;
+
+            case BinaryExpression { NodeType: ExpressionType.NotEqual } binaryExpr:
+                ProcessInequalityClause(binaryExpr);
+                break;
+
+            case BinaryExpression binaryExpr:
+                throw new NotSupportedException($"Binary expression type '{binaryExpr.NodeType}' is not supported. Supported operators: AndAlso (&&), OrElse (||), Equal (==), NotEqual (!=).");
+
+            case UnaryExpression { NodeType: ExpressionType.Not } unaryExpr:
+                ProcessNotExpression(unaryExpr);
+                break;
+
+            case MethodCallExpression methodCall:
+                ProcessMethodCallClause(methodCall, filters, queryTerms);
+                break;
+
+            default:
+                throw new NotSupportedException($"Expression type '{expression.NodeType}' is not supported in Keenable search filters.");
+        }
+    }
+
+    /// <summary>
+    /// Processes an equality expression and maps the property to a Keenable API filter directly.
+    /// </summary>
+    private static void ProcessEqualityClause(BinaryExpression binaryExpr, List<(string FieldName, object Value)> filters)
+    {
+        string? propertyName = null;
+        object? value = null;
+
+        if (binaryExpr.Left is MemberExpression leftMember)
+        {
+            propertyName = leftMember.Member.Name;
+            value = ExtractValue(binaryExpr.Right);
+        }
+        else if (binaryExpr.Right is MemberExpression rightMember)
+        {
+            propertyName = rightMember.Member.Name;
+            value = ExtractValue(binaryExpr.Left);
+        }
+
+        if (propertyName != null && value != null)
+        {
+            var mappedFieldName = MapPropertyToKeenableFilter(propertyName);
+            if (mappedFieldName != null)
+            {
+                filters.Add((mappedFieldName, value));
+            }
+            else
+            {
+                throw new NotSupportedException(
+                    $"Property '{propertyName}' cannot be mapped to Keenable API filters. " +
+                    $"Supported properties: {string.Join(", ", s_validFieldNames)}. " +
+                    "Example: page => page.Site == \"learn.microsoft.com\" && page.PublishedAfter == \"2025-01-01\"");
+            }
+        }
+        else
+        {
+            throw new NotSupportedException("Unable to extract property name and value from equality expression.");
+        }
+    }
+
+    /// <summary>
+    /// Processes an inequality expression, which is not supported by the Keenable API.
+    /// </summary>
+    private static void ProcessInequalityClause(BinaryExpression binaryExpr)
+    {
+        string? propertyName = null;
+
+        if (binaryExpr.Left is MemberExpression leftMember)
+        {
+            propertyName = leftMember.Member.Name;
+        }
+        else if (binaryExpr.Right is MemberExpression rightMember)
+        {
+            propertyName = rightMember.Member.Name;
+        }
+
+        if (propertyName != null)
+        {
+            throw new NotSupportedException($"Inequality operator (!=) is not directly supported for property '{propertyName}'. Use NOT operator instead: !(page.{propertyName} == value).");
+        }
+
+        throw new NotSupportedException("Unable to extract property name and value from inequality expression.");
+    }
+
+    /// <summary>
+    /// Processes a NOT (negation) expression, which is not supported by the Keenable API.
+    /// </summary>
+    private static void ProcessNotExpression(UnaryExpression unaryExpr)
+    {
+        if (unaryExpr.Operand is BinaryExpression binaryExpr && binaryExpr.NodeType == ExpressionType.Equal)
+        {
+            throw new NotSupportedException("NOT operator (!) with equality is not directly supported. Most web search APIs don't support negative filtering.");
+        }
+
+        throw new NotSupportedException("NOT operator (!) is only supported with simple equality expressions.");
+    }
+
+    /// <summary>
+    /// Processes a method call expression (Contains) and maps to filters or query terms directly.
+    /// </summary>
+    private static void ProcessMethodCallClause(MethodCallExpression methodCall, List<(string FieldName, object Value)> filters, List<string> queryTerms)
+    {
+        if (methodCall.Method.Name == "Contains")
+        {
+            if (methodCall.Object is MemberExpression member)
+            {
+                // Instance method: property.Contains(value) - e.g., page.Site.Contains("learn.microsoft.com")
+                var propertyName = member.Member.Name;
+                var value = ExtractValue(methodCall.Arguments[0]);
+
+                if (value != null)
+                {
+                    if (propertyName.Equals("Site", StringComparison.OrdinalIgnoreCase))
+                    {
+                        // For Contains on the site property, map to equality filter
+                        filters.Add((Site, value));
+                    }
+                    else if (propertyName.Equals("Title", StringComparison.OrdinalIgnoreCase))
+                    {
+                        // For Title.Contains(), add the term to the search query
+                        queryTerms.Add(value.ToString() ?? string.Empty);
+                    }
+                    else
+                    {
+                        throw new NotSupportedException($"Contains method is only supported for the Site and Title properties, not '{propertyName}'.");
+                    }
+                }
+            }
+            else
+            {
+                throw new NotSupportedException(
+                    "Collection Contains filters (e.g., array.Contains(page.Property)) are not supported by Keenable Search API. " +
+                    "Consider either: (1) performing multiple separate searches for each value, or " +
+                    "(2) retrieving broader results and filtering on the client side.");
+            }
+        }
+        else
+        {
+            throw new NotSupportedException($"Method '{methodCall.Method.Name}' is not supported in Keenable search filters. Only 'Contains' is supported.");
+        }
+    }
+
+    /// <summary>
+    /// Maps KeenableWebPage property names to Keenable API filter parameter names.
+    /// </summary>
+    /// <param name="propertyName">The property name from KeenableWebPage.</param>
+    /// <returns>The corresponding Keenable API parameter name, or null if not mappable.</returns>
+    private static string? MapPropertyToKeenableFilter(string propertyName) =>
+        propertyName.ToUpperInvariant() switch
+        {
+            "SITE" => Site,
+            "PUBLISHEDAFTER" => PublishedAfter,
+            "PUBLISHEDBEFORE" => PublishedBefore,
+            _ => null // Property not mappable to Keenable filters
+        };
+
+    /// <summary>
+    /// Extracts a constant value from an expression.
+    /// </summary>
+    /// <param name="expression">The expression to extract the value from.</param>
+    /// <returns>The extracted value, or null if extraction failed.</returns>
+    private static object? ExtractValue(Expression expression)
+    {
+        return expression switch
+        {
+            ConstantExpression constant => constant.Value,
+            MemberExpression member => ExtractMemberValue(member),
+            _ => throw new NotSupportedException(
+                $"Unable to extract value from expression of node type '{expression.NodeType}'. " +
+                "Only constant expressions and member access are supported for AOT compatibility. " +
+                "Expression: " + expression)
+        };
+    }
+
+    /// <summary>
+    /// Extracts a value from a member expression by walking the member access chain.
+    /// </summary>
+    /// <param name="memberExpression">The member expression to evaluate.</param>
+    /// <returns>The extracted value, or null if extraction failed.</returns>
+    private static object? ExtractMemberValue(MemberExpression memberExpression)
+    {
+        // Recursively evaluate the member's expression (handles nested member access)
+        var target = memberExpression.Expression is not null
+            ? ExtractValue(memberExpression.Expression)
+            : null;
+
+        return memberExpression.Member switch
+        {
+            System.Reflection.FieldInfo field => field.GetValue(target),
+            System.Reflection.PropertyInfo property => property.GetValue(target),
+            _ => null
+        };
+    }
+
+    #endregion
+
+    #region Private Methods
+
+    private readonly ILogger _logger;
+    private readonly HttpClient _httpClient;
+    private readonly string? _apiKey;
+    private readonly Uri _uri;
+    private readonly KeenableTextSearchOptions? _searchOptions;
+    private readonly ITextSearchStringMapper _stringMapper;
+    private readonly ITextSearchResultMapper _resultMapper;
+
+    private static readonly ITextSearchStringMapper s_defaultStringMapper = new DefaultTextSearchStringMapper();
+    private static readonly ITextSearchResultMapper s_defaultResultMapper = new DefaultTextSearchResultMapper();
+
+    private const string DefaultUri = "https://api.keenable.ai";
+    private const string SearchPath = "v1/search";
+    private const string PublicSearchPath = "v1/search/public";
+    private const int MaxResults = 50;
+
+    /// <summary>
+    /// Header that identifies the calling application to the service. Required by the public endpoint.
+    /// </summary>
+    private const string TitleHeaderName = "X-Keenable-Title";
+    private const string TitleHeaderValue = "semantic-kernel";
+    private const string ApiKeyHeaderName = "X-API-Key";
+
+    private const string Site = "site";
+    private const string PublishedAfter = "published_after";
+    private const string PublishedBefore = "published_before";
+
+    private static readonly string[] s_validFieldNames = [Site, PublishedAfter, PublishedBefore];
+
+    /// <summary>
+    /// Build the full search URI from the base endpoint. The public path is used when no API key is configured.
+    /// </summary>
+    private static Uri BuildSearchUri(Uri endpoint, bool isPublic)
+    {
+        var baseUri = endpoint.AbsoluteUri.EndsWith("/", StringComparison.Ordinal) ? endpoint : new Uri(endpoint.AbsoluteUri + "/");
+        return new Uri(baseUri, isPublic ? PublicSearchPath : SearchPath);
+    }
+
+    /// <summary>
+    /// Execute a Keenable search query and return the results.
+    /// </summary>
+    /// <param name="query">What to search for.</param>
+    /// <param name="top">Number of results to return.</param>
+    /// <param name="skip">Number of results to skip.</param>
+    /// <param name="filters">Pre-extracted filter key-value pairs.</param>
+    /// <param name="cancellationToken">The <see cref="CancellationToken"/> to monitor for cancellation requests. The default is <see cref="CancellationToken.None"/>.</param>
+    private async Task<KeenableSearchResponse?> ExecuteSearchAsync(string query, int top, int skip, List<(string FieldName, object Value)> filters, CancellationToken cancellationToken)
+    {
+        using HttpResponseMessage response = await this.SendPostRequestAsync(query, top, skip, filters, cancellationToken).ConfigureAwait(false);
+
+        this._logger.LogDebug("Response received: {StatusCode}", response.StatusCode);
+
+        string json = await response.Content.ReadAsStringWithExceptionMappingAsync(cancellationToken).ConfigureAwait(false);
+
+        // Sensitive data, logging as trace, disabled by default
+        this._logger.LogTrace("Response content received: {Data}", json);
+
+        var searchResponse = JsonSerializer.Deserialize<KeenableSearchResponse>(json);
+
+        // The API has no offset parameter, so the request asks for top + skip results and the first skip are dropped here.
+        if (skip > 0 && searchResponse?.Results is { Count: > 0 })
+        {
+            searchResponse.Results = searchResponse.Results.Skip(skip).ToList();
+        }
+
+        return searchResponse;
+    }
+
+    /// <summary>
+    /// Sends a POST request to the search endpoint.
+    /// </summary>
+    /// <param name="query">The query string.</param>
+    /// <param name="top">Number of results to return.</param>
+    /// <param name="skip">Number of results to skip.</param>
+    /// <param name="filters">Pre-extracted filter key-value pairs.</param>
+    /// <param name="cancellationToken">A cancellation token to cancel the request.</param>
+    /// <returns>A <see cref="HttpResponseMessage"/> representing the response from the request.</returns>
+    private async Task<HttpResponseMessage> SendPostRequestAsync(string query, int top, int skip, List<(string FieldName, object Value)> filters, CancellationToken cancellationToken)
+    {
+        Verify.NotNull(query);
+
+        if (top is <= 0 or > MaxResults)
+        {
+            throw new ArgumentOutOfRangeException(nameof(top), top, $"{nameof(top)} count value must be greater than 0 and have a maximum value of {MaxResults}.");
+        }
+
+        if (skip < 0 || top + skip > MaxResults)
+        {
+            throw new ArgumentOutOfRangeException(nameof(skip), skip, $"{nameof(skip)} value must be equal or greater than 0 and {nameof(top)} + {nameof(skip)} must not exceed {MaxResults}.");
+        }
+
+        var requestContent = this.BuildRequestContent(query, top, skip, filters);
+
+        using var httpRequestMessage = new HttpRequestMessage(HttpMethod.Post, this._uri)
+        {
+            Content = GetJsonContent(requestContent)
+        };
+
+        httpRequestMessage.Headers.Add(TitleHeaderName, TitleHeaderValue);
+
+        if (!string.IsNullOrEmpty(this._apiKey))
+        {
+            httpRequestMessage.Headers.Add(ApiKeyHeaderName, this._apiKey);
+        }
+
+        return await this._httpClient.SendWithSuccessCheckAsync(httpRequestMessage, cancellationToken).ConfigureAwait(false);
+    }
+
+    /// <summary>
+    /// Return the search results as instances of <see cref="KeenableSearchResult"/>.
+    /// </summary>
+    /// <param name="searchResponse">Response containing the web pages matching the query.</param>
+    /// <param name="cancellationToken">Cancellation token</param>
+    private async IAsyncEnumerable<object> GetResultsAsObjectAsync(KeenableSearchResponse? searchResponse, [EnumeratorCancellation] CancellationToken cancellationToken)
+    {
+        if (searchResponse?.Results is null)
+        {
+            yield break;
+        }
+
+        foreach (var result in searchResponse.Results)
+        {
+            yield return result;
+            await Task.Yield();
+        }
+    }
+
+    /// <summary>
+    /// Return the search results as instances of <see cref="KeenableWebPage"/>.
+    /// </summary>
+    /// <param name="searchResponse">Response containing the web pages matching the query.</param>
+    /// <param name="cancellationToken">Cancellation token</param>
+    private async IAsyncEnumerable<KeenableWebPage> GetResultsAsWebPageAsync(KeenableSearchResponse? searchResponse, [EnumeratorCancellation] CancellationToken cancellationToken)
+    {
+        if (searchResponse?.Results is null)
+        {
+            yield break;
+        }
+
+        foreach (var result in searchResponse.Results)
+        {
+            yield return KeenableWebPage.FromSearchResult(result);
+            await Task.Yield();
+        }
+    }
+
+    /// <summary>
+    /// Return the search results as instances of <see cref="TextSearchResult"/>.
+    /// </summary>
+    /// <param name="searchResponse">Response containing the web pages matching the query.</param>
+    /// <param name="cancellationToken">Cancellation token</param>
+    private async IAsyncEnumerable<TextSearchResult> GetResultsAsTextSearchResultAsync(KeenableSearchResponse? searchResponse, [EnumeratorCancellation] CancellationToken cancellationToken)
+    {
+        if (searchResponse?.Results is null)
+        {
+            yield break;
+        }
+
+        foreach (var result in searchResponse.Results)
+        {
+            yield return this._resultMapper.MapFromResultToTextSearchResult(result);
+            await Task.Yield();
+        }
+    }
+
+    /// <summary>
+    /// Return the search results as instances of <see cref="string"/>.
+    /// </summary>
+    /// <param name="searchResponse">Response containing the web pages matching the query.</param>
+    /// <param name="cancellationToken">Cancellation token</param>
+    private async IAsyncEnumerable<string> GetResultsAsStringAsync(KeenableSearchResponse? searchResponse, [EnumeratorCancellation] CancellationToken cancellationToken)
+    {
+        if (searchResponse?.Results is null)
+        {
+            yield break;
+        }
+
+        foreach (var result in searchResponse.Results)
+        {
+            yield return this._stringMapper.MapFromResultToString(result);
+            await Task.Yield();
+        }
+    }
+
+    /// <summary>
+    /// Return the results metadata.
+    /// </summary>
+    /// <param name="searchResponse">Response containing the documents matching the query.</param>
+    private static Dictionary<string, object?>? GetResultsMetadata(KeenableSearchResponse? searchResponse)
+    {
+        return new Dictionary<string, object?>()
+        {
+            { "Query", searchResponse?.Query },
+        };
+    }
+
+    /// <summary>
+    /// Default implementation which maps from a <see cref="KeenableSearchResult"/> to a <see cref="string"/>
+    /// </summary>
+    private sealed class DefaultTextSearchStringMapper : ITextSearchStringMapper
+    {
+        /// <inheritdoc />
+        public string MapFromResultToString(object result)
+        {
+            if (result is not KeenableSearchResult searchResult)
+            {
+                throw new ArgumentException("Result must be a KeenableSearchResult", nameof(result));
+            }
+
+            return searchResult.Text;
+        }
+    }
+
+    /// <summary>
+    /// Default implementation which maps from a <see cref="KeenableSearchResult"/> to a <see cref="TextSearchResult"/>
+    /// </summary>
+    private sealed class DefaultTextSearchResultMapper : ITextSearchResultMapper
+    {
+        /// <inheritdoc />
+        public TextSearchResult MapFromResultToTextSearchResult(object result)
+        {
+            if (result is not KeenableSearchResult searchResult)
+            {
+                throw new ArgumentException("Result must be a KeenableSearchResult", nameof(result));
+            }
+
+            return new TextSearchResult(searchResult.Text) { Name = searchResult.Title, Link = searchResult.Url };
+        }
+    }
+
+    /// <summary>
+    /// Extracts filter key-value pairs from a legacy <see cref="TextSearchFilter"/>.
+    /// This shim converts the obsolete FilterClause-based format to the internal (FieldName, Value) list.
+    /// It will be removed when the legacy ITextSearch interface is retired.
+    /// </summary>
+#pragma warning disable CS0618 // Obsolete TextSearchFilter, FilterClause
+    private static List<(string FieldName, object Value)> ExtractFiltersFromLegacy(TextSearchFilter? filter)
+    {
+        var filters = new List<(string FieldName, object Value)>();
+        if (filter is not null)
+        {
+            foreach (var clause in filter.FilterClauses)
+            {
+                if (clause is EqualToFilterClause eq)
+                {
+                    filters.Add((eq.FieldName, eq.Value));
+                }
+                else
+                {
+                    throw new NotSupportedException(
+                        $"Filter clause type '{clause.GetType().Name}' is not supported by Keenable Text Search. Only EqualToFilterClause is supported.");
+                }
+            }
+        }
+        return filters;
+    }
+#pragma warning restore CS0618
+
+    /// <summary>
+    /// Build a Keenable API request from pre-extracted filter key-value pairs.
+    /// Both LINQ and legacy paths converge here after producing the same (FieldName, Value) list.
+    /// </summary>
+    /// <param name="query">The query.</param>
+    /// <param name="top">Number of results to return.</param>
+    /// <param name="skip">Number of results to skip.</param>
+    /// <param name="filters">Pre-extracted filter key-value pairs.</param>
+    private KeenableSearchRequest BuildRequestContent(string query, int top, int skip, List<(string FieldName, object Value)> filters)
+    {
+        string? site = null;
+        string? publishedAfter = null;
+        string? publishedBefore = null;
+
+        foreach (var (fieldName, value) in filters)
+        {
+            if (fieldName.Equals(Site, StringComparison.OrdinalIgnoreCase) && value is not null)
+            {
+                site = value.ToString()!;
+            }
+            else if (fieldName.Equals(PublishedAfter, StringComparison.OrdinalIgnoreCase) && value is not null)
+            {
+                publishedAfter = FormatDate(value);
+            }
+            else if (fieldName.Equals(PublishedBefore, StringComparison.OrdinalIgnoreCase) && value is not null)
+            {
+                publishedBefore = FormatDate(value);
+            }
+            else
+            {
+                throw new ArgumentException($"Unknown equality filter clause field name '{fieldName}', must be one of {string.Join(",", s_validFieldNames)}", nameof(filters));
+            }
+        }
+
+        return new KeenableSearchRequest(
+            query,
+            top + skip,
+            this._searchOptions?.SnippetMaxLength,
+            publishedAfter,
+            publishedBefore,
+            site);
+    }
+
+    /// <summary>
+    /// Format a date filter value as YYYY-MM-DD. Strings are passed through unchanged.
+    /// </summary>
+    private static string FormatDate(object value) => value switch
+    {
+        DateTimeOffset dto => dto.ToString("yyyy-MM-dd", CultureInfo.InvariantCulture),
+        DateTime dt => dt.ToString("yyyy-MM-dd", CultureInfo.InvariantCulture),
+        _ => value.ToString()!,
+    };
+
+    private static readonly JsonSerializerOptions s_jsonOptionsCache = new()
+    {
+        DefaultIgnoreCondition = JsonIgnoreCondition.WhenWritingNull,
+    };
+
+    private static StringContent GetJsonContent(object payload)
+    {
+        string strPayload = JsonSerializer.Serialize(payload, s_jsonOptionsCache);
+        return new(strPayload, Encoding.UTF8, "application/json");
+    }
+
+    #endregion
+}

--- a/dotnet/src/Plugins/Plugins.Web/Keenable/KeenableTextSearch.cs
+++ b/dotnet/src/Plugins/Plugins.Web/Keenable/KeenableTextSearch.cs
@@ -38,8 +38,14 @@ public sealed class KeenableTextSearch : ITextSearch, ITextSearch<KeenableWebPag
     /// <param name="options">Options used when creating this instance of <see cref="KeenableTextSearch"/>.</param>
     public KeenableTextSearch(string? apiKey = null, KeenableTextSearchOptions? options = null)
     {
+        var endpoint = options?.Endpoint ?? new Uri(DefaultUri);
+        if (!string.Equals(endpoint.Scheme, Uri.UriSchemeHttps, StringComparison.OrdinalIgnoreCase))
+        {
+            throw new ArgumentException($"The Keenable endpoint must use HTTPS, got '{endpoint}'. The API key is sent as a request header and must not travel in clear text.", nameof(options));
+        }
+
         this._apiKey = string.IsNullOrWhiteSpace(apiKey) ? null : apiKey;
-        this._uri = BuildSearchUri(options?.Endpoint ?? new Uri(DefaultUri), this._apiKey is null);
+        this._uri = BuildSearchUri(endpoint, this._apiKey is null);
         this._searchOptions = options;
         this._logger = options?.LoggerFactory?.CreateLogger(typeof(KeenableTextSearch)) ?? NullLogger.Instance;
         this._httpClient = options?.HttpClient ?? HttpClientProvider.GetHttpClient();
@@ -60,7 +66,8 @@ public sealed class KeenableTextSearch : ITextSearch, ITextSearch<KeenableWebPag
         var filters = ExtractFiltersFromLegacy(searchOptions.Filter);
         KeenableSearchResponse? searchResponse = await this.ExecuteSearchAsync(query, searchOptions.Top, searchOptions.Skip, filters, cancellationToken).ConfigureAwait(false);
 
-        long? totalCount = searchOptions.IncludeTotalCount ? searchResponse?.Results.Count : null;
+        // The API does not report a total count.
+        long? totalCount = null;
 
         return new KernelSearchResults<string>(this.GetResultsAsStringAsync(searchResponse, cancellationToken), totalCount, GetResultsMetadata(searchResponse));
     }
@@ -72,7 +79,8 @@ public sealed class KeenableTextSearch : ITextSearch, ITextSearch<KeenableWebPag
         var filters = ExtractFiltersFromLegacy(searchOptions.Filter);
         KeenableSearchResponse? searchResponse = await this.ExecuteSearchAsync(query, searchOptions.Top, searchOptions.Skip, filters, cancellationToken).ConfigureAwait(false);
 
-        long? totalCount = searchOptions.IncludeTotalCount ? searchResponse?.Results.Count : null;
+        // The API does not report a total count.
+        long? totalCount = null;
 
         return new KernelSearchResults<TextSearchResult>(this.GetResultsAsTextSearchResultAsync(searchResponse, cancellationToken), totalCount, GetResultsMetadata(searchResponse));
     }
@@ -84,7 +92,8 @@ public sealed class KeenableTextSearch : ITextSearch, ITextSearch<KeenableWebPag
         var filters = ExtractFiltersFromLegacy(searchOptions.Filter);
         KeenableSearchResponse? searchResponse = await this.ExecuteSearchAsync(query, searchOptions.Top, searchOptions.Skip, filters, cancellationToken).ConfigureAwait(false);
 
-        long? totalCount = searchOptions.IncludeTotalCount ? searchResponse?.Results.Count : null;
+        // The API does not report a total count.
+        long? totalCount = null;
 
         return new KernelSearchResults<object>(this.GetResultsAsObjectAsync(searchResponse, cancellationToken), totalCount, GetResultsMetadata(searchResponse));
     }
@@ -98,10 +107,11 @@ public sealed class KeenableTextSearch : ITextSearch, ITextSearch<KeenableWebPag
     /// <inheritdoc/>
     async Task<KernelSearchResults<string>> ITextSearch<KeenableWebPage>.SearchAsync(string query, TextSearchOptions<KeenableWebPage>? searchOptions, CancellationToken cancellationToken)
     {
-        var (modifiedQuery, top, skip, includeTotalCount, filters) = ExtractSearchParameters(query, searchOptions);
+        var (modifiedQuery, top, skip, filters) = ExtractSearchParameters(query, searchOptions);
         KeenableSearchResponse? searchResponse = await this.ExecuteSearchAsync(modifiedQuery, top, skip, filters, cancellationToken).ConfigureAwait(false);
 
-        long? totalCount = includeTotalCount ? searchResponse?.Results.Count : null;
+        // The API does not report a total count.
+        long? totalCount = null;
 
         return new KernelSearchResults<string>(this.GetResultsAsStringAsync(searchResponse, cancellationToken), totalCount, GetResultsMetadata(searchResponse));
     }
@@ -109,10 +119,11 @@ public sealed class KeenableTextSearch : ITextSearch, ITextSearch<KeenableWebPag
     /// <inheritdoc/>
     async Task<KernelSearchResults<TextSearchResult>> ITextSearch<KeenableWebPage>.GetTextSearchResultsAsync(string query, TextSearchOptions<KeenableWebPage>? searchOptions, CancellationToken cancellationToken)
     {
-        var (modifiedQuery, top, skip, includeTotalCount, filters) = ExtractSearchParameters(query, searchOptions);
+        var (modifiedQuery, top, skip, filters) = ExtractSearchParameters(query, searchOptions);
         KeenableSearchResponse? searchResponse = await this.ExecuteSearchAsync(modifiedQuery, top, skip, filters, cancellationToken).ConfigureAwait(false);
 
-        long? totalCount = includeTotalCount ? searchResponse?.Results.Count : null;
+        // The API does not report a total count.
+        long? totalCount = null;
 
         return new KernelSearchResults<TextSearchResult>(this.GetResultsAsTextSearchResultAsync(searchResponse, cancellationToken), totalCount, GetResultsMetadata(searchResponse));
     }
@@ -120,10 +131,11 @@ public sealed class KeenableTextSearch : ITextSearch, ITextSearch<KeenableWebPag
     /// <inheritdoc/>
     async Task<KernelSearchResults<KeenableWebPage>> ITextSearch<KeenableWebPage>.GetSearchResultsAsync(string query, TextSearchOptions<KeenableWebPage>? searchOptions, CancellationToken cancellationToken)
     {
-        var (modifiedQuery, top, skip, includeTotalCount, filters) = ExtractSearchParameters(query, searchOptions);
+        var (modifiedQuery, top, skip, filters) = ExtractSearchParameters(query, searchOptions);
         KeenableSearchResponse? searchResponse = await this.ExecuteSearchAsync(modifiedQuery, top, skip, filters, cancellationToken).ConfigureAwait(false);
 
-        long? totalCount = includeTotalCount ? searchResponse?.Results.Count : null;
+        // The API does not report a total count.
+        long? totalCount = null;
 
         return new KernelSearchResults<KeenableWebPage>(this.GetResultsAsWebPageAsync(searchResponse, cancellationToken), totalCount, GetResultsMetadata(searchResponse));
     }
@@ -137,15 +149,14 @@ public sealed class KeenableTextSearch : ITextSearch, ITextSearch<KeenableWebPag
     /// This is the primary entry point for the LINQ-based filtering path.
     /// Keenable supports query modification via Title.Contains() which appends terms to the query.
     /// </summary>
-    private static (string ModifiedQuery, int Top, int Skip, bool IncludeTotalCount, List<(string FieldName, object Value)> Filters) ExtractSearchParameters<TRecord>(string query, TextSearchOptions<TRecord>? searchOptions)
+    private static (string ModifiedQuery, int Top, int Skip, List<(string FieldName, object Value)> Filters) ExtractSearchParameters<TRecord>(string query, TextSearchOptions<TRecord>? searchOptions)
     {
         var top = searchOptions?.Top ?? 3;
         var skip = searchOptions?.Skip ?? 0;
-        var includeTotalCount = searchOptions?.IncludeTotalCount ?? false;
 
         if (searchOptions?.Filter == null)
         {
-            return (query, top, skip, includeTotalCount, []);
+            return (query, top, skip, []);
         }
 
         var filters = new List<(string FieldName, object Value)>();
@@ -158,12 +169,13 @@ public sealed class KeenableTextSearch : ITextSearch, ITextSearch<KeenableWebPag
             ? $"{query} {string.Join(" ", queryTerms)}".Trim()
             : query;
 
-        return (modifiedQuery, top, skip, includeTotalCount, filters);
+        return (modifiedQuery, top, skip, filters);
     }
 
     /// <summary>
     /// Walks a LINQ expression tree and extracts Keenable API filter key-value pairs and query terms directly.
-    /// Supports equality expressions, Contains() method calls, and logical AND/OR operators.
+    /// Supports equality comparisons on Site, PublishedAfter and PublishedBefore, Title.Contains() and Site.Contains(),
+    /// combined with logical AND only. OR, NOT and inequality cannot be expressed as a single request and are rejected.
     /// </summary>
     /// <param name="expression">The expression to analyze.</param>
     /// <param name="filters">The list to add filter key-value pairs to.</param>
@@ -172,11 +184,15 @@ public sealed class KeenableTextSearch : ITextSearch, ITextSearch<KeenableWebPag
     {
         switch (expression)
         {
-            case BinaryExpression { NodeType: ExpressionType.AndAlso or ExpressionType.OrElse } binaryExpr:
-                // Handle AND/OR expressions by recursively analyzing both sides
+            case BinaryExpression { NodeType: ExpressionType.AndAlso } binaryExpr:
+                // Handle AND expressions by recursively analyzing both sides; every clause ends up in the same request
                 ExtractFiltersFromExpression(binaryExpr.Left, filters, queryTerms);
                 ExtractFiltersFromExpression(binaryExpr.Right, filters, queryTerms);
                 break;
+
+            case BinaryExpression { NodeType: ExpressionType.OrElse }:
+                // A single request cannot express alternatives; merging both sides would silently search only the last one
+                throw new NotSupportedException(UnsupportedFilterMessage("Logical OR (||)"));
 
             case BinaryExpression { NodeType: ExpressionType.Equal } binaryExpr:
                 ProcessEqualityClause(binaryExpr, filters);
@@ -187,7 +203,7 @@ public sealed class KeenableTextSearch : ITextSearch, ITextSearch<KeenableWebPag
                 break;
 
             case BinaryExpression binaryExpr:
-                throw new NotSupportedException($"Binary expression type '{binaryExpr.NodeType}' is not supported. Supported operators: AndAlso (&&), OrElse (||), Equal (==), NotEqual (!=).");
+                throw new NotSupportedException(UnsupportedFilterMessage($"Binary expression type '{binaryExpr.NodeType}'"));
 
             case UnaryExpression { NodeType: ExpressionType.Not } unaryExpr:
                 ProcessNotExpression(unaryExpr);
@@ -198,7 +214,7 @@ public sealed class KeenableTextSearch : ITextSearch, ITextSearch<KeenableWebPag
                 break;
 
             default:
-                throw new NotSupportedException($"Expression type '{expression.NodeType}' is not supported in Keenable search filters.");
+                throw new NotSupportedException(UnsupportedFilterMessage($"Expression type '{expression.NodeType}'"));
         }
     }
 
@@ -258,12 +274,9 @@ public sealed class KeenableTextSearch : ITextSearch, ITextSearch<KeenableWebPag
             propertyName = rightMember.Member.Name;
         }
 
-        if (propertyName != null)
-        {
-            throw new NotSupportedException($"Inequality operator (!=) is not directly supported for property '{propertyName}'. Use NOT operator instead: !(page.{propertyName} == value).");
-        }
-
-        throw new NotSupportedException("Unable to extract property name and value from inequality expression.");
+        throw new NotSupportedException(UnsupportedFilterMessage(propertyName is null
+            ? "Inequality operator (!=)"
+            : $"Inequality operator (!=) on property '{propertyName}'"));
     }
 
     /// <summary>
@@ -271,13 +284,16 @@ public sealed class KeenableTextSearch : ITextSearch, ITextSearch<KeenableWebPag
     /// </summary>
     private static void ProcessNotExpression(UnaryExpression unaryExpr)
     {
-        if (unaryExpr.Operand is BinaryExpression binaryExpr && binaryExpr.NodeType == ExpressionType.Equal)
-        {
-            throw new NotSupportedException("NOT operator (!) with equality is not directly supported. Most web search APIs don't support negative filtering.");
-        }
-
-        throw new NotSupportedException("NOT operator (!) is only supported with simple equality expressions.");
+        throw new NotSupportedException(UnsupportedFilterMessage($"NOT operator (!) on '{unaryExpr.Operand}'"));
     }
+
+    /// <summary>
+    /// Builds the message for an unsupported filter construct, stating what the connector does support.
+    /// </summary>
+    private static string UnsupportedFilterMessage(string what) =>
+        $"{what} is not supported in Keenable search filters. " +
+        "Only equality comparisons (==) on Site, PublishedAfter and PublishedBefore, Title.Contains() and Site.Contains(), combined with &&, are supported. " +
+        "Apply other conditions client-side or run multiple queries.";
 
     /// <summary>
     /// Processes a method call expression (Contains) and maps to filters or query terms directly.

--- a/dotnet/src/Plugins/Plugins.Web/Keenable/KeenableTextSearchOptions.cs
+++ b/dotnet/src/Plugins/Plugins.Web/Keenable/KeenableTextSearchOptions.cs
@@ -1,0 +1,47 @@
+﻿// Copyright (c) Microsoft. All rights reserved.
+
+using System;
+using System.Net.Http;
+using Microsoft.Extensions.Logging;
+using Microsoft.SemanticKernel.Data;
+
+namespace Microsoft.SemanticKernel.Plugins.Web.Keenable;
+
+/// <summary>
+/// Options used to construct an instance of <see cref="KeenableTextSearch"/>.
+/// </summary>
+public sealed class KeenableTextSearchOptions
+{
+    /// <summary>
+    /// The base URI of the Keenable search service. The URI must use HTTPS.
+    /// The connector appends <c>/v1/search</c> when an API key is configured and <c>/v1/search/public</c> otherwise.
+    /// Defaults to <c>https://api.keenable.ai</c>.
+    /// </summary>
+    public Uri? Endpoint { get; init; } = null;
+
+    /// <summary>
+    /// Requested maximum length, in characters, of the snippet returned for each result.
+    /// The service treats this as a hint. When null the service default is used.
+    /// </summary>
+    public int? SnippetMaxLength { get; set; }
+
+    /// <summary>
+    /// The HTTP client to use for making requests.
+    /// </summary>
+    public HttpClient? HttpClient { get; init; } = null;
+
+    /// <summary>
+    /// The <see cref="ILoggerFactory"/> to use for logging. If null, no logging will be performed.
+    /// </summary>
+    public ILoggerFactory? LoggerFactory { get; init; } = null;
+
+    /// <summary>
+    /// <see cref="ITextSearchStringMapper" /> instance that can map a <see cref="KeenableSearchResult"/> to a <see cref="string"/>
+    /// </summary>
+    public ITextSearchStringMapper? StringMapper { get; init; } = null;
+
+    /// <summary>
+    /// <see cref="ITextSearchResultMapper" /> instance that can map a <see cref="KeenableSearchResult"/> to a <see cref="TextSearchResult"/>
+    /// </summary>
+    public ITextSearchResultMapper? ResultMapper { get; init; } = null;
+}

--- a/dotnet/src/Plugins/Plugins.Web/Keenable/KeenableTextSearchOptions.cs
+++ b/dotnet/src/Plugins/Plugins.Web/Keenable/KeenableTextSearchOptions.cs
@@ -13,7 +13,7 @@ namespace Microsoft.SemanticKernel.Plugins.Web.Keenable;
 public sealed class KeenableTextSearchOptions
 {
     /// <summary>
-    /// The base URI of the Keenable search service. The URI must use HTTPS.
+    /// The base URI of the Keenable search service. The URI must use HTTPS; any other scheme is rejected when the search instance is created.
     /// The connector appends <c>/v1/search</c> when an API key is configured and <c>/v1/search/public</c> otherwise.
     /// Defaults to <c>https://api.keenable.ai</c>.
     /// </summary>

--- a/dotnet/src/Plugins/Plugins.Web/Keenable/KeenableWebPage.cs
+++ b/dotnet/src/Plugins/Plugins.Web/Keenable/KeenableWebPage.cs
@@ -1,0 +1,90 @@
+﻿// Copyright (c) Microsoft. All rights reserved.
+
+using System;
+
+namespace Microsoft.SemanticKernel.Plugins.Web.Keenable;
+
+/// <summary>
+/// Represents a type-safe web page result from Keenable search for use with generic ITextSearch&lt;TRecord&gt; interface.
+/// This class provides compile-time type safety and IntelliSense support for Keenable search filtering.
+/// </summary>
+public sealed class KeenableWebPage
+{
+    /// <summary>
+    /// Gets or sets the title of the web page.
+    /// </summary>
+    public string? Title { get; set; }
+
+    /// <summary>
+    /// Gets or sets the URL of the web page.
+    /// </summary>
+    public Uri? Url { get; set; }
+
+    /// <summary>
+    /// Gets or sets the passage of the page text relevant to the query.
+    /// </summary>
+    public string? Snippet { get; set; }
+
+    /// <summary>
+    /// Gets or sets the short description of the web page.
+    /// </summary>
+    public string? Description { get; set; }
+
+    /// <summary>
+    /// Gets or sets when the page was published, if known.
+    /// </summary>
+    public DateTimeOffset? PublishedAt { get; set; }
+
+    /// <summary>
+    /// Gets or sets the site filter for search results.
+    /// Maps to Keenable's 'site' parameter (e.g., "learn.microsoft.com").
+    /// </summary>
+    public string? Site { get; set; }
+
+    /// <summary>
+    /// Gets or sets the earliest publication date filter for search results.
+    /// Maps to Keenable's 'published_after' parameter (YYYY-MM-DD).
+    /// </summary>
+    public string? PublishedAfter { get; set; }
+
+    /// <summary>
+    /// Gets or sets the latest publication date filter for search results.
+    /// Maps to Keenable's 'published_before' parameter (YYYY-MM-DD).
+    /// </summary>
+    public string? PublishedBefore { get; set; }
+
+    /// <summary>
+    /// Initializes a new instance of the <see cref="KeenableWebPage"/> class.
+    /// </summary>
+    public KeenableWebPage()
+    {
+    }
+
+    /// <summary>
+    /// Initializes a new instance of the <see cref="KeenableWebPage"/> class with specified values.
+    /// </summary>
+    /// <param name="title">The title of the web page.</param>
+    /// <param name="url">The URL of the web page.</param>
+    /// <param name="snippet">The passage of the page text relevant to the query.</param>
+    /// <param name="description">The short description of the web page.</param>
+    /// <param name="publishedAt">When the page was published, if known.</param>
+    public KeenableWebPage(string? title, Uri? url, string? snippet, string? description = null, DateTimeOffset? publishedAt = null)
+    {
+        this.Title = title;
+        this.Url = url;
+        this.Snippet = snippet;
+        this.Description = description;
+        this.PublishedAt = publishedAt;
+    }
+
+    /// <summary>
+    /// Creates a KeenableWebPage from a KeenableSearchResult.
+    /// </summary>
+    /// <param name="result">The search result to convert.</param>
+    /// <returns>A new KeenableWebPage instance.</returns>
+    internal static KeenableWebPage FromSearchResult(KeenableSearchResult result)
+    {
+        Uri? url = string.IsNullOrWhiteSpace(result.Url) ? null : new Uri(result.Url);
+        return new KeenableWebPage(result.Title, url, result.Snippet, result.Description, result.PublishedAt);
+    }
+}

--- a/dotnet/src/Plugins/Plugins.Web/WebKernelBuilderExtensions.cs
+++ b/dotnet/src/Plugins/Plugins.Web/WebKernelBuilderExtensions.cs
@@ -4,6 +4,7 @@ using Microsoft.SemanticKernel.Data;
 using Microsoft.SemanticKernel.Plugins.Web.Bing;
 using Microsoft.SemanticKernel.Plugins.Web.Brave;
 using Microsoft.SemanticKernel.Plugins.Web.Google;
+using Microsoft.SemanticKernel.Plugins.Web.Keenable;
 using Microsoft.SemanticKernel.Plugins.Web.Tavily;
 
 namespace Microsoft.SemanticKernel;
@@ -67,6 +68,24 @@ public static class WebKernelBuilderExtensions
         Verify.NotNull(builder);
         builder.Services.AddGoogleTextSearch(searchEngineId, apiKey, options, serviceId);
 
+        return builder;
+    }
+
+    /// <summary>
+    /// Register an <see cref="ITextSearch"/> instance with the specified service ID.
+    /// </summary>
+    /// <param name="builder">The <see cref="IKernelBuilder"/> to register the <see cref="ITextSearch"/> on.</param>
+    /// <param name="apiKey">Optional API key used to authenticate requests against the Search service. When null or empty the public endpoint is used.</param>
+    /// <param name="options">Instance of <see cref="KeenableTextSearchOptions"/> to used when creating the <see cref="KeenableTextSearch"/>.</param>
+    /// <param name="serviceId">An optional service id to use as the service key.</param>
+    public static IKernelBuilder AddKeenableTextSearch(
+        this IKernelBuilder builder,
+        string? apiKey = null,
+        KeenableTextSearchOptions? options = null,
+        string? serviceId = default)
+    {
+        Verify.NotNull(builder);
+        builder.Services.AddKeenableTextSearch(apiKey, options, serviceId);
         return builder;
     }
 

--- a/dotnet/src/Plugins/Plugins.Web/WebServiceCollectionExtensions.cs
+++ b/dotnet/src/Plugins/Plugins.Web/WebServiceCollectionExtensions.cs
@@ -7,6 +7,7 @@ using Microsoft.SemanticKernel.Data;
 using Microsoft.SemanticKernel.Plugins.Web.Bing;
 using Microsoft.SemanticKernel.Plugins.Web.Brave;
 using Microsoft.SemanticKernel.Plugins.Web.Google;
+using Microsoft.SemanticKernel.Plugins.Web.Keenable;
 using Microsoft.SemanticKernel.Plugins.Web.Tavily;
 
 namespace Microsoft.SemanticKernel;
@@ -92,6 +93,33 @@ public static class WebServiceCollectionExtensions
                 var selectedOptions = options ?? sp.GetService<GoogleTextSearchOptions>();
 
                 return new GoogleTextSearch(searchEngineId, apiKey, selectedOptions);
+            });
+
+        return services;
+    }
+
+    /// <summary>
+    /// Register an <see cref="ITextSearch"/> instance with the specified service ID.
+    /// </summary>
+    /// <param name="services">The <see cref="IServiceCollection"/> to register the <see cref="ITextSearch"/> on.</param>
+    /// <param name="apiKey">Optional API key used to authenticate requests against the Search service. When null or empty the public endpoint is used.</param>
+    /// <param name="options">Instance of <see cref="KeenableTextSearchOptions"/> to used when creating the <see cref="KeenableTextSearch"/>.</param>
+    /// <param name="serviceId">An optional service id to use as the service key.</param>
+    public static IServiceCollection AddKeenableTextSearch(
+        this IServiceCollection services,
+        string? apiKey = null,
+        KeenableTextSearchOptions? options = null,
+        string? serviceId = default)
+    {
+        Verify.NotNull(services);
+
+        services.AddKeyedSingleton<ITextSearch>(
+            serviceId,
+            (sp, _) =>
+            {
+                var selectedOptions = options ?? sp.GetService<KeenableTextSearchOptions>();
+
+                return new KeenableTextSearch(apiKey, selectedOptions);
             });
 
         return services;


### PR DESCRIPTION
### Motivation and Context

This adds a web search connector for [Keenable](https://keenable.ai) to `Plugins.Web`, next to the Bing, Brave, Google and Tavily connectors. It is the only connector in `Plugins.Web` that works with no API key: `apiKey` is optional, and a key only lifts the per-IP rate limits of the public endpoint. That makes it a usable default for the text search samples, RAG and function-calling scenarios where a user has not signed up for a search provider yet.

CONTRIBUTING.md asks for plugins to live in separate repos, but `Plugins.Web` has kept accepting web search connectors from outside (#11308, Brave) and inside (#11227, Tavily), so this follows those two.

I work at Keenable.

### Description

`KeenableTextSearch` implements `ITextSearch` and `ITextSearch<KeenableWebPage>` in the same shape as `BraveTextSearch` and `TavilyTextSearch` after the LINQ refactor: shared `ExecuteSearchAsync`, the legacy `TextSearchFilter` shim, the expression walker, default string and result mappers, and `AddKeenableTextSearch` on `IKernelBuilder` and `IServiceCollection`.

- Without a key the connector posts to `https://api.keenable.ai/v1/search/public` with the `X-Keenable-Title: semantic-kernel` header the public endpoint requires; with a key it posts to `/v1/search` with `X-API-Key`. The key is sent as a header only, never in the body.
- Options: `Endpoint` (base address), `SnippetMaxLength` (a hint to the service), plus the usual `HttpClient`, `LoggerFactory`, `StringMapper`, `ResultMapper`. Nothing else, to stay 1:1 with what the API exposes.
- Filters: `site`, `published_after`, `published_before` through `TextSearchFilter.Equality(...)` or LINQ on `KeenableWebPage` (`page.Site == "learn.microsoft.com"`); `Title.Contains(...)` appends to the query like the other connectors. `DateTime` and `DateTimeOffset` filter values are formatted as `YYYY-MM-DD`.
- `TextSearchResult` maps `title`, `snippet` (falling back to `description` when the snippet is empty) and `url`. The raw `KeenableSearchResult` is public and keeps unknown fields in `AdditionalProperties`.
- `Top` is 1 to 50. The API has no offset, so `Skip` requests `Top + Skip` results and drops the first `Skip` client side.
- Non-2xx responses go through `SendWithSuccessCheckAsync` and surface as `HttpOperationException`, so a 429 is an error, not an empty result.

Also included: unit tests with recorded fixtures (request shape for keyless and keyed calls, endpoint override, filters, mapping and fallback, skip, validation, non-2xx), an integration test in the `BaseTextSearchTests` shape (skipped by default like the others, no key needed to run it), a `Keenable_TextSearch` Concepts sample with an optional `Keenable:ApiKey` setting, and the `TestConfiguration.Keenable` entry.

Verified locally with SDK 10.0.400: `Plugins.Web`, `Plugins.UnitTests`, `IntegrationTests` and `Concepts` build with 0 warnings, `dotnet format --verify-no-changes` passes on all four, and the 40 new unit tests pass. A live keyless run through the connector returned 5 of 5 results with non-empty snippets.

### Contribution Checklist

- [x] The code builds clean without any errors or warnings
- [x] The PR follows the [SK Contribution Guidelines](https://github.com/microsoft/semantic-kernel/blob/main/CONTRIBUTING.md) and the [pre-submission formatting script](https://github.com/microsoft/semantic-kernel/blob/main/CONTRIBUTING.md#development-scripts) raises no violations
- [x] All unit tests pass, and I have added new tests where possible
- [x] I didn't break anyone :smile:
