### PR TITLE
docs: fix 'allows to' grammar in Copilot Studio skill README

### DIFF
--- a/python/samples/demos/copilot_studio_skill/README.md
+++ b/python/samples/demos/copilot_studio_skill/README.md
@@ -1,6 +1,6 @@
 # Extend Copilot Studio with Semantic Kernel
 
-This template demonstrates how to build a [Copilot Studio Skill](https://learn.microsoft.com/en-us/microsoft-copilot-studio/advanced-use-skills) that allows to extend agent capabilities with a custom API running in Azure with the help of the Semantic Kernel.
+This template demonstrates how to build a [Copilot Studio Skill](https://learn.microsoft.com/en-us/microsoft-copilot-studio/advanced-use-skills) that allows you to extend agent capabilities with a custom API running in Azure with the help of the Semantic Kernel.
 
 ![Copilot Studio using the Semantic Kernel skill within a topic](image.png)
 


### PR DESCRIPTION
Fixes grammar `allows to` → `allows you to` in the Copilot Studio skill demo README.