### PR TITLE
docs: remove duplicate 'the' in sessions Python tool README

### DIFF
--- a/python/semantic_kernel/core_plugins/sessions_python_tool/README.md
+++ b/python/semantic_kernel/core_plugins/sessions_python_tool/README.md
@@ -12,7 +12,7 @@ Next, as an environment variable or in the .env file, add the `poolManagementEnd
 https://eastus.acasessions.io/subscriptions/{{subscriptionId}}/resourceGroups/{{resourceGroup}}/sessionPools/{{sessionPool}}/python/execute
 ```
 
-You can also provide the the `ACA_TOKEN_ENDPOINT` if you want to override the default value of `https://acasessions.io/.default`. If this token endpoint doesn't need to be overridden, then it is
+You can also provide the `ACA_TOKEN_ENDPOINT` if you want to override the default value of `https://acasessions.io/.default`. If this token endpoint doesn't need to be overridden, then it is
 not necessary to include this as an environment variable, in the .env file, or via the plugin's constructor. Please follow the [Azure Container Apps Documentation](https://learn.microsoft.com/en-us/azure/container-apps/sessions-code-interpreter) to review the proper role required to authenticate with the `AsyncTokenCredential`.
 
 Next, let's move on to implementing the plugin in code. It is possible to add the code interpreter plugin as follows:


### PR DESCRIPTION
### Description
Fix doubled word: \"the the \`ACA_TOKEN_ENDPOINT\`\" → \"the \`ACA_TOKEN_ENDPOINT\`\" in the sessions Python tool README.

### Contribution Checklist
- [x] The code builds clean without any errors or warnings
- [ ] The PR follows SK Contribution Guidelines (https://learn.microsoft.com/en-us/semantic-kernel/support/contributing)
- [x] Any AI contribution and the way it was used is documented in the description of the PR
- [ ] Unit tests are included / updated where applicable
- [x] Documentation is updated where applicable