### PR TITLE
docs: remove duplicate 'the' in telemetry sample README

### DIFF
--- a/python/samples/demos/telemetry/README.md
+++ b/python/samples/demos/telemetry/README.md
@@ -70,7 +70,7 @@ Please refer to here on how to analyze metrics in [Azure Monitor](https://learn.
 
 > Make sure you have the dashboard running to receive telemetry data.
 
-Once the the sample finishes running, navigate to http://localhost:18888 in a web browser to see the telemetry data. Follow the instructions [here](https://learn.microsoft.com/en-us/dotnet/aspire/fundamentals/dashboard/explore) to authenticate to the dashboard and start exploring!
+Once the sample finishes running, navigate to http://localhost:18888 in a web browser to see the telemetry data. Follow the instructions [here](https://learn.microsoft.com/en-us/dotnet/aspire/fundamentals/dashboard/explore) to authenticate to the dashboard and start exploring!
 
 ## Console output
 


### PR DESCRIPTION
### Description
Fix doubled word: \"Once the the sample\" → \"Once the sample\" in the telemetry demo README.

### Contribution Checklist
- [x] The code builds clean without any errors or warnings
- [ ] The PR follows SK Contribution Guidelines (https://learn.microsoft.com/en-us/semantic-kernel/support/contributing)
- [x] Any AI contribution and the way it was used is documented in the description of the PR
- [ ] Unit tests are included / updated where applicable
- [x] Documentation is updated where applicable