### PR TITLE
docs: remove duplicate 'of' in ADR 0054

### DIFF
--- a/docs/decisions/0054-processes.md
+++ b/docs/decisions/0054-processes.md
@@ -279,7 +279,7 @@ The instance of `KernelProcess` that we've created is nothing more than an objec
 
 #### Step 5 - Run the Process:
 
-Running a Process requires using a "connector" to a supported runtime. As part of the core packages we will include an in-process runtime that is capable of of running a process locally on a dev machine or in a server. This runtime will initially use memory or file based persistence and will allow for easy development and debugging.
+Running a Process requires using a "connector" to a supported runtime. As part of the core packages we will include an in-process runtime that is capable of running a process locally on a dev machine or in a server. This runtime will initially use memory or file based persistence and will allow for easy development and debugging.
 
 Additionally we will provide support for [Orleans](https://learn.microsoft.com/en-us/dotnet/orleans/overview) and [Dapr Actor](https://docs.dapr.io/developing-applications/building-blocks/actors/actors-overview/) based runtimes which will allow customers to easily deploy processes as a distributed and highly scalable cloud based system.
 


### PR DESCRIPTION
### Description
Fix doubled word: \"of of running\" → \"of running\" in ADR 0054 (processes).

### Contribution Checklist
- [x] The code builds clean without any errors or warnings
- [ ] The PR follows SK Contribution Guidelines (https://learn.microsoft.com/en-us/semantic-kernel/support/contributing)
- [x] Any AI contribution and the way it was used is documented in the description of the PR
- [ ] Unit tests are included / updated where applicable
- [x] Documentation is updated where applicable