### PR TITLE
docs: remove duplicate 'the' in ADR 0072

### DIFF
--- a/docs/decisions/0072-agents-with-memory.md
+++ b/docs/decisions/0072-agents-with-memory.md
@@ -68,7 +68,7 @@ Building a service to host an agent comes with challenges.
 It's hard to build a stateful service, but service consumers expect an experience that looks stateful from the outside.
 E.g. on each invocation, the user expects that the service can continue a conversation they are having.
 
-This means that where the the service is exposing a local agent with local conversation state management (e.g. via `ChatHistory`)
+This means that where the service is exposing a local agent with local conversation state management (e.g. via `ChatHistory`)
 that conversation state needs to be loaded and persisted for each invocation of the service.
 
 It also means that any memory components that may have some in-memory state will need to be loaded and persisted too.


### PR DESCRIPTION
### Description
Fix doubled word: \"the the service\" → \"the service\" in ADR 0072 (agents with memory).

### Contribution Checklist
- [x] The code builds clean without any errors or warnings
- [ ] The PR follows SK Contribution Guidelines (https://learn.microsoft.com/en-us/semantic-kernel/support/contributing)
- [x] Any AI contribution and the way it was used is documented in the description of the PR
- [ ] Unit tests are included / updated where applicable
- [x] Documentation is updated where applicable