### PR TITLE
ci: pin octokit/graphql-action to full commit SHA in label-discussions.yml

### DIFF
--- a/.github/workflows/label-discussions.yml
+++ b/.github/workflows/label-discussions.yml
@@ -20,7 +20,7 @@ jobs:
           (github.event.discussion.category.name == 'General' ||
            github.event.discussion.category.name == 'Ideas' ||
            github.event.discussion.category.name == 'Q&A')
-        uses: octokit/graphql-action@v2.x
+        uses: octokit/graphql-action@f7836e89a7e5bac63911bbe9653c21147b3d9bc3 # v2.3.3
         with:
           query: |
             mutation($labelableId: ID!) {
@@ -48,7 +48,7 @@ jobs:
            contains(github.event.discussion.body, 'Python') ||
            contains(github.event.discussion.title, 'python') ||
            contains(github.event.discussion.title, 'Python'))
-        uses: octokit/graphql-action@v2.x
+        uses: octokit/graphql-action@f7836e89a7e5bac63911bbe9653c21147b3d9bc3 # v2.3.3
         with:
           query: |
             mutation($labelableId: ID!) {
@@ -88,7 +88,7 @@ jobs:
            contains(github.event.discussion.body, 'CSharp') ||
            contains(github.event.discussion.title, 'csharp') ||
            contains(github.event.discussion.title, 'CSharp'))
-        uses: octokit/graphql-action@v2.x
+        uses: octokit/graphql-action@f7836e89a7e5bac63911bbe9653c21147b3d9bc3 # v2.3.3
         with:
           query: |
             mutation($labelableId: ID!) {


### PR DESCRIPTION
## Summary

`label-discussions.yml` still references `octokit/graphql-action@v2.x` in all three of its steps. `v2.x` is a **branch**, not a tag (verified via `GET /repos/octokit/graphql-action/branches`), so it is a mutable ref: whoever can push to (or otherwise retarget) that branch can change what code runs here.

This looks like a gap left by the recent action-pinning pass (#14307), which pinned third-party actions across the workflow files to full commit SHAs using `pinact`. That PR's own description notes "*References that were already pinned to a SHA, or that used immutable release tags, were left unchanged*" — `v2.x` is neither, but as a branch-shaped ref rather than the more common `vN` major-tag form, it appears to have slipped past that pass (it isn't in #14307's diff, and it also isn't touched by the still-open community attempt at the same class of fix, #14121).

## Why it matters

This workflow triggers on `discussion: created` — any user can open a discussion in a public repo, no approval gate like `pull_request_target` has. The job runs with `permissions: discussions: write` and `secrets.GITHUB_TOKEN` in its environment. If `octokit/graphql-action`'s `v2.x` branch were ever repointed (maintainer account compromise, or a bad rebase), that would grant code execution in this job's context — the same class of supply-chain risk #14307 already cites (tj-actions/changed-files, codfish/semantic-release-action).

## What changed

Pinned all three occurrences to the commit the `v2.x` branch currently resolves to, which is the same commit as the latest v2 release tag:

```
octokit/graphql-action@f7836e89a7e5bac63911bbe9653c21147b3d9bc3 # v2.3.3
```

(`GET /repos/octokit/graphql-action/git/refs/heads/v2.x` and `GET /repos/octokit/graphql-action/git/refs/tags/v2.3.3` both currently resolve to this SHA.)

This follows the exact `uses: owner/action@<sha> # vX.Y.Z` convention already used everywhere else in this repo's workflows. No behavior change — same code, just addressed by an immutable reference instead of a movable branch.

## Is this safe to merge?

Yes. Same commit, same behavior, only the reference is now immutable. Dependabot's existing `github-actions` ecosystem watch (`.github/dependabot.yml`) will pick up future version bumps for this pinned SHA the same way it does for the other actions pinned in #14307.

🤖 Generated with [Claude Code](https://claude.com/claude-code)