### PR TITLE
docs: remove duplicate 'the' in ADR 0048

### DIFF
--- a/docs/decisions/0048-agent-chat-serialization.md
+++ b/docs/decisions/0048-agent-chat-serialization.md
@@ -15,7 +15,7 @@ Formalizing a mechanism that supports serialization and deserialization of any `
 #### Goals
 - **Capture & Restore Primary Chat History**: The primary `AgentChat` history must be captured and restored for full fidelity.
 - **Capture & Restore Channel State**: In addition to the primary chat history, the state for each `AgentChannel` within the `AgentChat` must be captured and restored.
-- **Capture Agent Metadata**: Capturing the agent Identifier, Name, and Type upon serialization provides a guidance on how to restore the `AgentChat` during deserialization.
+- **Capture Agent Metadata**: Capturing the agent Identifier, Name, and Type upon serialization provides guidance on how to restore the `AgentChat` during deserialization.
 
 
 #### Non-Goals

--- a/docs/decisions/0048-agent-chat-serialization.md
+++ b/docs/decisions/0048-agent-chat-serialization.md
@@ -15,7 +15,7 @@ Formalizing a mechanism that supports serialization and deserialization of any `
 #### Goals
 - **Capture & Restore Primary Chat History**: The primary `AgentChat` history must be captured and restored for full fidelity.
 - **Capture & Restore Channel State**: In addition to the primary chat history, the state for each `AgentChannel` within the `AgentChat` must be captured and restored.
-- **Capture Agent Metadata**: Capturing the agent Identifier, Name, and Type upon serialization provides a guidance on how to restore the the `AgentChat` during deserialization.
+- **Capture Agent Metadata**: Capturing the agent Identifier, Name, and Type upon serialization provides a guidance on how to restore the `AgentChat` during deserialization.
 
 
 #### Non-Goals


### PR DESCRIPTION
### Description
Fix doubled word: \"the the \`AgentChat\`\" → \"the \`AgentChat\`\" in ADR 0048 (agent chat serialization).

### Contribution Checklist
- [x] The code builds clean without any errors or warnings
- [ ] The PR follows SK Contribution Guidelines (https://learn.microsoft.com/en-us/semantic-kernel/support/contributing)
- [x] Any AI contribution and the way it was used is documented in the description of the PR
- [ ] Unit tests are included / updated where applicable
- [x] Documentation is updated where applicable