### PR TITLE
docs: remove duplicate 'the' in .NET processes sample README

### DIFF
--- a/dotnet/samples/GettingStartedWithProcesses/README.md
+++ b/dotnet/samples/GettingStartedWithProcesses/README.md
@@ -261,7 +261,7 @@ The processes in this subsection contain the following modifications/additions t
 ###### Potato Fries Preparation With Knife Sharpening and Ingredient Stock Process
 
 The following processes is a modification on the process [Potato Fries Preparation](#potato-fries-preparation-process) 
-with the the stateful steps mentioned previously.
+with the stateful steps mentioned previously.
 
 ``` mermaid
 flowchart LR
@@ -296,7 +296,7 @@ flowchart LR
 ###### Fried Fish Preparation With Knife Sharpening and Ingredient Stock Process
 
 The following process is a modification on the process [Fried Fish Preparation](#fried-fish-preparation-process) 
-with the the stateful steps mentioned previously.
+with the stateful steps mentioned previously.
 
 ``` mermaid
 flowchart LR


### PR DESCRIPTION
Removes duplicate word `the the` → `the` in the .NET GettingStartedWithProcesses sample README.